### PR TITLE
float.h: adjust macro values for aarch64

### DIFF
--- a/usr/src/head/float.h
+++ b/usr/src/head/float.h
@@ -93,12 +93,12 @@ extern int __flt_rounds;
 	(!defined(_STRICT_STDC) && !defined(__XOPEN_OR_POSIX))
 #if defined(__sparc)
 #define	DECIMAL_DIG	36
-/* XXXARM: Really? */
-#elif defined(__i386) || defined(__amd64) || defined(__aarch64__)
+#elif defined(__i386) || defined(__amd64)
 #define	DECIMAL_DIG	21
+#elif defined(__aarch64__)
+#define	DECIMAL_DIG	17
 #endif
 #endif /* defined(__EXTENSIONS__) || defined(_STDC_C99)... */
-
 
 #if defined(__i386) || defined(__amd64)
 
@@ -127,17 +127,16 @@ extern int __flt_rounds;
 #define	LDBL_MAX_10_EXP	(+4932)
 
 #elif defined(__aarch64__)
-/* XXXARM: We should verify these against the compiler builtins */
 
 /* Follows IEEE standards for 128-bit floating point */
 #define	LDBL_MANT_DIG	113
-#define	LDBL_EPSILON	1.925929944387235853055977942584927319E-34L
+#define	LDBL_EPSILON	1.92592994438723585305597794258492732E-34L
 #define	LDBL_DIG	33
 #define	LDBL_MIN_EXP	(-16381)
-#define	LDBL_MIN	3.362103143112093506262677817321752603E-4932L
+#define	LDBL_MIN	3.36210314311209350626267781732175260E-4932L
 #define	LDBL_MIN_10_EXP	(-4931)
 #define	LDBL_MAX_EXP	(+16384)
-#define	LDBL_MAX	1.189731495357231765085759326628007016E+4932L
+#define	LDBL_MAX	1.18973149535723176508575932662800702E+4932L
 #define	LDBL_MAX_10_EXP	(+4932)
 
 #else
@@ -145,7 +144,6 @@ extern int __flt_rounds;
 #error "Unknown architecture!"
 
 #endif
-
 
 #ifdef	__cplusplus
 }


### PR DESCRIPTION
These values were expanded from the compiler builtins and verified against values documented in the <float.h> table of the Arm Compiler for Embedded Reference Guide for accuracy.

Note that the compiler guide documents DECIMAL_DIG with the value of 17, however the compiler builtin reports this as 36.

Linux also defines this as 36, but FreeBSD and (arm64) macOS define this as 17.

Since the compiler guide uses 17 I figured that it would make sense to err on the side of caution and use 17 for now.

Our compiler output for reference:

