### PR TITLE
tty: up the input queue limit to 2K

### DIFF
--- a/usr/src/head/limits.h
+++ b/usr/src/head/limits.h
@@ -73,6 +73,11 @@ extern "C" {
 #define	ARG_MAX		_ARG_MAX32	/* max length of arguments to exec */
 #endif	/* _LP64 */
 
+
+/*
+ * These two symbols have their historical values, the actual buffer is
+ * larger.
+ */
 #ifndef MAX_CANON
 #define	MAX_CANON	256	/* max bytes in line for canonical processing */
 #endif

--- a/usr/src/uts/common/io/ldterm.c
+++ b/usr/src/uts/common/io/ldterm.c
@@ -566,8 +566,8 @@ static struct module_info ldtermmiinfo = {
 	0x0bad,
 	"ldterm",
 	0,
-	256,
-	HIWAT,
+	_TTY_BUFSIZ,
+	_TTY_BUFSIZ,
 	LOWAT
 };
 
@@ -793,7 +793,7 @@ ldtermopen(queue_t *q, dev_t *devp, int oflag, int sflag, cred_t *crp)
 	strop = (struct stroptions *)bp->b_wptr;
 	strop->so_flags = SO_READOPT|SO_HIWAT|SO_LOWAT|SO_NDELON|SO_ISTTY;
 	strop->so_readopt = RMSGN;
-	strop->so_hiwat = HIWAT;
+	strop->so_hiwat = _TTY_BUFSIZ;
 	strop->so_lowat = LOWAT;
 	bp->b_wptr += sizeof (struct stroptions);
 	bp->b_datap->db_type = M_SETOPTS;
@@ -1895,7 +1895,7 @@ escaped:
 	 * Allows MAX_CANON bytes in the buffer before throwing awaying
 	 * the the overflow of characters.
 	 */
-	if ((tp->t_msglen > ((MAX_CANON + 1) - (int)tp->t_maxeuc)) &&
+	if ((tp->t_msglen > ((_TTY_BUFSIZ + 1) - (int)tp->t_maxeuc)) &&
 	    !((tp->t_state & TS_MEUC) && tp->t_eucleft)) {
 
 		/*
@@ -4383,7 +4383,7 @@ ldterm_do_ioctl(queue_t *q, mblk_t *mp)
 			}
 			if ((tp->t_maxeuc > 1) || (tp->t_state & TS_MEUC)) {
 				if (!tp->t_eucp_mp) {
-					if (!(tp->t_eucp_mp = allocb(CANBSIZ,
+					if (!(tp->t_eucp_mp = allocb(_TTY_BUFSIZ,
 					    BPRI_HI))) {
 						tp->t_maxeuc = 1;
 						tp->t_state &= ~TS_MEUC;
@@ -4612,7 +4612,7 @@ ldterm_do_ioctl(queue_t *q, mblk_t *mp)
 		tp->t_state &= ~TS_MEUC;
 		if (maxbytelen > 1 || maxscreenlen > 1) {
 			if (!tp->t_eucp_mp) {
-				if (!(tp->t_eucp_mp = allocb(CANBSIZ,
+				if (!(tp->t_eucp_mp = allocb(_TTY_BUFSIZ,
 				    BPRI_HI))) {
 					cmn_err(CE_WARN,
 					    "Can't allocate eucp_mp");

--- a/usr/src/uts/common/io/ptem.c
+++ b/usr/src/uts/common/io/ptem.c
@@ -28,8 +28,6 @@
  * Use is subject to license terms.
  */
 
-#pragma ident	"%Z%%M%	%I%	%E% SMI" /* from S5R4 1.13 */
-
 /*
  * Description:
  *
@@ -106,8 +104,8 @@ static struct module_info ptem_info = {
 	0xabcd,
 	"ptem",
 	0,
-	512,
-	512,
+	_TTY_BUFSIZ,
+	_TTY_BUFSIZ,
 	128
 };
 
@@ -201,7 +199,7 @@ ptemopen(
 	mop->b_wptr += sizeof (struct stroptions);
 	sop = (struct stroptions *)mop->b_rptr;
 	sop->so_flags = SO_HIWAT | SO_LOWAT | SO_ISTTY;
-	sop->so_hiwat = 512;
+	sop->so_hiwat = _TTY_BUFSIZ;
 	sop->so_lowat = 256;
 
 	/*

--- a/usr/src/uts/common/io/ptm.c
+++ b/usr/src/uts/common/io/ptm.c
@@ -380,7 +380,7 @@ ptmopen(
 		sop->so_flags = SO_HIWAT | SO_LOWAT;
 	else
 		sop->so_flags = SO_HIWAT | SO_LOWAT | SO_ISTTY;
-	sop->so_hiwat = 512;
+	sop->so_hiwat = _TTY_BUFSIZ;
 	sop->so_lowat = 256;
 	putnext(rqp, mop);
 

--- a/usr/src/uts/common/io/pts.c
+++ b/usr/src/uts/common/io/pts.c
@@ -139,8 +139,8 @@ static struct module_info pts_info = {
 	0xface,
 	"pts",
 	0,
-	512,
-	512,
+	_TTY_BUFSIZ,
+	_TTY_BUFSIZ,
 	128
 };
 
@@ -409,7 +409,7 @@ ptsopen(
 	mop->b_wptr += sizeof (struct stroptions);
 	sop = (struct stroptions *)mop->b_rptr;
 	sop->so_flags = SO_HIWAT | SO_LOWAT | SO_ISTTY;
-	sop->so_hiwat = 512;
+	sop->so_hiwat = _TTY_BUFSIZ;
 	sop->so_lowat = 256;
 	putnext(rqp, mop);
 

--- a/usr/src/uts/common/io/zcons.c
+++ b/usr/src/uts/common/io/zcons.c
@@ -215,7 +215,7 @@ static struct module_info zc_info = {
 	"zcons",
 	0,
 	INFPSZ,
-	2048,
+	_TTY_BUFSIZ,
 	128
 };
 
@@ -501,7 +501,7 @@ zc_master_open(zc_state_t *zcs,
 		sop->so_flags = SO_HIWAT | SO_LOWAT;
 	else
 		sop->so_flags = SO_HIWAT | SO_LOWAT | SO_ISTTY;
-	sop->so_hiwat = 512;
+	sop->so_hiwat = _TTY_BUFSIZ;
 	sop->so_lowat = 256;
 	putnext(rqp, mop);
 
@@ -576,7 +576,7 @@ zc_slave_open(zc_state_t *zcs,
 	mop->b_wptr += sizeof (struct stroptions);
 	sop = (struct stroptions *)(void *)mop->b_rptr;
 	sop->so_flags = SO_HIWAT | SO_LOWAT | SO_ISTTY;
-	sop->so_hiwat = 512;
+	sop->so_hiwat = _TTY_BUFSIZ;
 	sop->so_lowat = 256;
 	putnext(rqp, mop);
 

--- a/usr/src/uts/common/sys/param.h
+++ b/usr/src/uts/common/sys/param.h
@@ -71,13 +71,25 @@ extern "C" {
 #endif
 #endif /* !defined(_XPG6) || defined(__EXTENSIONS__) */
 
+/* The actual size of the TTY input queue */
+#define	_TTY_BUFSIZ	2048
+
+/*
+ * These defines all have their historical value.  The actual size of the tty
+ * buffer both for the line-editor in ldterm, and in general, is above as
+ * _TTY_BUFSIZ.
+ *
+ * We leave these defines at their historical value to match the behaviour of
+ * BSD and Linux.
+ */
 #ifndef	MAX_INPUT
 #define	MAX_INPUT	512	/* Maximum bytes stored in the input queue */
 #endif
-
 #ifndef	MAX_CANON
 #define	MAX_CANON	256	/* Maximum bytes for canonical processing */
 #endif
+#define	CANBSIZ		256	/* max size of typewriter line	*/
+
 
 #define	UID_NOBODY	60001	/* user ID no body */
 #define	GID_NOBODY	UID_NOBODY
@@ -116,8 +128,6 @@ extern "C" {
 #define	MINEPHUID	0x80000000u	/* min ephemeral user id */
 
 #define	NMOUNT		40	/* est. of # mountable fs for quota calc */
-
-#define	CANBSIZ		256	/* max size of typewriter line	*/
 
 #define	NOFILE		20	/* this define is here for	*/
 				/* compatibility purposes only	*/


### PR DESCRIPTION
This heavy handedly ups the limit for TTY input to 2 kilobytes.

This includes for the line-editing provided by canonical mode
(previously 256 bytes), and input in genereal (previously 512 bytes).

This is heavy handed because I just upped the queue lengths and high
water marks all the way up and down the stack both in the modules, and
the values we push up to the stream head.

I have left the constants that "defined" (they didn't, they just matched
it) these limits alone, as that seems to be what both FreeBSD and Linux
have done, and I'm not at all sure what the implications of being
different would be.

These limits are
CANBSIZ
MAX_CANON
MAX_INPUT
_POSIX_MAX_INPUT
_POSIX_MAX_CANON

I added a new symbol with the _real_ value, which hopefully makes things
easier to follow.

I've tested this with cat | wc -c, and get the expected value of 2049
(because of the newline).