### PR TITLE
Second set of upstream patches

### DIFF
--- a/usr/src/cmd/Makefile
+++ b/usr/src/cmd/Makefile
@@ -47,8 +47,10 @@ FIRST_SUBDIRS=		\
 	isaexec		\
 	platexec
 
-COMMON_SUBDIRS=	\
+COMMON_SUBDIRS=		\
 	allocate	\
+	lp		\
+	perl		\
 	Adm		\
 	adbgen		\
 	acct		\
@@ -221,21 +223,20 @@ COMMON_SUBDIRS=	\
 	loadkeys	\
 	locale		\
 	localedef	\
-	locator		\
 	lockstat	\
+	locator		\
 	lofiadm		\
 	logadm		\
 	logger		\
 	login		\
 	logins		\
 	logname		\
-	lp		\
 	look		\
 	ls		\
 	mach		\
 	mail		\
-	mailx		\
 	mailwrapper	\
+	mailx		\
 	make		\
 	makekey		\
 	man		\
@@ -283,20 +284,19 @@ COMMON_SUBDIRS=	\
 	pcidr		\
 	pcieadm		\
 	pcieb		\
-	perl		\
 	pfexec		\
 	pfexecd		\
-	pg		\
 	pginfo		\
 	pgstat		\
 	pgrep		\
 	picl		\
 	plimit		\
-	plockstat	\
 	policykit	\
 	pools		\
 	power		\
 	ppgsz		\
+	pg		\
+	plockstat	\
 	pr		\
 	prctl		\
 	print		\
@@ -326,8 +326,8 @@ COMMON_SUBDIRS=	\
 	rm		\
 	rmdir		\
 	rmmount		\
-	rmvolmgr	\
 	rmt		\
+	rmvolmgr	\
 	roles		\
 	rpcbind		\
 	rpcgen		\
@@ -435,9 +435,9 @@ COMMON_SUBDIRS=	\
 	zoneadmd	\
 	zonecfg		\
 	zonename	\
-	zonestat	\
-	zlook		\
 	zpool		\
+	zlook		\
+	zonestat	\
 	zstreamdump	\
 	ztest
 

--- a/usr/src/cmd/Makefile
+++ b/usr/src/cmd/Makefile
@@ -210,6 +210,7 @@ COMMON_SUBDIRS=		\
 	kbd		\
 	keyserv		\
 	killall		\
+	krb5		\
 	kvmstat		\
 	last		\
 	lastcomm	\
@@ -460,7 +461,6 @@ COMMON_SUBDIRS=		\
 # format - not 64bit clean (but just printf stuff)
 # gss - not 64bit clean
 # isns - not 64bit clean
-# krb5 - not 64bit clean
 # luxadm - super confused about platforms, and probably needs libs
 # nohup - not ported (header bits gone awry)
 # oawk - not 64bit clean?
@@ -488,7 +488,6 @@ $(NOT_AARCH64_BLD)COMMON_SUBDIRS +=	\
 	format		\
 	gss		\
 	isns		\
-	krb5		\
 	latencytop	\
 	luxadm		\
 	nohup		\

--- a/usr/src/cmd/Makefile
+++ b/usr/src/cmd/Makefile
@@ -423,6 +423,7 @@ COMMON_SUBDIRS=		\
 	xargs		\
 	xstr		\
 	yes		\
+	ypcmd		\
 	yppasswd	\
 	zdb		\
 	zdump		\
@@ -475,7 +476,6 @@ COMMON_SUBDIRS=		\
 # tsol - not ported (or 64bit clean)
 # truss - not ported
 # vi - not 64bit clean / not ported
-# ypcmd - not 64bit clean
 $(NOT_AARCH64_BLD)COMMON_SUBDIRS +=	\
 	abi		\
 	availdevs	\
@@ -508,7 +508,6 @@ $(NOT_AARCH64_BLD)COMMON_SUBDIRS +=	\
 	tsol		\
 	truss		\
 	vi		\
-	ypcmd		\
 
 aarch64_SUBDIRS=	\
 	ahciem		\

--- a/usr/src/cmd/cmd-inet/usr.bin/Makefile
+++ b/usr/src/cmd/cmd-inet/usr.bin/Makefile
@@ -31,13 +31,10 @@
 include $(SRC)/Makefile.master
 
 PROG=		finger rdate ruptime rwho whois
-# XXXARM: Not 64bit clean, see also below
-$(NOT_AARCH64_BLD)SUIDPROG=	rcp rlogin rsh
+SUIDPROG=	rcp rlogin rsh
 ALL=		$(PROG) $(SUIDPROG)
 SRCS=		$(ALL:%=%.c)
-
-# XXXARM: not 64bit clean
-$(NOT_AARCH64_BLD)KCMDPROGS= rcp rlogin rsh
+KCMDPROGS=	rcp rlogin rsh
 
 SUBDIRS=	chat dns-sd ftp nc netstat \
 		pppdump pppstats rdist talk telnet tftp

