### PR TITLE
First part of more upstreams

### DIFF
--- a/usr/src/cmd/Makefile
+++ b/usr/src/cmd/Makefile
@@ -385,6 +385,7 @@ COMMON_SUBDIRS=	\
 	tr		\
 	trapstat	\
 	true		\
+	tsol		\
 	tty		\
 	ttymon		\
 	tzreload	\
@@ -473,7 +474,6 @@ COMMON_SUBDIRS=	\
 # tput - not 64bit clean
 # tbl - not 64bit clean
 # troff - not 64bit clean
-# tsol - not ported (or 64bit clean)
 # truss - not ported
 # vi - not 64bit clean / not ported
 # ypcmd - not 64bit clean
@@ -512,7 +512,6 @@ $(NOT_AARCH64_BLD)COMMON_SUBDIRS +=	\
 	tput		\
 	tbl		\
 	troff		\
-	tsol		\
 	truss		\
 	volcheck	\
 	volrmmount	\

--- a/usr/src/cmd/Makefile
+++ b/usr/src/cmd/Makefile
@@ -149,6 +149,7 @@ COMMON_SUBDIRS=	\
 	fdisk		\
 	ficl		\
 	filesync	\
+	file		\
 	find		\
 	flowadm		\
 	flowstat	\
@@ -456,7 +457,6 @@ COMMON_SUBDIRS=	\
 # csh - not 64bit clean
 # csplit - not 64bit clean
 # eqn - not 64bit clean
-# file - wants bits of sys/core.h 64bit apps can't see
 # format - not 64bit clean (but just printf stuff)
 # gss - not 64bit clean
 # isns - not 64bit clean
@@ -488,7 +488,6 @@ $(NOT_AARCH64_BLD)COMMON_SUBDIRS +=	\
 	csh		\
 	csplit		\
 	eqn		\
-	file		\
 	hal		\
 	format		\
 	gss		\

--- a/usr/src/cmd/cmd-inet/usr.sbin/Makefile
+++ b/usr/src/cmd/cmd-inet/usr.sbin/Makefile
@@ -64,14 +64,12 @@ K5RSHDOBJS=	in.rshd.o
 K5TELNETOBJS=	in.telnetd.o
 SRCS=		$(PROGSRCS) $(OTHERSRC)
 
-SUBDIRS=	in.rdisc \
-		in.talkd inetadm inetconv ipmpstat ipqosconf \
-		nwamadm nwamcfg routeadm \
-		wificonfig ifconfig traceroute ping ipsecutils ipadm \
-		ilbadm
-
+SUBDIRS=	ifconfig ilbadm in.rdisc in.routed \
+		in.talkd inetadm inetconv ipadm ipmpstat ipqosconf ipsecutils \
+		nwamadm nwamcfg ping routeadm \
+		traceroute wificonfig
 # XXXARM: not 64bit clean
-$(NOT_AARCH64_BLD)SUBDIRS += in.routed snoop sppptun
+$(NOT_AARCH64_BLD)SUBDIRS += snoop sppptun
 
 MSGSUBDIRS=	ifconfig ilbadm in.routed in.talkd \
 		inetadm inetconv ipadm ipmpstat ipqosconf ipsecutils \

--- a/usr/src/pkg/manifests/SUNWcs.p5m
+++ b/usr/src/pkg/manifests/SUNWcs.p5m
@@ -142,7 +142,7 @@ link path=etc/log target=../var/adm/log
 file path=etc/logadm.conf group=sys preserve=true timestamp=19700101T000000Z
 dir  path=etc/logadm.d group=sys
 file path=etc/logindevperm group=sys preserve=true
-$(not_aarch64)file path=etc/magic mode=0444
+file path=etc/magic mode=0444
 dir  path=etc/mail group=mail
 file path=etc/mail/mailx.rc preserve=true
 file path=etc/mailcap preserve=true
@@ -621,7 +621,7 @@ file path=usr/bin/false mode=0555
 file path=usr/bin/fdetach mode=0555
 file path=usr/bin/fdformat mode=4555
 hardlink path=usr/bin/fgrep target=../../usr/bin/grep
