### PR TITLE
aarch64: use virtual counter

### DIFF
--- a/usr/src/psm/stand/boot/aarch64/Makefile.com
+++ b/usr/src/psm/stand/boot/aarch64/Makefile.com
@@ -39,6 +39,7 @@ DTC_BASE	= $(EXTRA)/dtc
 SRT0_O = srt0.o
 OBJS +=				\
 	aarch64_subr.o		\
+	arch_timer.o		\
 	assfail.o		\
 	bitext.o		\
 	boot_aarch64.o		\

--- a/usr/src/psm/stand/boot/aarch64/common/arch_timer.c
+++ b/usr/src/psm/stand/boot/aarch64/common/arch_timer.c
@@ -1,0 +1,186 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2023 Brian McKenzie
+ */
+
+/*
+ * Generic timer interface.
+ */
+
+#include <sys/types.h>
+#include <sys/promif.h>
+#include <sys/controlregs.h>
+#include <sys/arch_timer.h>
+
+#include "arch_timer_private.h"
+
+/* Generic timer control bits */
+#define	CNT_CTL_ENABLE	(1u << 0)
+#define	CNT_CTL_IMASK	(1u << 1)
+#define	CNT_CTL_ISTATUS	(1u << 2)
+
+struct arch_timer_ops {
+	void (*write_cnt_cval)(uint64_t);
+	uint64_t (*read_cnt_ctl)(void);
+	void (*write_cnt_ctl)(uint64_t);
+	uint64_t (*read_cnt_ct)(void);
+};
+
+static struct arch_timer_ops timer_ops[] = {
+	[TMR_PHYS] = {
+		.write_cnt_cval = write_cntp_cval,
+		.read_cnt_ctl = read_cntp_ctl,
+		.write_cnt_ctl = write_cntp_ctl,
+		.read_cnt_ct = read_cntpct,
+	},
+	[TMR_VIRT] = {
+		.write_cnt_cval = write_cntv_cval,
+		.read_cnt_ctl = read_cntv_ctl,
+		.write_cnt_ctl = write_cntv_ctl,
+		.read_cnt_ct = read_cntvct,
+	},
+};
+
+static struct arch_timer_ops *ops;
+
+static uint64_t timer_freq = 0;
+
+void
+arch_timer_mask_irq(void)
+{
+	uint64_t ctl;
+
+	ctl = ops->read_cnt_ctl();
+	ctl |= CNT_CTL_IMASK;
+	ops->write_cnt_ctl(ctl);
+}
+
+void
+arch_timer_unmask_irq(void)
+{
+	uint64_t ctl;
+
+	ctl = ops->read_cnt_ctl();
+	ctl &= ~CNT_CTL_IMASK;
+	ops->write_cnt_ctl(ctl);
+}
+
+void
+arch_timer_enable(void)
+{
+	uint64_t ctl;
+
+	ctl = ops->read_cnt_ctl();
+	ctl |= CNT_CTL_ENABLE;
+	ops->write_cnt_ctl(ctl);
+}
+
+void
+arch_timer_disable(void)
+{
+	uint64_t ctl;
+
+	ctl = ops->read_cnt_ctl();
+	ctl &= ~CNT_CTL_ENABLE;
+	ops->write_cnt_ctl(ctl);
+}
+
+void
+arch_timer_set_cval(uint64_t cval)
+{
+	ops->write_cnt_cval(cval);
+}
+
+static void
+arch_timer_find_node(pnode_t node, void *arg)
+{
+	if (!prom_is_compatible(node, "arm,armv8-timer"))
+		return;
+
+	*(pnode_t *)arg = node;
+}
+
+static uint64_t
+arch_timer_find_clock_freq(void)
+{
+	pnode_t node;
+	uint64_t freq = 0;
+
+	prom_walk(arch_timer_find_node, &node);
+
+	if (node > 0)
+		freq = prom_get_prop_int(node, "clock-frequency", 0);
+
+	return (freq);
+}
+
+uint64_t
+arch_timer_freq(void)
+{
+	if (timer_freq)
+		return (timer_freq);
+
+	/*
+	 * Attempt to get the clock frequency from the device tree before
+	 * falling back to cntfrq_el0. This is a workaround for systems where
+	 * the the firmware either misconfigures or never sets cntfrq_el0.
+	 */
+	if ((timer_freq = arch_timer_find_clock_freq()) > 0)
+		return (timer_freq);
+
+	if ((timer_freq = read_cntfrq()) > 0)
+		return (timer_freq);
+
+	/* If we got here then we don't have a frequency at all. */
+	prom_panic("arch_timer_freq: missing frequency\n");
+
+	/* NOTREACHED */
+	return (0);
+}
+
+uint64_t
+arch_timer_count(void)
+{
+	return (ops->read_cnt_ct());
+}
+
+void
+arch_timer_select(arch_timer_t type)
+{
+	ops = &timer_ops[type];
+}
+
+void
+init_arch_timer(arch_timer_t type)
+{
+	arch_timer_select(type);
+	arch_timer_set_cval(CNT_CVAL_MAX);
+	arch_timer_enable();
+}
+
+void
+arch_timer_udelay(uint32_t us)
+{
+	int32_t delay;
+	uint32_t first, last;
+	uint32_t ticks_per_usec = (arch_timer_freq() / 1000000) + 1;
+
+	first = arch_timer_count();
+	delay = us * ticks_per_usec;
+
+	while (delay > 0) {
+		last = arch_timer_count();
+		delay -= (last - first);
+		first = last;
+	}
+}

