### PR TITLE
Refactor GICv2 support into a module

### DIFF
--- a/usr/src/pkg/manifests/system-kernel-platform.p5m
+++ b/usr/src/pkg/manifests/system-kernel-platform.p5m
@@ -51,6 +51,7 @@ $(aarch64_ONLY)file path=platform/armv8/kernel/dacf/aarch64/consconfig_dacf \
     mode=0755
 $(aarch64_ONLY)dir path=platform/armv8/kernel/drv
 $(aarch64_ONLY)dir path=platform/armv8/kernel/drv/aarch64
+$(aarch64_ONLY)file path=platform/armv8/kernel/drv/aarch64/gicv2
 $(aarch64_ONLY)file path=platform/armv8/kernel/drv/aarch64/ns16550a
 $(aarch64_ONLY)file path=platform/armv8/kernel/drv/aarch64/rootnex
 $(aarch64_ONLY)file path=platform/armv8/kernel/drv/aarch64/simple-bus

--- a/usr/src/uts/aarch64/promif/prom_utils.c
+++ b/usr/src/uts/aarch64/promif/prom_utils.c
@@ -275,3 +275,37 @@ prom_is_compatible(pnode_t node, const char *name)
 	}
 	return (B_FALSE);
 }
+
+pnode_t
+prom_find_compatible(pnode_t node, const char *compatible)
+{
+	pnode_t child;
+
+	if (prom_is_compatible(node, compatible))
+		return (node);
+
+	child = prom_childnode(node);
+
+	while (child > 0) {
+		node = prom_find_compatible(child, compatible);
+		if (node > 0)
+			return (node);
+
+		child = prom_nextnode(child);
+	}
+
+	return (OBP_NONODE);
+}
+
+boolean_t
+prom_has_compatible(const char *compatible)
+{
+	pnode_t node;
+
+	node = prom_find_compatible(prom_rootnode(), compatible);
+
+	if (node == OBP_NONODE)
+		return (B_FALSE);
+
+	return (B_TRUE);
+}

--- a/usr/src/uts/aarch64/sys/gic.h
+++ b/usr/src/uts/aarch64/sys/gic.h
@@ -21,6 +21,7 @@
  */
 /*
  * Copyright 2017 Hayashi Naoyuki
+ * Copyright 2023 Michael van der Westhuizen
  */
 
 #ifndef _SYS_GIC_H
@@ -402,11 +403,48 @@ struct gic_cpuif {
 void gic_mask_level_irq(int irq);
 void gic_unmask_level_irq(int irq);
 
-void gic_send_ipi(cpuset_t cpuset, uint32_t irq);
+void gic_send_ipi(cpuset_t cpuset, int irq);
+int gic_init(void);
 void gic_init_primary(void);
 void gic_init_secondary(int);
 void gic_config_irq(uint32_t irq, bool is_edge);
 int gic_num_cpus(void);
+
+/*
+ * Types and data structure filled by GIC implementation modukles
+ */
+typedef void (*mask_level_irq_t)(int irq);
+typedef void (*unmask_level_irq_t)(int irq);
+typedef void (*send_ipi_t)(cpuset_t cpuset, int irq);
+typedef void (*init_primary_t)(void);
+typedef void (*init_secondary_t)(int id);
+typedef void (*config_irq_t)(uint32_t irq, bool is_edge);
+typedef int (*num_cpus_t)(void);
+typedef int (*addspl_t)(int irq, int ipl, int min_ipl, int max_ipl);
+typedef int (*delspl_t)(int irq, int ipl, int min_ipl, int max_ipl);
+typedef int (*setlvl_t)(int irq);
+typedef void (*setlvlx_t)(int ipl, int irq);
+
+typedef struct gic_ops {
+	mask_level_irq_t	mask_level_irq;
+	unmask_level_irq_t	unmask_level_irq;
+	send_ipi_t		send_ipi;
+	init_primary_t		init_primary;
+	init_secondary_t	init_secondary;
+	config_irq_t		config_irq;
+	num_cpus_t		num_cpus;
+	addspl_t		addspl;
+	delspl_t		delspl;
+	setlvl_t		setlvl;
+	setlvlx_t		setlvlx;
+} gic_ops_t;
+
+extern gic_ops_t gic_ops;
+
+/*
+ * Populated when MMIO access to the CPU interface is needed.
+ */
+extern volatile struct gic_cpuif *gic_cpuif;
 
 #ifdef __cplusplus
 }

--- a/usr/src/uts/aarch64/sys/promif.h
+++ b/usr/src/uts/aarch64/sys/promif.h
@@ -258,6 +258,8 @@ extern int prom_get_prop_index(pnode_t node, const char *prop_name,
     const char *name);
 extern void prom_driver_register(const struct prom_compat *data);
 extern boolean_t prom_is_compatible(pnode_t node, const char *name);
+extern pnode_t prom_find_compatible(pnode_t node, const char *compatible);
+extern boolean_t prom_has_compatible(const char *compatible);
 extern void prom_walk(void(*func)(pnode_t, void*), void *arg);
 extern int prom_get_reg_address(pnode_t node, int index, uint64_t *reg);
 extern int prom_get_reg_size(pnode_t node, int index, uint64_t *regsize);

--- a/usr/src/uts/armv8/Makefile.armv8
+++ b/usr/src/uts/armv8/Makefile.armv8
@@ -199,5 +199,6 @@ GENASSYM_DEFS	 = $(MACHINE_DEFS) $(OPTION_DEFS) \
 DRV_KMODS += simple-bus
 DRV_KMODS += rootnex
 DRV_KMODS += ns16550a
+DRV_KMODS += gicv2
 
 DACF_KMODS += consconfig_dacf

--- a/usr/src/uts/armv8/Makefile.files
+++ b/usr/src/uts/armv8/Makefile.files
@@ -78,6 +78,8 @@ ROOTNEX_OBJS += rootnex.o
 
 NS16550A_OBJS += ns16550a.o
 
+GICV2_OBJS += gicv2.o
+
 ASSYM_DEPS +=			\
 	aarch64_subr.o		\
 	copy.o			\

