### PR TITLE
Fixes to support 'pkg update' and 'beadm activate'

### DIFF
--- a/usr/src/cmd/boot/bootadm/bootadm.c
+++ b/usr/src/cmd/boot/bootadm/bootadm.c
@@ -3400,6 +3400,10 @@ use_mkisofs()
 		return (B_TRUE);
 	}
 
+	 /* XXXARM: For complicated reasons, aarch64 _must_ use hsfs right now */
+	if (is_flag_on(IS_AARCH64_TARGET))
+		return (B_TRUE);
+
 	/* If working on an alt-root, do not use HSFS unless asked via -F */
 	if (bam_alt_root)
 		return (B_FALSE);
@@ -3408,9 +3412,6 @@ use_mkisofs()
 	 * Then check that the system/boot-archive config/format property
 	 * is "hsfs" or empty.
 	 */
-	 /* XXXARM: For complicated reasons, aarch64 _must_ use hsfs right now */
-	if (is_flag_on(IS_AARCH64_TARGET))
-		return (B_TRUE);
 	if ((prop = scf_simple_prop_get(NULL, BOOT_ARCHIVE_FMRI, SCF_PG_CONFIG,
 	    SCF_PROPERTY_FORMAT)) == NULL) {
 		/* Could not find property, use mkisofs */

--- a/usr/src/lib/libbe/common/be_activate.c
+++ b/usr/src/lib/libbe/common/be_activate.c
@@ -1034,9 +1034,12 @@ be_do_installboot_helper(zpool_handle_t *zphp, nvlist_t *child, char *stage1,
 
 		(void) snprintf(install_cmd, sizeof (install_cmd),
 		    "%s %s %s %s", BE_INSTALL_BOOT, flag, stage2, diskname);
+	} else if (be_is_isa("aarch64")) {
+		/* XXXARM: Nothing to do yet for aarch64 */
+		return (BE_SUCCESS);
 	} else {
-		be_print_err(gettext("%s: unsupported architecture.\n"),
-		    __func__);
+		be_print_err(gettext("%s: unsupported architecture: %s.\n"),
+		    __func__, be_get_default_isa());
 		return (BE_ERR_BOOTFILE_INST);
 	}
 
@@ -1404,9 +1407,15 @@ be_do_installboot(be_transaction_data_t *bt, uint16_t flags)
 		(void) snprintf(stage2, sizeof (stage2),
 		    "%s/usr/platform/%s%s", tmp_mntpt,
 		    platform, BE_SPARC_BOOTBLK);
+	} else if (be_is_isa("aarch64")) {
+		/* XXXARM: Nothing to do yet for aarch64 */
+		if (be_mounted)
+			(void) _be_unmount(bt->obe_name, 0);
+		free(tmp_mntpt);
+		return (BE_SUCCESS);
 	} else {
-		be_print_err(gettext("%s: unsupported architecture.\n"),
-		    __func__);
+		be_print_err(gettext("%s: unsupported architecture: %s.\n"),
+		    __func__, be_get_default_isa());
 		return (BE_ERR_BOOTFILE_INST);
 	}
 
@@ -1446,7 +1455,6 @@ be_do_installboot(be_transaction_data_t *bt, uint16_t flags)
 	}
 
 done:
-	ZFS_CLOSE(zhp);
 	if (be_mounted)
 		(void) _be_unmount(bt->obe_name, 0);
 	zpool_close(zphp);


### PR DESCRIPTION
With these, I can boot a pi from an older image and then do a `pkg update` to end up with a new activated BE with the new bits:

```
root@braich:/# pkg set-property auto-be-name %D
root@braich:~# pkg update -f
            Packages to update:      535
       Create boot environment:      Yes
     Activate boot environment:      Yes
      Name of boot environment: 20230616
Create backup boot environment:       No

DOWNLOAD                                PKGS         FILES    XFER (MB)   SPEED
SUNWcs                                 0/535      407/5836    5.8/144.4  1.5M/s
...
```
and, after a reboot:
```
root@braich:/var/adm# beadm list
BE             Active Mountpoint Space  Policy Created
omnios-r151047 -      -          27.65M static 2023-06-15 18:56
20230616       NR     /          1.13G  static 2023-06-16 23:00
```


```