--- a/usr/src/cmd/cmd-inet/usr.bin/rcp.c
+++ b/usr/src/cmd/cmd-inet/usr.bin/rcp.c
@@ -1825,30 +1825,11 @@ zclose(int fd)
 static int
 notzero(char *p, int n)
 {
-	register int result = 0;
+	while (n-- > 0)
+		if (*p++ != '\0')
+			return 1;
 
-	while ((int)p & 3 && --n >= 0)
-		result |= *p++;
-
-	while ((n -= 4 * sizeof (int)) >= 0) {
-		/* LINTED */
-		result |= ((int *)p)[0];
-		/* LINTED */
-		result |= ((int *)p)[1];
-		/* LINTED */
-		result |= ((int *)p)[2];
-		/* LINTED */
-		result |= ((int *)p)[3];
-		if (result)
-			return (result);
-		p += 4 * sizeof (int);
-	}
-	n += 4 * sizeof (int);
-
-	while (--n >= 0)
-		result |= *p++;
-
-	return (result);
+	return 0;
 }
 
 /*

--- a/usr/src/cmd/krb5/kadmin/dbutil/ovload.c
+++ b/usr/src/cmd/krb5/kadmin/dbutil/ovload.c
@@ -35,6 +35,8 @@
 #define LINESIZE	32768 /* XXX */
 #define PLURAL(count)	(((count) == 1) ? error_message(IMPORT_SINGLE_RECORD) : error_message(IMPORT_PLURAL_RECORDS))
 
+extern caddr_t xdralloc_getdata(XDR *xdrs);
+
 static int parse_pw_hist_ent(current, hist)
    char *current;
    osa_pw_hist_ent *hist;

--- a/usr/src/cmd/krb5/kadmin/kclient/Makefile
+++ b/usr/src/cmd/krb5/kadmin/kclient/Makefile
@@ -73,7 +73,7 @@ ksmb:=		LDFLAGS += -R/usr/lib/smbsrv
 kconf:=		LDFLAGS += $(KRUNPATH)
 
 KS_LDLIBS =	$(LDLIBS) $(KMECHLIB)
-KD_LDLIBS =	$(LDLIBS) -L$(ROOT)/usr/lib/smbsrv -lsmbns
+KD_LDLIBS =	$(LDLIBS) -L$(ROOT)/usr/lib/smbsrv -lsmbns -L$(ADJUNCT_PROTO)/usr/lib/mps
 KSMB_LDLIBS =	$(LDLIBS) -L$(ROOT)/usr/lib/smbsrv -lsmb
 KC_LDLIBS =	$(LDLIBS) $(KMECHLIB)
 

