### PR TITLE
sendmail: connect to the build

### DIFF
--- a/exception_lists/cstyle
+++ b/exception_lists/cstyle
@@ -1252,3 +1252,4 @@ usr/src/uts/intel/io/vmm/amd/ivrs_*.c
 usr/src/uts/intel/sys/vmm.h
 usr/src/uts/intel/sys/vmm_dev.h
 usr/src/lib/lib9p/common/*
+usr/src/cmd/sendmail/*

--- a/usr/src/cmd/Makefile
+++ b/usr/src/cmd/Makefile
@@ -346,6 +346,7 @@ COMMON_SUBDIRS=	\
 	scsi		\
 	sdiff		\
 	sed		\
+	sendmail	\
 	setfacl		\
 	setmnt		\
 	setpgrp		\
@@ -467,7 +468,6 @@ COMMON_SUBDIRS=	\
 # oawk - not 64bit clean?
 # prtdiag - not ported
 # refer - not 64bit clean
-# sendmail - not 64bit clean (probably our build of it is hosed)
 # sh - not 64bit clean
 # srchtxt - not 64bit clean
 # tput - not 64bit clean
@@ -495,7 +495,6 @@ $(NOT_AARCH64_BLD)COMMON_SUBDIRS +=	\
 	prtdiag		\
 	refer		\
 	rmformat	\
-	sendmail	\
 	sh		\
 	srchtxt		\
 	tput		\

--- a/usr/src/cmd/sendmail/db/db_int.h
+++ b/usr/src/cmd/sendmail/db/db_int.h
@@ -10,6 +10,8 @@
 #ifndef _DB_INTERNAL_H_
 #define	_DB_INTERNAL_H_
 
+#include <stddef.h>
+
 #include "db.h"				/* Standard DB include file. */
 #include "queue.h"
 #include "shqueue.h"
@@ -67,10 +69,10 @@
  * an array.
  */
 #undef	SSZ
-#define SSZ(name, field)	((int)&(((name *)0)->field))
+#define SSZ(name, field)	offsetof(name, field)
 
 #undef	SSZA
-#define SSZA(name, field)	((int)&(((name *)0)->field[0]))
+#define SSZA(name, field)	offsetof(name, field)
 
 /* Macros to return per-process address, offsets based on shared regions. */
 #define	R_ADDR(base, offset)	((void *)((u_int8_t *)((base)->addr) + offset))

--- a/usr/src/cmd/sendmail/libmilter/aarch64/Makefile
+++ b/usr/src/cmd/sendmail/libmilter/aarch64/Makefile
@@ -1,0 +1,28 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License, Version 1.0 only
+# (the "License").  You may not use this file except in compliance
+# with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+# Copyright 2004 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+include ../Makefile.com
+
+install: all $(ROOTLIBS) $(ROOTLINKS)

--- a/usr/src/cmd/sendmail/libmilter/listener.c
+++ b/usr/src/cmd/sendmail/libmilter/listener.c
@@ -576,7 +576,7 @@ mi_thread_handle_wrapper(arg)
 	**  is not used anywhere.
 	*/
 
-	return (void *) mi_handle_session(arg);
+	return (void *)(uintptr_t)mi_handle_session(arg);
 }
 #endif /* _FFR_WORKERS_POOL */
 

--- a/usr/src/cmd/sendmail/src/Makefile
+++ b/usr/src/cmd/sendmail/src/Makefile
@@ -41,6 +41,9 @@ OBJS= alias.o arpadate.o bf.o collect.o conf.o control.o convtime.o daemon.o \
 
 SRCS=	$(OBJS:%.o=%.c)
 
+# This is fine for aarch64 and not, as everyone else is 32bit
+LDFLAGS += -L$(ADJUNCT_PROTO)/usr/lib/mps
+
 MAPFILES =	$(MAPFILE.INT) $(MAPFILE.NGB)
 LDFLAGS +=	$(MAPFILES:%=-Wl,-M%)
 

--- a/usr/src/cmd/sendmail/util/Makefile
+++ b/usr/src/cmd/sendmail/util/Makefile
@@ -44,6 +44,9 @@ OBJS=		$(PROG:%=%.o)
 
 SRCS=		$(PROG:%=%.c)
 
