### PR TITLE
PTE_PFN_MASK should extract 48 bits

### DIFF
--- a/usr/src/uts/aarch64/sys/pte.h
+++ b/usr/src/uts/aarch64/sys/pte.h
@@ -90,7 +90,7 @@ typedef uint64_t pte_t;
 #define	PTE_TABLE_UXNT		(1ull << 60)
 #define	PTE_TABLE_PXNT		(1ull << 59)
 
-#define	PTE_PFN_MASK		0x000000fffffff000ull
+#define	PTE_PFN_MASK		0x0000fffffffff000ull
 
 #endif /* !_ASM */
 


### PR DESCRIPTION
The PTE_PFN_MASK macro only extracts 40 bits of the intermediate physical address from a PTE. Extract the full 48 bits, supporting machines with physical memory mapped at higher addresses (such as qemu sbsa-ref).

We still need to consider extracting a full 52 bits for LPA/LPA2 systems when we start supporting those.