### PR TITLE
libc: preserve the TCB when recycling `ulwp_t` on variant 1 TLS platforms

### DIFF
--- a/usr/src/lib/libc/port/locale/localeimpl.c
+++ b/usr/src/lib/libc/port/locale/localeimpl.c
@@ -316,7 +316,7 @@ locdata_get(int category, const char *locname)
 	int len;
 	int i;
 
-	if (locname == NULL || *locname == 0) {
+	if (locname == NULL || *locname == '\0') {
 		locname = get_locale_env(category);
 	}
 

--- a/usr/src/lib/libc/port/threads/thr.c
+++ b/usr/src/lib/libc/port/threads/thr.c
@@ -225,8 +225,9 @@ hash_out(ulwp_t *ulwp, uberdata_t *udp)
 }
 
 /*
- * Retain stack information for thread structures that are being recycled for
- * new threads.  All other members of the thread structure should be zeroed.
+ * Retain stack information (and on variant 1, the TCB) for thread structures
+ * that are being recycled for new threads.  All other members of the thread
+ * structure should be zeroed.
  */
 static void
 ulwp_clean(ulwp_t *ulwp)
@@ -236,6 +237,9 @@ ulwp_clean(ulwp_t *ulwp)
 	size_t guardsize = ulwp->ul_guardsize;
 	uintptr_t stktop = ulwp->ul_stktop;
 	size_t stksiz = ulwp->ul_stksiz;
+#if _TLS_VARIANT == 1
+	tcb_t tcb = ulwp->ul_tcb;
+#endif
 
 	(void) memset(ulwp, 0, sizeof (*ulwp));
 
@@ -244,6 +248,9 @@ ulwp_clean(ulwp_t *ulwp)
 	ulwp->ul_guardsize = guardsize;
 	ulwp->ul_stktop = stktop;
 	ulwp->ul_stksiz = stksiz;
+#if _TLS_VARIANT == 1
+	ulwp->ul_tcb = tcb;
+#endif
 }
 
 static int stackprot;


### PR DESCRIPTION
Previously, when we recycled a thread off the dead list, we'd zero the whole `ulwp_t` except for the stack information.  On variant 1 TLS platforms we absolutely must preserve the `tcb_t` too, as it's where the thread-pointer points.

Failure to do this means that `__curthread()` (two-underscores) will return NULL, while `_curthread()` (one-underscore) will continue to return our `ulwp_t` (see the difference between the two described in thr_inlines.h).

There are as you may imagine varied symptoms to this.  The primary and most noticeable happens due to an optimization in `lmalloc()`.  If `__curthread()` is `NULL` lmalloc uses the global `&__uberdata` but also _does not do any locking_ on the assumption that there is only one thread.  Because of the cleared TCB of any recycled thread this means that any recycled thread did no locking during internal to libc allocation.

The most common, but difficult, symptom of this is that two threads, in `lmalloc()` for a small allocation at the same time, could receive the same pointer in return.  Further symptoms include freelist corruption, other symptoms of the inherent use-after-free when one thread frees this memory, and double free when the other does as well.

The most repeatable symptom of this is that libc-test's `wcsrtombs()` test would fail in the threaded case repeatably, but after a variable amount of time and in variable ways.  The rapid cycling through threads in this test practically guaranteeing that we'd recycle them often, and lose one of the races.  Other victims of this same basic issue would be atexit(3C) and related, and error reporting in the case of assertion failures or libc panicks, and the failure of thr_main(3C).

It is possible, but not confirmed, that the occasional bad `lfree()` from svc.configd(8) is this same bug.

---

@rmustacc this is the bug I've been talking to you about -- with a much more embarrassing cause than I'd ever predicted.  I'd be grateful if you and @citrus-it could take a thoughtful look at it.

Something I've been wondering (and failing at) is whether we can assert the `ulwp_t` is fine, given that prior to `libc_init` it will definitely not be. 