--- a/usr/src/psm/stand/boot/aarch64/common/arch_timer_private.h
+++ b/usr/src/psm/stand/boot/aarch64/common/arch_timer_private.h
@@ -1,0 +1,35 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2023 Brian McKenzie
+ */
+
+/*
+ * Private prototypes and definitions for the generic timer interface.
+ */
+
+#ifndef __COMMON_ARCH_TIMER_PRIVATE_H
+#define	__COMMON_ARCH_TIMER_PRIVATE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <sys/arch_timer.h>
+
+extern void init_arch_timer(arch_timer_t type);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __COMMON_ARCH_TIMER_PRIVATE_H */

--- a/usr/src/psm/stand/boot/aarch64/common/prom_gettime.c
+++ b/usr/src/psm/stand/boot/aarch64/common/prom_gettime.c
@@ -24,10 +24,9 @@
 
 #include <sys/promif.h>
 #include <sys/sysmacros.h>
-#include <sys/controlregs.h>
+#include <sys/arch_timer.h>
 
 u_int prom_gettime(void)
 {
-	return read_cntpct() * 10000 / read_cntfrq();
+	return arch_timer_count() * 10000 / arch_timer_freq();
 }
-

--- a/usr/src/psm/stand/boot/aarch64/meson-gxbb/dwmac.c
+++ b/usr/src/psm/stand/boot/aarch64/meson-gxbb/dwmac.c
@@ -29,6 +29,7 @@
 #include <sys/byteorder.h>
 #include <sys/sysmacros.h>
 #include <sys/controlregs.h>
+#include <sys/arch_timer.h>
 #include <sys/platmod.h>
 
 #include <sys/boot.h>
@@ -72,11 +73,7 @@ static struct emac_sc *emac_dev[3];
 static void
 emac_usecwait(int usec)
 {
-	uint64_t cnt = (read_cntpct() / (read_cntfrq() / 1000000)) + usec + 2;
-	for (;;) {
-		if ((read_cntpct() / (read_cntfrq() / 1000000)) > cnt)
-			break;
-	}
+	arch_timer_udelay(usec);
 }
 
 static void

--- a/usr/src/psm/stand/boot/aarch64/meson-gxbb/machdep.c
+++ b/usr/src/psm/stand/boot/aarch64/meson-gxbb/machdep.c
@@ -46,6 +46,8 @@
 #include <sys/bootvfs.h>
 #include <sys/psci.h>
 #include <sys/gxbb_smc.h>