--- a/usr/src/uts/armv8/gicv2/Makefile
+++ b/usr/src/uts/armv8/gicv2/Makefile
@@ -1,0 +1,65 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2023 Michael van der Westhuizen
+#
+
+#
+#	Path to the base of the uts directory tree (usually /usr/src/uts).
+#
+UTSBASE	= ../..
+
+#
+#	Define the module and object file sets.
+#
+MODULE		= gicv2
+OBJECTS		= $(GICV2_OBJS:%=$(OBJS_DIR)/%)
+ROOTMODULE	= $(ROOT_PSM_DRV_DIR)/$(MODULE)
+CONF_SRCDIR	= $(UTSBASE)/armv8/os/
+
+#
+#	Include common rules.
+#
+include $(UTSBASE)/armv8/Makefile.armv8
+
+#
+#       Define targets
+#
+ALL_TARGET	= $(BINARY)
+INSTALL_TARGET	= $(BINARY) $(ROOTMODULE)
+
+#
+#	Overrides
+#
+ALL_BUILDS	= $(ALL_BUILDSONLY64)
+DEF_BUILDS	= $(DEF_BUILDSONLY64)
+
+#
+#	Default build targets.
+#
+.KEEP_STATE:
+
+all:		$(ALL_DEPS)
+
+def:		$(DEF_DEPS)
+
+clean:		$(CLEAN_DEPS)
+
+clobber:	$(CLOBBER_DEPS)
+
+install:	$(INSTALL_DEPS)
+
+
+#
+#	Include common targets.
+#
+include $(UTSBASE)/armv8/Makefile.targ

--- a/usr/src/uts/armv8/os/gic.c
+++ b/usr/src/uts/armv8/os/gic.c
@@ -1,550 +1,191 @@
 /*
- * CDDL HEADER START
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
  *
- * The contents of this file are subject to the terms of the
- * Common Development and Distribution License (the "License").
- * You may not use this file except in compliance with the License.
- *
- * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
- * or http://www.opensolaris.org/os/licensing.
- * See the License for the specific language governing permissions
- * and limitations under the License.
- *
- * When distributing Covered Code, include this CDDL HEADER in each
- * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
- * If applicable, add the following below this CDDL HEADER, with the
- * fields enclosed by brackets "[]" replaced with your own identifying
- * information: Portions Copyright [yyyy] [name of copyright owner]
- *
- * CDDL HEADER END
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
  */
 
 /*
- * Copyright 2017 Hayashi Naoyuki
+ * Copyright 2023 Michael van der Westhuizen
  */
 
 #include <sys/types.h>
 #include <sys/gic.h>
-#include <sys/avintr.h>
-#include <sys/smp_impldefs.h>
+#include <sys/cmn_err.h>
 #include <sys/promif.h>
+#include <sys/errno.h>
+#include <sys/modctl.h>
+
+static void stub_not_config(void);
+static void stub_setlvlx(int ipl, int irq);
 
 /*
- * These are shadowed copies of GICD_IPRIORITYR<0-7>, and GICD_ISENABLER[0]
- *
- * That is the priority and enabled status of SGIs and PPIs, which are CPU
- * local, and the registers for same are banked per-CPU in the distributor.
- *
- * XXXARM: It's possible these were intended to keep these in sync across all
- * CPUs, but they don't outside of initial config.
+ * Used by implementations to ensure that they only fill in gic_ops when
+ * appropriate.
  */
-static volatile uint32_t ipriorityr_private[8];
-static volatile uint32_t ienable_private;
+char *gic_module_name = NULL;
 
 /*
- * This is used to record whether an IRQ is edge or level triggered.
- * A set bit in this mask is an edge triggered interrupt, a 0 is level triggered.
- *
- * We use this in `gic_mask_level_irq` and `gic_unmask_level_irq` to decide
- * whether to enable or disable that IRQ, these functions ignore
- * edge-triggered interrupts.  This is set when `gic_config_irq` and never
- * altered (which makes sense).
+ * This is terrible, The interrupt trap code needs the GIC
+ * CPU interface base address for GICv2. In implementations
+ * that implement the system register interface we have to
+ * leave this NULL so that the code in ml/exceptions.S can
+ * identify the right thing to do.
  */
-static uint32_t intr_cfg[1024 / 32];
+volatile struct gic_cpuif *gic_cpuif = NULL;
 
-/*
- * Protect access to global GIC state.
- * In the current implementation, the distributor.
- */
-lock_t gic_lock;
+gic_ops_t gic_ops = {
+	.mask_level_irq		= (mask_level_irq_t)stub_not_config,
+	.unmask_level_irq	= (mask_level_irq_t)stub_not_config,
+	.send_ipi		= (send_ipi_t)stub_not_config,
+	.init_primary		= (init_primary_t)stub_not_config,
+	.init_secondary		= (init_secondary_t)stub_not_config,
+	.config_irq		= (config_irq_t)stub_not_config,
+	.num_cpus		= (num_cpus_t)stub_not_config,
+	.addspl			= (addspl_t)stub_not_config,
+	.delspl			= (delspl_t)stub_not_config,
+	.setlvl			= (setlvl_t)stub_not_config,
+	.setlvlx		= stub_setlvlx
+};
 
-/* Base addresses of the cpu interface and distributor */
-volatile struct gic_cpuif *gic_cpuif;
-volatile struct gic_dist *gic_dist;
-
-/*
- * Mapping from cpuid to GIC target identifier
- * XXXARM: Another place we cap at 8 CPUs
- */
-static uint8_t gic_target[8];
-
-/*
- * CPUs for which we have initialized the GIC.  Used to limit IPIs to only
- * those CPUs we can target.
- */
-static cpuset_t gic_cpuset;
-
-/*
- * Enable IRQ in the distributor, which will now be forwarded to a cpu.
- *
- * It is IMPLEMENTATION DEFINED whether SGIs can be enabled or disabled here,
- * we never try.
- */
 static void
-gic_enable_irq(int irq)
+stub_not_config(void)
 {
-	if (irq >= GIC_INTID_MIN_PPI) {
-		gic_dist->isenabler[GICD_IRQ_TO_ISENABLER(irq)] =
-		    GICD_IRQ_TO_ISENABLER_FIELD(irq);
-	}
+	prom_panic("GIC not configured\n");
 }
 
-/*
- * Disable IRQ in the distributor, which will now cease being forwarded to a
- * cpu.
- *
- * It is IMPLEMENTATION DEFINED whether SGIs can be enabled or disabled here,
- * we never try.
- */
 static void
-gic_disable_irq(int irq)
+stub_setlvlx(int ipl, int irq)
 {
-	if (irq >= GIC_INTID_MIN_PPI) {
-		gic_dist->icenabler[GICD_IRQ_TO_ISENABLER(irq)] =
-		    GICD_IRQ_TO_ISENABLER_FIELD(irq);
-	}
+	/*
+	 * Nothing to do here.
+	 *
+	 * setlvlx is called while locking and printing in the early kmem_init
+	 * path (console_{enter,exit}, putq, cprintf) and in startup (cmn_err
+	 * and mod_setup, reaching many of the same locks as in the kmem_init
+	 * path).
+	 *
+	 * Adjusting the priority level this early is unnecessary, since
+	 * interrupts are completely disabled. Locking is also unnecessary,
+	 * since only one CPU is running. However, avoiding these calls in this
+	 * case would overly complicate the general case of running the system,
+	 * so we just allow to calls to be no-ops prior to loading a GIC
+	 * implementation module.
+	 */
 }
 
