### PR TITLE
switch to our exception vector much earlier, and improvements for early crashes

### DIFF
--- a/usr/src/uts/armv8/ml/exceptions.S
+++ b/usr/src/uts/armv8/ml/exceptions.S
@@ -56,65 +56,93 @@
 	.err;					\
 	.endif
 
+	.data
+unexpected_exception:	.asciz "unexpected exception type"
+
+#define UNEXPECTED()				\
+	clrex;					\
+	adrp x0, unexpected_exception;		\
+	add x0, x0, :lo12:unexpected_exception;	\
+	bl panic
+
+/*
+ * This is the AArch64 exception vector used by the hardware, each entry is 128 byte
+ * aligned, and 32 instructions (128 bytes) long.
+ *
+ * We represent this as a single large function (exception_vector), which we can put in VBAR,
+ * and a nested function per-entry to make things easier to refer to while debugging.
+ *
+ * It is important that ALTENTRY is used, so alignment is not altered, and the
+ * vector keeps it specified shape.
+ */
+	.text
 	.balign	2048
 	ENTRY(exception_vector)
 	/*
 	 * From Current Exception level with SP_EL0
 	 */
 	.balign	VECTOR_ENTRY_SIZE
-from_current_el_sp0_sync:
-0:	b	0b
+ALTENTRY(from_current_el_sp0_sync)
+	UNEXPECTED()
 	CHECK_VECTOR_ENTRY(from_current_el_sp0_sync)
+SET_SIZE(from_current_el_sp0_sync)
 
 	.balign	VECTOR_ENTRY_SIZE
-from_current_el_sp0_irq:
-0:	b	0b
+ALTENTRY(from_current_el_sp0_irq)
+	UNEXPECTED()
 	CHECK_VECTOR_ENTRY(from_current_el_sp0_irq)
+SET_SIZE(from_current_el_sp0_irq)
 
 	.balign	VECTOR_ENTRY_SIZE
-from_current_el_sp0_fiq:
-0:	b	0b
+ALTENTRY(from_current_el_sp0_fiq)
+	UNEXPECTED()
 	CHECK_VECTOR_ENTRY(from_current_el_sp0_fiq)
+	SET_SIZE(from_current_el_sp0_fiq)
 
 	.balign	VECTOR_ENTRY_SIZE
-from_current_el_sp0_error:
-0:	b	0b
+ALTENTRY(from_current_el_sp0_error)
+	UNEXPECTED()
 	CHECK_VECTOR_ENTRY(from_current_el_sp0_error)
+SET_SIZE(from_current_el_sp0_error)
 
 	/*
 	 * From Current Exception level with SP_ELx
 	 */
 	.balign	VECTOR_ENTRY_SIZE
-from_current_el_sync:
+ALTENTRY(from_current_el_sync)
 	clrex
 	__SAVE_REGS
 	__SAVE_FRAME
 	b	from_current_el_sync_handler
 	CHECK_VECTOR_ENTRY(from_current_el_sync)
+SET_SIZE(from_current_el_sync)
 
 	.balign	VECTOR_ENTRY_SIZE
-from_current_el_irq:
+ALTENTRY(from_current_el_irq)
 	clrex
 	__SAVE_REGS
 	__SAVE_FRAME
 	b	irq_handler
 	CHECK_VECTOR_ENTRY(from_current_el_irq)
+SET_SIZE(from_current_el_irq)
 
 	.balign	VECTOR_ENTRY_SIZE
-from_current_el_fiq:
-0:	b	0b
+ALTENTRY(from_current_el_fiq)
+	UNEXPECTED()
 	CHECK_VECTOR_ENTRY(from_current_el_fiq)
+SET_SIZE(from_current_el_fiq)
 
 	.balign	VECTOR_ENTRY_SIZE
-from_current_el_error:
-0:	b	0b
+ALTENTRY(from_current_el_error)
+	UNEXPECTED()
 	CHECK_VECTOR_ENTRY(from_current_el_error)
+SET_SIZE(from_current_el_error)
 
 	/*
 	 * From Lower Exception level using aarch64
 	 */
 	.balign	VECTOR_ENTRY_SIZE
-from_lower_el_aarch64_sync:
+ALTENTRY(from_lower_el_aarch64_sync)
 	clrex
 	__SAVE_REGS
 	__TERMINATE_FRAME
