### PR TITLE
start trying to fix the pf_key tests

### DIFF
--- a/usr/src/cmd/cmd-inet/usr.sbin/ipsecutils/ipsecconf.c
+++ b/usr/src/cmd/cmd-inet/usr.sbin/ipsecutils/ipsecconf.c
@@ -3805,7 +3805,15 @@ scan:
 			 * leftover buffer.
 			 */
 			if (*buf != '\0') {
-				(void) strlcpy(lo_buf, buf, sizeof (lo_buf));
+				/*
+				 * NB: buf may point into lo_buf if we are
+				 * reading leftovers, thus we must use
+				 * memmove as there may be overlap.
+				 */
+				size_t len = MIN(strlen(buf) + 1,
+				    sizeof (lo_buf));
+
+				memmove(lo_buf, buf, len);
 				*leftover = lo_buf;
 			} else {
 				*leftover = NULL;
@@ -3929,8 +3937,16 @@ ret:
 				 * leftover buffer if any.
 				 */
 				if (*buf != '\0') {
-					(void) strlcpy(lo_buf, buf,
+					/*
+					 * NB: buf may point into lo_buf if we
+					 * are reading leftovers, thus we must
+					 * use memmove as there may be
+					 * overlap.
+					 */
+					size_t len = MIN(strlen(buf) + 1,
 					    sizeof (lo_buf));
+
+					memmove(lo_buf, buf, len);
 					*leftover = lo_buf;
 				} else {
 					*leftover = NULL;
@@ -3994,8 +4010,17 @@ ret:
 					 * leftover buffer.
 					 */
 					if (*buf != '\0') {
-						(void) strlcpy(lo_buf, buf,
+						/*
+						 * NB: buf may point into
+						 * lo_buf if we are reading
+						 * leftovers, thus we must use
+						 * memmove as there may be
+						 * overlap.
+						 */
+						size_t len = MIN(strlen(buf) + 1,
 						    sizeof (lo_buf));
+
+						memmove(lo_buf, buf, len);
 						*leftover = lo_buf;
 					} else {
 						*leftover = NULL;

--- a/usr/src/test/os-tests/tests/pf_key/acquire-compare.sh
+++ b/usr/src/test/os-tests/tests/pf_key/acquire-compare.sh
@@ -15,6 +15,10 @@
 # Copyright 2019 Joyent, Inc.
 #
 
+# All the network management commands are in /sbin or /usr/sbin, neither of
+# which is in the default $PATH
+export PATH=/sbin:/usr/sbin:$PATH
+
 # we can't presume /usr/bin/timeout is there
 timeout_cmd() {
     $* &
@@ -37,6 +41,12 @@ fi
 
 # NOTE: If multihomed, this may fail in interesting ways...
 MY_IP=`netstat -in -f inet | egrep -v "Name|lo0" | awk '{print $4}' | head -1`
+
+if [[ -z $MY_IP ]]; then
+    echo "Error: could not determine local network address." >&2
+    exit 255
+fi
+
 TEST_REMOTE_DST1=10.90.1.25
 TEST_REMOTE_DST2=10.19.84.2
 TEST_REMOTE_DST3=10.19.84.3


### PR DESCRIPTION
This doesn't succeed in fixing the tests -- I'm not sure what they need in the way of network env beyond "a network", as I fixed -- but it fixes _something_.

Most trivially, fix PATH for the tests and check we succeeded in finding a network.

Less trivially, fix ipsecconf(8), which in some circumstances will attempt to `strlcpy()` with overlapping buffers and on ARM -- but nowhere else we run, shucks -- fail, as the current ARM memcpy is not overlap safe in that specific path (our "undefined behaviour" smashes the buffer.  i386's is apparently "work").

@danmcd could you look at especially ipsecconf?  That fix should go to illumos-gate, but I don't have a sensible test setup for x86 right now.