-/*
- * If this is a level-triggered IRQ which is not an SGI, enable it
- * See comments about SGIs in enable/disable_irq
- */
-void
-gic_unmask_level_irq(int irq)
-{
-	if ((irq >= GIC_INTID_MIN_PPI) &&
-	    ((intr_cfg[irq / 32] & (1u << (irq % 32))) == 0)) {
-		ASSERT(irq != 225);
-		gic_enable_irq(irq);
-	}
-}
-
-/*
- * If this is a level-triggered IRQ which is not an SGI, disable it
- * See comments about SGIs in enable/disable_irq
- */
 void
 gic_mask_level_irq(int irq)
 {
-	if ((irq >= GIC_INTID_MIN_PPI) &&
-	    ((intr_cfg[irq / 32] & (1u << (irq % 32))) == 0)) {
-		ASSERT(irq != 225);
-		gic_disable_irq(irq);
-	}
+	gic_ops.mask_level_irq(irq);
 }
 
-/*
- * Configure whether IRQ is edge or level triggered.
- * Additionally record this in in `intr_cfg`.
- */
+void
+gic_unmask_level_irq(int irq)
+{
+	gic_ops.unmask_level_irq(irq);
+}
+
+void
+gic_send_ipi(cpuset_t cpuset, int irq)
+{
+	gic_ops.send_ipi(cpuset, irq);
+}
+
+void
+gic_init_primary(void)
+{
+	gic_ops.init_primary();
+}
+
+void
+gic_init_secondary(int id)
+{
+	gic_ops.init_secondary(id);
+}
+
 void
 gic_config_irq(uint32_t irq, bool is_edge)
 {
-	uint32_t v = (is_edge ? 0x2 : 0);
-
-	/*
-	 * §8.9.7 Software must disable an interrupt before the value of the
-	 * corresponding programmable Int_config field is changed. GIC
-	 * behavior is otherwise UNPREDICTABLE.
-	 */
-	ASSERT((gic_dist->isenabler[GICD_IRQ_TO_ISENABLER(irq)] &
-	    GICD_IRQ_TO_ISENABLER_FIELD(irq)) == 0);
-
-	/*
-	 * GICD_ICFGR<n> is a packed field with 2 bits per interrupt, the even
-	 * bit is reserved, the odd bit is 1 for edge-triggered 0 for
-	 * level.
-	 */
-	gic_dist->icfgr[GICD_IRQ_TO_ICFGR(irq)] =
-	    (gic_dist->icfgr[GICD_IRQ_TO_ICFGR(irq)] &
-	    ~GICD_IRQ_TO_ICFGR_FIELD(irq, 0x3)) |
-	    GICD_IRQ_TO_ICFGR_FIELD(irq, v);
-
-	if (is_edge)
-		intr_cfg[irq / 32] |= (1u << (irq % 32));
-	else
-		intr_cfg[irq / 32] &= ~(1u << (irq % 32));
+	gic_ops.config_irq(irq, is_edge);
 }
 
-/*
- * Mask interrupts of priority lower than or equal to IRQ.
- */
 int
-setlvl(int irq)
+gic_num_cpus(void)
 {
-	int new_ipl;
-	new_ipl = autovect[irq].avh_hi_pri;
-
-	if (new_ipl != 0) {
-		gic_cpuif->pmr = GIC_IPL_TO_PRI(new_ipl);
-	}
-
-	return (new_ipl);
+	return (gic_ops.num_cpus());
 }
 
-/*
- * Unmask level IRQ if it's level triggered and mask interrupts
- * less than or equal to IPL.
- *
- * XXXARM: Is this really what setlvlx should do?
- */
-void
-setlvlx(int ipl, int irq)
-{
-	/*
-	 * Allow code to pass a -1 IRQ to just change GICC_PMR
-	 * see armv8/intr.c:do_splx(), among others.
-	 */
-	if (irq >= 0)
-		gic_unmask_level_irq(irq);
-	gic_cpuif->pmr = GIC_IPL_TO_PRI(ipl);
-}
-
-/*
- * Set the priority of IRQ to IPL
- * If IRQ is an SGI or PPI, shadow that priority into `ipriorityr_private`
- */
-static void
-gic_set_ipl(uint32_t irq, uint32_t ipl)
-{
-	uint64_t old = read_daif();
-	set_daif(DAIF_SETCLEAR_IRQ);
-	lock_set(&gic_lock);
-
-	uint32_t ipriorityr = gic_dist->ipriorityr[GICD_IRQ_TO_IPRIORITYR(irq)];
-	ipriorityr &= ~(GICD_IRQ_TO_IPRIORITYR_FIELD(irq, 0xff));
-	ipriorityr |= GICD_IRQ_TO_IPRIORITYR_FIELD(irq, GIC_IPL_TO_PRI(ipl));
-	gic_dist->ipriorityr[GICD_IRQ_TO_IPRIORITYR(irq)] = ipriorityr;
-
-	if (irq <= GIC_INTID_PERCPU_MAX) {
-		ipriorityr_private[GICD_IRQ_TO_IPRIORITYR(irq)] = ipriorityr;
-	}
-
-	lock_clear(&gic_lock);
-	write_daif(old);
-}
-
-/*
- * Configure non-local IRQs to be delivered through the distributor.
- */
-static void
-gic_add_target(uint32_t irq)
-{
-	uint64_t old = read_daif();
-	set_daif(DAIF_SETCLEAR_IRQ);
-	lock_set(&gic_lock);
-	uint32_t coreMask = 0xFF; /* all 8 (XXXARM) cpus */
-
-	/*
-	 * Each GICD_ITARGETSR<n> contains 4 8-bit fields indicating that int
-	 * N is delivered to the cpus with 1 bits set in the value.
-	 *
-	 * XXXARM: Another place with an 8 cpu limit.
-	 *
-	 * We always program all interrupts to deliver to all possible CPUs,
-	 * trusting RAZ/WI for those which don't exist.
-	 */
-	if (irq > GIC_INTID_PERCPU_MAX) {
-		uint32_t tr = (gic_dist->itargetsr[GICD_IRQ_TO_ITARGETSR(irq)] &
-		    ~GICD_IRQ_TO_ITARGETSR_FIELD(irq, coreMask));
-
-		gic_dist->itargetsr[GICD_IRQ_TO_ITARGETSR(irq)] =
-		    tr | GICD_IRQ_TO_ITARGETSR_FIELD(irq, coreMask);
-	}
-
-	lock_clear(&gic_lock);
-	write_daif(old);
-}
-
-/*
- * Configure such that IRQ cannot happen at or above IPL
- *
- * There are complications here -- which this code doesn't handle -- which are
- * outlined in the pclusmp implementation, I have included that comment
- * below.
- *
- * (from i86pc/io/mp_platform_misc.c:apic_addspl_common)
- *  * Both add and delspl are complicated by the fact that different interrupts
- * may share IRQs. This can happen in two ways.
- * 1. The same H/W line is shared by more than 1 device
- * 1a. with interrupts at different IPLs
- * 1b. with interrupts at same IPL
- * 2. We ran out of vectors at a given IPL and started sharing vectors.
- * 1b and 2 should be handled gracefully, except for the fact some ISRs
- * will get called often when no interrupt is pending for the device.
- * For 1a, we handle it at the higher IPL.
- */
 static int
 gic_addspl(int irq, int ipl, int min_ipl, int max_ipl)
 {
-	gic_set_ipl((uint32_t)irq, (uint32_t)ipl);
-	gic_add_target((uint32_t)irq);
-	gic_enable_irq((uint32_t)irq);
-
-	if (irq <= GIC_INTID_PERCPU_MAX)
-		ienable_private |= (1u << irq);
-
-	return (0);
+	return (gic_ops.addspl(irq, ipl, min_ipl, max_ipl));
 }
 
