### PR TITLE
Fix make setup errors in libscf

### DIFF
--- a/usr/src/tools/svc/libscf/Makefile
+++ b/usr/src/tools/svc/libscf/Makefile
@@ -57,6 +57,8 @@ COMDIR =	$(SRC)/common/svc
 
 CPPFLAGS +=	-DNATIVE_BUILD $(DTEXTDOM) \
 		-I$(SRC)/lib/libscf/inc -I$(COMDIR) -I$(LIBUUTIL)/common \
+		-I$(SRC)/lib/libuutil/common -I$(SRC)/head \
+		-I$(SRC)/lib/libbrand/common \
 		-I$(ROOTHDRDIR)
 LDLIBS +=	-R '$$ORIGIN/../../lib/$(NATIVE_MACH)' -L$(ROOTONBLDLIBMACH) \
 		-luutil -lc -lgen -lnvpair -lsmbios


### PR DESCRIPTION
When building the current arm64-gate tree from a fresh setup I've experienced build errors in the tools build of libscf on both omnios-r151044 and omnios-r151046. Tweaking the Makefile to refer to the in-tree headers explicitly resolves the issue.