-$(not_aarch64)file path=usr/bin/file mode=0555
+file path=usr/bin/file mode=0555
 file path=usr/bin/find mode=0555
 file path=usr/bin/fmt mode=0555
 file path=usr/bin/fmtmsg mode=0555

--- a/usr/src/pkg/manifests/system-network-routing.p5m
+++ b/usr/src/pkg/manifests/system-network-routing.p5m
@@ -37,13 +37,12 @@ dir  path=lib/svc/manifest/network/routing group=sys
 file path=lib/svc/manifest/network/routing/ndp.xml group=sys mode=0444
 file path=lib/svc/manifest/network/routing/rdisc.xml group=sys mode=0444
 file path=lib/svc/manifest/network/routing/ripng.xml group=sys mode=0444
-$(not_aarch64)file path=lib/svc/manifest/network/routing/route.xml group=sys \
-    mode=0444
+file path=lib/svc/manifest/network/routing/route.xml group=sys mode=0444
 dir  path=lib/svc/method
 file path=lib/svc/method/svc-ndp mode=0555
 file path=lib/svc/method/svc-rdisc mode=0555
 file path=lib/svc/method/svc-ripng mode=0555
-$(not_aarch64)file path=lib/svc/method/svc-route mode=0555
+file path=lib/svc/method/svc-route mode=0555
 dir  path=usr group=sys
 dir  path=usr/lib
 dir  path=usr/lib/inet
@@ -51,8 +50,8 @@ file path=usr/lib/inet/in.ndpd mode=0555
 file path=usr/lib/inet/in.ripngd mode=0555
 dir  path=usr/sbin
 file path=usr/sbin/in.rdisc mode=0555
-$(not_aarch64)file path=usr/sbin/in.routed mode=0555
-$(not_aarch64)file path=usr/sbin/rtquery mode=0555
+file path=usr/sbin/in.routed mode=0555
+file path=usr/sbin/rtquery mode=0555
 dir  path=usr/share/man
 dir  path=usr/share/man/man5
 file path=usr/share/man/man5/gateways.5

--- a/usr/src/pkg/manifests/system-trusted.p5m
+++ b/usr/src/pkg/manifests/system-trusted.p5m
@@ -32,26 +32,25 @@ dir  path=lib
 dir  path=lib/svc
 dir  path=lib/svc/manifest group=sys
 dir  path=lib/svc/manifest/system group=sys
-$(not_aarch64)file path=lib/svc/manifest/system/tsol-zones.xml group=sys \
-    mode=0444
+file path=lib/svc/manifest/system/tsol-zones.xml group=sys mode=0444
 dir  path=lib/svc/method
-$(not_aarch64)file path=lib/svc/method/svc-tsol-zones mode=0555
+file path=lib/svc/method/svc-tsol-zones mode=0555
 dir  path=sbin group=sys
-$(not_aarch64)file path=sbin/tnctl group=sys mode=0555
+file path=sbin/tnctl group=sys mode=0555
 dir  path=usr group=sys
 dir  path=usr/bin
-$(not_aarch64)file path=usr/bin/getlabel mode=0555
-$(not_aarch64)file path=usr/bin/getzonepath mode=0555
-$(not_aarch64)file path=usr/bin/plabel mode=0555
-$(not_aarch64)file path=usr/bin/setlabel mode=0555
-$(not_aarch64)file path=usr/bin/updatehome mode=0555
+file path=usr/bin/getlabel mode=0555
+file path=usr/bin/getzonepath mode=0555
+file path=usr/bin/plabel mode=0555
+file path=usr/bin/setlabel mode=0555
+file path=usr/bin/updatehome mode=0555
 dir  path=usr/demo
-$(not_aarch64)dir path=usr/demo/tsol
-$(not_aarch64)file path=usr/demo/tsol/clonebylabel.sh mode=0555
-$(not_aarch64)file path=usr/demo/tsol/getmounts.sh mode=0555
-$(not_aarch64)file path=usr/demo/tsol/runinzone.ksh mode=0555
-$(not_aarch64)file path=usr/demo/tsol/runwlabel.ksh mode=0555
-$(not_aarch64)file path=usr/demo/tsol/waitforzone.ksh mode=0555
+dir  path=usr/demo/tsol
+file path=usr/demo/tsol/clonebylabel.sh mode=0555
+file path=usr/demo/tsol/getmounts.sh mode=0555
+file path=usr/demo/tsol/runinzone.ksh mode=0555
+file path=usr/demo/tsol/runwlabel.ksh mode=0555
+file path=usr/demo/tsol/waitforzone.ksh mode=0555
 dir  path=usr/include
 dir  path=usr/include/bsm
 dir  path=usr/lib