+# This is fine for aarch64 and not, as everyone else is 32bit
+LDFLAGS += -L$(ADJUNCT_PROTO)/usr/lib/mps
+
 editmap :=	LDLIBS += -lldap
 mail.local :=	LDLIBS += -lsocket -lnsl -lmail -lldap
 mailq :=	LDLIBS += -lsecdb
@@ -65,7 +68,7 @@ CPPFLAGS =	$(INCPATH) $(ENVDEF) $(SUNENVDEF) $(DBMDEF) $(CPPFLAGS.sm)
 
 # Nearly every support application provides sleep().  This isn't incompatible
 # with libc, but can be confined to the applications themselves.
-LDFLAGS +=	$(MAPFILE.NGB:%=-Wl,-M%)
+LDFLAGS += $(MAPFILE.NGB:%=-Wl,-M%)
 
 .KEEP_STATE:
 

--- a/usr/src/lib/Makefile
+++ b/usr/src/lib/Makefile
@@ -69,10 +69,8 @@ SUBDIRS +=		\
 # are built in parallel.
 
 # XXXARM: Things not built for AArch64 right now
-# libmilter -- seems 32bit and not 64bit clean
 # abi -- not ported/necessary
 # c_synonyms -- not ported/necessary
-# pylibbe, pysolaris, pyzfs -- no python yet
 # libdtrace_jni -- java
 # libzfs_jni -- java
 # libadt_jni -- java
@@ -84,7 +82,6 @@ SUBDIRS +=		\
 # libcpc -- not ported
 # libpctx -- part of cpc
 $(NOT_AARCH64_BLD)SUBDIRS += \
-	../cmd/sendmail/libmilter \
 	abi \
 	c_synonyms	\
 	libadt_jni	\
@@ -98,6 +95,7 @@ $(NOT_AARCH64_BLD)SUBDIRS += \
 	libm1
 
 SUBDIRS +=				\
+	../cmd/sendmail/libmilter \
 	../cmd/sgs/librtld_db	\
 	../cmd/sgs/libelf	\
 	auditd_plugins	\
@@ -389,6 +387,7 @@ i386_MSGSUBDIRS= libfdisk
 aarch64_MSGSUBDIRS= libfdisk
 
 HDRSUBDIRS=		\
+	../cmd/sendmail/libmilter	\
 	auditd_plugins	\
 	fm		\
 	hal		\
@@ -530,7 +529,6 @@ sparc_HDRSUBDIRS=	\
 	storage
 
 $(NOT_AARCH64_BLD)HDRSUBDIRS +=		\
-	../cmd/sendmail/libmilter	\
 	libcpc				\
 	libdtrace_jni			\
 	libpctx				\

--- a/usr/src/pkg/manifests/service-network-smtp-sendmail.p5m
+++ b/usr/src/pkg/manifests/service-network-smtp-sendmail.p5m
@@ -33,174 +33,142 @@ set name=info.classification value=org.opensolaris.category.2008:System/Core
 set name=org.opensolaris.noincorp value=true
 set name=variant.arch value=$(ARCH)
 dir  path=etc group=sys
-$(not_aarch64)link path=etc/aliases target=./mail/aliases mediator=mta \
+link path=etc/aliases target=./mail/aliases mediator=mta \
     mediator-implementation=sendmail
 dir  path=etc/mail group=mail
-$(not_aarch64)file path=etc/mail/aliases \
-    original_name=SUNWsndm:etc/mail/aliases preserve=true
+file path=etc/mail/aliases original_name=SUNWsndm:etc/mail/aliases preserve=true
 dir  path=etc/mail/cf group=mail
-$(not_aarch64)file path=etc/mail/cf/README group=mail mode=0444
+file path=etc/mail/cf/README group=mail mode=0444
 dir  path=etc/mail/cf/cf group=mail