@@ -129,48 +157,57 @@ from_lower_el_aarch64_sync:
 	bl	trap
 	b	user_rtt
 	CHECK_VECTOR_ENTRY(from_lower_el_aarch64_sync)
+SET_SIZE(from_lower_el_aarch64_sync)
 
 	.balign	VECTOR_ENTRY_SIZE
-from_lower_el_aarch64_irq:
+ALTENTRY(from_lower_el_aarch64_irq)
 	clrex
 	__SAVE_REGS
 	__TERMINATE_FRAME
 	b	irq_handler
 	CHECK_VECTOR_ENTRY(from_lower_el_aarch64_irq)
+SET_SIZE(from_lower_el_aarch64_irq)
 
 	.balign	VECTOR_ENTRY_SIZE
-from_lower_el_aarch64_fiq:
-0:	b	0b
+ALTENTRY(from_lower_el_aarch64_fiq)
+	UNEXPECTED()
 	CHECK_VECTOR_ENTRY(from_lower_el_aarch64_fiq)
+SET_SIZE(from_lower_el_aarch64_fiq)
 
 	.balign	VECTOR_ENTRY_SIZE
-from_lower_el_aarch64_error:
-0:	b	0b
+ALTENTRY(from_lower_el_aarch64_error)
+	UNEXPECTED()
 	CHECK_VECTOR_ENTRY(from_lower_el_aarch64_error)
+SET_SIZE(from_lower_el_aarch64_error)
 
 	/*
 	 * From Lower Exception level using aarch32
 	 */
 	.balign	VECTOR_ENTRY_SIZE
-from_lower_el_aarch32_sync:
-0:	b	0b
+ALTENTRY(from_lower_el_aarch32_sync)
+	UNEXPECTED()
 	CHECK_VECTOR_ENTRY(from_lower_el_aarch32_sync)
+SET_SIZE(from_lower_el_aarch32_sync)
 
 	.balign	VECTOR_ENTRY_SIZE
-from_lower_el_aarch32_irq:
-0:	b	0b
+ALTENTRY(from_lower_el_aarch32_irq)
+	UNEXPECTED()
 	CHECK_VECTOR_ENTRY(from_lower_el_aarch32_irq)
+SET_SIZE(from_lower_el_aarch32_irq)
 
 	.balign	VECTOR_ENTRY_SIZE
-from_lower_el_aarch32_fiq:
-0:	b	0b
+ALTENTRY(from_lower_el_aarch32_fiq)
+	UNEXPECTED()
 	CHECK_VECTOR_ENTRY(from_lower_el_aarch32_fiq)
+SET_SIZE(from_lower_el_aarch32_fiq)
 
 	.balign	VECTOR_ENTRY_SIZE
-from_lower_el_aarch32_error:
-0:	b	0b
+ALTENTRY(from_lower_el_aarch32_error)
+	UNEXPECTED()
 	CHECK_VECTOR_ENTRY(from_lower_el_aarch32_error)
+SET_SIZE(from_lower_el_aarch32_error)
 
+	.balign VECTOR_ENTRY_SIZE
 	SET_SIZE(exception_vector)
 
 	ENTRY(from_current_el_sync_handler)

--- a/usr/src/uts/armv8/ml/exceptions.S
+++ b/usr/src/uts/armv8/ml/exceptions.S
@@ -47,59 +47,73 @@
 #define THREADP(tp_reg)			\
 	   mrs tp_reg, tpidr_el1
 
+/* Each entry in the exception vector is 128 bytes / 32 instruction long */
+#define VECTOR_ENTRY_SIZE	128
+
+/* Fail the assembly if a vector entry is too large */
+#define	CHECK_VECTOR_ENTRY(name)		\
+	.if (. - name) > VECTOR_ENTRY_SIZE;	\
+	.err;					\
+	.endif
 
 	.balign	2048
 	ENTRY(exception_vector)
 	/*
 	 * From Current Exception level with SP_EL0
 	 */
-	.balign	0x80
+	.balign	VECTOR_ENTRY_SIZE
 from_current_el_sp0_sync:
 0:	b	0b
+	CHECK_VECTOR_ENTRY(from_current_el_sp0_sync)
 
-	.balign	0x80
+	.balign	VECTOR_ENTRY_SIZE
 from_current_el_sp0_irq:
 0:	b	0b