+#include <sys/arch_timer.h>
+#include "arch_timer_private.h"
 #include "ramdisk.h"
 #include "dwmac.h"
 #include "boot_plat.h"
@@ -327,6 +329,7 @@ void init_machdev(void)
 	prom_getprop(prom_rootnode(), "compatible", compatible + strlen(str) + 1);
 	prom_setprop(prom_rootnode(), "compatible", compatible, namelen);
 
+	init_arch_timer(TMR_PHYS);
 	init_dwmac();
 	init_mmc();
 }

--- a/usr/src/psm/stand/boot/aarch64/meson-gxbb/mmc.c
+++ b/usr/src/psm/stand/boot/aarch64/meson-gxbb/mmc.c
@@ -30,6 +30,7 @@
 #include <sys/byteorder.h>
 #include <sys/sysmacros.h>
 #include <sys/controlregs.h>
+#include <sys/arch_timer.h>
 #include <sys/dditypes.h>
 #include <sys/devops.h>
 #include <sys/sdcard/sda.h>
@@ -69,17 +70,13 @@ static struct mmc_sc *mmc_dev[3];
 static void
 usecwait(int usec)
 {
-	uint64_t cnt = (read_cntpct() / (read_cntfrq() / 1000000)) + usec + 2;
-	for (;;) {
-		if ((read_cntpct() / (read_cntfrq() / 1000000)) > cnt)
-			break;
-	}
+	arch_timer_udelay(usec);
 }
 
 static uint64_t
 get_usec()
 {
-	return (read_cntpct() / (read_cntfrq() / 1000000));
+	return (arch_timer_count() / (arch_timer_freq() / 1000000));
 }
 
 static void

--- a/usr/src/psm/stand/boot/aarch64/rpi4/genet.c
+++ b/usr/src/psm/stand/boot/aarch64/rpi4/genet.c
@@ -29,6 +29,7 @@
 #include <sys/byteorder.h>
 #include <sys/sysmacros.h>
 #include <sys/controlregs.h>
+#include <sys/arch_timer.h>
 #include <sys/platmod.h>
 #include <sys/platform.h>
 #include <sys/miiregs.h>
@@ -63,11 +64,7 @@ static struct genet_sc *genet_dev[3];
 static void
 genet_usecwait(int usec)
 {
-	uint64_t cnt = (read_cntpct() / (read_cntfrq() / 1000000)) + usec + 2;
-	for (;;) {
-		if ((read_cntpct() / (read_cntfrq() / 1000000)) > cnt)
-			break;
-	}
+	arch_timer_udelay(usec);
 }
 
 static void

--- a/usr/src/psm/stand/boot/aarch64/rpi4/machdep.c
+++ b/usr/src/psm/stand/boot/aarch64/rpi4/machdep.c
@@ -45,6 +45,8 @@
 #include <netinet/inetutil.h>
 #include <sys/bootvfs.h>
 #include <sys/psci.h>
+#include <sys/arch_timer.h>
+#include "arch_timer_private.h"
 #include "ramdisk.h"
 #include "boot_plat.h"
 #include "genet.h"
@@ -357,6 +359,7 @@ void init_machdev(void)
 	prom_getprop(prom_rootnode(), "compatible", compatible + strlen(str) + 1);
 	prom_setprop(prom_rootnode(), "compatible", compatible, namelen);
 
+	init_arch_timer(TMR_PHYS);
 	init_genet();
 	init_mmc();
 }

--- a/usr/src/psm/stand/boot/aarch64/rpi4/mmc.c
+++ b/usr/src/psm/stand/boot/aarch64/rpi4/mmc.c
@@ -30,6 +30,7 @@
 #include <sys/byteorder.h>
 #include <sys/sysmacros.h>
 #include <sys/controlregs.h>
