### PR TITLE
Prefer in-tree lz4 headers over adjunct proto

### DIFF
--- a/usr/src/cmd/vtfontcvt/Makefile.common
+++ b/usr/src/cmd/vtfontcvt/Makefile.common
@@ -18,7 +18,8 @@ PROG=	vtfontcvt
 OBJS=	vtfontcvt.o
 
 LZ4=	$(SRC)/common/lz4
-CPPFLAGS +=	-I$(LZ4)
+# The in-tree headers should take precedence over the adjunct
+CPPFLAGS.first +=	-I$(LZ4)
 LZ4_OBJS=	lz4.o
 OBJS	+=	$(LZ4_OBJS)
 

--- a/usr/src/lib/Makefile
+++ b/usr/src/lib/Makefile
@@ -72,7 +72,6 @@ SUBDIRS +=		\
 # libmilter -- seems 32bit and not 64bit clean
 # abi -- not ported/necessary
 # c_synonyms -- not ported/necessary
-# pylibbe, pysolaris, pyzfs -- no python yet
 # libdtrace_jni -- java
 # libzfs_jni -- java
 # libadt_jni -- java
@@ -98,9 +97,6 @@ $(NOT_AARCH64_BLD)SUBDIRS += \
 	libresolv	\
 	libzfs_jni	\
 	policykit	\
-	pylibbe		\
-	pysolaris	\
-	pyzfs		\
 	smbclnt		\
 	libm1
 
@@ -280,6 +276,9 @@ SUBDIRS +=				\
 	passwdutil	\
 	pkcs11		\
 	print		\
+	pylibbe		\
+	pysolaris	\
+	pyzfs		\
 	raidcfg_plugins	\
 	rpcsec_gss	\
 	sasl_plugins	\

--- a/usr/src/lib/libficl/Makefile.com
+++ b/usr/src/lib/libficl/Makefile.com
@@ -32,7 +32,8 @@ LZ4=		$(SRC)/common/lz4
 CSTD=	$(CSTD_GNU99)
 PNGLITE=	$(SRC)/common/pnglite
 CPPFLAGS +=	-I.. -I$(FICLDIR) -I$(FICLDIR)/emu -D_LARGEFILE64_SOURCE=1
-CPPFLAGS +=	-I$(PNGLITE) -I$(LZ4)
+# The in-tree headers should take precedence over the adjunct
+CPPFLAGS.first +=	-I$(PNGLITE) -I$(LZ4)
 CFLAGS += $(C_BIGPICFLAGS)
 CFLAGS64 += $(C_BIGPICFLAGS64)
 

--- a/usr/src/lib/libzpool/Makefile.com
+++ b/usr/src/lib/libzpool/Makefile.com
@@ -60,7 +60,6 @@ INCS += -I../common
 INCS += -I../../../uts/common/fs/zfs
 INCS += -I../../../uts/common/fs/zfs/lua
 INCS += -I../../../common/zfs
-INCS += -I../../../common/lz4
 INCS += -I../../../common
 INCS += -I../../libzutil/common
 
@@ -78,6 +77,8 @@ LDLIBS +=	-lcmdutils -lumem -lavl -lnvpair -lz -lc -lmd \
 		-lfakekernel -lzutil
 NATIVE_LIBS +=	libz.so
 CPPFLAGS.first =	-I$(SRC)/lib/libfakekernel/common
+# The in-tree headers should take precedence over the adjunct
+CPPFLAGS.first +=	-I../../../common/lz4
 CPPFLAGS +=	$(INCS)	-DDEBUG -D_FAKE_KERNEL
 
 

--- a/usr/src/tools/vtfontcvt/Makefile
+++ b/usr/src/tools/vtfontcvt/Makefile
@@ -19,6 +19,7 @@ include		../Makefile.tools
 include		$(CMDDIR)/Makefile.common
 
 NATIVE_LIBS	+= libumem.so
+CPPFLAGS	+= -I$(LZ4)
 CPPFLAGS	+= -I../../uts/common
 .KEEP_STATE:
 


### PR DESCRIPTION
When building this on OmniOS, we use a sysroot as the adjunct proto, and that sysroot includes a newer version of LZ4 than that in the tree. Unfortunately, a few places set CPPFLAGS so that the adjunct is preferred over the in-tree headers, which they should not be.