--- a/usr/src/cmd/krb5/kadmin/kclient/kconf.c
+++ b/usr/src/cmd/krb5/kadmin/kclient/kconf.c
@@ -117,7 +117,8 @@ main(int argc, char **argv)
 {
 	profile_t	profile;
 	errcode_t	code;
-	char		c, *realm, *kdcs, *master, *domain, *token, *lasts;
+	int		c;
+	char		*realm, *kdcs, *master, *domain, *token, *lasts;
 	char		*file, **ret_values = NULL;
 	boolean_t	set_change = FALSE;
 	struct profile_string_list values;

--- a/usr/src/cmd/krb5/kadmin/kclient/kdyndns.c
+++ b/usr/src/cmd/krb5/kadmin/kclient/kdyndns.c
@@ -46,7 +46,8 @@ usage()
 int
 main(int argc, char **argv)
 {
-	char c, fqdn[MAXHOSTNAMELEN];
+	int c;
+	char fqdn[MAXHOSTNAMELEN];
 	int ret = 0;
 
 	(void) setlocale(LC_ALL, "");

--- a/usr/src/cmd/krb5/kadmin/kclient/ksetpw.c
+++ b/usr/src/cmd/krb5/kadmin/kclient/ksetpw.c
@@ -57,7 +57,8 @@ main(int argc, char **argv)
 	krb5_keytab kt = NULL;
 	krb5_kvno kvno = 1;
 	krb5_principal victim, salt = NULL;
-	char c, *vprincstr, *ktname, *token, *lasts, *newpw;
+	int c;
+	char *vprincstr, *ktname, *token, *lasts, *newpw;
 	int result_code, i, len, nflag = 0;
 	krb5_data result_code_string, result_string;
 

--- a/usr/src/cmd/krb5/kadmin/kclient/ksmb.c
+++ b/usr/src/cmd/krb5/kadmin/kclient/ksmb.c
@@ -58,7 +58,8 @@ usage()
 int
 main(int argc, char **argv)
 {
-	char c, fqdn[MAXHOSTNAMELEN], server[MAXHOSTNAMELEN];
+	int c;
+	char fqdn[MAXHOSTNAMELEN], server[MAXHOSTNAMELEN];
 	char *newpw;
 	int ret = 0;
 

--- a/usr/src/cmd/krb5/ldap_util/Makefile
+++ b/usr/src/cmd/krb5/ldap_util/Makefile
@@ -71,7 +71,7 @@ SMATCH=off
 
 LDFLAGS += $(KRUNPATH) $(KERBRUNPATH)
 LDLIBS += -L $(ROOT_KLIBDIR) -L $(KRB5LIB) -lkadm5srv -lkdb -lkdb_ldap \
-	-lmech_krb5
+	-lmech_krb5 -L$(ADJUNCT_PROTO)/usr/lib/mps
 
 .KEEP_STATE:
 

--- a/usr/src/cmd/ypcmd/Makefile
+++ b/usr/src/cmd/ypcmd/Makefile
@@ -56,7 +56,11 @@ ROOTDIRS =	$(ROOT) $(ROOTUSR) $(ROOTLIB) $(ROOTETC) $(ROOTVAR) \
 		$(ROOTUSRSBIN) $(ROOTBIN)
 
 $(LNSLPROG) :=	LDLIBS += -lnsl
-$(NIS2LDAPPROG) := LDLIBS += -lc -lnsl -lnisdb
+$(NIS2LDAPPROG) := LDLIBS += -lc -lnsl -lnisdb -L$(ADJUNCT_PROTO)/usr/lib/mps
+
+# XXXARM: _Unwind_Resume
+$(AARCH64_BLD)$(NIS2LDAPPROG) := LDLIBS += -lgcc
+
 stdethers :=	LDLIBS += -lsocket
 makedbm :=	MAPFILES = $(MAPFILE.INT) $(MAPFILE.NGB)
 makedbm :=	LDFLAGS += $(MAPFILES:%=-Wl,-M%)

--- a/usr/src/cmd/ypcmd/revnetgroup/getgroup.c
+++ b/usr/src/cmd/ypcmd/revnetgroup/getgroup.c
@@ -29,6 +29,7 @@
 
 #include <stdio.h>
 #include <ctype.h>
+#include <stdlib.h>
 #include <string.h>
 #include "table.h"
 #include "util.h"

--- a/usr/src/cmd/ypcmd/revnetgroup/table.c
+++ b/usr/src/cmd/ypcmd/revnetgroup/table.c
@@ -27,6 +27,7 @@
 #ident	"%Z%%M%	%I%	%E% SMI"	/* SMI4.1 1.4 */
 
 #include <ctype.h>
+#include <stdlib.h>
 #include "util.h"
 #include "table.h"
 

--- a/usr/src/cmd/ypcmd/revnetgroup/util.h
+++ b/usr/src/cmd/ypcmd/revnetgroup/util.h
@@ -48,11 +48,6 @@ extern "C" {
 	(dst = (char *) malloc((unsigned)(num) + 1),\
 	(void)strncpy(dst,src,num),(dst)[num] = EOS) 
 
-/*
-extern char *malloc();
-*/
-extern char *alloca();
-
 char *getaline();
 void fatal();
 

--- a/usr/src/cmd/ypcmd/yppasswd/Makefile
+++ b/usr/src/cmd/ypcmd/yppasswd/Makefile
@@ -41,7 +41,11 @@ ROOTDIRS =	$(NETSVC) $(NETYP)
 
 # include library definitions
 #LDLIBS +=	-lrpcsvc -lnsl -lcrypt -lintl -lgen
-LDLIBS +=	-lnsl -lnisdb -lc
+LDLIBS +=	-lnsl -lnisdb -lc -L$(ADJUNCT_PROTO)/usr/lib/mps
+
+# XXXARM: _Unwind_Resume
+$(AARCH64_BLD) LDLIBS += -lgcc
+
 MAPFILES =	$(MAPFILE.INT) $(MAPFILE.NGB)
 LDFLAGS +=	$(MAPFILES:%=-Wl,-M%)
 

--- a/usr/src/cmd/ypcmd/yppasswd/yplckpwdf.c
+++ b/usr/src/cmd/ypcmd/yppasswd/yplckpwdf.c
@@ -67,7 +67,7 @@ yplckpwdf()
 	flock.l_type = F_WRLCK;
 	(void) sigset(SIGALRM, almhdlr);
 	(void) alarm(S_WAITTIME);
-	retval = fcntl(fildes, F_SETLKW, (int)&flock);
+	retval = fcntl(fildes, F_SETLKW, &flock);
 	(void) alarm(0);
 	(void) sigset(SIGALRM, SIG_DFL);
 	return (retval);
@@ -84,7 +84,7 @@ ypulckpwdf()
 		return (-1);
 
 	flock.l_type = F_UNLCK;
-	(void) fcntl(fildes, F_SETLK, (int)&flock);
+	(void) fcntl(fildes, F_SETLK, &flock);
 	(void) close(fildes);
 	fildes = -1;
 	return (0);

--- a/usr/src/cmd/ypcmd/yppoll.c
+++ b/usr/src/cmd/ypcmd/yppoll.c
@@ -90,8 +90,6 @@ static void getypserv();
 extern void exit();
 extern int getdomainname();
 extern int gethostname();
-extern unsigned int strlen();
-extern int strcmp();
 
 /*
  * This is the mainline for the yppoll process.

--- a/usr/src/cmd/ypcmd/ypserv_ancil.c
+++ b/usr/src/cmd/ypcmd/ypserv_ancil.c
@@ -37,6 +37,7 @@ static	char sccsid[] = "@(#)ypserv_ancil.c 1.13 88/02/08 Copyr 1984 Sun Micro";
 #endif
 
 #include <dirent.h>
+#include <stdlib.h>
 #include <syslog.h>
 #include "ypsym.h"
 #include "ypdefs.h"
@@ -46,10 +47,7 @@ USE_DBM
 #include "shim.h"
 #include "yptol.h"
 
-extern unsigned int strlen();
-extern int strcmp();
 extern int isvar_sysv();
-extern char *strncpy();
 extern int yp_getkey();
 
 /*

--- a/usr/src/cmd/ypcmd/ypset.c
+++ b/usr/src/cmd/ypcmd/ypset.c
@@ -93,7 +93,6 @@ extern void exit();
 extern int getdomainname();
 extern int gethostname();
 extern struct netconfig *getnetconfigent();
-extern unsigned int strlen();
 
 /*
  * This is the mainline for the ypset process.  It pulls whatever arguments

--- a/usr/src/cmd/ypcmd/ypxfr.c
+++ b/usr/src/cmd/ypcmd/ypxfr.c
@@ -88,6 +88,7 @@
 #include <rpcsvc/yp_prot.h>
 #include <unistd.h>
 #include <stdlib.h>
+#include <stdarg.h>
 #include <rpcsvc/nis.h>
 #include "ypdefs.h"
 #include "yp_b.h"
@@ -209,7 +210,7 @@ bool add_private_entries();
 bool new_mapfiles();
 void del_mapfiles();
 void set_output();
-void logprintf();
+void logprintf(const char *fmt, ...);
 bool send_ypclear();
 void xfr_exit();
 void send_callback();
@@ -343,13 +344,14 @@ set_output()
 		}
 	}
 }
+
 /*
  * This constructs a logging record.
  */
 void
-logprintf(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
-/*VARARGS*/
+logprintf(const char *fmt, ...)
 {
+	va_list va;
 	struct timeval t;
 
 	fseek(stderr, 0, 2);
@@ -357,8 +359,10 @@ logprintf(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 		(void) gettimeofday(&t, NULL);
 		(void) fprintf(stderr, "%19.19s: ", ctime(&t.tv_sec));
 	}
-	(void) fprintf(stderr, (char *)arg1, arg2, arg3, arg4, arg5,
-				arg6, arg7);
+
+	va_start(va, fmt);
+	vfprintf(stderr, fmt, va);
+	va_end(va);
 	fflush(stderr);
 }
 

--- a/usr/src/pkg/manifests/SUNWcs.p5m
+++ b/usr/src/pkg/manifests/SUNWcs.p5m
@@ -459,7 +459,7 @@ file path=lib/svc/method/svc-sockfilter mode=0555
 file path=lib/svc/method/svc-utmpd mode=0555
 file path=lib/svc/method/system-log mode=0555
 file path=lib/svc/method/vtdaemon mode=0555
-$(not_aarch64)file path=lib/svc/method/yp mode=0555
+file path=lib/svc/method/yp mode=0555
 dir  path=lib/svc/monitor
 dir  path=lib/svc/seed
 # global.db is not needed in non-global zones, and it's pretty large.
@@ -1401,7 +1401,7 @@ file path=usr/sbin/locator mode=0555
 link path=usr/sbin/lockfs target=../lib/fs/ufs/lockfs
 file path=usr/sbin/lofiadm mode=0555
 file path=usr/sbin/logadm mode=0555
-$(not_aarch64)file path=usr/sbin/makedbm mode=0555
+file path=usr/sbin/makedbm mode=0555
 file path=usr/sbin/mkdevalloc mode=0555
 hardlink path=usr/sbin/mkdevmaps target=../../usr/sbin/mkdevalloc
 file path=usr/sbin/mkfile mode=0555

--- a/usr/src/pkg/manifests/service-network-network-clients.p5m
+++ b/usr/src/pkg/manifests/service-network-network-clients.p5m
@@ -34,12 +34,12 @@ set name=variant.arch value=$(ARCH)
 dir  path=usr group=sys
 dir  path=usr/bin
 file path=usr/bin/filesync mode=0555
-$(not_aarch64)file path=usr/bin/rcp mode=4555
+file path=usr/bin/rcp mode=4555
 file path=usr/bin/rdate mode=0555
 file path=usr/bin/rdist mode=4555
 link path=usr/bin/remsh target=./rsh
-$(not_aarch64)file path=usr/bin/rlogin mode=4555
-$(not_aarch64)file path=usr/bin/rsh mode=4555
+file path=usr/bin/rlogin mode=4555
+file path=usr/bin/rsh mode=4555
 file path=usr/bin/rup mode=0555
 file path=usr/bin/ruptime mode=0555
 file path=usr/bin/rusers mode=0555

--- a/usr/src/pkg/manifests/service-network-nis.p5m
+++ b/usr/src/pkg/manifests/service-network-nis.p5m
@@ -32,43 +32,40 @@ set name=info.classification \
 set name=variant.arch value=$(ARCH)
 dir  path=etc group=sys
 dir  path=etc/default group=sys
-$(not_aarch64)file path=etc/default/yppasswdd group=sys \
+file path=etc/default/yppasswdd group=sys \
     original_name=SUNWyp:etc/default/yppasswdd preserve=renamenew
 dir  path=lib
 dir  path=lib/svc
 dir  path=lib/svc/manifest group=sys
 dir  path=lib/svc/manifest/network group=sys
 dir  path=lib/svc/manifest/network/nis group=sys
-$(not_aarch64)file path=lib/svc/manifest/network/nis/passwd.xml group=sys \
-    mode=0444
-$(not_aarch64)file path=lib/svc/manifest/network/nis/server.xml group=sys \
-    mode=0444
-$(not_aarch64)file path=lib/svc/manifest/network/nis/update.xml group=sys \
-    mode=0444
-$(not_aarch64)file path=lib/svc/manifest/network/nis/xfr.xml group=sys mode=0444
+file path=lib/svc/manifest/network/nis/passwd.xml group=sys mode=0444
+file path=lib/svc/manifest/network/nis/server.xml group=sys mode=0444
+file path=lib/svc/manifest/network/nis/update.xml group=sys mode=0444
+file path=lib/svc/manifest/network/nis/xfr.xml group=sys mode=0444
 dir  path=usr group=sys
 dir  path=usr/lib
-$(not_aarch64)dir path=usr/lib/netsvc group=sys
-$(not_aarch64)dir path=usr/lib/netsvc/yp
-$(not_aarch64)file path=usr/lib/netsvc/yp/inityp2l mode=0555
-$(not_aarch64)file path=usr/lib/netsvc/yp/mkalias mode=0555
-$(not_aarch64)file path=usr/lib/netsvc/yp/multi mode=0555
-$(not_aarch64)file path=usr/lib/netsvc/yp/multi.awk mode=0555
-$(not_aarch64)file path=usr/lib/netsvc/yp/rpc.yppasswdd mode=0555
-$(not_aarch64)file path=usr/lib/netsvc/yp/rpc.ypupdated mode=0555
-$(not_aarch64)file path=usr/lib/netsvc/yp/stdethers mode=0555
-$(not_aarch64)file path=usr/lib/netsvc/yp/stdhosts mode=0555
-$(not_aarch64)file path=usr/lib/netsvc/yp/udpublickey mode=0555
-$(not_aarch64)file path=usr/lib/netsvc/yp/ypmap2src mode=0555
-$(not_aarch64)file path=usr/lib/netsvc/yp/yppush mode=0555
-$(not_aarch64)file path=usr/lib/netsvc/yp/ypserv mode=0555
-$(not_aarch64)file path=usr/lib/netsvc/yp/ypxfr_1perday mode=0555
-$(not_aarch64)file path=usr/lib/netsvc/yp/ypxfr_1perhour mode=0555
-$(not_aarch64)file path=usr/lib/netsvc/yp/ypxfr_2perday mode=0555
-$(not_aarch64)file path=usr/lib/netsvc/yp/ypxfrd mode=0555
+dir  path=usr/lib/netsvc group=sys
+dir  path=usr/lib/netsvc/yp
+file path=usr/lib/netsvc/yp/inityp2l mode=0555
+file path=usr/lib/netsvc/yp/mkalias mode=0555
+file path=usr/lib/netsvc/yp/multi mode=0555
+file path=usr/lib/netsvc/yp/multi.awk mode=0555
+file path=usr/lib/netsvc/yp/rpc.yppasswdd mode=0555
+file path=usr/lib/netsvc/yp/rpc.ypupdated mode=0555
+file path=usr/lib/netsvc/yp/stdethers mode=0555
+file path=usr/lib/netsvc/yp/stdhosts mode=0555
+file path=usr/lib/netsvc/yp/udpublickey mode=0555
+file path=usr/lib/netsvc/yp/ypmap2src mode=0555
+file path=usr/lib/netsvc/yp/yppush mode=0555
+file path=usr/lib/netsvc/yp/ypserv mode=0555
+file path=usr/lib/netsvc/yp/ypxfr_1perday mode=0555
+file path=usr/lib/netsvc/yp/ypxfr_1perhour mode=0555
+file path=usr/lib/netsvc/yp/ypxfr_2perday mode=0555
+file path=usr/lib/netsvc/yp/ypxfrd mode=0555
 dir  path=usr/sbin
-$(not_aarch64)file path=usr/sbin/mknetid mode=0555
-$(not_aarch64)file path=usr/sbin/revnetgroup mode=0555
+file path=usr/sbin/mknetid mode=0555
+file path=usr/sbin/revnetgroup mode=0555
 file path=usr/share/man/man5/NISLDAPmapping.5
 file path=usr/share/man/man5/securenets.5
 file path=usr/share/man/man5/updaters.5
@@ -87,11 +84,11 @@ file path=usr/share/man/man8/ypserv.8
 link path=usr/share/man/man8/ypupdated.8 target=rpc.ypupdated.8
 link path=usr/share/man/man8/ypxfrd.8 target=ypserv.8
 dir  path=var group=sys
-$(not_aarch64)dir path=var/yp
-$(not_aarch64)file path=var/yp/Makefile mode=0555 \
-    original_name=SUNWyp:var/yp/Makefile preserve=renamenew
-$(not_aarch64)dir path=var/yp/binding
-$(not_aarch64)file path=var/yp/updaters mode=0500
+dir  path=var/yp
+file path=var/yp/Makefile mode=0555 original_name=SUNWyp:var/yp/Makefile \
+    preserve=renamenew
+dir  path=var/yp/binding
+file path=var/yp/updaters mode=0500
 legacy pkg=SUNWypr desc="NIS Server for Solaris 2.6 and up" \
     name="NIS Server for Solaris (root)"
 legacy pkg=SUNWypu desc="NIS Server for Solaris 2.6 and up" \

--- a/usr/src/pkg/manifests/service-security-kerberos-5.p5m
+++ b/usr/src/pkg/manifests/service-security-kerberos-5.p5m
@@ -39,20 +39,17 @@ dir  path=lib/svc
 dir  path=lib/svc/manifest group=sys
 dir  path=lib/svc/manifest/network group=sys
 dir  path=lib/svc/manifest/network/security group=sys
-$(not_aarch64)file path=lib/svc/manifest/network/security/kadmin.xml group=sys \
-    mode=0444
-$(not_aarch64)file path=lib/svc/manifest/network/security/krb5kdc.xml \
-    group=sys mode=0444
-$(not_aarch64)file path=lib/svc/manifest/network/security/ktkt_warn.xml \
-    group=sys mode=0444
+file path=lib/svc/manifest/network/security/kadmin.xml group=sys mode=0444
+file path=lib/svc/manifest/network/security/krb5kdc.xml group=sys mode=0444
+file path=lib/svc/manifest/network/security/ktkt_warn.xml group=sys mode=0444
 dir  path=usr group=sys
 dir  path=usr/bin
-$(not_aarch64)file path=usr/bin/kdestroy mode=0555
-$(not_aarch64)file path=usr/bin/kinit mode=0555
-$(not_aarch64)file path=usr/bin/klist mode=0555
-$(not_aarch64)file path=usr/bin/kpasswd mode=0555
-$(not_aarch64)file path=usr/bin/krb5-config mode=0555
-$(not_aarch64)file path=usr/bin/ktutil mode=0555
+file path=usr/bin/kdestroy mode=0555
+file path=usr/bin/kinit mode=0555
+file path=usr/bin/klist mode=0555
+file path=usr/bin/kpasswd mode=0555
+file path=usr/bin/krb5-config mode=0555
+file path=usr/bin/ktutil mode=0555
 dir  path=usr/lib
 $(MULTILIB_ONLY)dir path=usr/lib/$(ARCH64)
 $(MULTILIB_ONLY)dir path=usr/lib/$(ARCH64)/gss
@@ -69,7 +66,7 @@ $(MULTILIB_ONLY)dir path=usr/lib/krb5/$(ARCH64)
 $(MULTILIB_ONLY)link path=usr/lib/krb5/$(ARCH64)/libkadm5clnt.so \
     target=./libkadm5clnt.so.1
 $(MULTILIB_ONLY)file path=usr/lib/krb5/$(ARCH64)/libkadm5clnt.so.1
-$(not_aarch64)file path=usr/lib/krb5/ktkt_warnd mode=0555
+file path=usr/lib/krb5/ktkt_warnd mode=0555
 link path=usr/lib/krb5/libkadm5clnt.so target=./libkadm5clnt.so.1
 file path=usr/lib/krb5/libkadm5clnt.so.1
 link path=usr/lib/krb5/libss.so target=libss.so.1

--- a/usr/src/pkg/manifests/system-network-nis.p5m
+++ b/usr/src/pkg/manifests/system-network-nis.p5m
@@ -34,24 +34,22 @@ set name=info.classification \
 set name=variant.arch value=$(ARCH)
 dir  path=etc group=sys
 file path=etc/nsswitch.nis group=sys
-$(not_aarch64)file path=etc/publickey original_name=SUNWnis:etc/publickey \
-    preserve=true
+file path=etc/publickey original_name=SUNWnis:etc/publickey preserve=true
 dir  path=lib
 dir  path=lib/svc
 dir  path=lib/svc/manifest group=sys
 dir  path=lib/svc/manifest/network group=sys
 dir  path=lib/svc/manifest/network/nis group=sys
-$(not_aarch64)file path=lib/svc/manifest/network/nis/client.xml group=sys \
-    mode=0444
+file path=lib/svc/manifest/network/nis/client.xml group=sys mode=0444
 dir  path=lib/svc/manifest/network/rpc group=sys
 dir  path=usr group=sys
 dir  path=usr/bin
 file path=usr/bin/chkey group=sys mode=4555
 file path=usr/bin/ldaplist mode=0555
-$(not_aarch64)file path=usr/bin/ypcat group=other mode=0555
-$(not_aarch64)file path=usr/bin/ypmatch group=other mode=0555
+file path=usr/bin/ypcat group=other mode=0555
+file path=usr/bin/ypmatch group=other mode=0555
 file path=usr/bin/yppasswd mode=0555
-$(not_aarch64)file path=usr/bin/ypwhich group=other mode=0555
+file path=usr/bin/ypwhich group=other mode=0555
 dir  path=usr/lib
 dir  path=usr/lib/ldap
 file path=usr/lib/ldap/idsconfig mode=0555
@@ -60,19 +58,19 @@ link path=usr/lib/libnisdb.so target=./libnisdb.so.2
 file path=usr/lib/libnisdb.so.2
 dir  path=usr/lib/netsvc group=sys
 dir  path=usr/lib/netsvc/nis group=sys
-$(not_aarch64)dir path=usr/lib/netsvc/yp
-$(not_aarch64)file path=usr/lib/netsvc/yp/ypbind mode=0555
-$(not_aarch64)file path=usr/lib/netsvc/yp/ypstart mode=0555
-$(not_aarch64)file path=usr/lib/netsvc/yp/ypstop mode=0555
-$(not_aarch64)file path=usr/lib/netsvc/yp/ypxfr mode=0555
+dir  path=usr/lib/netsvc/yp
+file path=usr/lib/netsvc/yp/ypbind mode=0555
+file path=usr/lib/netsvc/yp/ypstart mode=0555
+file path=usr/lib/netsvc/yp/ypstop mode=0555
+file path=usr/lib/netsvc/yp/ypxfr mode=0555
 dir  path=usr/sbin
 file path=usr/sbin/ldapaddent mode=0555
 file path=usr/sbin/ldapclient mode=0555
 file path=usr/sbin/newkey group=sys mode=0555
-$(not_aarch64)file path=usr/sbin/ypalias mode=0555
-$(not_aarch64)file path=usr/sbin/ypinit mode=0555
-$(not_aarch64)file path=usr/sbin/yppoll mode=0555
-$(not_aarch64)file path=usr/sbin/ypset mode=0555
+file path=usr/sbin/ypalias mode=0555
+file path=usr/sbin/ypinit mode=0555
+file path=usr/sbin/yppoll mode=0555
+file path=usr/sbin/ypset mode=0555
 dir  path=usr/share/man
 dir  path=usr/share/man/man1
 file path=usr/share/man/man1/chkey.1
@@ -102,12 +100,11 @@ link path=usr/share/man/man8/ypxfr_1perhour.8 target=ypxfr.8
 link path=usr/share/man/man8/ypxfr_2perday.8 target=ypxfr.8
 dir  path=var group=sys
 dir  path=var/ldap group=sys
-$(not_aarch64)dir path=var/yp
-$(not_aarch64)file path=var/yp/aliases mode=0555 \
-    original_name=SUNWnis:var/yp/aliases preserve=true
-$(not_aarch64)dir path=var/yp/binding
-$(not_aarch64)file path=var/yp/nicknames \
-    original_name=SUNWnis:var/yp/nicknames preserve=true
+dir  path=var/yp
+file path=var/yp/aliases mode=0555 original_name=SUNWnis:var/yp/aliases \
+    preserve=true
+dir  path=var/yp/binding
+file path=var/yp/nicknames original_name=SUNWnis:var/yp/nicknames preserve=true
 legacy pkg=SUNWnisr \
     desc="configuration files and directories for the Network Information System (NIS)" \
     name="Network Information System, (Root)"

--- a/usr/src/pkg/manifests/system-security-kerberos-5.p5m
+++ b/usr/src/pkg/manifests/system-security-kerberos-5.p5m
@@ -44,26 +44,25 @@ dir  path=lib/svc
 dir  path=lib/svc/manifest group=sys
 dir  path=lib/svc/manifest/network group=sys
 dir  path=lib/svc/manifest/network/security group=sys
-$(not_aarch64)file path=lib/svc/manifest/network/security/krb5_prop.xml \
-    group=sys mode=0444
+file path=lib/svc/manifest/network/security/krb5_prop.xml group=sys mode=0444
 dir  path=usr group=sys
 dir  path=usr/lib
 dir  path=usr/lib/krb5
 file path=usr/lib/krb5/README.db2 mode=0444
 link path=usr/lib/krb5/db2.so target=db2.so.1
 file path=usr/lib/krb5/db2.so.1
-$(not_aarch64)file path=usr/lib/krb5/kadmind mode=0500
-$(not_aarch64)file path=usr/lib/krb5/kconf mode=0555
-$(not_aarch64)file path=usr/lib/krb5/kdyndns mode=0555
+file path=usr/lib/krb5/kadmind mode=0500
+file path=usr/lib/krb5/kconf mode=0555
+file path=usr/lib/krb5/kdyndns mode=0555
 link path=usr/lib/krb5/kldap.so target=kldap.so.1
 file path=usr/lib/krb5/kldap.so.1
-$(not_aarch64)file path=usr/lib/krb5/klookup mode=0555
-$(not_aarch64)file path=usr/lib/krb5/kprop mode=0555
-$(not_aarch64)file path=usr/lib/krb5/kprop_script mode=0555
-$(not_aarch64)file path=usr/lib/krb5/kpropd mode=0555
-$(not_aarch64)file path=usr/lib/krb5/krb5kdc mode=0500
-$(not_aarch64)file path=usr/lib/krb5/ksetpw mode=0555
-$(not_aarch64)file path=usr/lib/krb5/ksmb mode=0555
+file path=usr/lib/krb5/klookup mode=0555
+file path=usr/lib/krb5/kprop mode=0555
+file path=usr/lib/krb5/kprop_script mode=0555
+file path=usr/lib/krb5/kpropd mode=0555
+file path=usr/lib/krb5/krb5kdc mode=0500
+file path=usr/lib/krb5/ksetpw mode=0555
+file path=usr/lib/krb5/ksmb mode=0555
 link path=usr/lib/krb5/libdb2.so target=libdb2.so.1
 file path=usr/lib/krb5/libdb2.so.1
 link path=usr/lib/krb5/libdyn.so target=libdyn.so.1
@@ -75,18 +74,18 @@ file path=usr/lib/krb5/libkdb.so.1
 link path=usr/lib/krb5/libkdb_ldap.so target=libkdb_ldap.so.1
 file path=usr/lib/krb5/libkdb_ldap.so.1
 dir  path=usr/lib/security
-$(not_aarch64)file path=usr/lib/security/pam_krb5_first mode=0444
-$(not_aarch64)file path=usr/lib/security/pam_krb5_only mode=0444
-$(not_aarch64)file path=usr/lib/security/pam_krb5_optional mode=0444
+file path=usr/lib/security/pam_krb5_first mode=0444
+file path=usr/lib/security/pam_krb5_only mode=0444
+file path=usr/lib/security/pam_krb5_optional mode=0444
 dir  path=usr/sbin
-$(not_aarch64)file path=usr/sbin/k5srvutil mode=0555
-$(not_aarch64)file path=usr/sbin/kadmin mode=0555
-$(not_aarch64)file path=usr/sbin/kadmin.local mode=0555
-$(not_aarch64)file path=usr/sbin/kclient mode=0555
-$(not_aarch64)file path=usr/sbin/kdb5_ldap_util mode=0555
-$(not_aarch64)file path=usr/sbin/kdb5_util mode=0555
-$(not_aarch64)file path=usr/sbin/kdcmgr mode=0555
-$(not_aarch64)file path=usr/sbin/kproplog mode=0555
+file path=usr/sbin/k5srvutil mode=0555
+file path=usr/sbin/kadmin mode=0555
+file path=usr/sbin/kadmin.local mode=0555
+file path=usr/sbin/kclient mode=0555
+file path=usr/sbin/kdb5_ldap_util mode=0555
+file path=usr/sbin/kdb5_util mode=0555
+file path=usr/sbin/kdcmgr mode=0555
+file path=usr/sbin/kproplog mode=0555
 dir  path=usr/share
 dir  path=usr/share/lib
 dir  path=usr/share/lib/ldif group=sys


### PR DESCRIPTION
First patch fixes the order in the usr/src/Makefile to be somewhat more similar to the original so we have less changes to upstream eventually. Rest is mostly either missing include files and wrong local prototypes or limited data types.