+	CHECK_VECTOR_ENTRY(from_current_el_sp0_irq)
 
-	.balign	0x80
+	.balign	VECTOR_ENTRY_SIZE
 from_current_el_sp0_fiq:
 0:	b	0b
+	CHECK_VECTOR_ENTRY(from_current_el_sp0_fiq)
 
-	.balign	0x80
+	.balign	VECTOR_ENTRY_SIZE
 from_current_el_sp0_error:
 0:	b	0b
-
+	CHECK_VECTOR_ENTRY(from_current_el_sp0_error)
 
 	/*
 	 * From Current Exception level with SP_ELx
 	 */
-	.balign	0x80
+	.balign	VECTOR_ENTRY_SIZE
 from_current_el_sync:
 	clrex
 	__SAVE_REGS
 	__SAVE_FRAME
 	b	from_current_el_sync_handler
+	CHECK_VECTOR_ENTRY(from_current_el_sync)
 
-	.balign	0x80
+	.balign	VECTOR_ENTRY_SIZE
 from_current_el_irq:
 	clrex
 	__SAVE_REGS
 	__SAVE_FRAME
 	b	irq_handler
+	CHECK_VECTOR_ENTRY(from_current_el_irq)
 
-	.balign	0x80
+	.balign	VECTOR_ENTRY_SIZE
 from_current_el_fiq:
 0:	b	0b
+	CHECK_VECTOR_ENTRY(from_current_el_fiq)
 
-	.balign	0x80
+	.balign	VECTOR_ENTRY_SIZE
 from_current_el_error:
 0:	b	0b
-
+	CHECK_VECTOR_ENTRY(from_current_el_error)
 
 	/*
 	 * From Lower Exception level using aarch64
 	 */
-	.balign	0x80
+	.balign	VECTOR_ENTRY_SIZE
 from_lower_el_aarch64_sync:
 	clrex
 	__SAVE_REGS
@@ -114,43 +128,49 @@ from_lower_el_aarch64_sync:
 
 	bl	trap
 	b	user_rtt
+	CHECK_VECTOR_ENTRY(from_lower_el_aarch64_sync)
 
-	.balign	0x80
+	.balign	VECTOR_ENTRY_SIZE
 from_lower_el_aarch64_irq:
 	clrex
 	__SAVE_REGS
 	__TERMINATE_FRAME
 	b	irq_handler
+	CHECK_VECTOR_ENTRY(from_lower_el_aarch64_irq)
 
-	.balign	0x80
+	.balign	VECTOR_ENTRY_SIZE
 from_lower_el_aarch64_fiq:
 0:	b	0b
+	CHECK_VECTOR_ENTRY(from_lower_el_aarch64_fiq)
 
-	.balign	0x80
+	.balign	VECTOR_ENTRY_SIZE
 from_lower_el_aarch64_error:
 0:	b	0b
-
+	CHECK_VECTOR_ENTRY(from_lower_el_aarch64_error)
 
 	/*
 	 * From Lower Exception level using aarch32
 	 */
-	.balign	0x80
+	.balign	VECTOR_ENTRY_SIZE
 from_lower_el_aarch32_sync:
 0:	b	0b
+	CHECK_VECTOR_ENTRY(from_lower_el_aarch32_sync)
 
-	.balign	0x80
+	.balign	VECTOR_ENTRY_SIZE
 from_lower_el_aarch32_irq:
 0:	b	0b
+	CHECK_VECTOR_ENTRY(from_lower_el_aarch32_irq)
 
-	.balign	0x80
+	.balign	VECTOR_ENTRY_SIZE
 from_lower_el_aarch32_fiq:
 0:	b	0b
+	CHECK_VECTOR_ENTRY(from_lower_el_aarch32_fiq)
 
-	.balign	0x80
+	.balign	VECTOR_ENTRY_SIZE
 from_lower_el_aarch32_error:
 0:	b	0b
+	CHECK_VECTOR_ENTRY(from_lower_el_aarch32_error)
 
-	.balign	0x80
 	SET_SIZE(exception_vector)
 
 	ENTRY(from_current_el_sync_handler)