-$(not_aarch64)file path=etc/mail/cf/cf/Makefile group=mail mode=0444
-$(not_aarch64)link path=etc/mail/cf/cf/main.cf target=sendmail.cf
-$(not_aarch64)link path=etc/mail/cf/cf/main.mc target=sendmail.mc
-$(not_aarch64)file path=etc/mail/cf/cf/sendmail.cf group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/cf/sendmail.mc group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/cf/submit.cf group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/cf/submit.mc group=mail mode=0444
-$(not_aarch64)link path=etc/mail/cf/cf/subsidiary.cf target=sendmail.cf
-$(not_aarch64)link path=etc/mail/cf/cf/subsidiary.mc target=sendmail.mc
+file path=etc/mail/cf/cf/Makefile group=mail mode=0444
+link path=etc/mail/cf/cf/main.cf target=sendmail.cf
+link path=etc/mail/cf/cf/main.mc target=sendmail.mc
+file path=etc/mail/cf/cf/sendmail.cf group=mail mode=0444
+file path=etc/mail/cf/cf/sendmail.mc group=mail mode=0444
+file path=etc/mail/cf/cf/submit.cf group=mail mode=0444
+file path=etc/mail/cf/cf/submit.mc group=mail mode=0444
+link path=etc/mail/cf/cf/subsidiary.cf target=sendmail.cf
+link path=etc/mail/cf/cf/subsidiary.mc target=sendmail.mc
 dir  path=etc/mail/cf/domain group=mail
-$(not_aarch64)file path=etc/mail/cf/domain/generic.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/domain/solaris-antispam.m4 group=mail \
-    mode=0444
-$(not_aarch64)file path=etc/mail/cf/domain/solaris-generic.m4 group=mail \
-    mode=0444
+file path=etc/mail/cf/domain/generic.m4 group=mail mode=0444
+file path=etc/mail/cf/domain/solaris-antispam.m4 group=mail mode=0444
+file path=etc/mail/cf/domain/solaris-generic.m4 group=mail mode=0444
 dir  path=etc/mail/cf/feature group=mail
-$(not_aarch64)file path=etc/mail/cf/feature/accept_unqualified_senders.m4 \
-    group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/accept_unresolvable_domains.m4 \
-    group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/access_db.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/allmasquerade.m4 group=mail \
+file path=etc/mail/cf/feature/accept_unqualified_senders.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/accept_unresolvable_domains.m4 group=mail \
     mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/always_add_domain.m4 group=mail \
-    mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/badmx.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/bestmx_is_local.m4 group=mail \
-    mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/bitdomain.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/blacklist_recipients.m4 group=mail \
-    mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/block_bad_helo.m4 group=mail \
-    mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/compat_check.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/conncontrol.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/delay_checks.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/dnsbl.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/domaintable.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/enhdnsbl.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/generics_entire_domain.m4 \
-    group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/genericstable.m4 group=mail \
-    mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/greet_pause.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/ldap_routing.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/limited_masquerade.m4 group=mail \
-    mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/local_lmtp.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/local_no_masquerade.m4 group=mail \
-    mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/local_procmail.m4 group=mail \
-    mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/lookupdotdomain.m4 group=mail \
-    mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/loose_relay_check.m4 group=mail \
-    mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/mailertable.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/masquerade_entire_domain.m4 \
-    group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/masquerade_envelope.m4 group=mail \
-    mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/msp.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/mtamark.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/no_default_msa.m4 group=mail \
-    mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/nocanonify.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/notsticky.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/nouucp.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/nullclient.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/preserve_local_plus_detail.m4 \
-    group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/preserve_luser_host.m4 group=mail \
-    mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/promiscuous_relay.m4 group=mail \
-    mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/queuegroup.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/ratecontrol.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/redirect.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/relay_based_on_MX.m4 group=mail \
-    mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/relay_entire_domain.m4 group=mail \
-    mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/relay_hosts_only.m4 group=mail \
-    mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/relay_local_from.m4 group=mail \
-    mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/relay_mail_from.m4 group=mail \
-    mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/require_rdns.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/smrsh.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/stickyhost.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/use_client_ptr.m4 group=mail \
-    mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/use_ct_file.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/use_cw_file.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/uucpdomain.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/virtuser_entire_domain.m4 \
-    group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/feature/virtusertable.m4 group=mail \
-    mode=0444
+file path=etc/mail/cf/feature/access_db.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/allmasquerade.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/always_add_domain.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/badmx.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/bestmx_is_local.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/bitdomain.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/blacklist_recipients.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/block_bad_helo.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/compat_check.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/conncontrol.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/delay_checks.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/dnsbl.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/domaintable.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/enhdnsbl.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/generics_entire_domain.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/genericstable.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/greet_pause.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/ldap_routing.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/limited_masquerade.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/local_lmtp.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/local_no_masquerade.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/local_procmail.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/lookupdotdomain.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/loose_relay_check.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/mailertable.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/masquerade_entire_domain.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/masquerade_envelope.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/msp.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/mtamark.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/no_default_msa.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/nocanonify.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/notsticky.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/nouucp.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/nullclient.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/preserve_local_plus_detail.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/preserve_luser_host.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/promiscuous_relay.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/queuegroup.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/ratecontrol.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/redirect.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/relay_based_on_MX.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/relay_entire_domain.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/relay_hosts_only.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/relay_local_from.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/relay_mail_from.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/require_rdns.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/smrsh.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/stickyhost.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/use_client_ptr.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/use_ct_file.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/use_cw_file.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/uucpdomain.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/virtuser_entire_domain.m4 group=mail mode=0444
+file path=etc/mail/cf/feature/virtusertable.m4 group=mail mode=0444
 dir  path=etc/mail/cf/m4 group=mail
