### PR TITLE
Clean up prom_printf locking

### DIFF
--- a/usr/src/uts/aarch64/promif/prom_printf.c
+++ b/usr/src/uts/aarch64/promif/prom_printf.c
@@ -28,9 +28,7 @@
 #include <sys/controlregs.h>
 #include <sys/promif.h>
 #include <sys/promimpl.h>
-#include <sys/spl.h>
 #include <sys/varargs.h>
-#include <sys/x_call.h>
 
 static void _doprint(const char *, va_list, void (*)(char, char **), char **);
 static void _printn(uint64_t, int, int, int, void (*)(char, char **), char **);
@@ -53,42 +51,24 @@ _sput(char c, char **p)
 	*p += 1;
 }
 
-/*
- * XXXARM: On other platforms this is unlocked, here it is very locked,
- * this is not a design decision
- */
-lock_t promprint_lock;
-
 void
 prom_printf(const char *fmt, ...)
 {
 	va_list adx;
-	ushort_t old;
-
-	lock_set_spl(&promprint_lock, ipltospl(XC_HI_PIL), &old);
 
 	va_start(adx, fmt);
 	(void) _doprint(fmt, adx, _pput, (char **)0);
 	va_end(adx);
-
-	lock_clear(&promprint_lock);
-	splx(old);
 }
 
 void
 prom_vprintf(const char *fmt, va_list adx)
 {
 	va_list tadx;
-	ushort_t old;
-
-	lock_set_spl(&promprint_lock, ipltospl(XC_HI_PIL), &old);
 
 	va_copy(tadx, adx);
 	(void) _doprint(fmt, tadx, _pput, (char **)0);
 	va_end(tadx);
-
-	lock_clear(&promprint_lock);
-	splx(old);
 }
 
 /*VARARGS2*/


### PR DESCRIPTION
The locking here is terribly pessimistic and as noted in the code, does not align with what's done on other platforms. It's possible that this is a remnant of debugging in the initial port from Hayashi.

Clean this up. It's been boot tested on Qemu.