--- a/usr/src/uts/armv8/os/mlsetup.c
+++ b/usr/src/uts/armv8/os/mlsetup.c
@@ -160,7 +160,6 @@ mlsetup(struct regs *rp)
 	CPU->cpu_id = 0;
 	CPU->cpu_m.affinity = read_mpidr() & MPIDR_AFF_MASK;
 	CPU->cpu_dispatch_pri = t0.t_pri;
-
 	/*
 	 * Save the boot EL. Bits [3:2] hold the value, so we
 	 * shift the bits over to get the integer form.
@@ -171,6 +170,13 @@ mlsetup(struct regs *rp)
 	 * Select the system timer. Use the phys timer only if EL2.
 	 */
 	arch_timer_select((CPU->cpu_m.mcpu_boot_el == 2) ? TMR_PHYS : TMR_VIRT);
+
+	/*
+	 * Switch to our own exception vector as early as possible.
+	 * We need the concept of time, so that's now.
+	 */
+	extern void exception_vector(void);
+	write_vbar((uintptr_t)exception_vector);
 
 	/*
 	 * Initialize thread/cpu microstate accounting

--- a/usr/src/uts/armv8/os/psci.c
+++ b/usr/src/uts/armv8/os/psci.c
@@ -47,51 +47,65 @@ static uint32_t psci_system_suspend_id = 0xc400000e;
 static uint32_t psci_set_suspend_mode_id = 0x8400000f;
 static uint32_t psci_stat_residency_id = 0xc4000010;
 static uint32_t psci_stat_count_id = 0xc4000011;
+
+static boolean_t psci_initialized = B_FALSE;
 static boolean_t pcsi_method_is_hvc = B_FALSE;
 
 static inline uint64_t
 psci_smc64(uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3)
 {
-	register uint64_t x0 __asm__ ("x0") = a0;
-	register uint64_t x1 __asm__ ("x1") = a1;
-	register uint64_t x2 __asm__ ("x2") = a2;
-	register uint64_t x3 __asm__ ("x3") = a3;
+	register uint64_t x0 __asm__("x0") = a0;
+	register uint64_t x1 __asm__("x1") = a1;
+	register uint64_t x2 __asm__("x2") = a2;
+	register uint64_t x3 __asm__("x3") = a3;
 
-	__asm__ volatile ("smc #0"
+	__asm__ volatile("smc #0"
 	    : "+r"(x0), "+r"(x1), "+r"(x2), "+r"(x3)
 	    :
 	    :
 	    "x4", "x5", "x6", "x7", "x8", "x9", "x10", "x11",
 	    "x12", "x13", "x14", "x15", "x16", "x17", "x18", "memory", "cc");
 
-	return x0;
+	return (x0);
 }
 
 static inline uint64_t
 psci_hvc64(uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3)
 {
-	register uint64_t x0 __asm__ ("x0") = a0;
-	register uint64_t x1 __asm__ ("x1") = a1;
-	register uint64_t x2 __asm__ ("x2") = a2;
-	register uint64_t x3 __asm__ ("x3") = a3;
+	register uint64_t x0 __asm__("x0") = a0;
+	register uint64_t x1 __asm__("x1") = a1;
+	register uint64_t x2 __asm__("x2") = a2;
+	register uint64_t x3 __asm__("x3") = a3;
 
-	__asm__ volatile ("hvc #0"
+	__asm__ volatile("hvc #0"
 	    : "+r"(x0), "+r"(x1), "+r"(x2), "+r"(x3)
 	    :
 	    :
 	    "x4", "x5", "x6", "x7", "x8", "x9", "x10", "x11",
 	    "x12", "x13", "x14", "x15", "x16", "x17", "x18", "memory", "cc");
 
-	return x0;
+	return (x0);
 }
 
-static inline uint64_t
+static uint64_t
 psci_call(uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3)
 {
-	if (pcsi_method_is_hvc)
-		return psci_hvc64(a0, a1, a2, a3);
-	else
-		return psci_smc64(a0, a1, a2, a3);
+	/*
+	 * We may get here very early if panicking, attempt to be useful, and
+	 * not panic recursively
+	 */
+	if (!panicstr)
+		VERIFY(psci_initialized);
+
+	if (panicstr != NULL && !psci_initialized) {
+		prom_printf("ERROR: attempted PSCI call before "
+		    "it's initialized\n");
+		return (0);
+	} else if (pcsi_method_is_hvc) {
+		return (psci_hvc64(a0, a1, a2, a3));
+	} else {
+		return (psci_smc64(a0, a1, a2, a3));
+	}
 }
 
 static void