-$(not_aarch64)file path=etc/mail/cf/m4/cf.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/m4/cfhead.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/m4/proto.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/m4/version.m4 group=mail mode=0444
+file path=etc/mail/cf/m4/cf.m4 group=mail mode=0444
+file path=etc/mail/cf/m4/cfhead.m4 group=mail mode=0444
+file path=etc/mail/cf/m4/proto.m4 group=mail mode=0444
+file path=etc/mail/cf/m4/version.m4 group=mail mode=0444
 dir  path=etc/mail/cf/mailer group=mail
-$(not_aarch64)file path=etc/mail/cf/mailer/local.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/mailer/procmail.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/mailer/smtp.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/mailer/uucp.m4 group=mail mode=0444
+file path=etc/mail/cf/mailer/local.m4 group=mail mode=0444
+file path=etc/mail/cf/mailer/procmail.m4 group=mail mode=0444
+file path=etc/mail/cf/mailer/smtp.m4 group=mail mode=0444
+file path=etc/mail/cf/mailer/uucp.m4 group=mail mode=0444
 dir  path=etc/mail/cf/ostype group=mail
-$(not_aarch64)file path=etc/mail/cf/ostype/solaris2.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/ostype/solaris2.ml.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/ostype/solaris2.pre5.m4 group=mail mode=0444
-$(not_aarch64)file path=etc/mail/cf/ostype/solaris8.m4 group=mail mode=0444
+file path=etc/mail/cf/ostype/solaris2.m4 group=mail mode=0444
+file path=etc/mail/cf/ostype/solaris2.ml.m4 group=mail mode=0444
+file path=etc/mail/cf/ostype/solaris2.pre5.m4 group=mail mode=0444
+file path=etc/mail/cf/ostype/solaris8.m4 group=mail mode=0444
 dir  path=etc/mail/cf/sh group=mail
-$(not_aarch64)link path=etc/mail/cf/sh/check-hostname \
+link path=etc/mail/cf/sh/check-hostname \
     target=../../../../usr/sbin/check-hostname
-$(not_aarch64)link path=etc/mail/cf/sh/check-permissions \
+link path=etc/mail/cf/sh/check-permissions \
     target=../../../../usr/sbin/check-permissions
-$(not_aarch64)file path=etc/mail/cf/sh/makeinfo.sh group=mail mode=0444
-$(not_aarch64)file path=etc/mail/helpfile
-$(not_aarch64)file path=etc/mail/local-host-names \
+file path=etc/mail/cf/sh/makeinfo.sh group=mail mode=0444
+file path=etc/mail/helpfile
+file path=etc/mail/local-host-names \
     original_name=SUNWsndm:etc/mail/local-host-names preserve=true