@@ -103,21 +102,21 @@ file path=usr/lib/lp/postscript/tsol_separator.ps group=lp mode=0555 \
     original_name=SUNWts:usr/lib/lp/postscript/tsol_separator.ps \
     preserve=renamenew
 file path=usr/lib/lp/postscript/tsol_trailer.ps group=lp mode=0555
-$(not_aarch64)file path=usr/lib/lslabels group=sys mode=0555
+file path=usr/lib/lslabels group=sys mode=0555
 $(not_aarch64)dir path=usr/lib/zones
 $(not_aarch64)file path=usr/lib/zones/zoneshare group=sys mode=0555
 $(not_aarch64)file path=usr/lib/zones/zoneunshare group=sys mode=0555
 dir  path=usr/sbin
 file path=usr/sbin/add_allocatable mode=0555
-$(not_aarch64)file path=usr/sbin/atohexlabel group=sys mode=0555
+file path=usr/sbin/atohexlabel group=sys mode=0555
 $(not_aarch64)file path=usr/sbin/chk_encodings group=sys mode=0555
-$(not_aarch64)file path=usr/sbin/hextoalabel group=sys mode=0555
+file path=usr/sbin/hextoalabel group=sys mode=0555
 hardlink path=usr/sbin/remove_allocatable target=add_allocatable
-$(not_aarch64)file path=usr/sbin/tnchkdb group=sys mode=0555
-$(not_aarch64)link path=usr/sbin/tnctl target=../../sbin/tnctl
-$(not_aarch64)file path=usr/sbin/tnd group=sys mode=0555
-$(not_aarch64)file path=usr/sbin/tninfo group=sys mode=0555
-$(not_aarch64)file path=usr/sbin/txzonemgr group=sys mode=0555
+file path=usr/sbin/tnchkdb group=sys mode=0555
+link path=usr/sbin/tnctl target=../../sbin/tnctl
+file path=usr/sbin/tnd group=sys mode=0555
+file path=usr/sbin/tninfo group=sys mode=0555
+file path=usr/sbin/txzonemgr group=sys mode=0555
 dir  path=usr/share/man
 dir  path=usr/share/man/man1
 file path=usr/share/man/man1/getlabel.1

--- a/usr/src/pkg/manifests/system-xopen-xcu4.p5m
+++ b/usr/src/pkg/manifests/system-xopen-xcu4.p5m
@@ -59,7 +59,7 @@ file path=usr/xpg4/bin/expr mode=0555
 link path=usr/xpg4/bin/fc target=../../bin/alias
 link path=usr/xpg4/bin/fg target=../../bin/alias
 link path=usr/xpg4/bin/fgrep target=../../bin/grep
-$(not_aarch64)file path=usr/xpg4/bin/file mode=0555
+file path=usr/xpg4/bin/file mode=0555
 file path=usr/xpg4/bin/find mode=0555
 file path=usr/xpg4/bin/getconf mode=0555
 link path=usr/xpg4/bin/getopts target=../../bin/alias


### PR DESCRIPTION
This are two patches one is to enable file and in.routed which now compile as the actual patches needed were not so much
arm problems but generic build problems which were upstreamed to the upstream repo. The second one is for trusted solaris which is however of limited use as we are missing the zone part still then again usr/src/cmd/tsol compiles and does deliver some binaries and scripts. Probably it should be EOF upstream if people think trusted solaris is of no use going forward. I can also drop this patch but thought it wouldn't harm. I also restored some of the original Makefile for usr/src/cmd/cmd-inet/usr.sbin to keep the changes between upstream and this branch to the absolute minimum but may not known why they were changed the way they are. When we agree on either integrating this in whatever form and after whatever changes I will upstream the next chunk. Hopefully giving people better possibilities to review things. If in further upstreams to much is captured let me know and I can split things in even smaller chunks but I think I have reasonable chunks now.