### PR TITLE
Disable conditional dependencies on python modules

### DIFF
--- a/usr/src/pkg/manifests/system-file-system-zfs.p5m
+++ b/usr/src/pkg/manifests/system-file-system-zfs.p5m
@@ -154,5 +154,6 @@ license usr/src/uts/common/fs/zfs/THIRDPARTYLICENSE.cityhash \
     license=usr/src/uts/common/fs/zfs/THIRDPARTYLICENSE.cityhash
 license usr/src/uts/common/fs/zfs/THIRDPARTYLICENSE.lz4 \
     license=usr/src/uts/common/fs/zfs/THIRDPARTYLICENSE.lz4
-depend type=conditional fmri=system/library/python/zfs$(PYTHON3_PKGVERS) \
+$(not_aarch64)depend type=conditional \
+    fmri=system/library/python/zfs$(PYTHON3_PKGVERS) \
     predicate=runtime/python$(PYTHON3_PKGVERS)

--- a/usr/src/pkg/manifests/system-library.p5m
+++ b/usr/src/pkg/manifests/system-library.p5m
@@ -1353,7 +1353,8 @@ license usr/src/man/man3c/THIRDPARTYLICENSE.getentropy \
     license=usr/src/man/man3c/THIRDPARTYLICENSE.getentropy
 license usr/src/uts/common/sys/THIRDPARTYLICENSE.unicode \
     license=usr/src/uts/common/sys/THIRDPARTYLICENSE.unicode
-depend type=conditional fmri=system/library/python/solaris$(PYTHON3_PKGVERS) \
+$(not_aarch64)depend type=conditional \
+    fmri=system/library/python/solaris$(PYTHON3_PKGVERS) \
     predicate=runtime/python$(PYTHON3_PKGVERS)
 
 #


### PR DESCRIPTION
The build of the in-gate python modules (pysolaris, pylibbe, pyzfs) is currently disabled, but we do have a working python-311 package in the OmniOS repository. When this is installed, system/library suddenly gains a dependency on solaris-311, and zfs gains one on pyzfs-311. While the python modules are disabled, so should the conditional dependencies be.