-/*
- * XXXARM: Comment taken verbatim from i86pc/io/mp_platform_misc.c:apic_delspl_common)
- *
- * Recompute mask bits for the given interrupt vector.
- * If there is no interrupt servicing routine for this
- * vector, this function should disable interrupt vector
- * from happening at all IPLs. If there are still
- * handlers using the given vector, this function should
- * disable the given vector from happening below the lowest
- * IPL of the remaining handlers.
- */
 static int
 gic_delspl(int irq, int ipl, int min_ipl, int max_ipl)
 {
-	if (autovect[irq].avh_hi_pri == 0) {
-		gic_disable_irq((uint32_t)irq);
-		gic_set_ipl((uint32_t)irq, 0);
-		if (irq <= GIC_INTID_PERCPU_MAX)
-			ienable_private &= ~(1u << irq);
-	}
-
-	return (0);
+	return (gic_ops.addspl(irq, ipl, min_ipl, max_ipl));
 }
 
 int (*addspl)(int, int, int, int) = gic_addspl;
 int (*delspl)(int, int, int, int) = gic_delspl;
 
-/*
- * Send an IRQ as an IPI to processors in `cpuset`.
- *
- * Processors not targetable by the GIC will be silently ignored.
- */
-void
-gic_send_ipi(cpuset_t cpuset, uint32_t irq)
-{
-	uint32_t target = 0;
-	CPUSET_AND(cpuset, gic_cpuset);
-	while (!CPUSET_ISNULL(cpuset)) {
-		uint_t cpu;
-		CPUSET_FIND(cpuset, cpu);
-		target |= gic_target[cpu];
-		CPUSET_DEL(cpuset, cpu);
-	}
-	uint64_t old = read_daif();
-	set_daif(DAIF_SETCLEAR_IRQ);
-	dsb(ish);
-
-	gic_dist->sgir = GICD_SGIR(0, target, 0, irq);
-
-	write_daif(old);
-}
-
-static pnode_t
-find_gic(pnode_t nodeid, int depth)
-{
-	if (prom_is_compatible(nodeid, "arm,cortex-a15-gic") ||
-	    prom_is_compatible(nodeid, "arm,gic-400")) {
-		return (nodeid);
-	}
-
-	pnode_t child = prom_childnode(nodeid);
-	while (child > 0) {
-		pnode_t node = find_gic(child, depth + 1);
-		if (node > 0)
-			return (node);
-		child = prom_nextnode(child);
-	}
-	return (OBP_NONODE);
-}
-
-/*
- * Return the target representing the current cpu from the GIC point of view
- * by reading the target field of a target specific interrupt.
- *
- * This sets the Nth bit for target N
- *
- * XXXARM: Only works without affinity routing.
- */
-static uint_t
-gic_get_target(void)
-{
-	return (1 << (__builtin_ctz(gic_dist->itargetsr[0] & 0xff)));
-}
-
-/*
- * Initialize the GIC on the boot CPU, including any global initialization.
- */
-void
-gic_init_primary(void)
-{
-	uint64_t old = read_daif();
-	set_daif(DAIF_SETCLEAR_IRQ);
-
-	LOCK_INIT_HELD(&gic_lock);
-
-	pnode_t node = find_gic(prom_rootnode(), 0);
-
-	if (node > 0) {
-		uint64_t base;
-		if (prom_get_reg_address(node, 0, &base) == 0) {
-			gic_dist = (struct gic_dist *)(uintptr_t)(base + SEGKPM_BASE);
-		}
-		if (prom_get_reg_address(node, 1, &base) == 0) {
-			gic_cpuif = (struct gic_cpuif *)(uintptr_t)(base + SEGKPM_BASE);
-		}
-	}
-
-	/*
-	 * §8.9.4 GICD_CTLR, Distributor Control Register
-	 *
-	 * GICD_CTRLR.DS resets as 0 if the field is R/W, but there are
-	 * implications it might be DS=1 RAO/WI on some hardware.
-	 *
-	 * We (try to) configure it to 0, and then assert it is 0, such that
-	 * the meaning of settings below contingent on DS are obvious.
-	 *
-	 * This is probably paranoia
-	 */
-	gic_dist->ctlr = (gic_dist->ctlr & ~GICD_CTLR_DS_MASK);
-	ASSERT(GICD_CTLR_DS(gic_dist->ctlr) == 0);
-
-	/*
-	 * Clear enabled/pending/active status of all interrupts, and put them
-	 * in group 0.
-	 */
-	for (int i = 0; i < 32; i++) {
-		gic_dist->icenabler[i] = 0xffffffff;
-		gic_dist->icpendr[i]   = 0xffffffff;
-		gic_dist->icactiver[i] = 0xffffffff;
-		gic_dist->igroupr[i] = 0;
-	}
-
-	/* Make all but the first 32 interrupts level triggered */
-	for (int i = 1; i < 64; i++) {
-		gic_dist->icfgr[i] = 0;
-	}
-
-	/*
-	 * Initialize interrupt priorities.
-	 *
-	 * Set the CPU-specific interrupts to the lowest possible priority, and
-	 * keep a private copy of that priority.
-	 */
-	for (int i = 0; i < 8; i++) {
-		gic_dist->ipriorityr[i] = 0xffffffff;
-		ipriorityr_private[i] = gic_dist->ipriorityr[i];
-	}
-
-	/*
-	 * Set the rest of the interrupts to the lowest possible priority, and
-	 * route them to all CPUs.
-	 */
-	for (int i = 8; i < 256; i++) {
-		gic_dist->itargetsr[i] = 0xffffffff;
-		gic_dist->ipriorityr[i] = 0xffffffff;
-	}
-
-	/* Enable group 0 interrupts, disable everything else */
-	gic_cpuif->ctlr = GICC_CTLR_ENABLE_GROUP0;
-
-	/*
-	 * Configure the priority fields with 5 bits of group priority and 3
-	 * bits of subpriority.
-	 */
-	gic_cpuif->bpr = 3;
-
-	/* Unmask all interrupt priorities */
-	gic_cpuif->pmr = 0xFF;
-
-	/*
-	 * Enable group 0 interrupts
-	 * disable secure group 1 interrupts
-	 * disable non-secure group 1 interrupts.
-	 * disable non-secure affinity routing
-	 * disable secure affinity routing
-	 * enable security (don't set DS)
-	 * disable 1 of N wakeup if possible.
-	 *
-	 * XXXARM: Read this back and see if we get values we don't expect?
-	 * XXXARM: Should we be waiting for .RWP to clear?
-	 */
-	gic_dist->ctlr = GICD_CTLR_ENABLE_GROUP0;
-
-	lock_clear(&gic_lock);
-	write_daif(old);
-
-	CPUSET_ONLY(gic_cpuset, 0);
-
-	gic_target[0] = gic_get_target();
-}
-
-/*
- * Initialize the GIC for a new non-boot CPU.
- *
- * XXXARM: Can this be partially common with init_primary?
- */
-void
-gic_init_secondary(processorid_t id)
-{
-	uint64_t old = read_daif();
-	set_daif(DAIF_SETCLEAR_IRQ);
-	lock_set(&gic_lock);
-
-	/*
-	 * Clear enabled/pending/active status of the CPU-specific interrupts,
-	 * and put them in group 0.
-	 */
-	gic_dist->icenabler[0] = 0xffffffff;
-	gic_dist->icpendr[0]   = 0xffffffff;
-	gic_dist->icactiver[0] = 0xffffffff;
-	gic_dist->igroupr[0] = 0;
-
-	/*
-	 * XXXARM: Original comment here: SGIは設定しない
-	 * Google translate: "Do not configure SGI"
-	 *
-	 * Make interrupts 32-63 default to level triggered.
-	 */
-	gic_dist->icfgr[1] = 0;
-
-	/*
-	 * Initialize interrupt priorities from their global state in
-	 * `ipriorityr_private`
-	 *
-	 * XXXARM: Only used when not affinity routing?
-	 */
-	for (int i = 0; i < 8; i++) {
-		gic_dist->ipriorityr[i] = ipriorityr_private[i];
-	}
-
-	/*
-	 * Initialize interrupt enabling for interrupts 0-32 from their global
-	 * state in `ienable_private`.
-	 */
-	gic_dist->isenabler[0] = ienable_private;
-
-	/* Enable group 0 interrupts, disable everything else */
-	gic_cpuif->ctlr = GICC_CTLR_ENABLE_GROUP0;
-
-	/*
-	 * Configure the priority fields with 5 bits of group priority and 3
-	 * bits of subpriority.
-	 */
-	gic_cpuif->bpr = 3;
-
-	/* Unmask all interrupt priorities */
-	gic_cpuif->pmr = 0xFF;
-
-	CPUSET_ADD(gic_cpuset, id);
-	gic_target[id] = gic_get_target();
-
-	lock_clear(&gic_lock);
-	write_daif(old);
-}
-
-/* The maximum number of CPUs supported by the GIC without affinity routing */
 int