-$(not_aarch64)link path=etc/mail/main.cf target=sendmail.cf
-$(not_aarch64)file path=etc/mail/sendmail.cf mode=0444 \
+link path=etc/mail/main.cf target=sendmail.cf
+file path=etc/mail/sendmail.cf mode=0444 \
     original_name=SUNWsndm:etc/mail/sendmail.cf preserve=renameold
-$(not_aarch64)link path=etc/mail/sendmail.hf target=helpfile
-$(not_aarch64)file path=etc/mail/submit.cf mode=0444 \
+link path=etc/mail/sendmail.hf target=helpfile
+file path=etc/mail/submit.cf mode=0444 \
     original_name=SUNWsndm:etc/mail/submit.cf preserve=renameold
-$(not_aarch64)link path=etc/mail/subsidiary.cf target=sendmail.cf
-$(not_aarch64)file path=etc/mail/trusted-users \
-    original_name=SUNWsndm:etc/mail/trusted-users preserve=true
+link path=etc/mail/subsidiary.cf target=sendmail.cf
+file path=etc/mail/trusted-users original_name=SUNWsndm:etc/mail/trusted-users \
+    preserve=true
 dir  path=lib
 dir  path=lib/svc
 dir  path=lib/svc/manifest group=sys
 dir  path=lib/svc/manifest/network group=sys
-$(not_aarch64)file path=lib/svc/manifest/network/sendmail-client.xml group=sys \
-    mode=0444
-$(not_aarch64)file path=lib/svc/manifest/network/smtp-sendmail.xml group=sys \
-    mode=0444
+file path=lib/svc/manifest/network/sendmail-client.xml group=sys mode=0444
+file path=lib/svc/manifest/network/smtp-sendmail.xml group=sys mode=0444
 dir  path=lib/svc/method
-$(not_aarch64)file path=lib/svc/method/sendmail-client mode=0555
-$(not_aarch64)file path=lib/svc/method/smtp-sendmail mode=0555
+file path=lib/svc/method/sendmail-client mode=0555
+file path=lib/svc/method/smtp-sendmail mode=0555
 dir  path=lib/svc/share
 file path=lib/svc/share/sendmail_include.sh mode=0444
 dir  path=usr group=sys
 dir  path=usr/bin
-$(not_aarch64)file path=usr/bin/mailcompat mode=0555
+file path=usr/bin/mailcompat mode=0555
 link path=usr/bin/mailq target=../lib/smtp/sendmail/mailq mediator=mta \
     mediator-implementation=sendmail
-$(not_aarch64)file path=usr/bin/mailstats mode=0555
-$(not_aarch64)file path=usr/bin/mconnect mode=0555
-$(not_aarch64)file path=usr/bin/praliases mode=0555
-$(not_aarch64)file path=usr/bin/vacation mode=0555
+file path=usr/bin/mailstats mode=0555
+file path=usr/bin/mconnect mode=0555
+file path=usr/bin/praliases mode=0555
+file path=usr/bin/vacation mode=0555
 dir  path=usr/include
 dir  path=usr/include/libmilter
-$(not_aarch64)file path=usr/include/libmilter/README
-$(not_aarch64)file path=usr/include/libmilter/mfapi.h
-$(not_aarch64)file path=usr/include/libmilter/mfdef.h
+file path=usr/include/libmilter/README
+file path=usr/include/libmilter/mfapi.h
+file path=usr/include/libmilter/mfdef.h
 dir  path=usr/lib
 dir  path=usr/lib/help
 dir  path=usr/lib/help/auths
@@ -208,24 +176,24 @@ dir  path=usr/lib/help/auths/locale
 dir  path=usr/lib/help/auths/locale/C
 file path=usr/lib/help/auths/locale/C/MailHeader.html
 file path=usr/lib/help/auths/locale/C/MailQueue.html