+#include <sys/arch_timer.h>
 #include <sys/dditypes.h>
 #include <sys/devops.h>
 #include <sys/sdcard/sda.h>
@@ -68,17 +69,13 @@ static struct mmc_sc *mmc_dev[3];
 static void
 usecwait(int usec)
 {
-	uint64_t cnt = (read_cntpct() / (read_cntfrq() / 1000000)) + usec + 2;
-	for (;;) {
-		if ((read_cntpct() / (read_cntfrq() / 1000000)) > cnt)
-			break;
-	}
+	arch_timer_udelay(usec);
 }
 
 static uint64_t
 get_usec()
 {
-	return (read_cntpct() / (read_cntfrq() / 1000000));
+	return (arch_timer_count() / (arch_timer_freq() / 1000000));
 }
 
 static void

--- a/usr/src/psm/stand/boot/aarch64/virt/machdep.c
+++ b/usr/src/psm/stand/boot/aarch64/virt/machdep.c
@@ -45,6 +45,8 @@
 #include <netinet/inetutil.h>
 #include <sys/bootvfs.h>
 #include <sys/psci.h>
+#include <sys/arch_timer.h>
+#include "arch_timer_private.h"
 #include "ramdisk.h"
 #include "boot_plat.h"
 #include "virtnet.h"
@@ -441,6 +443,7 @@ void init_machdev(void)
 	prom_getprop(prom_rootnode(), "compatible", compatible + strlen(str) + 1);
 	prom_setprop(prom_rootnode(), "compatible", compatible, namelen);
 
+	init_arch_timer(TMR_PHYS);
 	init_virtnet();
 	init_virtblk();
 }

--- a/usr/src/uts/aarch64/asm/controlregs.h
+++ b/usr/src/uts/aarch64/asm/controlregs.h
@@ -165,6 +165,14 @@ read_cntpct(void)
 }
 
 static inline uint64_t
+read_cntvct(void)
+{
+	uint64_t reg;
+	__asm__ __volatile__("mrs %0, cntvct_el0":"=r"(reg)::"memory");
+	return (reg);
+}
+
+static inline uint64_t
 read_cntfrq(void)
 {
 	uint64_t reg;
@@ -206,6 +214,48 @@ read_cntp_tval(void)
 	uint64_t reg;
 	__asm__ __volatile__("mrs %0, cntp_tval_el0":"=r"(reg)::"memory");
 	return (reg);
+}
+
+static inline uint64_t
+read_cntv_ctl(void)
+{
+	uint64_t reg;
+	__asm__ __volatile__("mrs %0, cntv_ctl_el0":"=r"(reg)::"memory");
+	return (reg);
+}
+
+static inline void
+write_cntv_ctl(uint64_t reg)
+{
+	__asm__ __volatile__("msr cntv_ctl_el0, %0"::"r"(reg):"memory");
+}
+
+static inline uint64_t
+read_cntv_cval(void)
+{
+	uint64_t reg;
+	__asm__ __volatile__("mrs %0, cntv_cval_el0":"=r"(reg)::"memory");
+	return (reg);
+}
+
+static inline void
+write_cntv_cval(uint64_t reg)
+{
+	__asm__ __volatile__("msr cntv_cval_el0, %0"::"r"(reg):"memory");
+}
+
+static inline uint64_t
+read_cntv_tval(void)
+{
+	uint64_t reg;
+	__asm__ __volatile__("mrs %0, cntv_tval_el0":"=r"(reg)::"memory");
+	return (reg);
+}
+
+static inline void
+write_cntv_tval(uint64_t reg)
+{
+	__asm__ __volatile__("msr cntv_tval_el0, %0"::"r"(reg):"memory");
 }
 
 static inline void
@@ -434,7 +484,6 @@ write_cpacr_el1(uint64_t reg)
 #define	DAIF_IRQ	(1 << 7)
 #define	DAIF_SERROR	(1 << 8)
 #define	DAIF_DEBUG	(1 << 9)