-gic_num_cpus(void)
+setlvl(int irq)
 {
-	return (GICD_TYPER_CPUNUMBER(gic_dist->typer) + 1);
+	return (gic_ops.setlvl(irq));
+}
+
+void
+setlvlx(int ipl, int irq)
+{
+	gic_ops.setlvlx(ipl, irq);
+}
+
+/*
+ * GIC Initialisation
+ */
+static void
+set_gic_module_name(void)
+{
+	if (prom_has_compatible("arm,gic-400") ||
+	    prom_has_compatible("arm,cortex-a15-gic")) {
+		gic_module_name = "gicv2";
+		return;
+	}
+
+#if XXXARM
+	if (prom_has_compatible("arm,gic-v3")) {
+		gic_module_name = "gicv3";
+		return;
+	}
+#endif
+
+	gic_module_name = NULL;
+}
+
+int
+gic_init(void)
+{
+	set_gic_module_name();
+	if (gic_module_name == NULL)
+		return (ENOTSUP);
+
+	if (modload("drv", gic_module_name) == -1)
+		return (ENOENT);
+
+	/*
+	 * XXXARM: separate CPU initialisation from general initialisation
+	 *
+	 * This is where we would call:
+	 * - gic_ops.init()
+	 * - gic_ops_init_cpu(...)
+	 */
+	gic_ops.init_primary();
+	return (0);
 }

