### PR TITLE
Teach `prom_nextprop` about "name" and "unit-address" pseudo-properties

### DIFF
--- a/usr/src/uts/aarch64/sys/obpdefs.h
+++ b/usr/src/uts/aarch64/sys/obpdefs.h
@@ -88,9 +88,17 @@ typedef	phandle_t pnode_t;
 /*
  * Max size of a path component and a property name (not value)
  * These are standard definitions.
+ *
+ * In both P1275 and devicetree these are limited to 32 bytes, however in the
+ * wild on ARM we have seen longer values.  These are set higher and warnings
+ * issued from the PROM layer when such properties are seen.
+ *
+ * XXXARM: At least for right now.
  */
-#define	OBP_MAXDRVNAME		32	/* defined in P1275 */
-#define	OBP_MAXPROPNAME		32	/* defined in P1275 */
+#define	OBP_MAXDRVNAME		64
+#define	OBP_MAXPROPNAME		64
+
+#define	OBP_STANDARD_MAXPROPNAME	32
 
 /*
  *

--- a/usr/src/uts/armv8/os/ddi_impl.c
+++ b/usr/src/uts/armv8/os/ddi_impl.c
@@ -931,9 +931,9 @@ impl_sunbus_name_child(dev_info_t *child, char *name, int namelen)
 	pnode_t node = ddi_get_nodeid(child);
 	if (node > 0) {
 		char buf[MAXNAMELEN] = {0};
-		int len = prom_getproplen(node, "addr");
+		int len = prom_getproplen(node, "unit-address");
 		if (0 < len && len < MAXNAMELEN) {
-			prom_getprop(node, "addr", buf);
+			prom_getprop(node, "unit-address", buf);
 			if (strlen(buf) < namelen)
 				strcpy(name, buf);
 		}


### PR DESCRIPTION
The devicetree specification[1] contains a change from the 1275 device tree on which it's based, in that nodes have inherent names (and optionally unit addresses), encoded in the form `<name>(@<unit-address>)?`.

The rest of illumos expects these to be properties, and the original code synthesised these in `prom_getprop`, `prom_getproplen` and `prom_setprop`, but failed to synthesize them in `prom_nextprop`.

In this change we:

- Fix that oversight, so that prtconf(8), etc. don't get confused.
- Rename the original "addr" pseudo property to "unit-address", as everything expects
- Remove the code in `prom_setprop` which allows device name and unit-address to change, we don't use it, and it can only lead to confusion.

[1]: https://devicetree-specification.readthedocs.io/en/v0.3/devicetree-basics.html#properties