-
 
 static inline uint64_t
 read_daif(void)

--- a/usr/src/uts/aarch64/os/archdep.c
+++ b/usr/src/uts/aarch64/os/archdep.c
@@ -50,6 +50,7 @@
 #include <sys/kobj.h>
 #include <sys/promif.h>
 #include <sys/sysmacros.h>
+#include <sys/arch_timer.h>
 
 uint_t adj_shift;
 
@@ -209,11 +210,11 @@ gethrtime_waitfree(void)
 hrtime_t
 gethrtime(void)
 {
-	uint64_t pct = read_cntpct();
-	uint64_t timer_freq = read_cntfrq();
+	uint64_t ct = arch_timer_count();
+	uint64_t timer_freq = arch_timer_freq();
 
-	uint64_t x = pct / timer_freq;
-	uint64_t y = pct % timer_freq;
+	uint64_t x = ct / timer_freq;
+	uint64_t y = ct % timer_freq;
 	hrtime_t nsec = x * NANOSEC + y * NANOSEC / timer_freq;
 	return (nsec);
 }
@@ -221,14 +222,14 @@ gethrtime(void)
 hrtime_t
 gethrtime_unscaled(void)
 {
-	return (hrtime_t)read_cntpct();
+	return (hrtime_t)arch_timer_count();
 }
 
 void
 scalehrtime(hrtime_t *hrt)
 {
 	hrtime_t pct = *hrt;
-	uint64_t timer_freq = read_cntfrq();
+	uint64_t timer_freq = arch_timer_freq();
 
 	uint64_t x = pct / timer_freq;
 	uint64_t y = pct % timer_freq;
@@ -239,7 +240,7 @@ scalehrtime(hrtime_t *hrt)
 uint64_t
 unscalehrtime(hrtime_t nsec)
 {
-	uint64_t timer_freq = read_cntfrq();
+	uint64_t timer_freq = arch_timer_freq();
 
 	uint64_t x = nsec / NANOSEC;
 	uint64_t y = nsec % NANOSEC;
@@ -256,11 +257,11 @@ gethrestime(timespec_t *tp)
 hrtime_t
 dtrace_gethrtime(void)
 {
-	uint64_t pct = read_cntpct();
-	uint64_t timer_freq = read_cntfrq();
+	uint64_t ct = arch_timer_count();
+	uint64_t timer_freq = arch_timer_freq();
 
-	uint64_t x = pct / timer_freq;
-	uint64_t y = pct % timer_freq;
+	uint64_t x = ct / timer_freq;
+	uint64_t y = ct % timer_freq;
 	hrtime_t nsec = x * NANOSEC + y * NANOSEC / timer_freq;
 	return (nsec);
 }

--- a/usr/src/uts/aarch64/sys/arch_timer.h
+++ b/usr/src/uts/aarch64/sys/arch_timer.h
@@ -1,0 +1,50 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2023 Brian McKenzie
+ */
+
+/*
+ * Prototypes and definitions for the generic timer interface.
+ */
+
+#ifndef __SYS_ARCH_TIMER_H
+#define	__SYS_ARCH_TIMER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <sys/types.h>
+
+#define	CNT_CVAL_MAX	0xfffffffffffffffful
+
+typedef enum arch_timer_type {
+	TMR_PHYS,
+	TMR_VIRT,
+} arch_timer_t;
+
+extern void arch_timer_mask_irq(void);
+extern void arch_timer_unmask_irq(void);
+extern void arch_timer_enable(void);
+extern void arch_timer_disable(void);
+extern void arch_timer_set_cval(uint64_t cval);
+extern uint64_t arch_timer_freq(void);
+extern uint64_t arch_timer_count(void);
+extern void arch_timer_select(arch_timer_t type);
+extern void arch_timer_udelay(uint32_t us);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __SYS_ARCH_TIMER_H */

--- a/usr/src/uts/aarch64/sys/mutex_impl.h
+++ b/usr/src/uts/aarch64/sys/mutex_impl.h
@@ -100,7 +100,7 @@ typedef union mutex_impl {
 			}
 
 /* low overhead clock read */
-#define	MUTEX_GETTICK()	read_cntpct()
+#define	MUTEX_GETTICK()	arch_timer_count()
 extern void null_xcall(void);
 #define	MUTEX_SYNC()	{	\
 			cpuset_t set;   \

--- a/usr/src/uts/armv8/Makefile.files
+++ b/usr/src/uts/armv8/Makefile.files
@@ -67,7 +67,8 @@ CORE_OBJS +=			\
 	notes.o			\
 	hold_page.o		\
 	ssp.o			\
-	psci.o
+	psci.o			\
+	arch_timer.o
 
 CORE_OBJS += $(PCI_STRING_OBJS)
 

--- a/usr/src/uts/armv8/ml/swtch.S
+++ b/usr/src/uts/armv8/ml/swtch.S
@@ -180,7 +180,7 @@
 	ldrh	w0, [x19, #T_FLAG]
 	ands	w0, w0, #T_INTR_THREAD
 	b.eq	1f
-	mrs	x0, cntpct_el0
+	bl	arch_timer_count
 	str	x0, [x19, #T_INTR_START]
 1:
 	bl	__dtrace_probe___sched_on__cpu
@@ -289,7 +289,7 @@
 	ldrh	w0, [x19, #T_FLAG]
 	ands	w0, w0, #T_INTR_THREAD
 	b.eq	1f
-	mrs	x0, cntpct_el0
+	bl	arch_timer_count
 	str	x0, [x19, #T_INTR_START]
 1:
 	bl	__dtrace_probe___sched_on__cpu

--- a/usr/src/uts/armv8/os/arch_timer.c
+++ b/usr/src/uts/armv8/os/arch_timer.c
@@ -1,0 +1,177 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2023 Brian McKenzie
+ */
+
+/*
+ * Generic timer interface.
+ */
+
+#include <sys/types.h>
+#include <sys/promif.h>
+#include <sys/cmn_err.h>
+#include <sys/controlregs.h>
+#include <sys/arch_timer.h>
+
+/* Generic timer control bits */
+#define	CNT_CTL_ENABLE	(1u << 0)
+#define	CNT_CTL_IMASK	(1u << 1)
+#define	CNT_CTL_ISTATUS	(1u << 2)
+
+struct arch_timer_ops {
+	void (*write_cnt_cval)(uint64_t);
+	uint64_t (*read_cnt_ctl)(void);
+	void (*write_cnt_ctl)(uint64_t);
+	uint64_t (*read_cnt_ct)(void);
+};
+
+static struct arch_timer_ops timer_ops[] = {
+	[TMR_PHYS] = {
+		.write_cnt_cval = write_cntp_cval,
+		.read_cnt_ctl = read_cntp_ctl,
+		.write_cnt_ctl = write_cntp_ctl,
+		.read_cnt_ct = read_cntpct,
+	},
+	[TMR_VIRT] = {
+		.write_cnt_cval = write_cntv_cval,
+		.read_cnt_ctl = read_cntv_ctl,
+		.write_cnt_ctl = write_cntv_ctl,
+		.read_cnt_ct = read_cntvct,
+	},
+};
+
+static struct arch_timer_ops *ops;
+
+static uint64_t timer_freq = 0;
+
+void
+arch_timer_mask_irq(void)
+{
+	uint64_t ctl;
+
+	ctl = ops->read_cnt_ctl();
+	ctl |= CNT_CTL_IMASK;
+	ops->write_cnt_ctl(ctl);
+}
+
+void
+arch_timer_unmask_irq(void)
+{
+	uint64_t ctl;
+
+	ctl = ops->read_cnt_ctl();
+	ctl &= ~CNT_CTL_IMASK;
+	ops->write_cnt_ctl(ctl);
+}
+
+void
+arch_timer_enable(void)
+{
+	uint64_t ctl;
+
+	ctl = ops->read_cnt_ctl();
+	ctl |= CNT_CTL_ENABLE;
+	ops->write_cnt_ctl(ctl);
+}
+
+void
+arch_timer_disable(void)
+{
+	uint64_t ctl;
+
+	ctl = ops->read_cnt_ctl();
+	ctl &= ~CNT_CTL_ENABLE;
+	ops->write_cnt_ctl(ctl);
+}
+
+void
+arch_timer_set_cval(uint64_t cval)
+{
+	ops->write_cnt_cval(cval);
+}
+
+static void
+arch_timer_find_node(pnode_t node, void *arg)
+{
+	if (!prom_is_compatible(node, "arm,armv8-timer"))
+		return;
+
+	*(pnode_t *)arg = node;
+}
+
+static uint64_t
+arch_timer_find_clock_freq(void)
+{
+	pnode_t node;
+	uint64_t freq = 0;
+
+	prom_walk(arch_timer_find_node, &node);
+
+	if (node > 0)
+		freq = prom_get_prop_int(node, "clock-frequency", 0);
+
+	return (freq);
+}
+
+uint64_t
+arch_timer_freq(void)
+{
+	if (timer_freq)
+		return (timer_freq);
+
+	/*
+	 * Attempt to get the clock frequency from the device tree before
+	 * falling back to cntfrq_el0. This is a workaround for systems where
+	 * the the firmware either misconfigures or never sets cntfrq_el0.
+	 */
+	if ((timer_freq = arch_timer_find_clock_freq()) > 0)
+		return (timer_freq);
+
+	if ((timer_freq = read_cntfrq()) > 0)
+		return (timer_freq);
+
+	/* If we got here then we don't have a frequency at all. */
+	cmn_err(CE_PANIC, "arch_timer_freq: missing frequency");
+
+	/* NOTREACHED */
+	return (0);
+}
+
+uint64_t
+arch_timer_count(void)
+{
+	return (ops->read_cnt_ct());
+}
+
+void
+arch_timer_select(arch_timer_t type)
+{
+	ops = &timer_ops[type];
+}
+
+void
+arch_timer_udelay(uint32_t us)
+{
+	int32_t delay;
+	uint32_t first, last;
+	uint32_t ticks_per_usec = (arch_timer_freq() / 1000000) + 1;
+
+	first = arch_timer_count();
+	delay = us * ticks_per_usec;
+
+	while (delay > 0) {
+		last = arch_timer_count();
+		delay -= (last - first);
+		first = last;
+	}
+}

--- a/usr/src/uts/armv8/os/machdep.c
+++ b/usr/src/uts/armv8/os/machdep.c
@@ -53,6 +53,7 @@
 #include <sys/controlregs.h>
 #include <sys/x_call.h>
 #include <sys/consdev.h>
+#include <sys/arch_timer.h>
 
 int maxphys = MMU_PAGESIZE * 16;	/* 128k */
 int klustsize = MMU_PAGESIZE * 16;	/* 128k */
@@ -118,7 +119,7 @@ console_exit(int busy, int spl)
 u_longlong_t
 randtick(void)
 {
-	return (read_cntpct());
+	return (arch_timer_count());
 }
 
 void
@@ -131,11 +132,11 @@ tenmicrosec(void)
 		while (gethrtime() < end)
 			SMT_PAUSE();
 	} else {
-		uint64_t timer_freq = read_cntfrq();
-		uint64_t end_count = read_cntpct() + timer_freq /
+		uint64_t timer_freq = arch_timer_freq();
+		uint64_t end_count = arch_timer_count() + timer_freq /
 		    (MICROSEC / 10);
 
-		while (read_cntpct() < end_count)
+		while (arch_timer_count() < end_count)
 			SMT_PAUSE();
 	}
 }

--- a/usr/src/uts/armv8/os/ssp.c
+++ b/usr/src/uts/armv8/os/ssp.c
@@ -74,7 +74,7 @@
 #include <sys/cmn_err.h>
 #include <sys/time.h>
 #include <sys/note.h>
-#include <sys/controlregs.h>
+#include <sys/arch_timer.h>
 
 /*
  * The symbol __stack_chk_guard contains the magic guard value used
@@ -107,7 +107,7 @@ __stack_chk_fail(void)
 
 static void salsa_hash(unsigned int *);
 
-#define	SSP_GET_TICK read_cntpct
+#define	SSP_GET_TICK arch_timer_count
 
 /* called from os/startup.c */
 void

--- a/usr/src/uts/armv8/os/startup.c
+++ b/usr/src/uts/armv8/os/startup.c
@@ -85,6 +85,7 @@
 #include <sys/gic.h>
 #include <sys/psci.h>
 #include <sys/controlregs.h>
+#include <sys/arch_timer.h>
 
 extern void brand_init(void);
 extern void pcf_init(void);
@@ -1107,7 +1108,7 @@ set_soft_hostid(void)
 			(void) modunload(i);
 		}
 		if (hostid == HW_INVALID_HOSTID) {
-			tsc = read_cntpct();
+			tsc = arch_timer_count();
 			hostid = (int32_t)tsc & 0x0CFFFFF;
 		}
 	} else {

--- a/usr/src/uts/armv8/sys/machcpuvar.h
+++ b/usr/src/uts/armv8/sys/machcpuvar.h
@@ -62,6 +62,8 @@ struct	machcpu {
 	char		*mcpu_revision;
 	uint64_t	mcpu_midr;
 	uint64_t	mcpu_revidr;
+
+	uint64_t	mcpu_boot_el;
 };
 
 #ifndef NINTR_THREADS

--- a/usr/src/uts/armv8/vm/vm_dep.h
+++ b/usr/src/uts/armv8/vm/vm_dep.h
@@ -45,14 +45,14 @@ extern "C" {
 #include <sys/param.h>
 #include <sys/memnode.h>
 #include <sys/atomic.h>
-#include <sys/controlregs.h>
+#include <sys/arch_timer.h>
 
 
 /*
  * WARNING: vm_dep.h is included by files in common.
  */
 
-#define	GETTICK()	read_cntpct()
+#define	GETTICK()	arch_timer_count()
 /*
  * Do not use this function for obtaining clock tick.  This
  * is called by callers who do not need to have a guarenteed

--- a/usr/src/uts/common/sys/cpc_impl.h
+++ b/usr/src/uts/common/sys/cpc_impl.h
@@ -208,19 +208,8 @@ enum dcpc_mask_attr {
 extern uint64_t ultra_gettick(void);
 #define	KCPC_GET_TICK ultra_gettick
 #elif defined(__aarch64__)
-/*
- * XXXARM: this is _wrong_ - the OS should only read the CNTVCT, phys is
- * (mostly) for type 2 hypervisors.
- *
- * In a processor that doesn't support the virtualization extensions, CNTVCT is
- * identical to CNTPCT.
- *
- * Why not CNTPCT?
- * ... Is always accessible from PL1 modes. However, if hypervisor extensions
- * are supported accesses to CNTPCT will generate a hyp-trap from PL1 unless
- * CNTHCTL.PL1PCTEN is set to 1.
- */
-#define	KCPC_GET_TICK read_cntpct
+extern uint64_t arch_timer_count(void);
+#define	KCPC_GET_TICK arch_timer_count
 #else
 extern hrtime_t tsc_read(void);
 #define	KCPC_GET_TICK tsc_read


### PR DESCRIPTION
The physical counter is mostly reserved for hypervisors.

Any non-secure access to CNTPCT_EL0 may be trapped to EL2 if EL2 is enabled by the current security state, unless CNTHCTL_EL2.EL0PCTEN = 1.

See p. 7859 and p. 7933 of the ARM ARM for more details.