### PR TITLE
More arm fixes

### DIFF
--- a/usr/src/cmd/Makefile
+++ b/usr/src/cmd/Makefile
@@ -227,6 +227,7 @@ COMMON_SUBDIRS=	\
 	ls		\
 	mach		\
 	mail		\
+	mailx		\
 	mailwrapper	\
 	make		\
 	makekey		\
@@ -452,7 +453,6 @@ COMMON_SUBDIRS=	\
 # file - wants bits of sys/core.h 64bit apps can't see
 # fwflash - needs libses
 # geniconvtbl - not 64bit clean
-# mailx - not 64bit clean
 # format - not 64bit clean (but just printf stuff)
 # gss - not 64bit clean
 # ipdadm - needs libipd
@@ -493,7 +493,6 @@ $(NOT_AARCH64_BLD)COMMON_SUBDIRS +=	\
 	file		\
 	fwflash		\
 	geniconvtbl	\
-	mailx		\
 	hal		\
 	format		\
 	gss		\

--- a/usr/src/cmd/Makefile
+++ b/usr/src/cmd/Makefile
@@ -372,6 +372,7 @@ COMMON_SUBDIRS=	\
 	th_tools	\
 	tic		\
 	time		\
+	tip		\
 	touch		\
 	tr		\
 	trapstat	\
@@ -470,7 +471,6 @@ COMMON_SUBDIRS=	\
 # sh - not 64bit clean
 # srchtxt - not 64bit clean
 # tput - not 64bit clean
-# tip - not 64bit clean
 # tbl - not 64bit clean
 # troff - not 64bit clean
 # tsol - not ported (or 64bit clean)
@@ -518,7 +518,6 @@ $(NOT_AARCH64_BLD)COMMON_SUBDIRS +=	\
 	sh		\
 	srchtxt		\
 	tput		\
-	tip		\
 	tbl		\
 	troff		\
 	tsol		\

--- a/usr/src/cmd/Makefile
+++ b/usr/src/cmd/Makefile
@@ -240,6 +240,7 @@ COMMON_SUBDIRS=	\
 	mkfifo		\
 	mkfile		\
 	mkmsgs		\
+	mknod		\
 	mkpwdict	\
 	mktemp		\
 	modload		\
@@ -460,7 +461,6 @@ COMMON_SUBDIRS=	\
 # isns - not 64bit clean
 # krb5 - not 64bit clean
 # luxadm - super confused about platforms, and probably needs libs
-# mknod - not 64bit clean
 # nohup - not ported (header bits gone awry)
 # oawk - not 64bit clean?
 # prtdiag - not ported
@@ -500,7 +500,6 @@ $(NOT_AARCH64_BLD)COMMON_SUBDIRS +=	\
 	krb5		\
 	latencytop	\
 	luxadm		\
-	mknod		\
 	nohup		\
 	oawk		\
 	pcitool		\

--- a/usr/src/cmd/Makefile
+++ b/usr/src/cmd/Makefile
@@ -161,6 +161,7 @@ COMMON_SUBDIRS=	\
 	fuser		\
 	gcore		\
 	gencat		\
+	geniconvtbl	\
 	genmsg		\
 	getconf		\
 	getdevpolicy	\
@@ -454,7 +455,6 @@ COMMON_SUBDIRS=	\
 # eqn - not 64bit clean
 # file - wants bits of sys/core.h 64bit apps can't see
 # fwflash - needs libses
-# geniconvtbl - not 64bit clean
 # format - not 64bit clean (but just printf stuff)
 # gss - not 64bit clean
 # ipdadm - needs libipd
@@ -491,7 +491,6 @@ $(NOT_AARCH64_BLD)COMMON_SUBDIRS +=	\
 	eqn		\
 	file		\
 	fwflash		\
-	geniconvtbl	\
 	hal		\
 	format		\
 	gss		\

--- a/usr/src/cmd/Makefile
+++ b/usr/src/cmd/Makefile
@@ -51,6 +51,7 @@ COMMON_SUBDIRS=	\
 	allocate	\
 	Adm		\
 	adbgen		\
+	acct		\
 	acctadm		\
 	arch		\
 	asa		\
@@ -445,7 +446,6 @@ COMMON_SUBDIRS=	\
 # volrmmmount - needs dbus
 # cdrw - needs dbus
 #
-# acct - not 64bit clean
 # bc - not 64bit clean
 # cpc - not ported (nor libcpc)
 # csh - not 64bit clean
@@ -482,7 +482,6 @@ $(NOT_AARCH64_BLD)COMMON_SUBDIRS +=	\
 	perl		\
 	availdevs	\
 	bdiff		\
-	acct		\
 	bnu		\
 	cdrw		\
 	bc		\

--- a/usr/src/cmd/Makefile
+++ b/usr/src/cmd/Makefile
@@ -86,6 +86,7 @@ COMMON_SUBDIRS=	\
 	connstat	\
 	consadm		\
 	coreadm		\
+	cpio		\
 	cron		\
 	crypt		\
 	ctfconvert	\
@@ -446,7 +447,6 @@ COMMON_SUBDIRS=	\
 # backup - not 64bit clean
 # cpc - not ported (nor libcpc)
 # csh - not 64bit clean
-# cpio - not 64bit clean
 # csplit - not 64bit clean
 # eqn - not 64bit clean
 # file - wants bits of sys/core.h 64bit apps can't see
@@ -489,7 +489,6 @@ $(NOT_AARCH64_BLD)COMMON_SUBDIRS +=	\
 	backup		\
 	cpc		\
 	csh		\
-	cpio		\
 	csplit		\
 	eqn		\
 	file		\

--- a/usr/src/cmd/Makefile
+++ b/usr/src/cmd/Makefile
@@ -60,6 +60,7 @@ COMMON_SUBDIRS=	\
 	autopush	\
 	awk		\
 	awk_xpg4	\
+	backup		\
 	banner		\
 	bart		\
 	basename	\
@@ -444,7 +445,6 @@ COMMON_SUBDIRS=	\
 #
 # acct - not 64bit clean
 # bc - not 64bit clean
-# backup - not 64bit clean
 # cpc - not ported (nor libcpc)
 # csh - not 64bit clean
 # csplit - not 64bit clean
@@ -486,7 +486,6 @@ $(NOT_AARCH64_BLD)COMMON_SUBDIRS +=	\
 	bnu		\
 	cdrw		\
 	bc		\
-	backup		\
 	cpc		\
 	csh		\
 	csplit		\

--- a/usr/src/cmd/Makefile
+++ b/usr/src/cmd/Makefile
@@ -363,6 +363,7 @@ COMMON_SUBDIRS=	\
 	syslogd		\
 	tabs		\
 	tail		\
+	tar		\
 	tcopy		\
 	tcpd		\
 	th_tools	\
@@ -468,7 +469,6 @@ COMMON_SUBDIRS=	\
 # sendmail - not 64bit clean (probably our build of it is hosed)
 # sh - not 64bit clean
 # srchtxt - not 64bit clean
-# tar - not 64bit clean
 # tput - not 64bit clean
 # tip - not 64bit clean
 # tbl - not 64bit clean
@@ -520,7 +520,6 @@ $(NOT_AARCH64_BLD)COMMON_SUBDIRS +=	\
 	sendmail	\
 	sh		\
 	srchtxt		\
