### PR TITLE
add "name" and "addr" props to the FDT, to more easily act like other platforms

### DIFF
--- a/usr/src/uts/armv8/os/ddi_impl.c
+++ b/usr/src/uts/armv8/os/ddi_impl.c
@@ -931,9 +931,9 @@ impl_sunbus_name_child(dev_info_t *child, char *name, int namelen)
 	pnode_t node = ddi_get_nodeid(child);
 	if (node > 0) {
 		char buf[MAXNAMELEN] = {0};
-		int len = prom_getproplen(node, "addr");
+		int len = prom_getproplen(node, "unit-address");
 		if (0 < len && len < MAXNAMELEN) {
-			prom_getprop(node, "addr", buf);
+			prom_getprop(node, "unit-address", buf);
 			if (strlen(buf) < namelen)
 				strcpy(name, buf);
 		}

--- a/usr/src/uts/armv8/os/startup.c
+++ b/usr/src/uts/armv8/os/startup.c
@@ -1265,25 +1265,17 @@ startup_modules(void)
 		*cp = 0;
 	}
 
-	/*
-	 * Create a kernel device tree. First, create rootnex and
-	 * then invoke bus specific code to probe devices.
-	 */
-	setup_ddi();
-
-	/*
-	 * Set up the CPU module subsystem for the boot cpu in the native
-	 * case, and all physical cpu resource in the xpv dom0 case.
-	 * Modifies the device tree, so this must be done after
-	 * setup_ddi().
-	 */
-	/*
-	 * Fake a prom tree such that /dev/openprom continues to work
-	 */
 	PRM_POINT("startup_modules: calling prom_setup...");
 	prom_setup();
 
 	PRM_POINT("startup_modules() done");
+
+	/*
+	 * Create the kernel device tree. First, create rootnex and then invoke
+	 * bus specific code to probe devices.  Must happen after prom_setup()
+	 * which inserts properties into the tree.
+	 */
+	setup_ddi();
 }
 
 /*


### PR DESCRIPTION
There's an assumption in common code that prom device tree nodes have a "name" property.  In the FDT nodes are named inherently, not by a property, and so we have to fake it.

Rather than trying to fake it in getprop/setprop/etc as was done originally just add pseudo properties to the tree as we build it.

We also add the "addr" property, which is used to name child devices in the actual device tree, but could later be replaced with something else.

This fixes `prtconf -pd`, the problem with which was that prom_nextprop did _not_ insert fake entries for "name" and "addr", unlike get/set, and so the verbose openprom snapshot did not contain names, though the non-verbose did, and without names all `prtconf` can do is print "no data available" once per node.

I have not tested that this works with PCI as we don't have any platform with pci except raspberrypi 4 (which I don't have), and even then we don't enumerate PCI, so unless it does, there are no nodes to lookup anyway.  I haven't fixed the endianness issue that probably exists, because I can't test it.

I'd be grateful if @citrus-it or @hadfl could test on rpi4, and could take a glance, and additionally if @rmustacc could take a glance.

Further, @rmustacc asked in the past about the name of our root nexus.  I happened to notice that at present we don't name the root prom tree node.  i86pc calls this i86pc, I don't remember what SPARC uses.  Opinions on what we should do?  For now, the empty string seems fine.

(I haven't fixed nits in this yet, in case someone has a problem with the method.  I will before I merge)