### PR TITLE
gic: Fix `addspl` v. `delspl` typo that would crash oddly inconsistently

### DIFF
--- a/usr/src/uts/armv8/os/gic.c
+++ b/usr/src/uts/armv8/os/gic.c
@@ -129,7 +129,7 @@ gic_addspl(int irq, int ipl, int min_ipl, int max_ipl)
 static int
 gic_delspl(int irq, int ipl, int min_ipl, int max_ipl)
 {
-	return (gic_ops.addspl(irq, ipl, min_ipl, max_ipl));
+	return (gic_ops.delspl(irq, ipl, min_ipl, max_ipl));
 }
 
 int (*addspl)(int, int, int, int) = gic_addspl;


### PR DESCRIPTION
Because we assert that an interrupt is disabled before we configure it, and because `delspl` was typoed to `addspl`, we would crash enabling virtio (at least `vioif`) because `delspl` was in fact enabling that interrupt and failing the assertion.

I do not understand why this didn't happen consistently, nor why it didn't happen to _everything_.

@hadfl @citrus-it it'd be nice if you tried this on rpi4, because I'm paranoid about that now.
@r1mikey I assume you agree the change is correct?