-	tar		\
 	tput		\
 	tip		\
 	tbl		\

--- a/usr/src/cmd/Makefile
+++ b/usr/src/cmd/Makefile
@@ -415,6 +415,7 @@ COMMON_SUBDIRS=	\
 	zoneadmd	\
 	zonecfg		\
 	zonename	\
+	zonestat	\
 	zlook		\
 	zpool		\
 	zstreamdump	\
@@ -476,7 +477,6 @@ COMMON_SUBDIRS=	\
 # truss - not ported
 # vi - not 64bit clean / not ported
 # ypcmd - not 64bit clean
-# zonestat - not 64bit clean, needs to use the good readdir_r
 $(NOT_AARCH64_BLD)COMMON_SUBDIRS +=	\
 	abi		\
 	perl		\
@@ -531,7 +531,6 @@ $(NOT_AARCH64_BLD)COMMON_SUBDIRS +=	\
 	volrmmount	\
 	vi		\
 	ypcmd		\
-	zonestat	\
 
 aarch64_SUBDIRS=	\
 	ahciem

--- a/usr/src/cmd/acct/acctcom.c
+++ b/usr/src/cmd/acct/acctcom.c
@@ -556,7 +556,7 @@ println(void)
 	    a->ac_tty != 0xffff? devtolin(a->ac_tty):"?");
 #else
 	fprintf(stdout, " %-*.*s", OUTPUT_LSZ, OUTPUT_LSZ,
-	    a->ac_tty != (dev_t)-1? devtolin(a->ac_tty):"?");
+	    a->ac_tty != (dev32_t)-1 ? devtolin(a->ac_tty) : "?");
 #endif
 	t = a->ac_btime;
 	cftime(time_buf, DATE_FMT1, &t);

--- a/usr/src/cmd/acct/acctprc.c
+++ b/usr/src/cmd/acct/acctprc.c
@@ -62,6 +62,7 @@ void **root = NULL;
 
 void output(void);
 void enter(struct ptmp *);
+extern char *uidtonam(uid_t);
 
 int
 main(int argc, char **argv)