--- a/usr/src/uts/armv8/os/gicv2.c
+++ b/usr/src/uts/armv8/os/gicv2.c
@@ -1,0 +1,594 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright 2017 Hayashi Naoyuki
+ * Copyright 2023 Michael van der Westhuizen
+ */
+
+#include <sys/types.h>
+#include <sys/gic.h>
+#include <sys/avintr.h>
+#include <sys/smp_impldefs.h>
+#include <sys/promif.h>
+
+extern char *gic_module_name;
+
+/*
+ * These are shadowed copies of GICD_IPRIORITYR<0-7>, and GICD_ISENABLER[0]
+ *
+ * That is the priority and enabled status of SGIs and PPIs, which are CPU
+ * local, and the registers for same are banked per-CPU in the distributor.
+ *
+ * XXXARM: It's possible these were intended to keep these in sync across all
+ * CPUs, but they don't outside of initial config.
+ */
+static volatile uint32_t ipriorityr_private[8];
+static volatile uint32_t ienable_private;
+
+/*
+ * This is used to record whether an IRQ is edge or level triggered.
+ * A set bit in this mask is an edge triggered interrupt, a 0 is level
+ * triggered.
+ *
+ * We use this in `gicv2_mask_level_irq` and `gicv2_unmask_level_irq` to decide
+ * whether to enable or disable that IRQ, these functions ignore
+ * edge-triggered interrupts.  This is set when `gicv2_config_irq` and never
+ * altered (which makes sense).
+ */
+static uint32_t intr_cfg[1024 / 32];
+
+/*
+ * Protect access to global GIC state.
+ * In the current implementation, the distributor.
+ */
+static lock_t gicv2_lock;
+
+/* Base addresses of the distributor */
+static volatile struct gic_dist *gic_dist;
+
+/*
+ * Mapping from cpuid to GIC target identifier
+ * XXXARM: Another place we cap at 8 CPUs
+ */
+static uint8_t gicv2_target[8];
+
+/*
+ * CPUs for which we have initialized the GIC.  Used to limit IPIs to only
+ * those CPUs we can target.
+ */
+static cpuset_t gicv2_cpuset;
+
+/*
+ * Enable IRQ in the distributor, which will now be forwarded to a cpu.
+ *
+ * It is IMPLEMENTATION DEFINED whether SGIs can be enabled or disabled here,
+ * we never try.
+ */
+static void
+gicv2_enable_irq(int irq)
+{
+	if (irq >= GIC_INTID_MIN_PPI) {
+		gic_dist->isenabler[GICD_IRQ_TO_ISENABLER(irq)] =
+		    GICD_IRQ_TO_ISENABLER_FIELD(irq);
+	}
+}
+
+/*
+ * Disable IRQ in the distributor, which will now cease being forwarded to a
+ * cpu.
+ *
+ * It is IMPLEMENTATION DEFINED whether SGIs can be enabled or disabled here,
+ * we never try.
+ */
+static void
+gicv2_disable_irq(int irq)
+{
+	if (irq >= GIC_INTID_MIN_PPI) {
+		gic_dist->icenabler[GICD_IRQ_TO_ISENABLER(irq)] =
+		    GICD_IRQ_TO_ISENABLER_FIELD(irq);
+	}
+}
+
+/*
+ * If this is a level-triggered IRQ which is not an SGI, enable it
+ * See comments about SGIs in enable/disable_irq
+ */
+static void
+gicv2_unmask_level_irq(int irq)
+{
+	if ((irq >= GIC_INTID_MIN_PPI) &&
+	    ((intr_cfg[irq / 32] & (1u << (irq % 32))) == 0)) {
+		ASSERT(irq != 225);
+		gicv2_enable_irq(irq);
+	}
+}
+
+/*
+ * If this is a level-triggered IRQ which is not an SGI, disable it
+ * See comments about SGIs in enable/disable_irq
+ */
+static void
+gicv2_mask_level_irq(int irq)
+{
+	if ((irq >= GIC_INTID_MIN_PPI) &&
+	    ((intr_cfg[irq / 32] & (1u << (irq % 32))) == 0)) {
+		ASSERT(irq != 225);
+		gicv2_disable_irq(irq);
+	}
+}
+
+/*
+ * Configure whether IRQ is edge or level triggered.
+ * Additionally record this in in `intr_cfg`.
+ */
+static void
+gicv2_config_irq(uint32_t irq, bool is_edge)
+{
+	uint32_t v = (is_edge ? 0x2 : 0);
+
+	/*
+	 * §8.9.7 Software must disable an interrupt before the value of the
+	 * corresponding programmable Int_config field is changed. GIC
+	 * behavior is otherwise UNPREDICTABLE.
+	 */
+	ASSERT((gic_dist->isenabler[GICD_IRQ_TO_ISENABLER(irq)] &
+	    GICD_IRQ_TO_ISENABLER_FIELD(irq)) == 0);
+
+	/*
+	 * GICD_ICFGR<n> is a packed field with 2 bits per interrupt, the even
+	 * bit is reserved, the odd bit is 1 for edge-triggered 0 for
+	 * level.
+	 */
+	gic_dist->icfgr[GICD_IRQ_TO_ICFGR(irq)] =
+	    (gic_dist->icfgr[GICD_IRQ_TO_ICFGR(irq)] &
+	    ~GICD_IRQ_TO_ICFGR_FIELD(irq, 0x3)) |
+	    GICD_IRQ_TO_ICFGR_FIELD(irq, v);
+
+	if (is_edge)
+		intr_cfg[irq / 32] |= (1u << (irq % 32));
+	else
+		intr_cfg[irq / 32] &= ~(1u << (irq % 32));
+}
+
+/*
+ * Mask interrupts of priority lower than or equal to IRQ.
+ */
+static int
+gicv2_setlvl(int irq)
+{
+	int new_ipl;
+	new_ipl = autovect[irq].avh_hi_pri;
+
+	if (new_ipl != 0) {
+		gic_cpuif->pmr = GIC_IPL_TO_PRI(new_ipl);
+	}
+
+	return (new_ipl);
+}
+
+/*
+ * Unmask level IRQ if it's level triggered and mask interrupts
+ * less than or equal to IPL.
+ *
+ * XXXARM: Is this really what setlvlx should do?
+ */
+static void
+gicv2_setlvlx(int ipl, int irq)
+{
+	/*
+	 * Allow code to pass a -1 IRQ to just change GICC_PMR
+	 * see armv8/intr.c:do_splx(), among others.
+	 */
+	if (irq >= 0)
+		gicv2_unmask_level_irq(irq);
+	gic_cpuif->pmr = GIC_IPL_TO_PRI(ipl);
+}
+
+/*
+ * Set the priority of IRQ to IPL
+ * If IRQ is an SGI or PPI, shadow that priority into `ipriorityr_private`
+ */
+static void
+gicv2_set_ipl(uint32_t irq, uint32_t ipl)
+{
+	uint64_t old = read_daif();
+	set_daif(DAIF_SETCLEAR_IRQ);
+	lock_set(&gicv2_lock);
+
+	uint32_t ipriorityr = gic_dist->ipriorityr[GICD_IRQ_TO_IPRIORITYR(irq)];
+	ipriorityr &= ~(GICD_IRQ_TO_IPRIORITYR_FIELD(irq, 0xff));
+	ipriorityr |= GICD_IRQ_TO_IPRIORITYR_FIELD(irq, GIC_IPL_TO_PRI(ipl));
+	gic_dist->ipriorityr[GICD_IRQ_TO_IPRIORITYR(irq)] = ipriorityr;
+
+	if (irq <= GIC_INTID_PERCPU_MAX) {
+		ipriorityr_private[GICD_IRQ_TO_IPRIORITYR(irq)] = ipriorityr;
+	}
+
+	lock_clear(&gicv2_lock);
+	write_daif(old);
+}
+
+/*
+ * Configure non-local IRQs to be delivered through the distributor.
+ */
+static void
+gicv2_add_target(uint32_t irq)
+{
+	uint64_t old = read_daif();
+	set_daif(DAIF_SETCLEAR_IRQ);
+	lock_set(&gicv2_lock);
+	uint32_t coreMask = 0xFF; /* all 8 (XXXARM) cpus */
+
+	/*
+	 * Each GICD_ITARGETSR<n> contains 4 8-bit fields indicating that int
+	 * N is delivered to the cpus with 1 bits set in the value.
+	 *
+	 * XXXARM: Another place with an 8 cpu limit.
+	 *
+	 * We always program all interrupts to deliver to all possible CPUs,
+	 * trusting RAZ/WI for those which don't exist.
+	 */
+	if (irq > GIC_INTID_PERCPU_MAX) {
+		uint32_t tr = (gic_dist->itargetsr[GICD_IRQ_TO_ITARGETSR(irq)] &
+		    ~GICD_IRQ_TO_ITARGETSR_FIELD(irq, coreMask));
+
+		gic_dist->itargetsr[GICD_IRQ_TO_ITARGETSR(irq)] =
+		    tr | GICD_IRQ_TO_ITARGETSR_FIELD(irq, coreMask);
+	}
+
+	lock_clear(&gicv2_lock);
+	write_daif(old);
+}
+
+/*
+ * Configure such that IRQ cannot happen at or above IPL
+ *
+ * There are complications here -- which this code doesn't handle -- which are
+ * outlined in the pclusmp implementation, I have included that comment
+ * below.
+ *
+ * (from i86pc/io/mp_platform_misc.c:apic_addspl_common)
+ *  * Both add and delspl are complicated by the fact that different interrupts
+ * may share IRQs. This can happen in two ways.
+ * 1. The same H/W line is shared by more than 1 device
+ * 1a. with interrupts at different IPLs
+ * 1b. with interrupts at same IPL
+ * 2. We ran out of vectors at a given IPL and started sharing vectors.
+ * 1b and 2 should be handled gracefully, except for the fact some ISRs
+ * will get called often when no interrupt is pending for the device.
+ * For 1a, we handle it at the higher IPL.
+ */
+static int
+gicv2_addspl(int irq, int ipl, int min_ipl, int max_ipl)
+{
+	gicv2_set_ipl((uint32_t)irq, (uint32_t)ipl);
+	gicv2_add_target((uint32_t)irq);
+	gicv2_enable_irq((uint32_t)irq);
+
+	if (irq <= GIC_INTID_PERCPU_MAX)
+		ienable_private |= (1u << irq);
+
+	return (0);
+}
+
+/*
+ * XXXARM: Comment taken verbatim from
+ *         i86pc/io/mp_platform_misc.c:apic_delspl_common)
+ *
+ * Recompute mask bits for the given interrupt vector.
+ * If there is no interrupt servicing routine for this
+ * vector, this function should disable interrupt vector
+ * from happening at all IPLs. If there are still
+ * handlers using the given vector, this function should
+ * disable the given vector from happening below the lowest
+ * IPL of the remaining handlers.
+ */
+static int
+gicv2_delspl(int irq, int ipl, int min_ipl, int max_ipl)
+{
+	if (autovect[irq].avh_hi_pri == 0) {
+		gicv2_disable_irq((uint32_t)irq);
+		gicv2_set_ipl((uint32_t)irq, 0);
+		if (irq <= GIC_INTID_PERCPU_MAX)
+			ienable_private &= ~(1u << irq);
+	}
+
+	return (0);
+}
+
+/*
+ * Send an IRQ as an IPI to processors in `cpuset`.
+ *
+ * Processors not targetable by the GIC will be silently ignored.
+ */
+static void
+gicv2_send_ipi(cpuset_t cpuset, int irq)
+{
+	uint32_t target = 0;
+	CPUSET_AND(cpuset, gicv2_cpuset);
+	while (!CPUSET_ISNULL(cpuset)) {
+		uint_t cpu;
+		CPUSET_FIND(cpuset, cpu);
+		target |= gicv2_target[cpu];
+		CPUSET_DEL(cpuset, cpu);
+	}
+	uint64_t old = read_daif();
+	set_daif(DAIF_SETCLEAR_IRQ);
+	dsb(ish);
+
+	gic_dist->sgir = GICD_SGIR(0, target, 0, irq);
+
+	write_daif(old);
+}
+
+static pnode_t
+find_gic(pnode_t nodeid, int depth)
+{
+	if (prom_is_compatible(nodeid, "arm,cortex-a15-gic") ||
+	    prom_is_compatible(nodeid, "arm,gic-400")) {
+		return (nodeid);
+	}
+
+	pnode_t child = prom_childnode(nodeid);
+	while (child > 0) {
+		pnode_t node = find_gic(child, depth + 1);
+		if (node > 0)
+			return (node);
+		child = prom_nextnode(child);
+	}
+	return (OBP_NONODE);
+}
+
+/*
+ * Return the target representing the current cpu from the GIC point of view
+ * by reading the target field of a target specific interrupt.
+ *
+ * This sets the Nth bit for target N
+ *
+ * XXXARM: Only works without affinity routing.
+ */
+static uint_t
+gicv2_get_target(void)
+{
+	return (1 << (__builtin_ctz(gic_dist->itargetsr[0] & 0xff)));
+}
+
+/*
+ * Initialize the GIC on the boot CPU, including any global initialization.
+ */
+static void
+gicv2_init_primary(void)
+{
+	uint64_t old = read_daif();
+	set_daif(DAIF_SETCLEAR_IRQ);
+
+	LOCK_INIT_HELD(&gicv2_lock);
+
+	pnode_t node = find_gic(prom_rootnode(), 0);
+
+	if (node > 0) {
+		uint64_t base;
+		if (prom_get_reg_address(node, 0, &base) == 0) {
+			gic_dist =
+			    (struct gic_dist *)(uintptr_t)(base + SEGKPM_BASE);
+		}
+		if (prom_get_reg_address(node, 1, &base) == 0) {
+			gic_cpuif =
+			    (struct gic_cpuif *)(uintptr_t)(base + SEGKPM_BASE);
+		}
+	}
+
+	/*
+	 * §8.9.4 GICD_CTLR, Distributor Control Register
+	 *
+	 * GICD_CTRLR.DS resets as 0 if the field is R/W, but there are
+	 * implications it might be DS=1 RAO/WI on some hardware.
+	 *
+	 * We (try to) configure it to 0, and then assert it is 0, such that
+	 * the meaning of settings below contingent on DS are obvious.
+	 *
+	 * This is probably paranoia
+	 */
+	gic_dist->ctlr = (gic_dist->ctlr & ~GICD_CTLR_DS_MASK);
+	ASSERT(GICD_CTLR_DS(gic_dist->ctlr) == 0);
+
+	/*
+	 * Clear enabled/pending/active status of all interrupts, and put them
+	 * in group 0.
+	 */
+	for (int i = 0; i < 32; i++) {
+		gic_dist->icenabler[i] = 0xffffffff;
+		gic_dist->icpendr[i]   = 0xffffffff;
+		gic_dist->icactiver[i] = 0xffffffff;
+		gic_dist->igroupr[i] = 0;
+	}
+
+	/* Make all but the first 32 interrupts level triggered */
+	for (int i = 1; i < 64; i++) {
+		gic_dist->icfgr[i] = 0;
+	}
+
+	/*
+	 * Initialize interrupt priorities.
+	 *
+	 * Set the CPU-specific interrupts to the lowest possible priority, and
+	 * keep a private copy of that priority.
+	 */
+	for (int i = 0; i < 8; i++) {
+		gic_dist->ipriorityr[i] = 0xffffffff;
+		ipriorityr_private[i] = gic_dist->ipriorityr[i];
+	}
+
+	/*
+	 * Set the rest of the interrupts to the lowest possible priority, and
+	 * route them to all CPUs.
+	 */
+	for (int i = 8; i < 256; i++) {
+		gic_dist->itargetsr[i] = 0xffffffff;
+		gic_dist->ipriorityr[i] = 0xffffffff;
+	}
+
+	/* Enable group 0 interrupts, disable everything else */
+	gic_cpuif->ctlr = GICC_CTLR_ENABLE_GROUP0;
+
+	/*
+	 * Configure the priority fields with 5 bits of group priority and 3
+	 * bits of subpriority.
+	 */
+	gic_cpuif->bpr = 3;
+
+	/* Unmask all interrupt priorities */
+	gic_cpuif->pmr = 0xFF;
+
+	/*
+	 * Enable group 0 interrupts
+	 * disable secure group 1 interrupts
+	 * disable non-secure group 1 interrupts.
+	 * disable non-secure affinity routing
+	 * disable secure affinity routing
+	 * enable security (don't set DS)
+	 * disable 1 of N wakeup if possible.
+	 *
+	 * XXXARM: Read this back and see if we get values we don't expect?
+	 * XXXARM: Should we be waiting for .RWP to clear?
+	 */
+	gic_dist->ctlr = GICD_CTLR_ENABLE_GROUP0;
+
+	lock_clear(&gicv2_lock);
+	write_daif(old);
+
+	CPUSET_ONLY(gicv2_cpuset, 0);
+
+	gicv2_target[0] = gicv2_get_target();
+}
+
+/*
+ * Initialize the GIC for a new non-boot CPU.
+ *
+ * XXXARM: Can this be partially common with init_primary?
+ */
+static void
+gicv2_init_secondary(processorid_t id)
+{
+	uint64_t old = read_daif();
+	set_daif(DAIF_SETCLEAR_IRQ);
+	lock_set(&gicv2_lock);
+
+	/*
+	 * Clear enabled/pending/active status of the CPU-specific interrupts,
+	 * and put them in group 0.
+	 */
+	gic_dist->icenabler[0] = 0xffffffff;
+	gic_dist->icpendr[0]   = 0xffffffff;
+	gic_dist->icactiver[0] = 0xffffffff;
+	gic_dist->igroupr[0] = 0;
+
+	/*
+	 * XXXARM: Original comment here: SGIは設定しない
+	 * Google translate: "Do not configure SGI"
+	 *
+	 * Make interrupts 32-63 default to level triggered.
+	 */
+	gic_dist->icfgr[1] = 0;
+
+	/*
+	 * Initialize interrupt priorities from their global state in
+	 * `ipriorityr_private`
+	 *
+	 * XXXARM: Only used when not affinity routing?
+	 */
+	for (int i = 0; i < 8; i++) {
+		gic_dist->ipriorityr[i] = ipriorityr_private[i];
+	}
+
+	/*
+	 * Initialize interrupt enabling for interrupts 0-32 from their global
+	 * state in `ienable_private`.
+	 */
+	gic_dist->isenabler[0] = ienable_private;
+
+	/* Enable group 0 interrupts, disable everything else */
+	gic_cpuif->ctlr = GICC_CTLR_ENABLE_GROUP0;
+
+	/*
+	 * Configure the priority fields with 5 bits of group priority and 3
+	 * bits of subpriority.
+	 */
+	gic_cpuif->bpr = 3;
+
+	/* Unmask all interrupt priorities */
+	gic_cpuif->pmr = 0xFF;
+
+	CPUSET_ADD(gicv2_cpuset, id);
+	gicv2_target[id] = gicv2_get_target();
+
+	lock_clear(&gicv2_lock);
+	write_daif(old);
+}
+
+/* The maximum number of CPUs supported by the GIC without affinity routing */
+static int
+gicv2_num_cpus(void)
+{
+	return (GICD_TYPER_CPUNUMBER(gic_dist->typer) + 1);
+}
+
+static struct modlmisc modlmisc = {
+	&mod_miscops,
+	"Generic Interrupt Controller v2"
+};
+
+static struct modlinkage modlinkage = {
+	MODREV_1, (void *)&modlmisc, NULL
+};
+
+int
+_init(void)
+{
+	if (strcmp(gic_module_name, "gicv2") == 0) {
+		gic_ops.mask_level_irq = gicv2_mask_level_irq;
+		gic_ops.unmask_level_irq = gicv2_unmask_level_irq;
+		gic_ops.send_ipi = gicv2_send_ipi;
+		gic_ops.init_primary = gicv2_init_primary;
+		gic_ops.init_secondary = gicv2_init_secondary;
+		gic_ops.config_irq = gicv2_config_irq;
+		gic_ops.num_cpus = gicv2_num_cpus;
+		gic_ops.addspl = gicv2_addspl;
+		gic_ops.delspl = gicv2_delspl;
+		gic_ops.setlvl = gicv2_setlvl;
+		gic_ops.setlvlx = gicv2_setlvlx;
+	}
+
+	return (mod_install(&modlinkage));
+}
+
+int
+_fini(void)
+{
+	return (EBUSY);
+}
+
+int
+_info(struct modinfo *modinfop)
+{
+	return (mod_info(&modlinkage, modinfop));
+}

