### PR TITLE
Fix psm/stand/boot build options for rpi4 and meson-gxbb

### DIFF
--- a/usr/src/psm/Makefile.psm.64
+++ b/usr/src/psm/Makefile.psm.64
@@ -34,6 +34,6 @@ include $(SRC)/Makefile.master.64
 # XX64 all the stuff below this line should go away once the tools are fixed
 $(SPARC_BLD)ALWAYS_DEFS	+= -D__sparc -D__sparcv9 -D_SYSCALL32_IMPL
 $(SPARC_BLD)AS_DEFS	+= -D__sparc -D__sparcv9
-$(SPARC_BLD)CPPFLAGS	+= -D__sparc -D__sparcv9 -D_SYSCALL32 
+$(SPARC_BLD)CPPFLAGS	+= -D__sparc -D__sparcv9 -D_SYSCALL32
 $(SPARC_BLD)ASFLAGS	+= -D__sparc -D__sparcv9
 $(SPARC_BLD)LINTFLAGS64	+= -errchk=longptr64 -m64

--- a/usr/src/psm/stand/boot/aarch64/meson-gxbb/Makefile
+++ b/usr/src/psm/stand/boot/aarch64/meson-gxbb/Makefile
@@ -30,7 +30,7 @@ BOARD=	meson-gxbb
 include ../Makefile.com
 ROOT_PSM_DIR=$(ROOT_PLAT_DIR)/Amlogic,meson-gxbb
 
-.DELETE_ON_ERROR:
+.KEEP_STATE:
 
 all: $(NFSBOOT_BIN) $(DTB)
 $(NFS_SRT0) $(NFS_OBJS):  $(ASSYM_H)
@@ -42,9 +42,7 @@ CERRWARN += -_gcc=-Wno-unused-function
 CERRWARN += -_gcc=-Wno-unused-variable
 CERRWARN += -_gcc=-Wno-unused-but-set-variable
 
-include $(TOPDIR)/psm/Makefile.psm.64
 include $(BOOTSRCDIR)/Makefile.rules
-
 include ../Makefile.targ
 
 $(ROOT_PSM_NFSBOOT): $(NFSBOOT_BIN) $(ROOT_PSM_DIR)
@@ -56,4 +54,5 @@ $(ROOT_PSM_DTB): $(DTB) $(ROOT_PSM_DIR)
 	$(INS.file) $(DTB)
 
 %.dtb: dts/%.dts
-	$(ANSI_CPP) -nostdinc -I dts $(CPPINCS) -undef -x assembler-with-cpp $< | $(DTC) -o $@ -O dtb
+	$(ANSI_CPP) -nostdinc -I dts $(CPPINCS) -undef \
+		-x assembler-with-cpp $< | $(DTC) -o $@ -O dtb

--- a/usr/src/psm/stand/boot/aarch64/rpi4/Makefile
+++ b/usr/src/psm/stand/boot/aarch64/rpi4/Makefile
@@ -29,7 +29,7 @@ BOARD=	rpi4
 include ../Makefile.com
 ROOT_PSM_DIR=$(ROOT_PLAT_DIR)/RaspberryPi,4
 
-.DELETE_ON_ERROR:
+.KEEP_STATE:
 
 all: $(NFSBOOT_BIN)
 $(NFS_SRT0) $(NFS_OBJS):  $(ASSYM_H)
@@ -41,9 +41,7 @@ CERRWARN += -_gcc=-Wno-unused-function
 CERRWARN += -_gcc=-Wno-unused-variable
 CERRWARN += -_gcc=-Wno-unused-but-set-variable
 
-include $(TOPDIR)/psm/Makefile.psm.64
 include $(BOOTSRCDIR)/Makefile.rules
-
 include ../Makefile.targ
 
 $(ROOT_PSM_NFSBOOT): $(NFSBOOT_BIN) $(ROOT_PSM_DIR)


### PR DESCRIPTION
In particular, the inclusion of Makefile.psm.64 was overriding build flags which resulted in these pieces being built without the -mgeneral-regs-only flag, which produces code that tries to use the FPU -- and that is not available in early boot.