```sh
brian@omnios:~/Development/arm64-gate$ ./build/cross/bin/aarch64-unknown-solaris2.11-gcc -std=c99 -mcpu=cortex-a72 -dM -E - </dev/null                                                                                                                                                                                        
#define __DBL_MIN_EXP__ (-1021)
#define __LDBL_MANT_DIG__ 113
#define __UINT_LEAST16_MAX__ 0xffff
#define __ARM_SIZEOF_WCHAR_T 4
#define __DBL_DECIMAL_DIG__ 17
#define __ATOMIC_ACQUIRE 2
#define __FLT128_MAX_10_EXP__ 4932
#define __FLT_MIN__ 1.17549435082228750796873653722224568e-38F
#define __GCC_IEC_559_COMPLEX 2
#define __UINT_LEAST8_TYPE__ unsigned char
#define __FLT128_DIG__ 33
#define __INTMAX_C(c) c ## L
#define __CHAR_BIT__ 8
#define __UINT8_MAX__ 0xff
#define __WCHAR_MAX__ 0x7fffffff
#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_2 1
#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4 1
#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_8 1
#define __GCC_ATOMIC_CHAR_LOCK_FREE 2
#define __GCC_IEC_559 2
#define __FLT32X_DECIMAL_DIG__ 17
#define __FLT_EVAL_METHOD__ 0
#define __FLT64_DECIMAL_DIG__ 17
#define __GCC_ATOMIC_CHAR32_T_LOCK_FREE 2
#define __UINT_FAST32_TYPE__ unsigned int
#define __UINT_FAST64_MAX__ 0xffffffffffffffffUL
#define __SIG_ATOMIC_TYPE__ int
#define __DBL_MIN_10_EXP__ (-307)
#define __FINITE_MATH_ONLY__ 0
#define __FLT32X_MAX_EXP__ 1024
#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_1 1
#define __GNUC_PATCHLEVEL__ 0
#define __FLT32_HAS_DENORM__ 1
#define __UINT_FAST8_MAX__ 0xff
#define __INT8_C(c) c
#define __INT_LEAST8_WIDTH__ 8
#define __INTMAX_TYPE__ long int
#define __UINT_LEAST64_MAX__ 0xffffffffffffffffUL
#define __SHRT_MAX__ 0x7fff
#define __LDBL_MAX__ 1.18973149535723176508575932662800702e+4932L
#define __ARM_FEATURE_IDIV 1
#define __FLT64X_MAX_10_EXP__ 4932
#define __ARM_FP 14
#define __FLT64X_HAS_QUIET_NAN__ 1
#define __UINT_LEAST8_MAX__ 0xff
#define __FLT128_DENORM_MIN__ 6.47517511943802511092443895822764655e-4966F128
#define __UINTMAX_TYPE__ long unsigned int
#define __FLT_EVAL_METHOD_TS_18661_3__ 0
#define __CHAR_UNSIGNED__ 1
#define __UINT32_MAX__ 0xffffffffU
#define __DBL_DENORM_MIN__ ((double)4.94065645841246544176568792868221372e-324L)
#define __AARCH64_CMODEL_SMALL__ 1
#define __LDBL_MAX_EXP__ 16384
#define __INT_FAST32_WIDTH__ 32
#define __FLT128_MIN_EXP__ (-16381)
#define __sun 1
#define __FLT128_MIN_10_EXP__ (-4931)
#define __INT_LEAST16_WIDTH__ 16
#define __FLT64X_MIN_EXP__ (-16381)
#define __SCHAR_MAX__ 0x7f
#define __FLT128_MANT_DIG__ 113
#define __DBL_MAX__ ((double)1.79769313486231570814527423731704357e+308L)
#define __WCHAR_MIN__ (-__WCHAR_MAX__ - 1)
#define __INT64_C(c) c ## L
#define __GCC_ATOMIC_POINTER_LOCK_FREE 2
#define __SIZEOF_INT__ 4
#define __INT_FAST64_WIDTH__ 64
#define __PRAGMA_REDEFINE_EXTNAME 1
#define __FLT32X_MANT_DIG__ 53
#define __USER_LABEL_PREFIX__ 
#define __FLT32_MAX_10_EXP__ 38
#define __FLT64X_EPSILON__ 1.92592994438723585305597794258492732e-34F64x
#define __STDC_HOSTED__ 1
#define __DBL_DIG__ 15
#define __FLT32_DIG__ 6
#define __FLT_EPSILON__ 1.19209289550781250000000000000000000e-7F
#define __SHRT_WIDTH__ 16
#define __LDBL_MIN__ 3.36210314311209350626267781732175260e-4932L
#define __WINT_TYPE__ int
#define __FLT16_HAS_QUIET_NAN__ 1
#define __ARM_SIZEOF_MINIMAL_ENUM 4
#define __FLT64X_DENORM_MIN__ 6.47517511943802511092443895822764655e-4966F64x
#define __FP_FAST_FMA 1
#define __FLT32X_HAS_INFINITY__ 1
#define __INT32_MAX__ 0x7fffffff
#define __FLT16_DIG__ 3
#define __INT_WIDTH__ 32
#define __SIZEOF_LONG__ 8
#define __UINT16_C(c) c
#define __DECIMAL_DIG__ 36
#define __FLT64_EPSILON__ 2.22044604925031308084726333618164062e-16F64
#define __INT16_MAX__ 0x7fff
#define __FLT64X_MIN_10_EXP__ (-4931)
#define __LDBL_HAS_QUIET_NAN__ 1
#define __FLT16_MIN_EXP__ (-13)
#define __FLT64_MANT_DIG__ 53
#define __FLT64X_MANT_DIG__ 113
#define __GNUC__ 10
#define __FLT_HAS_DENORM__ 1
#define __SIZEOF_LONG_DOUBLE__ 16
#define __LDBL_MIN_EXP__ (-16381)
#define __FLT64_MAX_10_EXP__ 308
#define __FLT16_MAX_10_EXP__ 4
#define __illumos__ 1
#define __FLT32_HAS_INFINITY__ 1
#define __INT_FAST32_MAX__ 0x7fffffff
#define __DBL_HAS_INFINITY__ 1
#define __HAVE_SPECULATION_SAFE_VALUE 1
#define __SVR4 1
#define __INTPTR_WIDTH__ 64
#define __FLT32X_HAS_DENORM__ 1
#define __INT_FAST16_TYPE__ int
#define __STRICT_ANSI__ 1
#define __LDBL_HAS_DENORM__ 1
#define __FLT128_HAS_INFINITY__ 1
#define __FLT32_DECIMAL_DIG__ 9
#define __DBL_MAX_EXP__ 1024
#define __WCHAR_WIDTH__ 32
#define __FLT32_MAX__ 3.40282346638528859811704183484516925e+38F32
#define __GCC_ATOMIC_LONG_LOCK_FREE 2
#define __FLT16_DECIMAL_DIG__ 5
#define __FLT32_HAS_QUIET_NAN__ 1
#define __LONG_LONG_MAX__ 0x7fffffffffffffffLL
#define __SIZEOF_SIZE_T__ 8
#define __SIG_ATOMIC_WIDTH__ 32
#define __ARM_ALIGN_MAX_PWR 28
#define __SIZEOF_WINT_T__ 4
#define __LONG_LONG_WIDTH__ 64
#define __FLT32_MAX_EXP__ 128
#define __ARM_FP16_FORMAT_IEEE 1
#define __FLT_MIN_EXP__ (-125)
#define __FLT64_NORM_MAX__ 1.79769313486231570814527423731704357e+308F64
#define __FLT32X_MIN_EXP__ (-1021)
#define __INT_FAST64_TYPE__ long int
#define __ARM_FP16_ARGS 1
#define __FP_FAST_FMAF 1
#define __FLT128_NORM_MAX__ 1.18973149535723176508575932662800702e+4932F128
#define __FLT64_DENORM_MIN__ 4.94065645841246544176568792868221372e-324F64
#define __DBL_MIN__ ((double)2.22507385850720138309023271733240406e-308L)
#define __ARM_FEATURE_CLZ 1
#define __FLT16_DENORM_MIN__ 5.96046447753906250000000000000000000e-8F16
#define __unix__ 1
#define __FLT64X_NORM_MAX__ 1.18973149535723176508575932662800702e+4932F64x
#define __SIZEOF_POINTER__ 8
#define __GXX_ABI_VERSION 1014
#define __LP64__ 1
#define __DBL_HAS_QUIET_NAN__ 1
#define __FLT_EVAL_METHOD_C99__ 0
#define __FLT32X_EPSILON__ 2.22044604925031308084726333618164062e-16F32x
#define __FLT64_MIN_EXP__ (-1021)
#define __UINT64_MAX__ 0xffffffffffffffffUL
#define __LDBL_DECIMAL_DIG__ 36
#define __FLT_MAX__ 3.40282346638528859811704183484516925e+38F
#define __aarch64__ 1
#define __FLT64_MIN_10_EXP__ (-307)
#define __FLT64X_DECIMAL_DIG__ 36
#define __REGISTER_PREFIX__ 
#define __UINT16_MAX__ 0xffff
#define __INTMAX_WIDTH__ 64
#define __LDBL_HAS_INFINITY__ 1
#define __FLT32_MIN__ 1.17549435082228750796873653722224568e-38F32
#define __FLT_DIG__ 6
#define __NO_INLINE__ 1
#define __DEC_EVAL_METHOD__ 2
#define __FLT_MANT_DIG__ 24
#define __FLT16_MIN_10_EXP__ (-4)
#define __VERSION__ "10.4.0"
#define __UINT64_C(c) c ## UL
#define __WINT_MAX__ 0x7fffffff
#define __INT_LEAST32_MAX__ 0x7fffffff
#define __GCC_ATOMIC_INT_LOCK_FREE 2
#define __FLT32X_MIN__ 2.22507385850720138309023271733240406e-308F32x
#define __FLT128_MAX_EXP__ 16384
#define __FLT32_MANT_DIG__ 24
#define __FLOAT_WORD_ORDER__ __ORDER_LITTLE_ENDIAN__
#define __FLT16_MAX_EXP__ 16
#define __BIGGEST_ALIGNMENT__ 16
#define __INT32_C(c) c
#define __FLT128_HAS_DENORM__ 1
#define __SCHAR_WIDTH__ 8
#define __ORDER_PDP_ENDIAN__ 3412
#define __ARM_64BIT_STATE 1
#define __INT_FAST32_TYPE__ int
#define __UINT_LEAST16_TYPE__ short unsigned int
#define __SIZE_TYPE__ long unsigned int
#define __FLT64X_DIG__ 33
#define __ARM_FEATURE_FMA 1
#define __INT8_TYPE__ signed char
#define __ELF__ 1
#define __GCC_ASM_FLAG_OUTPUTS__ 1
#define __GCC_ATOMIC_TEST_AND_SET_TRUEVAL 1
#define __FLT_RADIX__ 2
#define __INT_LEAST16_TYPE__ short int
#define __ARM_ARCH_PROFILE 65
#define __LDBL_EPSILON__ 1.92592994438723585305597794258492732e-34L
#define __UINTMAX_C(c) c ## UL
#define __ARM_PCS_AAPCS64 1
#define __SIG_ATOMIC_MAX__ 0x7fffffff
#define __GCC_ATOMIC_WCHAR_T_LOCK_FREE 2
#define __SIZEOF_PTRDIFF_T__ 8
#define __ATOMIC_RELAXED 0
#define __LDBL_DIG__ 33
#define __AARCH64EL__ 1
#define __INT_FAST16_MAX__ 0x7fffffff
#define __FLT64_DIG__ 15
#define __UINT_FAST32_MAX__ 0xffffffffU
#define __UINT_LEAST64_TYPE__ long unsigned int
#define __FLT16_EPSILON__ 9.76562500000000000000000000000000000e-4F16
#define __FLT_HAS_QUIET_NAN__ 1
#define __FLT_MAX_10_EXP__ 38
#define __LONG_MAX__ 0x7fffffffffffffffL
#define __FLT64X_HAS_DENORM__ 1
#define __FLT_HAS_INFINITY__ 1
#define __unix 1
#define __DBL_HAS_DENORM__ 1
#define __UINT_FAST16_TYPE__ unsigned int
#define __FLT32X_HAS_QUIET_NAN__ 1
#define __CHAR16_TYPE__ short unsigned int
#define __FLT64X_MAX_EXP__ 16384
#define __SIZE_WIDTH__ 64
#define __INT_LEAST16_MAX__ 0x7fff
#define __FLT16_NORM_MAX__ 6.55040000000000000000000000000000000e+4F16
#define __INT64_MAX__ 0x7fffffffffffffffL
#define __FLT32_DENORM_MIN__ 1.40129846432481707092372958328991613e-45F32
#define __INT_LEAST64_TYPE__ long int
#define __INT16_TYPE__ short int
#define __INT_LEAST8_TYPE__ signed char
#define __FLT16_MAX__ 6.55040000000000000000000000000000000e+4F16
#define __STDC_VERSION__ 199901L
#define __INT_FAST8_MAX__ 0x7f
#define __ARM_ARCH 8
#define __FLT128_MAX__ 1.18973149535723176508575932662800702e+4932F128
#define __INTPTR_MAX__ 0x7fffffffffffffffL
#define __ARM_FEATURE_UNALIGNED 1
#define __FLT64_HAS_QUIET_NAN__ 1
#define __FLT32_MIN_10_EXP__ (-37)
#define __FLT32X_DIG__ 15
#define __UINT8_TYPE__ unsigned char
#define __PTRDIFF_WIDTH__ 64
#define __svr4__ 1
#define __FLT64_HAS_INFINITY__ 1
#define __FLT64X_MAX__ 1.18973149535723176508575932662800702e+4932F64x
#define __FLT16_HAS_INFINITY__ 1
#define __SIG_ATOMIC_MIN__ (-__SIG_ATOMIC_MAX__ - 1)
#define __PTRDIFF_MAX__ 0x7fffffffffffffffL
#define __FLT16_MANT_DIG__ 11
#define __INTPTR_TYPE__ long int
#define __UINT16_TYPE__ short unsigned int
#define __WCHAR_TYPE__ int
#define __UINTPTR_MAX__ 0xffffffffffffffffUL
#define __ARM_ARCH_8A 1
#define __INT_FAST64_MAX__ 0x7fffffffffffffffL
#define __FLT_NORM_MAX__ 3.40282346638528859811704183484516925e+38F
#define __UINT_FAST64_TYPE__ long unsigned int
#define __INT_MAX__ 0x7fffffff
#define __INT64_TYPE__ long int
#define __FLT_MAX_EXP__ 128
#define __ORDER_BIG_ENDIAN__ 4321
#define __DBL_MANT_DIG__ 53
#define __INT_LEAST64_MAX__ 0x7fffffffffffffffL
#define __GCC_ATOMIC_CHAR16_T_LOCK_FREE 2
#define __FP_FAST_FMAF32 1
#define __UINT_LEAST32_TYPE__ unsigned int
#define __SIZEOF_SHORT__ 2
#define __FLT32_NORM_MAX__ 3.40282346638528859811704183484516925e+38F32
#define __GCC_ATOMIC_BOOL_LOCK_FREE 2
#define __FLT64_MAX__ 1.79769313486231570814527423731704357e+308F64
#define __WINT_WIDTH__ 32
#define __FP_FAST_FMAF64 1
#define __INT_LEAST8_MAX__ 0x7f
#define __INT_LEAST64_WIDTH__ 64
#define __FLT32X_MAX_10_EXP__ 308
#define __SIZEOF_INT128__ 16
#define __FLT16_MIN__ 6.10351562500000000000000000000000000e-5F16
#define __LDBL_MAX_10_EXP__ 4932
#define __DBL_EPSILON__ ((double)2.22044604925031308084726333618164062e-16L)
#define __FLT32_MIN_EXP__ (-125)
#define __FLT128_MIN__ 3.36210314311209350626267781732175260e-4932F128
#define _LP64 1
#define __UINT8_C(c) c
#define __FLT64_MAX_EXP__ 1024
#define __INT_LEAST32_TYPE__ int
#define __sun__ 1
#define __UINT64_TYPE__ long unsigned int
#define __ARM_FEATURE_CRC32 1
#define __ARM_NEON 1
#define __FLT128_HAS_QUIET_NAN__ 1
#define __INTMAX_MAX__ 0x7fffffffffffffffL
#define __UINT_FAST8_TYPE__ unsigned char
#define __INT_FAST8_TYPE__ signed char
#define __FLT64X_MIN__ 3.36210314311209350626267781732175260e-4932F64x
#define __GNUC_STDC_INLINE__ 1
#define __FLT64_HAS_DENORM__ 1
#define __FLT32_EPSILON__ 1.19209289550781250000000000000000000e-7F32
#define __FP_FAST_FMAF32x 1
#define __FLT16_HAS_DENORM__ 1
#define __INT_FAST8_WIDTH__ 8
#define __FLT32X_MAX__ 1.79769313486231570814527423731704357e+308F32x
#define __DBL_NORM_MAX__ ((double)1.79769313486231570814527423731704357e+308L)
#define __FLT64X_HAS_INFINITY__ 1
#define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__
#define __ARM_ALIGN_MAX_STACK_PWR 16
#define __LDBL_DENORM_MIN__ 6.47517511943802511092443895822764655e-4966L
#define __SIZEOF_WCHAR_T__ 4
#define __UINT32_C(c) c ## U
#define __FLT_DENORM_MIN__ 1.40129846432481707092372958328991613e-45F
#define __WINT_MIN__ (-__WINT_MAX__ - 1)
#define __INT8_MAX__ 0x7f
#define __LONG_WIDTH__ 64
#define __FLT32X_NORM_MAX__ 1.79769313486231570814527423731704357e+308F32x
#define __CHAR32_TYPE__ unsigned int
#define __ARM_FEATURE_NUMERIC_MAXMIN 1
#define __INT32_TYPE__ int
#define __SIZEOF_DOUBLE__ 8
#define __FLT_MIN_10_EXP__ (-37)
#define __FLT64_MIN__ 2.22507385850720138309023271733240406e-308F64
#define __INT_LEAST32_WIDTH__ 32
#define __SIZEOF_FLOAT__ 4
#define __ATOMIC_CONSUME 1
#define __GNUC_MINOR__ 4
#define __INT_FAST16_WIDTH__ 32
#define __UINTMAX_MAX__ 0xffffffffffffffffUL
#define __FLT32X_DENORM_MIN__ 4.94065645841246544176568792868221372e-324F32x
#define __DBL_MAX_10_EXP__ 308
#define __INT16_C(c) c
#define __ARM_ARCH_ISA_A64 1
#define __STDC__ 1
#define __PTRDIFF_TYPE__ long int
#define __ATOMIC_SEQ_CST 5
#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_16 1
#define __UINT32_TYPE__ unsigned int
#define __FLT32X_MIN_10_EXP__ (-307)
#define __UINTPTR_TYPE__ long unsigned int
#define __LDBL_MIN_10_EXP__ (-4931)
#define __FLT128_EPSILON__ 1.92592994438723585305597794258492732e-34F128
#define __SIZEOF_LONG_LONG__ 8
#define __FLT128_DECIMAL_DIG__ 36
#define __GCC_ATOMIC_LLONG_LOCK_FREE 2
#define __FLT_DECIMAL_DIG__ 9
#define __UINT_FAST16_MAX__ 0xffffffffU
#define __LDBL_NORM_MAX__ 1.18973149535723176508575932662800702e+4932L
#define __GCC_ATOMIC_SHORT_LOCK_FREE 2
#define __ORDER_LITTLE_ENDIAN__ 1234
#define __SIZE_MAX__ 0xffffffffffffffffUL
#define __UINT_LEAST32_MAX__ 0xffffffffU
#define __ATOMIC_ACQ_REL 4
#define __ATOMIC_RELEASE 3
```