@@ -117,59 +131,70 @@ psci_init(void)
 			if (strcmp(method, "hvc") == 0)
 				pcsi_method_is_hvc = B_TRUE;
 		}
-		psci_cpu_suspend_id = (uint32_t)prom_get_prop_int(node, "cpu_suspend", (int)psci_cpu_suspend_id);
-		psci_cpu_off_id = (uint32_t)prom_get_prop_int(node, "cpu_off", (int)psci_cpu_off_id);
-		psci_cpu_on_id = (uint32_t)prom_get_prop_int(node, "cpu_on", (int)psci_cpu_on_id);
-		psci_migrate_id = (uint32_t)prom_get_prop_int(node, "migrate", (int)psci_migrate_id);
+		psci_cpu_suspend_id = (uint32_t)prom_get_prop_int(node,
+		    "cpu_suspend", (int)psci_cpu_suspend_id);
+		psci_cpu_off_id = (uint32_t)prom_get_prop_int(node,
+		    "cpu_off", (int)psci_cpu_off_id);
+		psci_cpu_on_id = (uint32_t)prom_get_prop_int(node,
+		    "cpu_on", (int)psci_cpu_on_id);
+		psci_migrate_id = (uint32_t)prom_get_prop_int(node,
+		    "migrate", (int)psci_migrate_id);
 	}
+
+	psci_initialized = B_TRUE;
 }
 
 uint32_t
 psci_version(void)
 {
-	return psci_call(pcsi_version_id, 0, 0, 0);
+	return (psci_call(pcsi_version_id, 0, 0, 0));
 }
 
 int32_t
-psci_cpu_suspend(uint32_t power_state, uint64_t entry_point_address, uint64_t context_id)
+psci_cpu_suspend(uint32_t power_state, uint64_t entry_point_address,
+    uint64_t context_id)
 {
-	return psci_call(psci_cpu_suspend_id, power_state, entry_point_address, context_id);
+	return (psci_call(psci_cpu_suspend_id, power_state, entry_point_address,
+	    context_id));
 }
 
 int32_t
 psci_cpu_off(void)
 {
-	return psci_call(psci_cpu_off_id, 0, 0, 0);
+	return (psci_call(psci_cpu_off_id, 0, 0, 0));
 }
 
 int32_t
-psci_cpu_on(uint64_t target_cpu, uint64_t entry_point_address, uint64_t context_id)
+psci_cpu_on(uint64_t target_cpu, uint64_t entry_point_address,
+    uint64_t context_id)
 {
-	return psci_call(psci_cpu_on_id, target_cpu, entry_point_address, context_id);
+	return (psci_call(psci_cpu_on_id, target_cpu, entry_point_address,
+	    context_id));
 }
 
 int32_t
 psci_affinity_info(uint64_t target_affinity, uint32_t lowest_affinity_level)
 {
-	return psci_call(psci_affinity_info_id, target_affinity, lowest_affinity_level, 0);
+	return (psci_call(psci_affinity_info_id, target_affinity,
+	    lowest_affinity_level, 0));
 }
 
 int32_t
 psci_migrate(uint64_t target_cpu)
 {
-	return psci_call(psci_migrate_id, target_cpu, 0, 0);
+	return (psci_call(psci_migrate_id, target_cpu, 0, 0));
 }
 
 int32_t
 psci_migrate_info_type(void)
 {
-	return psci_call(psci_migrate_info_type_id, 0, 0, 0);
+	return (psci_call(psci_migrate_info_type_id, 0, 0, 0));
 }
 
 uint64_t
 psci_migrate_info_up_cpu(void)
 {
-	return psci_call(psci_migrate_info_up_cpu_id, 0, 0, 0);
+	return (psci_call(psci_migrate_info_up_cpu_id, 0, 0, 0));
 }
 
 void