@@ -156,7 +157,7 @@ void print_node(const void *node, VISIT order, int level) {
 
 	if (order == postorder || order == leaf) {
 		tb.ta_uid = (*(struct utab **)node)->ut_uid;
-		CPYN(tb.ta_name, (char *)uidtonam((*(struct utab **)node)->ut_uid));
+		CPYN(tb.ta_name, uidtonam((*(struct utab **)node)->ut_uid));
 		tb.ta_cpu[0] = (*(struct utab **)node)->ut_cpu[0];
 		tb.ta_cpu[1] = (*(struct utab **)node)->ut_cpu[1];
                 tb.ta_kcore[0] = (*(struct utab **)node)->ut_kcore[0];

--- a/usr/src/cmd/backup/restore/symtab.c
+++ b/usr/src/cmd/backup/restore/symtab.c
@@ -592,7 +592,7 @@ dumpsymtable(char *filename, int checkpt)
 		    ep = ep->e_links) {
 			bcopy((char *)ep, (char *)tep, sizeof (*tep));
 			/* LINTED: type pun ok */
-			tep->e_name = (char *)stroff;
+			tep->e_name = (char *)(uintptr_t)stroff;
 			stroff += allocsize(ep->e_namlen);
 			tep->e_parent = (struct entry *)ep->e_parent->e_index;
 			if (ep->e_links != NIL)

--- a/usr/src/cmd/cpio/cpio.c
+++ b/usr/src/cmd/cpio/cpio.c
@@ -7661,7 +7661,7 @@ read_bar_file_hdr(void)
 	(void) sscanf(tmp_hdr->dbuf.chksum, "%8lo", &Gen.g_cksum);
 	(void) sscanf(tmp_hdr->dbuf.rdev, "%8lo", &Gen.g_rdev);
 
-#define	to_new_major(x)	(int)((unsigned)((x) & OMAXMAJ) << NBITSMINOR)
+#define	to_new_major(x)	(int)((unsigned long)((x) & OMAXMAJ) << NBITSMINOR)
 #define	to_new_minor(x)	(int)((x) & OMAXMIN)
 	Gen.g_rdev = to_new_major(Gen.g_rdev) | to_new_minor(Gen.g_rdev);
 	bar_linkflag = tmp_hdr->dbuf.linkflag;
@@ -8793,7 +8793,7 @@ read_xattr_hdr()
 	    sizeof (struct xattr_hdr));
 	(void) sscanf(xattrp->h_namesz, "%7d", &namelen);
 	if (link_len > 0) {
-		xattr_linkp = (struct xattr_buf *)((int)xattrp + (int)comp_len);
+		xattr_linkp = (struct xattr_buf *)(xattrp + comp_len);
 	} else {
 		xattr_linkp = NULL;
 	}
@@ -9193,7 +9193,7 @@ sl_insert(dev_t device, ino_t inode, int ftype)
 
 	if (s->bal == 0) {
 		s->bal = a;
-		head->llink = (sl_info_t *)((int)head->llink + 1);
+		head->llink = (sl_info_t *)((uintptr_t)head->llink + 1);
 		return (q);
 	} else if (s->bal == -a) {
 		s->bal = 0;
@@ -9357,7 +9357,7 @@ preview_attrs(char *s, char *attrparent)
 		return (1);
 	}
 
-	while (dp = readdir(dirp)) {
+	while ((dp = readdir(dirp)) != NULL) {
 		if (dp->d_name[0] == '.') {
 			if (dp->d_name[1] == '\0') {
 				Hiddendir = 1;

--- a/usr/src/cmd/geniconvtbl/aarch64/Makefile
+++ b/usr/src/cmd/geniconvtbl/aarch64/Makefile
@@ -1,0 +1,36 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License, Version 1.0 only
+# (the "License").  You may not use this file except in compliance
+# with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+# Copyright 1999, 2003 Sun Microsystems, Inc.
+# All rights reserved.
+# Use is subject to license terms.
+
+.KEEP_STATE:
+
+include ../Makefile.com
+
+_msg: $(MSGDOMAINPOFILE)
+
+all:	$(PROG) $(LIB)
+
+install: all $(ROOTBIN) $(ROOTPROG) $(ROOTLIB32) $(ROOTLINKS32)
+
+

--- a/usr/src/cmd/mailx/cmd1.c
+++ b/usr/src/cmd/mailx/cmd1.c
@@ -238,19 +238,19 @@ printhead(int mesg)
 	showto = 0;
 	if ((mp->m_flag & (MREAD|MNEW)) == (MREAD|MNEW))
 		dispc = 'R';
-	if (!(int)value("bsdcompat") && (mp->m_flag & (MREAD|MNEW)) == MREAD)
+	if (value("bsdcompat") == NOSTR && (mp->m_flag & (MREAD|MNEW)) == MREAD)
 		dispc = 'O';
 	if ((mp->m_flag & (MREAD|MNEW)) == MNEW)
 		dispc = 'N';
 	if ((mp->m_flag & (MREAD|MNEW)) == 0)
 		dispc = 'U';
 	if (mp->m_flag & MSAVED)
-		if ((int)value("bsdcompat"))
+		if (value("bsdcompat") != NOSTR)
 			dispc = '*';
 		else
 			dispc = 'S';
 	if (mp->m_flag & MPRESERVE)
-		if ((int)value("bsdcompat"))
+		if (value("bsdcompat") != NOSTR)
 			dispc = 'P';
 		else
 			dispc = 'H';
@@ -286,20 +286,20 @@ printhead(int mesg)
 
 	} else {
 		fromline = nameof(mp);
-		if (value("showto") &&
+		if (value("showto") != NOSTR &&
 		    samebody(myname, skin(fromline), FALSE) &&
 		    (cp = hfield("to", mp, addto))) {
 			showto = 1;
 			yankword(cp, fromline = name, sizeof (name),
 				docomma(cp));
 		}
-		if (value("showname"))
+		if (value("showname") != NOSTR)
 			fromline = dispname(fromline);
 		else
 			fromline = skin(fromline);
 	}
 	printf("%c%c%3d ", curind, dispc, mesg);
-	if ((int)value("showfull")) {
+	if (value("showfull") != NOSTR) {
 		if (showto)
 			printf("To %-15s ", fromline);
 		else

--- a/usr/src/cmd/mailx/cmd2.c
+++ b/usr/src/cmd/mailx/cmd2.c
@@ -280,7 +280,7 @@ savemsglist(char *file, int *msgvec, int flag)
 	lc = cc = 0;
 	bnry = 0;
 	if (flag & S_SAVING)
-		mflag = (int)value("alwaysignore")?(M_IGNORE|M_SAVING):M_SAVING;
+		mflag = value("alwaysignore") != NOSTR ? (M_IGNORE|M_SAVING) : M_SAVING;
 	else if (flag & S_NOIGNORE)
 		mflag = 0;
 	else

--- a/usr/src/cmd/mailx/collect.c
+++ b/usr/src/cmd/mailx/collect.c
@@ -121,7 +121,7 @@ collect(struct header *hp)
 	newi = ibuf;
 	removefile(tempMail);
 
-	ignintr = (int)value("ignore");
+	ignintr = value("ignore") != NOSTR;
 	hadintr = 1;
 	inhead = 1;
 	savehp = hp;
@@ -181,11 +181,11 @@ collect(struct header *hp)
 	if (intty && !tflag) {
 		if (hp->h_to == NOSTR)
 			hdrs |= GTO;
-		if (hp->h_subject == NOSTR && value("asksub"))
+		if (hp->h_subject == NOSTR && value("asksub") != NOSTR)
 			hdrs |= GSUBJECT;
-		if (hp->h_cc == NOSTR && value("askcc"))
+		if (hp->h_cc == NOSTR && value("askcc") != NOSTR)
 			hdrs |= GCC;
-		if (hp->h_bcc == NOSTR && value("askbcc"))
+		if (hp->h_bcc == NOSTR && value("askbcc") != NOSTR)
 			hdrs |= GBCC;
 		if (hdrs)
 			t &= ~GNL;
@@ -326,7 +326,7 @@ collect(struct header *hp)
 			continue;
 		}
 		if ((linebuf[0] != escape) || (rflag != NOSTR) ||
-		    (!intty && !(int)value("escapeok"))) {
+		    (!intty && value("escapeok") == NOSTR)) {
 			if (write(fileno(obuf),linebuf,nread) != nread)
 				goto werr;
 			continue;
@@ -438,7 +438,7 @@ collect(struct header *hp)
 				printf(gettext("~h: no can do!?\n"));
 				break;
 			}
-			grabh(hp, GMASK, (int)value("bsdcompat"));
+			grabh(hp, GMASK, value("bsdcompat") != NOSTR);
 			printf(gettext("(continue)\n"));
 			break;
 

--- a/usr/src/cmd/mailx/lex.c
+++ b/usr/src/cmd/mailx/lex.c
@@ -320,7 +320,7 @@ commands(void)
 top:
 		if ((shudprompt = (intty && !sourcing)) != 0) {
 			if (prompt == NOSTR) {
-				if ((int)value("bsdcompat"))
+				if (value("bsdcompat") != NOSTR)
 					prompt = "& ";
 				else
 					prompt = "";
@@ -328,7 +328,7 @@ top:
 #ifdef SIGCONT
 			sigset(SIGCONT, contin);
 #endif
-			if (intty && value("autoinc") &&
+			if (intty && value("autoinc") != NOSTR &&
 			    stat(editfile, &minfo) >= 0 &&
 			    minfo.st_size > mailsize) {
 				int OmsgCount, i;

--- a/usr/src/cmd/mailx/names.c
+++ b/usr/src/cmd/mailx/names.c
@@ -535,7 +535,7 @@ samebody(register char *user, register char *addr, int fuzzy)
 	char *allnet = value("allnet");
 	int nbangs = allnet ? (strcmp(allnet, "uucp") == 0) ? 2 : 1 : 0;
 
-	if (fuzzy && value("fuzzymatch")) {
+	if (fuzzy && value("fuzzymatch") != NOSTR) {
 		int i;
 
 		(void) strlcpy(ubuf, user, BUFSIZ);

--- a/usr/src/cmd/mailx/optim.c
+++ b/usr/src/cmd/mailx/optim.c
@@ -100,7 +100,7 @@ netmap(char name[], char from[])
 	 */
 	if (any('@', from) || any('%', from))
 		return(unuucp(makeremote(name, from)));
-	if (value("onehop") && (cp = strchr(name, '!')) && cp > name) {
+	if (value("onehop") != NOSTR && (cp = strchr(name, '!')) && cp > name) {
 		/*
 		 * "onehop" is set, meaning all machines are one UUCP
 		 * hop away (fat chance, in this day and age), and "name"
@@ -116,7 +116,7 @@ netmap(char name[], char from[])
 			name = strchr(name, '!') + 1;
 			if (cp == from) {
 				from[strlen(from)] = '!';
-				if (value("mustbang") && !strchr(name, '!'))
+				if (value("mustbang") != NOSTR && !strchr(name, '!'))
 					name = oname;
 				return(unuucp(name));
 			}
@@ -348,7 +348,7 @@ makeremote(char name[], char from[])
 	register char *cp;
 	char rbuf[BUFSIZ];
 
-	if (!value("makeremote"))
+	if (value("makeremote") == NOSTR)
 		return(name);
 	if (debug) fprintf(stderr, "makeremote(%s, %s) returns ", name, from);
 	cp = strrchr(from, '@');

--- a/usr/src/cmd/mailx/quit.c
+++ b/usr/src/cmd/mailx/quit.c
@@ -213,7 +213,7 @@ quit(
 	}
 	for (mp = &message[0]; mp < &message[msgCount]; mp++)
 		if (mp->m_flag & MBOX) {
-			if (msend(mp, obuf, (int)value("alwaysignore") ?
+			if (msend(mp, obuf, value("alwaysignore") != NOSTR ?
 			    M_IGNORE|M_SAVING : M_SAVING, fputs) < 0) {
 				perror(mbox);
 				if (!appending)

--- a/usr/src/cmd/mailx/send.c
+++ b/usr/src/cmd/mailx/send.c
@@ -657,7 +657,7 @@ puthead(struct header *hp, FILE *fo, int w, long clen)
 	gotcha = 0;
 	if (hp->h_to != NOSTR && (w & GTO))
 		fprintf(fo, "To: "), fmt(hp->h_to, fo), gotcha++;
-	if ((w & GSUBJECT) && (int)value("bsdcompat"))
+	if ((w & GSUBJECT) && value("bsdcompat") != NOSTR)
 		if (hp->h_subject != NOSTR && *hp->h_subject)
 			fprintf(fo, "Subject: %s\n", hp->h_subject), gotcha++;
 		else
@@ -673,7 +673,7 @@ puthead(struct header *hp, FILE *fo, int w, long clen)
 				hp->h_defopt), gotcha++;
 		else
 		fprintf(fo, "Default-Options: %s\n", hp->h_defopt), gotcha++;
-	if ((w & GSUBJECT) && !(int)value("bsdcompat"))
+	if ((w & GSUBJECT) && value("bsdcompat") == NOSTR)
 		if (hp->h_subject != NOSTR && *hp->h_subject)
 			fprintf(fo, "Subject: %s\n", hp->h_subject), gotcha++;
 		else

--- a/usr/src/cmd/mailx/stralloc.c
+++ b/usr/src/cmd/mailx/stralloc.c
@@ -76,7 +76,7 @@ salloc(unsigned size)
 #if defined(u3b) || defined(sparc)
 	s += 3;		/* needs alignment on quad boundary */
 	s &= ~03;
-#elif defined(i386)
+#elif defined(i386) || defined(__aarch64__)
 	s++;
 	s &= ~01;
 #else
@@ -131,7 +131,7 @@ srealloc(void *optr, unsigned size)
 #if defined(u3b) || defined(sparc)
 		s += 3;		/* needs alignment on quad boundary */
 		s &= ~03;
-#elif defined(i386)
+#elif defined(i386) || defined(__aarch64__)
 		s++;
 		s &= ~01;
 #else

--- a/usr/src/cmd/mailx/util.c
+++ b/usr/src/cmd/mailx/util.c
@@ -599,7 +599,7 @@ nameof(register struct message *mp)
 	int first = 1, wint = 0;
 	char	*tmp;
 
-	if (value("from") && (cp = hfield("from", mp, addto)) != NOSTR)
+	if (value("from") != NOSTR && (cp = hfield("from", mp, addto)) != NOSTR)
 		return ripoff(cp);
 	ibuf = setinput(mp);
 	copy("", namebuf);
@@ -646,7 +646,7 @@ newname:
 	for (cp = namebuf; *cp == '!'; cp++);
 	while (ishost(host, cp))
 		cp = strchr(cp, '!') + 1;
-	if (value("mustbang") && !strchr(cp, '!')) {
+	if (value("mustbang") != NOSTR && !strchr(cp, '!')) {
 		snprintf(linebuf, sizeof (linebuf), "%s!%s",
 			host, cp);
 		cp = linebuf;

--- a/usr/src/cmd/mknod/mknod.c
+++ b/usr/src/cmd/mknod/mknod.c
@@ -98,13 +98,13 @@ main(int argc, char **argv)
 			usage();
 		}
 		majno = (major_t)number(argv[3]);
-		if (majno == (major_t)-1 || majno > MAXMAJ) {
+		if (majno == (major_t)-1 || majno > (major_t)MAXMAJ32) {
 			(void) fprintf(stderr, "mknod: invalid major number "
 			    "'%s' - valid range is 0-%lu\n", argv[3], MAXMAJ);
 			return (2);
 		}
 		minno = (minor_t)number(argv[4]);
-		if (minno == (minor_t)-1 || minno > MAXMIN) {
+		if (minno == (minor_t)-1 || minno > (minor_t)MAXMIN32) {
 			(void) fprintf(stderr, "mknod: invalid minor number "
 			    "'%s' - valid range is 0-%lu\n", argv[4], MAXMIN);
 			return (2);

--- a/usr/src/cmd/tar/tar.c
+++ b/usr/src/cmd/tar/tar.c
@@ -8270,8 +8270,7 @@ read_xattr_hdr(attr_data_t **attrinfo)
 	    sizeof (struct xattr_hdr));
 	(void) sscanf(xattrp->h_namesz, "%7d", &namelen);
 	if (link_len > 0)
-		xattr_linkp = (struct xattr_buf *)
-		    ((int)xattrp + (int)comp_len);
+		xattr_linkp = (struct xattr_buf *)(xattrp + comp_len);
 	else
 		xattr_linkp = NULL;
 

--- a/usr/src/cmd/tip/hunt.c
+++ b/usr/src/cmd/tip/hunt.c
@@ -72,10 +72,10 @@ hunt(char *name)
 			t.c_cflag |= XCLUDE|HUPCL;
 			(void) ioctl(FD, TCSETSF, &t);
 			(void) signal(SIGALRM, f);
-			return ((int)cp);
+			return cp != NULL;
 		}
 		delock(uucplock);
 	}
 	(void) signal(SIGALRM, f);
-	return (deadfl ? -1 : (int)cp);
+	return (deadfl ? -1 : cp != NULL);
 }

--- a/usr/src/cmd/tip/remote.c
+++ b/usr/src/cmd/tip/remote.c
@@ -28,7 +28,7 @@ char *HO;	/* host name */
 
 int BR;		/* line speed for conversation */
 int FS;		/* frame size for transfers */
-char DU;	/* this host is dialed up */
+int DU;		/* this host is dialed up */
 char HW;	/* this device is hardwired, see hunt.c */
 char *ES;	/* escape character */
 char *EX;	/* exceptions */

--- a/usr/src/cmd/tip/tip.h
+++ b/usr/src/cmd/tip/tip.h
@@ -65,7 +65,7 @@ extern char	*HO;		/* host name */
 extern int	BR;		/* line speed for conversation */
 extern int	FS;		/* frame size for transfers */
 
-extern char	DU;		/* this host is dialed up */
+extern int	DU;		/* this host is dialed up */
 extern char	HW;		/* this device is hardwired, see hunt.c */
 extern char	*ES;		/* escape character */
 extern char	*EX;		/* exceptions */

--- a/usr/src/cmd/tip/value.c
+++ b/usr/src/cmd/tip/value.c
@@ -152,7 +152,7 @@ vtoken(char *s)
 		if (p = vlookup(s)) {
 			cp++;
 			if (p->v_type&NUMBER)
-				vassign(p, (char *)atoi(cp));
+				vassign(p, (char *)(intptr_t)atoi(cp));
 			else {
 				if (strcmp(s, "record") == 0)
 					if ((cp2 = expand(cp)) != NOSTR)
@@ -320,7 +320,7 @@ vstring(char *s, char *v)
 	if (p == 0)
 		return (1);
 	if (p->v_type&NUMBER)
-		vassign(p, (char *)atoi(v));
+		vassign(p, (char *)(intptr_t)atoi(v));
 	else {
 		if (strcmp(s, "record") == 0)
 			if ((v2 = expand(v)) != NOSTR)

--- a/usr/src/cmd/zonestat/zonestatd/zonestatd.c
+++ b/usr/src/cmd/zonestat/zonestatd/zonestatd.c
@@ -434,8 +434,6 @@ typedef struct zsd_ctl {
 	uint64_t	zsctl_vmusage_cache_num;
 
 	/* Info about procfs for scanning /proc */
-	struct dirent	*zsctl_procfs_dent;
-	long		zsctl_procfs_dent_size;
 	pool_value_t	*zsctl_pool_vals[3];
 
 	/* Counts on tracked entities */
@@ -2661,12 +2659,8 @@ zsd_refresh_procs(zsd_ctl_t *ctl, boolean_t init)
 		return;
 	}
 
-	dent = ctl->zsctl_procfs_dent;
-
-	(void) memset(dent, 0, ctl->zsctl_procfs_dent_size);
-
 	/* Walk all processes and compute each zone's usage on each pset. */
-	while (readdir_r(dir, dent) != 0) {
+	while ((dent = readdir(dir)) != NULL) {
 
 		if (strcmp(dent->d_name, ".") == 0 ||
 		    strcmp(dent->d_name, "..") == 0)
@@ -4053,7 +4047,6 @@ zsd_open(zsd_ctl_t *ctl)
 	zsd_system_t *system;
 
 	char path[MAXPATHLEN];
-	long pathmax;
 	struct statvfs svfs;
 	int ret;
 	int i;
@@ -4155,23 +4148,6 @@ check_exacct:
 
 	list_create(&ctl->zsctl_cpus, sizeof (zsd_cpu_t),
 	    offsetof(zsd_cpu_t, zsc_next));
-
-	pathmax = pathconf("/proc", _PC_NAME_MAX);
-	if (pathmax < 0) {
-		zsd_warn(gettext("Unable to determine max path of /proc"));
-		errno = EINVAL;
-		goto err;
-	}
-	size = sizeof (struct dirent) + pathmax + 1;
-
-	ctl->zsctl_procfs_dent_size = size;
-	if (ctl->zsctl_procfs_dent == NULL &&
-	    (ctl->zsctl_procfs_dent = (struct dirent *)calloc(1, size))
-	    == NULL) {
-		zsd_warn(gettext("Out of Memory"));
-		errno = ENOMEM;
-		goto err;
-	}
 
 	if (ctl->zsctl_pool_conf == NULL &&
 	    (ctl->zsctl_pool_conf = pool_conf_alloc()) == NULL) {

--- a/usr/src/pkg/manifests/SUNWcs.p5m
+++ b/usr/src/pkg/manifests/SUNWcs.p5m
@@ -627,7 +627,7 @@ file path=usr/bin/fmt mode=0555
 file path=usr/bin/fmtmsg mode=0555
 file path=usr/bin/fold mode=0555
 file path=usr/bin/fsstat mode=0555
-$(not_aarch64)file path=usr/bin/geniconvtbl mode=0555
+file path=usr/bin/geniconvtbl mode=0555
 file path=usr/bin/getconf mode=0555
 file path=usr/bin/getdev mode=0555
 file path=usr/bin/getdgrp mode=0555

--- a/usr/src/pkg/manifests/SUNWcs.p5m
+++ b/usr/src/pkg/manifests/SUNWcs.p5m
@@ -144,7 +144,7 @@ dir  path=etc/logadm.d group=sys
 file path=etc/logindevperm group=sys preserve=true
 $(not_aarch64)file path=etc/magic mode=0444
 dir  path=etc/mail group=mail
-$(not_aarch64)file path=etc/mail/mailx.rc preserve=true
+file path=etc/mail/mailx.rc preserve=true
 file path=etc/mailcap preserve=true
 file path=etc/mime.types preserve=true
 link path=etc/mkfs target=../usr/sbin/mkfs
@@ -666,7 +666,7 @@ file path=usr/bin/m4 mode=0555
 hardlink path=usr/bin/mac target=../../usr/lib/isaexec
 file path=usr/bin/mach mode=0555
 file path=usr/bin/mail group=mail mode=2511
-$(not_aarch64)file path=usr/bin/mailx group=mail mode=2511
+file path=usr/bin/mailx group=mail mode=2511
 $(not_aarch64)file path=usr/bin/makedev mode=0555
 file path=usr/bin/mesg mode=0555
 file path=usr/bin/mkdir mode=0555
@@ -1504,9 +1504,9 @@ file path=usr/sbin/zdump mode=0555
 file path=usr/sbin/zic mode=0555
 dir  path=usr/share
 dir  path=usr/share/lib
-$(not_aarch64)dir path=usr/share/lib/mailx
-$(not_aarch64)file path=usr/share/lib/mailx/mailx.help
-$(not_aarch64)file path=usr/share/lib/mailx/mailx.help.~
+dir  path=usr/share/lib/mailx
+file path=usr/share/lib/mailx/mailx.help
+file path=usr/share/lib/mailx/mailx.help.~
 $(not_aarch64)dir path=usr/share/lib/pub
 dir  path=usr/share/lib/tabset
 file path=usr/share/lib/tabset/3101
@@ -1709,4 +1709,4 @@ depend type=require fmri=system/data/zoneinfo
 #
 # The mailx binary calls /usr/lib/sendmail provided by mailwrapper
 #
-$(not_aarch64)depend type=require fmri=system/network/mailwrapper
+depend type=require fmri=system/network/mailwrapper

--- a/usr/src/pkg/manifests/SUNWcs.p5m
+++ b/usr/src/pkg/manifests/SUNWcs.p5m
@@ -200,7 +200,7 @@ link path=etc/rcS target=../sbin/rcS
 dir  path=etc/rcS.d group=sys
 file path=etc/rcS.d/README group=sys
 link path=etc/reboot target=../usr/sbin/halt
-$(not_aarch64)file path=etc/remote preserve=true
+file path=etc/remote preserve=true
 file path=etc/rpc group=sys preserve=true
 dir  path=etc/rpcsec group=sys
 dir  path=etc/saf
@@ -738,7 +738,7 @@ file path=usr/bin/tail mode=0555
 link path=usr/bin/tar target=../sbin/tar
 file path=usr/bin/tic mode=0555
 file path=usr/bin/time mode=0555
-$(not_aarch64)file path=usr/bin/tip owner=uucp mode=4511
+file path=usr/bin/tip owner=uucp mode=4511
 hardlink path=usr/bin/touch target=../../usr/bin/settime
 $(not_aarch64)file path=usr/bin/tpmadm mode=0555
 $(not_aarch64)file path=usr/bin/tput mode=0555
@@ -1541,7 +1541,7 @@ link path=usr/src target=./share/src
 link path=usr/tmp target=../var/tmp
 dir  path=var group=sys
 dir  path=var/adm group=sys mode=0775
-$(not_aarch64)file path=var/adm/aculog owner=uucp mode=0600 preserve=true
+file path=var/adm/aculog owner=uucp mode=0600 preserve=true
 dir  path=var/adm/exacct owner=adm group=adm
 dir  path=var/adm/log owner=adm group=adm
 file path=var/adm/spellhist mode=0666 preserve=true

--- a/usr/src/pkg/manifests/SUNWcs.p5m
+++ b/usr/src/pkg/manifests/SUNWcs.p5m
@@ -148,7 +148,7 @@ file path=etc/mail/mailx.rc preserve=true
 file path=etc/mailcap preserve=true
 file path=etc/mime.types preserve=true
 link path=etc/mkfs target=../usr/sbin/mkfs
-$(not_aarch64)link path=etc/mknod target=../usr/sbin/mknod
+link path=etc/mknod target=../usr/sbin/mknod
 file path=etc/mnttab group=root mode=0444 preserve=true
 file path=etc/motd group=sys preserve=true
 link path=etc/mount target=../sbin/mount
@@ -1403,7 +1403,7 @@ file path=usr/sbin/mkdevalloc mode=0555
 hardlink path=usr/sbin/mkdevmaps target=../../usr/sbin/mkdevalloc
 file path=usr/sbin/mkfile mode=0555
 link path=usr/sbin/mkfs target=./clri
-$(not_aarch64)file path=usr/sbin/mknod mode=0555
+file path=usr/sbin/mknod mode=0555
 file path=usr/sbin/modinfo group=sys mode=0555
 file path=usr/sbin/modload group=sys mode=0555
 file path=usr/sbin/modunload group=sys mode=0555

--- a/usr/src/pkg/manifests/SUNWcs.p5m
+++ b/usr/src/pkg/manifests/SUNWcs.p5m
@@ -585,7 +585,7 @@ file path=usr/bin/clear mode=0555
 file path=usr/bin/connstat mode=0555
 file path=usr/bin/coreadm mode=0555
 file path=usr/bin/cp mode=0555
-$(not_aarch64)file path=usr/bin/cpio mode=0555
+file path=usr/bin/cpio mode=0555
 file path=usr/bin/crle mode=0555
 file path=usr/bin/crontab mode=4555
 file path=usr/bin/crypt mode=0555

--- a/usr/src/pkg/manifests/SUNWcs.p5m
+++ b/usr/src/pkg/manifests/SUNWcs.p5m
@@ -91,7 +91,7 @@ file path=etc/dgroup.tab group=sys mode=0444 preserve=true
 dir  path=etc/dhcp group=sys
 file path=etc/dhcp/inittab group=sys preserve=true
 file path=etc/dhcp/inittab6 group=sys preserve=true
-$(not_aarch64)file path=etc/dumpdates group=sys mode=0664 preserve=true
+file path=etc/dumpdates group=sys mode=0664 preserve=true
 link path=etc/ff target=../usr/sbin/ff
 link path=etc/fmthard target=../usr/sbin/fmthard
 $(not_aarch64)link path=etc/format target=../usr/sbin/format
@@ -937,8 +937,8 @@ file path=usr/lib/fs/ufs/quotaoff mode=0555
 hardlink path=usr/lib/fs/ufs/quotaon target=../../../../usr/lib/fs/ufs/quotaoff
 file path=usr/lib/fs/ufs/repquota mode=0555
 file path=usr/lib/fs/ufs/tunefs mode=0555
-$(not_aarch64)file path=usr/lib/fs/ufs/ufsdump mode=4555
-$(not_aarch64)file path=usr/lib/fs/ufs/ufsrestore mode=4555
+file path=usr/lib/fs/ufs/ufsdump mode=4555
+file path=usr/lib/fs/ufs/ufsrestore mode=4555
 file path=usr/lib/fs/ufs/volcopy mode=0555
 file path=usr/lib/getoptcvt mode=0555
 dir  path=usr/lib/help
@@ -1486,8 +1486,8 @@ link path=usr/sbin/tunefs target=../lib/fs/ufs/tunefs
 link path=usr/sbin/tzreload target=../../sbin/tzreload
 link path=usr/sbin/uadmin target=../../sbin/uadmin
 $(i386_ONLY)file path=usr/sbin/ucodeadm mode=0555
-$(not_aarch64)link path=usr/sbin/ufsdump target=../lib/fs/ufs/ufsdump
-$(not_aarch64)link path=usr/sbin/ufsrestore target=../lib/fs/ufs/ufsrestore
+link path=usr/sbin/ufsdump target=../lib/fs/ufs/ufsdump
+link path=usr/sbin/ufsrestore target=../lib/fs/ufs/ufsrestore
 link path=usr/sbin/umount target=../../sbin/umount
 file path=usr/sbin/umountall group=sys mode=0555
 file path=usr/sbin/unlink mode=0555

--- a/usr/src/pkg/manifests/SUNWcs.p5m
+++ b/usr/src/pkg/manifests/SUNWcs.p5m
@@ -76,7 +76,7 @@ file path=etc/default/nss group=sys preserve=true
 file path=etc/default/passwd group=sys preserve=true
 file path=etc/default/su group=sys preserve=true
 file path=etc/default/syslogd group=sys preserve=true
-$(not_aarch64)file path=etc/default/tar group=sys preserve=true
+file path=etc/default/tar group=sys preserve=true
 file path=etc/default/useradd group=sys preserve=true
 file path=etc/default/utmpd group=sys preserve=true
 dir  path=etc/dev group=sys
@@ -273,7 +273,7 @@ file path=etc/sysevent/config/README group=sys mode=0444
 file path=etc/sysevent/config/SUNW,EC_dr,ESC_dr_req,sysevent.conf group=sys
 file path=etc/syslog.conf group=sys preserve=true
 dir  path=etc/system.d group=sys
-$(not_aarch64)link path=etc/tar target=../usr/sbin/tar
+link path=etc/tar target=../usr/sbin/tar
 link path=etc/telinit target=../sbin/init
 dir  path=etc/tm group=sys
 file path=etc/ttydefs group=sys preserve=true
@@ -735,7 +735,7 @@ file path=usr/bin/svcs mode=0555
 link path=usr/bin/sync target=../../sbin/sync
 file path=usr/bin/tabs mode=0555
 file path=usr/bin/tail mode=0555
-$(not_aarch64)link path=usr/bin/tar target=../sbin/tar
+link path=usr/bin/tar target=../sbin/tar
 file path=usr/bin/tic mode=0555
 file path=usr/bin/time mode=0555
 $(not_aarch64)file path=usr/bin/tip owner=uucp mode=4511
@@ -1478,7 +1478,7 @@ file path=usr/sbin/sysdef group=sys mode=2555
 file path=usr/sbin/syseventadm group=sys mode=0555
 file path=usr/sbin/syslogd group=sys mode=0555
 hardlink path=usr/sbin/tapes target=./devfsadm
-$(not_aarch64)file path=usr/sbin/tar mode=0555
+file path=usr/sbin/tar mode=0555
 file path=usr/sbin/traceroute mode=4555
 $(not_aarch64)file path=usr/sbin/trapstat mode=0555
 file path=usr/sbin/ttyadm group=sys mode=0755

--- a/usr/src/pkg/manifests/compatibility-ucb.p5m
+++ b/usr/src/pkg/manifests/compatibility-ucb.p5m
@@ -36,8 +36,7 @@ link path=etc/chroot target=../usr/sbin/chroot
 link path=etc/fuser target=../usr/sbin/fuser
 link path=etc/link target=../usr/sbin/link
 $(not_aarch64)dir path=etc/mail group=mail
-$(not_aarch64)file path=etc/mail/Mail.rc \
-    original_name=SUNWscp:etc/mail/Mail.rc preserve=true
+file path=etc/mail/Mail.rc original_name=SUNWscp:etc/mail/Mail.rc preserve=true
 link path=etc/mvdir target=../usr/sbin/mvdir
 link path=etc/pwck target=../usr/sbin/pwck
 link path=etc/termcap target=../usr/share/lib/termcap
@@ -89,7 +88,7 @@ $(not_aarch64)file path=usr/share/man/man1b/whoami.1b
 $(not_aarch64)dir path=usr/ucb
 $(i386_ONLY)dir path=usr/ucb/$(ARCH32)
 $(MULTILIB_ONLY)dir path=usr/ucb/$(ARCH64)
-$(not_aarch64)link path=usr/ucb/Mail target=../bin/mailx
+link path=usr/ucb/Mail target=../bin/mailx
 $(not_aarch64)link path=usr/ucb/arch target=../bin/arch
 $(not_aarch64)file path=usr/ucb/basename mode=0755
 $(not_aarch64)file path=usr/ucb/biff mode=0755
@@ -119,7 +118,7 @@ $(not_aarch64)file path=usr/ucb/ln mode=0755
 $(not_aarch64)link path=usr/ucb/logger target=../bin/logger
 $(not_aarch64)file path=usr/ucb/ls mode=0755
 $(not_aarch64)link path=usr/ucb/mach target=../bin/mach
-$(not_aarch64)link path=usr/ucb/mail target=../bin/mailx
+link path=usr/ucb/mail target=../bin/mailx
 $(not_aarch64)file path=usr/ucb/mkstr mode=0555
 $(not_aarch64)link path=usr/ucb/more target=../bin/more
 $(not_aarch64)link path=usr/ucb/netstat target=../bin/netstat

--- a/usr/src/pkg/manifests/system-accounting-legacy.p5m
+++ b/usr/src/pkg/manifests/system-accounting-legacy.p5m
@@ -32,11 +32,11 @@ set name=info.classification \
     value="org.opensolaris.category.2008:System/Administration and Configuration"
 set name=variant.arch value=$(ARCH)
 dir  path=etc group=sys
-$(not_aarch64)dir path=etc/acct owner=adm group=adm
-$(not_aarch64)file path=etc/acct/holidays \
-    original_name=SUNWacc:etc/acct/holidays preserve=true
+dir  path=etc/acct owner=adm group=adm
+file path=etc/acct/holidays original_name=SUNWacc:etc/acct/holidays \
+    preserve=true
 dir  path=etc/init.d group=sys
-$(not_aarch64)file path=etc/init.d/acct group=sys mode=0744 \
+file path=etc/init.d/acct group=sys mode=0744 \
     original_name=SUNWacc:etc/init.d/acct preserve=true
 dir  path=lib
 dir  path=lib/svc
@@ -47,43 +47,43 @@ dir  path=lib/svc/method
 file path=lib/svc/method/svc-sar group=sys mode=0555
 dir  path=usr group=sys
 dir  path=usr/bin
-$(not_aarch64)file path=usr/bin/acctcom mode=0555
+file path=usr/bin/acctcom mode=0555
 link path=usr/bin/sar target=../sbin/sar
 file path=usr/bin/timex group=sys mode=0555
 dir  path=usr/lib
-$(not_aarch64)dir path=usr/lib/acct
-$(not_aarch64)file path=usr/lib/acct/acctcms mode=0555
-$(not_aarch64)file path=usr/lib/acct/acctcon mode=0555
-$(not_aarch64)file path=usr/lib/acct/acctcon1 mode=0555
-$(not_aarch64)file path=usr/lib/acct/acctcon2 mode=0555
-$(not_aarch64)file path=usr/lib/acct/acctdisk mode=0555
-$(not_aarch64)file path=usr/lib/acct/acctdusg mode=0555
-$(not_aarch64)file path=usr/lib/acct/acctmerg mode=0555
-$(not_aarch64)file path=usr/lib/acct/accton group=adm mode=4755
-$(not_aarch64)file path=usr/lib/acct/acctprc mode=0555
-$(not_aarch64)file path=usr/lib/acct/acctprc1 mode=0555
-$(not_aarch64)file path=usr/lib/acct/acctprc2 mode=0555
-$(not_aarch64)file path=usr/lib/acct/acctwtmp mode=0555
-$(not_aarch64)file path=usr/lib/acct/chargefee mode=0555
-$(not_aarch64)file path=usr/lib/acct/ckpacct mode=0555
-$(not_aarch64)file path=usr/lib/acct/closewtmp mode=0555
-$(not_aarch64)file path=usr/lib/acct/dodisk mode=0555
-$(not_aarch64)file path=usr/lib/acct/fwtmp mode=0555
-$(not_aarch64)file path=usr/lib/acct/lastlogin mode=0555
-$(not_aarch64)file path=usr/lib/acct/monacct mode=0555
-$(not_aarch64)file path=usr/lib/acct/nulladm mode=0555
-$(not_aarch64)file path=usr/lib/acct/prctmp mode=0555
-$(not_aarch64)file path=usr/lib/acct/prdaily mode=0555
-$(not_aarch64)file path=usr/lib/acct/prtacct mode=0555
-$(not_aarch64)file path=usr/lib/acct/ptecms.awk mode=0555
-$(not_aarch64)file path=usr/lib/acct/ptelus.awk mode=0555
-$(not_aarch64)file path=usr/lib/acct/remove mode=0555
-$(not_aarch64)file path=usr/lib/acct/runacct mode=0555
-$(not_aarch64)file path=usr/lib/acct/shutacct mode=0555
-$(not_aarch64)file path=usr/lib/acct/startup mode=0555
-$(not_aarch64)file path=usr/lib/acct/turnacct mode=0555
-$(not_aarch64)file path=usr/lib/acct/utmp2wtmp mode=0555
-$(not_aarch64)file path=usr/lib/acct/wtmpfix mode=0555
+dir  path=usr/lib/acct
+file path=usr/lib/acct/acctcms mode=0555
+file path=usr/lib/acct/acctcon mode=0555
+file path=usr/lib/acct/acctcon1 mode=0555
+file path=usr/lib/acct/acctcon2 mode=0555
+file path=usr/lib/acct/acctdisk mode=0555
+file path=usr/lib/acct/acctdusg mode=0555
+file path=usr/lib/acct/acctmerg mode=0555
+file path=usr/lib/acct/accton group=adm mode=4755
+file path=usr/lib/acct/acctprc mode=0555
+file path=usr/lib/acct/acctprc1 mode=0555
+file path=usr/lib/acct/acctprc2 mode=0555
+file path=usr/lib/acct/acctwtmp mode=0555
+file path=usr/lib/acct/chargefee mode=0555
+file path=usr/lib/acct/ckpacct mode=0555
+file path=usr/lib/acct/closewtmp mode=0555
+file path=usr/lib/acct/dodisk mode=0555
+file path=usr/lib/acct/fwtmp mode=0555
+file path=usr/lib/acct/lastlogin mode=0555
+file path=usr/lib/acct/monacct mode=0555
+file path=usr/lib/acct/nulladm mode=0555
+file path=usr/lib/acct/prctmp mode=0555
+file path=usr/lib/acct/prdaily mode=0555
+file path=usr/lib/acct/prtacct mode=0555
+file path=usr/lib/acct/ptecms.awk mode=0555
+file path=usr/lib/acct/ptelus.awk mode=0555
+file path=usr/lib/acct/remove mode=0555
+file path=usr/lib/acct/runacct mode=0555
+file path=usr/lib/acct/shutacct mode=0555
+file path=usr/lib/acct/startup mode=0555
+file path=usr/lib/acct/turnacct mode=0555
+file path=usr/lib/acct/utmp2wtmp mode=0555
+file path=usr/lib/acct/wtmpfix mode=0555
 dir  path=usr/lib/sa owner=adm
 file path=usr/lib/sa/sa1 mode=0555
 file path=usr/lib/sa/sa2 mode=0555
@@ -136,10 +136,10 @@ link path=usr/share/man/man8/utmp2wtmp.8 target=acct.8
 link path=usr/share/man/man8/wtmpfix.8 target=fwtmp.8
 dir  path=var group=sys
 dir  path=var/adm group=sys mode=0775
-$(not_aarch64)dir path=var/adm/acct owner=adm group=adm mode=0775
-$(not_aarch64)dir path=var/adm/acct/fiscal owner=adm group=adm mode=0775
-$(not_aarch64)dir path=var/adm/acct/nite owner=adm group=adm mode=0775
-$(not_aarch64)dir path=var/adm/acct/sum owner=adm group=adm mode=0775
+dir  path=var/adm/acct owner=adm group=adm mode=0775
+dir  path=var/adm/acct/fiscal owner=adm group=adm mode=0775
+dir  path=var/adm/acct/nite owner=adm group=adm mode=0775
+dir  path=var/adm/acct/sum owner=adm group=adm mode=0775
 dir  path=var/adm/sa owner=adm group=sys mode=0775
 dir  path=var/spool
 dir  path=var/spool/cron group=sys

--- a/usr/src/pkg/manifests/system-zones.p5m
+++ b/usr/src/pkg/manifests/system-zones.p5m
@@ -52,18 +52,17 @@ file path=lib/svc/manifest/system/resource-mgmt.xml group=sys mode=0444 \
     variant.opensolaris.zone=global
 file path=lib/svc/manifest/system/zones.xml group=sys mode=0444 \
     variant.opensolaris.zone=global
-$(not_aarch64)file path=lib/svc/manifest/system/zonestat.xml group=sys \
-    mode=0444 variant.opensolaris.zone=global
+file path=lib/svc/manifest/system/zonestat.xml group=sys mode=0444 \
+    variant.opensolaris.zone=global
 dir  path=lib/svc/method variant.opensolaris.zone=global
 file path=lib/svc/method/svc-resource-mgmt mode=0555 \
     variant.opensolaris.zone=global
 file path=lib/svc/method/svc-zones mode=0555 variant.opensolaris.zone=global
-$(not_aarch64)file path=lib/svc/method/svc-zonestat mode=0555 \
-    variant.opensolaris.zone=global
+file path=lib/svc/method/svc-zonestat mode=0555 variant.opensolaris.zone=global
 dir  path=usr group=sys
 dir  path=usr/bin
 link path=usr/bin/zonename target=../../sbin/zonename
-$(not_aarch64)file path=usr/bin/zonestat mode=0555
+file path=usr/bin/zonestat mode=0555
 dir  path=usr/kernel group=sys
 dir  path=usr/kernel/drv group=sys
 dir  path=usr/kernel/drv/$(ARCH64) group=sys
@@ -86,8 +85,7 @@ file path=usr/lib/libzonecfg.so.1
 file path=usr/lib/libzonestat.so.1
 dir  path=usr/lib/zones
 file path=usr/lib/zones/zoneadmd mode=0555
-$(not_aarch64)file path=usr/lib/zones/zonestatd mode=0555 \
-    variant.opensolaris.zone=global
+file path=usr/lib/zones/zonestatd mode=0555 variant.opensolaris.zone=global
 dir  path=usr/sbin
 file path=usr/sbin/zlogin mode=0555
 file path=usr/sbin/zoneadm mode=0555

--- a/usr/src/pkg/manifests/text-locale.p5m
+++ b/usr/src/pkg/manifests/text-locale.p5m
@@ -44,29 +44,21 @@ $(not_aarch64)file path=usr/bin/srchtxt mode=0555
 file path=usr/bin/xgettext mode=0555
 dir  path=usr/lib
 file path=usr/lib/gmsgfmt mode=0555
-$(not_aarch64)dir path=usr/lib/iconv
+dir  path=usr/lib/iconv
 $(MULTILIB_ONLY)dir path=usr/lib/iconv/$(ARCH64)
 $(MULTILIB_ONLY)file path=usr/lib/iconv/$(ARCH64)/geniconvtbl.so mode=0555
-$(not_aarch64)dir path=usr/lib/iconv/geniconvtbl
-$(not_aarch64)file path=usr/lib/iconv/geniconvtbl.so mode=0555
-$(not_aarch64)dir path=usr/lib/iconv/geniconvtbl/binarytables
-$(not_aarch64)file \
-    path=usr/lib/iconv/geniconvtbl/binarytables/ISO646%ISO8859-1.bt mode=0444
-$(not_aarch64)file \
-    path=usr/lib/iconv/geniconvtbl/binarytables/ISO8859-1%ISO646.bt mode=0444
-$(not_aarch64)dir path=usr/lib/iconv/geniconvtbl/srcs
-$(not_aarch64)file \
-    path=usr/lib/iconv/geniconvtbl/srcs/ISO-2022-JP_to_eucJP.src mode=0444
-$(not_aarch64)file path=usr/lib/iconv/geniconvtbl/srcs/ISO646_to_ISO8859-1.src \
-    mode=0444
-$(not_aarch64)file path=usr/lib/iconv/geniconvtbl/srcs/ISO8859-1_to_ISO646.src \
-    mode=0444
-$(not_aarch64)file path=usr/lib/iconv/geniconvtbl/srcs/ISO8859-1_to_UTF-8.src \
-    mode=0444
-$(not_aarch64)file path=usr/lib/iconv/geniconvtbl/srcs/UTF-8_to_ISO8859-1.src \
-    mode=0444
-$(not_aarch64)file \
-    path=usr/lib/iconv/geniconvtbl/srcs/eucJP_to_ISO-2022-JP.src mode=0444
+dir  path=usr/lib/iconv/geniconvtbl
+file path=usr/lib/iconv/geniconvtbl.so mode=0555
+dir  path=usr/lib/iconv/geniconvtbl/binarytables
+file path=usr/lib/iconv/geniconvtbl/binarytables/ISO646%ISO8859-1.bt mode=0444
+file path=usr/lib/iconv/geniconvtbl/binarytables/ISO8859-1%ISO646.bt mode=0444
+dir  path=usr/lib/iconv/geniconvtbl/srcs
+file path=usr/lib/iconv/geniconvtbl/srcs/ISO-2022-JP_to_eucJP.src mode=0444
+file path=usr/lib/iconv/geniconvtbl/srcs/ISO646_to_ISO8859-1.src mode=0444
+file path=usr/lib/iconv/geniconvtbl/srcs/ISO8859-1_to_ISO646.src mode=0444
+file path=usr/lib/iconv/geniconvtbl/srcs/ISO8859-1_to_UTF-8.src mode=0444
+file path=usr/lib/iconv/geniconvtbl/srcs/UTF-8_to_ISO8859-1.src mode=0444
+file path=usr/lib/iconv/geniconvtbl/srcs/eucJP_to_ISO-2022-JP.src mode=0444
 dir  path=usr/share/man/man1
 file path=usr/share/man/man1/gencat.1
 file path=usr/share/man/man1/genmsg.1


### PR DESCRIPTION
This is a bit more controversial the trend on most platforms is to replace readdir_r with readdir given multi-threading is no longer a problem with readdir() . So I tried removing the usage of readdir_r from the 3 programs that still use it. It does cleanup things
a bit. fwflash still needs ses and scsi libraries which are not there so it cleaner but not working. Tested zonestat and that does
work and gives output for the global zone. I quoted in some commits the text from the manpage which seems to indicate this is the proper way of resolving things. I'm also fine with replacing the readdir_r from the two argument version to the 3 argument one and drop the two other patches.