### PR TITLE
initialize the stack protector

### DIFF
--- a/usr/src/uts/armv8/Makefile.armv8
+++ b/usr/src/uts/armv8/Makefile.armv8
@@ -76,7 +76,7 @@ SYM_MOD		= $(OBJS_DIR)/unix.sym
 
 UNIX_O		 = $(UNIX_DIR)/$(OBJS_DIR)/unix.o
 MODSTUBS_O	 = $(MODSTUBS_DIR)/$(OBJS_DIR)/modstubs.o
-GENLIB	 	 = $(GENLIB_DIR)/$(OBJS_DIR)/libgenunix.so
+GENLIB		 = $(GENLIB_DIR)/$(OBJS_DIR)/libgenunix.so
 # XXXARM: We have no platmods as yet, but this is left here so we remember how
 # they work.
 #PLATMOD		 = platmod
@@ -125,7 +125,7 @@ CFLAGS			+= $(CCMODE)
 CFLAGS			+= $(SPACEFLAG)
 CFLAGS			+= $(CCUNBOUND)
 CFLAGS			+= $(CFLAGS_uts)
-CFLAGS			+= -_gcc=-fstack-protector
+CFLAGS			+= $(STACKPROTECT_$(STACKPROTECT))
 
 INC_PATH		+= -I$(UTSBASE)/armv8
 INC_PATH		+= -I$(UTSBASE)/$(MACH)

--- a/usr/src/uts/armv8/Makefile.rules
+++ b/usr/src/uts/armv8/Makefile.rules
@@ -32,8 +32,10 @@ $(OBJS_DIR)/%.o:		$(UTSBASE)/armv8/io/%.c
 	$(COMPILE.c) -o $@ $<
 	$(CTFCONVERT_O)
 
+# XXXARM: We disable the stack protector, somewhat heavy-handedly, to protect
+# the call stack up to ssp_init() itself.
 $(OBJS_DIR)/%.o:		$(UTSBASE)/armv8/os/%.c
-	$(COMPILE.c) -I$(SRC)/contrib/libfdt -o $@ $<
+	$(COMPILE.c) -I$(SRC)/contrib/libfdt -_gcc=-fno-stack-protector -o $@ $<
 	$(CTFCONVERT_O)
 
 $(OBJS_DIR)/%.o:		$(UTSBASE)/armv8/vm/%.c

--- a/usr/src/uts/armv8/os/startup.c
+++ b/usr/src/uts/armv8/os/startup.c
@@ -260,6 +260,7 @@ static void startup_modules(void);
 static void startup_vm(void);
 static void startup_end(void);
 static void layout_kernel_va(void);
+extern void ssp_init(void);
 
 static void
 getl2cacheinfo(int *csz, int *lsz, int *assoc)
@@ -349,6 +350,7 @@ startup(void)
 
 	CPUSET_ONLY(cpu_ready_set, 0);	/* cpu 0 is boot cpu */
 
+	ssp_init();
 	startup_init();
 	startup_memlist();
 	startup_kmem();
@@ -1563,11 +1565,6 @@ void
 post_startup(void)
 {
 	extern void cpu_event_init_cpu(cpu_t *);
-
-	/*
-	 * Complete CPU module initialization
-	 */
-	//cmi_post_startup();
 
 	/*
 	 * Perform forceloading tasks for /etc/system.


### PR DESCRIPTION
We built with the stack protector enabled, variously, but never initialized it.  Now we do.

- call ssp_init() early in boot
- pass -fstack-protector into armv8 in a more normal way
- exclude armv8/os from it, to avoid bootstrapping issues as we do on intel