--- a/usr/src/uts/armv8/os/startup.c
+++ b/usr/src/uts/armv8/os/startup.c
@@ -406,9 +406,6 @@ startup_init(void)
 	 */
 	get_system_configuration();
 
-	/* Set up the interrupt controller for the primary CPU */
-	gic_init_primary();
-
 	PRM_POINT("startup_init() done");
 }
 
@@ -1232,6 +1229,12 @@ startup_modules(void)
 	 * Initialize segment management stuff.
 	 */
 	seg_init();
+
+	/*
+	 * Set up the interrupt controller for the primary CPU
+	 */
+	if (gic_init() != 0)
+		halt("Can't initialize GIC");
 
 	if (modload("fs", "specfs") == -1)
 		halt("Can't load specfs");


### PR DESCRIPTION
The aarch64 codebase only supports GICv2 at present, limiting the number of CPUs supported to eight.

The refactoring maintains the existing GIC interface, shimming the implementation (for setlvlx only) until a GIC module is loaded.

This approach allows for adding a GICv3 module at a later time.

Subsequent work will take advantage of moving GIC initialisation later in the startup sequence by using the device arena for mapping GIC register space.

Tested on the virt platform with two CPUs.
```
braich console login: root
The illumos Project     gic-rework-0-g8fc981eeb5        Oct. 07, 2023
illumos development build: michael 2023-Oct-07 [illumos-gate]
root@braich:~# /usr/sbin/modinfo -i 3
 Id         Loadaddr   Size Info Rev Module Name
  3 fffffffffa000000    e08   -   1  gicv2 (Generic Interrupt Controller v2)
root@braich:~#
```