### PR TITLE
don't alias simple-bus to itself

### DIFF
--- a/usr/src/pkg/manifests/system-kernel-platform.p5m
+++ b/usr/src/pkg/manifests/system-kernel-platform.p5m
@@ -205,7 +205,7 @@ $(i386_ONLY)driver name=rootnex
 $(aarch64_ONLY)driver name=rootnex
 
 # simple-bus, all platforms
-$(aarch64_ONLY)driver name=simple-bus alias=simple-bus
+$(aarch64_ONLY)driver name=simple-bus
 $(i386_ONLY)driver name=xdb
 $(i386_ONLY)driver name=xdf
 $(i386_ONLY)driver name=xenbus perms="* 0666 root sys"


### PR DESCRIPTION
Drivers attach based on their own name, as well as any aliases.  Aliasing a driver to itself just causes warnings about duplicates (which don't go to the console for some reason).

@hadfl since I screwed up xhci, I'd like you to look at this on rpi4 just in case?  I don't think it could possibly break, but I thought that about xhci too...