@@ -182,52 +207,58 @@ void
 psci_system_reset(void)
 {
 	psci_call(psci_system_reset_id, 0, 0, 0);
+
+	/* If we've got here we were asked to reset and could not, spin. */
+	for (;;)
+		__asm__("wfi");
 }
 
 int32_t
 psci_features(uint32_t psci_func_id)
 {
-	return psci_call(psci_features_id, psci_func_id, 0, 0);
+	return (psci_call(psci_features_id, psci_func_id, 0, 0));
 }
 
 int32_t
 psci_cpu_freeze(void)
 {
-	return psci_call(psci_cpu_freeze_id, 0, 0, 0);
+	return (psci_call(psci_cpu_freeze_id, 0, 0, 0));
 }
 
 int32_t
 psci_cpu_default_suspend(uint64_t entry_point_address, uint64_t context_id)
 {
-	return psci_call(psci_cpu_default_suspend_id, entry_point_address, context_id, 0);
+	return (psci_call(psci_cpu_default_suspend_id, entry_point_address,
+	    context_id, 0));
 }
 
 int32_t
 psci_node_hw_state(uint64_t target_cpu, uint32_t power_level)
 {
-	return psci_call(psci_node_hw_state_id, target_cpu, power_level, 0);
+	return (psci_call(psci_node_hw_state_id, target_cpu, power_level, 0));
 }
 
 int32_t
 psci_system_suspend(uint64_t entry_point_address, uint64_t context_id)
 {
-	return psci_call(psci_system_suspend_id, entry_point_address, context_id, 0);
+	return (psci_call(psci_system_suspend_id, entry_point_address,
+	    context_id, 0));
 }
 
 int32_t
 psci_set_suspend_mode(uint32_t mode)
 {
-	return psci_call(psci_set_suspend_mode_id, mode, 0, 0);
+	return (psci_call(psci_set_suspend_mode_id, mode, 0, 0));
 }
 
 uint64_t
 psci_stat_residency(uint64_t target_cpu, uint32_t power_state)
 {
-	return psci_call(psci_stat_residency_id, target_cpu, power_state, 0);
+	return (psci_call(psci_stat_residency_id, target_cpu, power_state, 0));
 }
 
 uint64_t
 psci_stat_count(uint64_t target_cpu, uint32_t power_state)
 {
-	return psci_call(psci_stat_count_id, target_cpu, power_state, 0);
+	return (psci_call(psci_stat_count_id, target_cpu, power_state, 0));
 }

--- a/usr/src/uts/armv8/os/startup.c
+++ b/usr/src/uts/armv8/os/startup.c
@@ -899,8 +899,6 @@ load_tod_module(char *todmod)
 		halt("Can't load TOD module");
 }
 
-extern void exception_vector(void);
-
 /*
  * XXXARM: This enables more than just IRQs
  * Not a great name
@@ -920,8 +918,6 @@ startup_end(void)
 	extern void cpu_event_init(void);
 
 	PRM_POINT("startup_end() starting...");
-
-	write_vbar((uintptr_t)exception_vector);
 
 	/*
 	 * Perform tasks that get done after most of the VM

--- a/usr/src/uts/common/os/zone.c
+++ b/usr/src/uts/common/os/zone.c
@@ -3037,8 +3037,10 @@ getzoneid(void)
 	proc_t *p = curproc;
 
 	/* This may happen for p0 during early boot, but not otherwise */
-	if (p->p_zone == NULL)
+	if (p->p_zone == NULL) {
+		ASSERT3P(p, ==, &p0);
 		return (GLOBAL_ZONEID);
+	}
 
 	return (p->p_zone->zone_id);
 }

--- a/usr/src/uts/common/os/zone.c
+++ b/usr/src/uts/common/os/zone.c
@@ -3034,7 +3034,13 @@ out:
 zoneid_t
 getzoneid(void)
 {
-	return (curproc->p_zone->zone_id);
+	proc_t *p = curproc;
+
+	/* This may happen for p0 during early boot, but not otherwise */
+	if (p->p_zone == NULL)
+		return (GLOBAL_ZONEID);
+
+	return (p->p_zone->zone_id);
 }
 
 /*


### PR DESCRIPTION
Fallout from a larger project I started.

This switches to our exception vector as soon as we possibly can, which means we get "good" crashes if we crash earlier, among other things.

It also makes the exception vector much more robust (I hope), and bandaids some warts that make panicking early panic over again (these are not necessarily good long-term fixes, but I believe they have no down side and to cure a problem that makes debugging those problems rough).

Each commit has a hopefully individually enlightening commit message

@jclulow we talked about `getzoneid` in the illumos bug I filed, if you wanted to see my crime
@citrus-it @hadfl @r1mikey can you take a look?