-$(not_aarch64)link path=usr/lib/libmilter.so target=libmilter.so.1
-$(not_aarch64)file path=usr/lib/libmilter.so.1
-$(not_aarch64)link path=usr/lib/mail target=../../etc/mail/cf
-$(not_aarch64)file path=usr/lib/mail.local mode=0555
-$(not_aarch64)link path=usr/lib/sendmail target=../lib/smtp/sendmail/sendmail \
-    mediator=mta mediator-implementation=sendmail
-$(not_aarch64)file path=usr/lib/smrsh mode=0555
-$(not_aarch64)dir path=usr/lib/smtp
-$(not_aarch64)dir path=usr/lib/smtp/sendmail
-$(not_aarch64)file path=usr/lib/smtp/sendmail/mailq mode=4555
-$(not_aarch64)link path=usr/lib/smtp/sendmail/newaliases target=sendmail
-$(not_aarch64)file path=usr/lib/smtp/sendmail/sendmail group=smmsp mode=2555
+link path=usr/lib/libmilter.so target=libmilter.so.1
+file path=usr/lib/libmilter.so.1
+link path=usr/lib/mail target=../../etc/mail/cf
+file path=usr/lib/mail.local mode=0555
+link path=usr/lib/sendmail target=../lib/smtp/sendmail/sendmail mediator=mta \
+    mediator-implementation=sendmail
+file path=usr/lib/smrsh mode=0555
+dir  path=usr/lib/smtp
+dir  path=usr/lib/smtp/sendmail
+file path=usr/lib/smtp/sendmail/mailq mode=4555
+link path=usr/lib/smtp/sendmail/newaliases target=sendmail
+file path=usr/lib/smtp/sendmail/sendmail group=smmsp mode=2555
 dir  path=usr/sbin
-$(not_aarch64)file path=usr/sbin/check-hostname group=mail mode=0555
-$(not_aarch64)file path=usr/sbin/check-permissions group=mail mode=0555
-$(not_aarch64)file path=usr/sbin/editmap mode=0555
-$(not_aarch64)file path=usr/sbin/etrn mode=0555
-$(not_aarch64)file path=usr/sbin/makemap mode=0555
+file path=usr/sbin/check-hostname group=mail mode=0555
+file path=usr/sbin/check-permissions group=mail mode=0555
+file path=usr/sbin/editmap mode=0555
+file path=usr/sbin/etrn mode=0555
+file path=usr/sbin/makemap mode=0555
 link path=usr/sbin/newaliases target=../lib/smtp/sendmail/newaliases \
     mediator=mta mediator-implementation=sendmail
 link path=usr/sbin/sendmail target=../lib/smtp/sendmail/sendmail mediator=mta \
@@ -261,8 +229,8 @@ dir  path=var group=sys
 dir  path=var/adm group=sys mode=0775
 dir  path=var/adm/sm.bin group=sys
 dir  path=var/spool
-$(not_aarch64)dir path=var/spool/clientmqueue owner=smmsp group=smmsp mode=0770
-$(not_aarch64)dir path=var/spool/mqueue mode=0750
+dir  path=var/spool/clientmqueue owner=smmsp group=smmsp mode=0770
+dir  path=var/spool/mqueue mode=0750
 group groupname=smmsp gid=25
 user username=smmsp ftpuser=false \
     gcos-field="SendMail Message Submission Program" group=smmsp home-dir=/ \
@@ -272,6 +240,6 @@ legacy pkg=SUNWsndmu desc="Sendmail Utilities" name="Sendmail (/usr)"
 license cr_Sun license=cr_Sun
 license lic_CDDL license=lic_CDDL
 # XXXARM: Because we don't actually build sendmail, we don't get the license
-$(not_aarch64)license usr/src/cmd/sendmail/THIRDPARTYLICENSE \
+license usr/src/cmd/sendmail/THIRDPARTYLICENSE \
     license=usr/src/cmd/sendmail/THIRDPARTYLICENSE
 depend type=require fmri=runtime/perl$(PERL_PKGVERS)


### PR DESCRIPTION
The problems in sendmail were:
 - a homebrew and incorrect offsetof(),
 - a warning that they comment doesn't matter
 - escaping `ADJUNCT_PROTO` when looking for nspr and friends.
 - assuming time_t was 32bit when calculating file IDs (thanks Andy Fiddaman for diagnosing that).

It seems likely, given everything, that other 32bit-isms may lurk in this version of sendmail, but basic functionality works to the degree I can test it.