### PR TITLE
Add a cpuinfo helper

### DIFF
--- a/usr/src/uts/aarch64/asm/controlregs.h
+++ b/usr/src/uts/aarch64/asm/controlregs.h
@@ -21,7 +21,7 @@
 
 /*
  * Copyright 2017 Hayashi Naoyuki
- * Copyright 2022 Michael van der Westhuizen
+ * Copyright 2023 Michael van der Westhuizen
  */
 
 #ifndef	_ASM_CONTROLREGS_H
@@ -366,6 +366,26 @@ read_par_el1(void)
 	__asm__ __volatile__("mrs %0, par_el1":"=r"(reg)::"memory");
 	return (reg);
 }
+
+#define	PAR_EL1_F		0x0000000000000001ull
+
+/*
+ * ... when PAR_EL1.F == 0
+ */
+#define	PAR_EL1_ATTR		0xFF00000000000000ull
+#define	PAR_EL1_PA_HI		0x000F000000000000ull
+#define	PAR_EL1_PA		0x0000FFFFFFFFF000ull
+#define	PAR_EL1_NSE		0x0000000000000800ull
+#define	PAR_EL1_NS		0x0000000000000200ull
+#define	PAR_EL1_SH		0x0000000000000180ull
+
+/*
+ * and when PAR_EL1.F == 1
+ */
+#define	PAR_EL1_S		0x0000000000000200ull
+#define	PAR_EL1_PTW		0x0000000000000100ull
+#define	PAR_EL1_FST		0x000000000000007Eull
+
 
 #define	dmb(_option_) do {				\
 	__asm__ __volatile__("dmb " #_option_ :::"memory");	\

--- a/usr/src/uts/aarch64/promif/prom_node.c
+++ b/usr/src/uts/aarch64/promif/prom_node.c
@@ -21,6 +21,7 @@
  */
 /*
  * Copyright 2017 Hayashi Naoyuki
+ * Copyright 2023 Michael van der Westhuizen
  */
 
 #include <libfdt.h>
@@ -120,12 +121,14 @@ prom_check_overlong_property(pnode_t nodeid, const char *name)
 		if ((nodename == NULL) || nodename[0] == '\0')
 			goto no_name;
 
-		cmn_err(CE_WARN, "PROM node '%s' request for over long property '%s'",
+		cmn_err(CE_WARN,
+		    "PROM node '%s' request for over long property '%s'",
 		    nodename, name);
 		return;
 
 no_name:
-		cmn_err(CE_WARN, "PROM node %u request for over long property '%s'",
+		cmn_err(CE_WARN,
+		    "PROM node %u request for over long property '%s'",
 		    nodeid, name);
 	}
 }
@@ -368,7 +371,7 @@ prom_nextprop(pnode_t nodeid, const char *name, char *next)
 	}
 	data = fdt_get_property_by_offset(fdtp, offset, NULL);
 	strlcpy(next, (char *)fdt_string(fdtp, fdt32_to_cpu(data->nameoff)),
-		OBP_MAXPROPNAME);
+	    OBP_MAXPROPNAME);
 	return (next);
 }
 
@@ -541,4 +544,22 @@ void
 prom_walk(void(*func)(pnode_t, void*), void *arg)
 {
 	prom_walk_dev(prom_rootnode(), func, arg);
+}
+
+boolean_t
+prom_node_has_property(pnode_t nodeid, const char *name)
+{
+	int offset;
+	int len;
+	const struct fdt_property *prop;
+
+	offset = fdt_node_offset_by_phandle(fdtp, nodeid);
+	if (offset < 0)
+		return (B_FALSE);
+
+	prop = fdt_get_property(fdtp, offset, name, &len);
+	if (prop == NULL)
+		return (B_FALSE);
+
+	return (B_TRUE);
 }

--- a/usr/src/uts/aarch64/sys/promif.h
+++ b/usr/src/uts/aarch64/sys/promif.h
@@ -24,6 +24,7 @@
  * Use is subject to license terms.
  *
  * Copyright 2017 Hayashi Naoyuki
+ * Copyright 2023 Michael van der Westhuizen
  */
 
 #ifndef _SYS_PROMIF_H
@@ -266,6 +267,7 @@ extern int prom_get_reg_size(pnode_t node, int index, uint64_t *regsize);
 extern void prom_power_off(void);
 extern int prom_get_bus_address(pnode_t node, uint64_t phys_addr,
     uint64_t *bus_addr);
+extern boolean_t prom_node_has_property(pnode_t nodeid, const char *name);
 
 #endif	/* _KERNEL */
 

--- a/usr/src/uts/armv8/Makefile.files
+++ b/usr/src/uts/armv8/Makefile.files
@@ -20,8 +20,12 @@
 #
 
 #
+# Copyright 2023 Michael van der Westhuizen
 # Copyright 2017 Hayashi Naoyuki
 #
+
+CORE_OBJS_FDT =			\
+	cpuinfo_fdt.o
 
 CORE_OBJS +=			\
 	aarch64_subr.o		\
@@ -68,7 +72,8 @@ CORE_OBJS +=			\
 	hold_page.o		\
 	ssp.o			\
 	psci.o			\
-	arch_timer.o
+	arch_timer.o		\
+	$(CORE_OBJS_FDT)
 
 CORE_OBJS += $(PCI_STRING_OBJS)
 

--- a/usr/src/uts/armv8/os/cpuinfo_fdt.c
+++ b/usr/src/uts/armv8/os/cpuinfo_fdt.c
@@ -1,0 +1,466 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2023 Michael van der Westhuizen
+ */
+
+#include <sys/types.h>
+#include <sys/obpdefs.h>
+#include <sys/cpuinfo.h>
+#include <asm/controlregs.h>
+#include <sys/promif.h>
+#include <sys/cpuvar.h>
+#include <sys/byteorder.h>
+#include <sys/systm.h>
+#include <sys/stddef.h>
+
+typedef enum {
+	CPUNODE_STATUS_OKAY	= 0,
+	CPUNODE_STATUS_DISABLED	= 1,
+	CPUNODE_STATUS_FAILED	= 2,
+	CPUNODE_STATUS_UNKNOWN	= 3,
+	CPUNODE_STATUS_OTHER	= 4,
+	CPUNODE_STATUS_ERROR	= 5,
+} cpunode_status_t;
+
+#define	CPUNODE_STATUS_IS_ENABLED(v)	((v) == CPUNODE_STATUS_OKAY || \
+					(v) == CPUNODE_STATUS_UNKNOWN)
+
+#define	CPUNODE_BAD_AFFINITY		0xffffffffffffffffull
+
+#define	CPUNODE_BAD_ENABLE_METHOD	-1
+
+#define	CPUNODE_BAD_PARKED_ADDRESS	0xffffffffffffffffull
+
+static list_t		ci_lst;
+static struct cpuinfo	ci0;
+
+/*
+ * Extract the MPIDR of the target CPU object, or CPUNODE_BAD_AFFINITY on error.
+ */
+static uint64_t
+get_cpu_mpidr(pnode_t node)
+{
+	int		cv;
+	int		ac;
+	uint64_t	affinity = CPUNODE_BAD_AFFINITY;
+	uint32_t	parts[2] = {0, 0};
+
+	cv = prom_get_size_cells(node);
+	if (cv != 0x0)
+		return (affinity);
+
+	ac = prom_get_address_cells(node);
+	if (ac != 1 && ac != 2)
+		return (affinity);
+
+	cv = prom_getprop(node, "reg", (caddr_t)parts);
+	if ((ac == 1 && cv != 4) || (ac == 2 && cv != 8))
+		return (affinity);
+
+	switch (ac) {
+	case 1:
+		affinity = (uint64_t)ntohl(parts[0]);
+		break;
+	case 2:
+		affinity = (uint64_t)ntohl(parts[0]);
+		affinity <<= 32;
+		affinity |= (uint64_t)ntohl(parts[1]);
+		break;
+	default:
+		break;
+	}
+
+	return (affinity);
+}
+
+static int
+get_enable_method(pnode_t node)
+{
+	/* enable-method: psci|spin-table */
+	int		cv;
+	boolean_t	exists;
+	char		prop[OBP_STANDARD_MAXPROPNAME];
+
+	exists = prom_node_has_property(node, "enable-method");
+	if (exists != B_TRUE)
+		return (CPUNODE_BAD_ENABLE_METHOD);
+
+	cv = prom_bounded_getprop(
+	    node, "enable-method", prop, OBP_STANDARD_MAXPROPNAME - 1);
+	if (cv < 0)
+		return (CPUNODE_BAD_ENABLE_METHOD);
+
+	if (strcmp(prop, "psci") == 0)
+		return (CPUINFO_ENABLE_METHOD_PSCI);
+	else if (strcmp(prop, "spin-table") == 0)
+		return (CPUINFO_ENABLE_METHOD_SPINTABLE_SIMPLE);
+
+	return (CPUNODE_BAD_ENABLE_METHOD);
+}
+
+static uint64_t
+get_parked_address(pnode_t node)
+{
+	int		cv;
+	int		ac;
+	uint64_t	parked_addr = CPUNODE_BAD_PARKED_ADDRESS;
+	uint32_t	parts[2] = {0, 0};
+
+	/*
+	 * XXXARM: This is a bit sketchy, but it should hold true due to the
+	 * #size-cells needed for the MPIDR.
+	 */
+	cv = prom_get_size_cells(node);
+	if (cv != 0x0)
+		return (parked_addr);
+
+	ac = prom_get_address_cells(node);
+	if (ac != 1 && ac != 2)
+		return (parked_addr);
+
+	cv = prom_getprop(node, "cpu-release-addr", (caddr_t)parts);
+	if ((ac == 1 && cv != 4) || (ac == 2 && cv != 8))
+		return (parked_addr);
+
+	switch (ac) {
+	case 1:
+		parked_addr = (uint64_t)ntohl(parts[0]);
+		break;
+	case 2:
+		parked_addr = (uint64_t)ntohl(parts[0]);
+		parked_addr <<= 32;
+		parked_addr |= (uint64_t)ntohl(parts[1]);
+		break;
+	default:
+		break;
+	}
+
+	return (parked_addr);
+}
+
+static cpunode_status_t
+get_cpu_status(pnode_t node)
+{
+	int		cv;
+	boolean_t	exists;
+	char		prop[OBP_STANDARD_MAXPROPNAME];
+
+	exists = prom_node_has_property(node, "status");
+	if (exists != B_TRUE)
+		return (CPUNODE_STATUS_UNKNOWN);
+
+	cv = prom_bounded_getprop(
+	    node, "status", prop, OBP_STANDARD_MAXPROPNAME - 1);
+	if (cv < 0)
+		return (CPUNODE_STATUS_ERROR);
+
+	if (strcmp(prop, "okay") == 0 || strcmp(prop, "ok") == 0)
+		return (CPUNODE_STATUS_OKAY);
+	else if (strcmp(prop, "disabled") == 0)
+		return (CPUNODE_STATUS_DISABLED);
+	else if (strncmp(prop, "fail", 4) == 0)
+		return (CPUNODE_STATUS_FAILED);
+
+	return (CPUNODE_STATUS_OTHER);
+}
+
+static boolean_t
+is_cpu_node(pnode_t node)
+{
+	int ret;
+	char prop[OBP_STANDARD_MAXPROPNAME];
+
+	ret = prom_getprop(node, "device_type", prop);
+	if (ret < 0)
+		return (B_FALSE);
+
+	return (strcmp(prop, "cpu") == 0 ? B_TRUE : B_FALSE);
+}
+
+static pnode_t
+next_cpu_node(pnode_t node)
+{
+	for (node = prom_nextnode(node); node > 0; node = prom_nextnode(node)) {
+		if (is_cpu_node(node) == B_TRUE) {
+			return (node);
+		}
+	}
+
+	return (node);
+}
+
+static pnode_t
+first_cpu_node(void)
+{
+	pnode_t	cpus;
+	pnode_t	node;
+
+	cpus = prom_finddevice("/cpus");
+	if (cpus <= 0)
+		return (cpus);
+
+	for (node = prom_childnode(cpus);
+	    node > 0; node = prom_nextnode(node)) {
+		if (is_cpu_node(node) == B_TRUE) {
+			return (node);
+		}
+	}
+
+	return (node);
+}
+
+struct cpuinfo *
+cpuinfo_first(void)
+{
+	return (list_head(&ci_lst));
+}
+
+struct cpuinfo *
+cpuinfo_next(struct cpuinfo *ci)
+{
+	return (list_next(&ci_lst, ci));
+}
+
+struct cpuinfo *
+cpuinfo_first_enabled(void)
+{
+	struct cpuinfo *ci;
+
+	ci = cpuinfo_first();
+	if (ci == cpuinfo_end())
+		return (ci);
+
+	do {
+		if (ci->ci_flags & CPUINFO_ENABLED)
+			break;
+	} while ((ci = cpuinfo_next(ci)) != cpuinfo_end());
+
+	return (ci);
+}
+
+struct cpuinfo *
+cpuinfo_next_enabled(struct cpuinfo *ci)
+{
+	if (ci == cpuinfo_end())
+		return (ci);
+
+	while ((ci = cpuinfo_next(ci)) != cpuinfo_end()) {
+		if (ci->ci_flags & CPUINFO_ENABLED)
+			break;
+	}
+
+	return (ci);
+}
+
+struct cpuinfo *
+cpuinfo_end(void)
+{
+	return (NULL);
+}
+
+static boolean_t
+is_gicv3(void)
+{
+	pnode_t	node;
+	node = prom_find_compatible(prom_rootnode(), "arm,gic-v3");
+	return (node == OBP_NONODE ? B_FALSE : B_TRUE);
+}
+
+/*
+ * In the FDT case we have to infer the CPU Interface Number.
+ *
+ * This seems a bit sketchy, but looking at edk2 sources (as
+ * DynamicTablesPkg/Library/FdtHwInfoParserLib/Gic/ArmGicCParser.c) and at
+ * u-boot sources (arch/arm/cpu/armv8/spin_table.c, arch/arm/cpu/armv8/start.S
+ * and arch/arm/cpu/armv8/spin_table_v8.S).
+ *
+ * Specifically, this comment from edk2 sums up the situation nicely:
+ *
+ * To fit the Affinity [0-3] a 32bits value, place the Aff3 on bits
+ * [31:24] instead of their original place ([39:32]).
+ *
+ * Furthermore, the CPU Interface Number is only poopulated for GICv2, as GICv3
+ * in legacy mode is unsupported by edk2.
+ *
+ * ARM Trusted Firmware updates the board device tree to use PSCI.
+ */
+static int
+fill_cpuinfo(pnode_t node, struct cpuinfo *ci)
+{
+	int st = get_cpu_status(node);
+	if (st == CPUNODE_STATUS_ERROR)
+		return (-1);
+
+	/*
+	 * Translate FDT CPU node status to ACPI-like "Enabled" and
+	 * "Online Capable" flags.
+	 */
+	ci->ci_flags = 0;
+	if (CPUNODE_STATUS_IS_ENABLED(st))
+		ci->ci_flags |= CPUINFO_ENABLED;
+	/*
+	 * There isn't really a notion of "Online Capable" in the FDT CPU node,
+	 * so no hot-pluggable CPUs for embedded devices (which makes sense).
+	 *
+	 * If there were such a notion we'd set the CPUINFO_ONLINE_CAPABLE bit
+	 * here if the CPU were not enabled but capable of coming online.
+	 *
+	 * Other flags we're not yet setting are the interrupt mode bits for
+	 * the performance and VGIC maintenance interrupts.
+	 */
+
+	ci->ci_mpidr = get_cpu_mpidr(node);
+	if (ci->ci_mpidr == CPUNODE_BAD_AFFINITY)
+		return (-1);
+
+	ci->ci_ppver = get_enable_method(node);
+	if (ci->ci_ppver == CPUNODE_BAD_ENABLE_METHOD)
+		return (-1);
+
+	if (ci->ci_ppver == CPUINFO_ENABLE_METHOD_SPINTABLE_SIMPLE) {
+		ci->ci_parked_addr = get_parked_address(node);
+		if (ci->ci_parked_addr == CPUNODE_BAD_PARKED_ADDRESS)
+			return (-1);
+	} else {
+		ci->ci_parked_addr = 0;
+	}
+
+	if (is_gicv3() == B_TRUE) {
+		ci->ci_cpuif = 0;
+	} else {
+		/* Assume GICv2, since we don't support anything else */
+		ci->ci_cpuif = (ci->ci_mpidr & 0x00ffffff) |
+		    ((ci->ci_mpidr >> 8) & 0xff000000);
+	}
+
+	return (0);
+}
+
+static struct cpuinfo *
+create_cpuinfo(pnode_t node)
+{
+	struct cpuinfo		*ci;
+	int			st;
+
+	ci = kmem_zalloc(sizeof (*ci), KM_SLEEP);
+
+	st = fill_cpuinfo(node, ci);
+	if (st != 0) {
+		kmem_free(ci, sizeof (*ci));
+		ci = NULL;
+	}
+
+	return (ci);
+}
+
+/*
+ * Initialize the CPU information list, incorporating the boot CPU already set
+ * up by a prior call to cpuinfo_bootstrap.
+ *
+ * After calling this function you can use the iterator functions
+ * cpuinfo_first/cpuinfo_first_enabled, cpuinfo_next/cpuinfo_next_enabled and
+ * cpuinfo_end.
+ */
+int
+cpuinfo_init(void)
+{
+	pnode_t		node;
+	int		n;
+	int		idx;
+	int		rv;
+	struct cpuinfo	*ci;
+
+	list_create(&ci_lst, sizeof (struct cpuinfo),
+	    offsetof(struct cpuinfo, ci_list_node));
+	list_insert_head(&ci_lst, &ci0);
+
+	for (node = first_cpu_node(), idx = 1;
+	    node > 0; node = next_cpu_node(node)) {
+		if (get_cpu_mpidr(node) == ci0.ci_mpidr)
+			continue;
+
+		ci = create_cpuinfo(node);
+		if (ci == NULL) {
+			while ((ci = list_remove_tail(&ci_lst)) != NULL) {
+				if (ci->ci_id != 0)
+					kmem_free(ci, sizeof (*ci));
+			}
+
+			list_destroy(&ci_lst);
+			return (-1);
+		}
+
+		ci->ci_id = idx++;
+		list_insert_tail(&ci_lst, ci);
+	}
+
+	return (0);
+}
+
+/*
+ * Bootstrap the boot processor CPU information, attach it to the passed boot
+ * processor structure (which must have cpu_id zero) and set the boot_ncpus,
+ * boot_max_ncpus and max_ncpus values.
+ */
+void
+cpuinfo_bootstrap(cpu_t *cp)
+{
+	pnode_t		node;
+	int		st;
+	int		cpu_count;
+	int		cpu_possible_count;
+
+	ASSERT(cp->cpu_id == 0);
+	cpu_count = cpu_possible_count = 0;
+
+	for (node = first_cpu_node(); node > 0; node = next_cpu_node(node)) {
+		st = get_cpu_status(node);
+
+		if (CPUNODE_STATUS_IS_ENABLED(st)) {
+			cpu_count++;
+			cpu_possible_count++;
+		} else {
+			/*
+			 * If we supported pluggable CPUs in FDT we'd add an
+			 * "else if" here and bump the cpu_possible_count iff
+			 * the CPU was online-capable.
+			 *
+			 * In the FDT case we simply bump cpu_possible_count
+			 * for all CPUs that have a status that is neither
+			 * explicitly nor implicitly "okay".
+			 */
+			cpu_possible_count++;
+		}
+
+		if (cp->cpu_m.mcpu_ci == NULL &&
+		    cp->cpu_m.affinity == get_cpu_mpidr(node)) {
+			st = fill_cpuinfo(node, &ci0);
+			if (st != 0) {
+				prom_panic("CPUINFO: failed to fill cpuinfo "
+				    "for the boot processor");
+			}
+			ci0.ci_id = 0;
+			cp->cpu_m.mcpu_ci = &ci0;
+		}
+	}
+
+	if (cp->cpu_m.mcpu_ci == NULL)
+		prom_panic("CPUINFO: did not find the boot processor");
+
+	/*
+	 * cpu_count is guaranteed to be greater than zero due to the check
+	 * for the boot processor cpuinfo having been set.
+	 */
+	boot_ncpus = cpu_count;
+	boot_max_ncpus = max_ncpus = cpu_possible_count;
+}

--- a/usr/src/uts/armv8/os/mlsetup.c
+++ b/usr/src/uts/armv8/os/mlsetup.c
@@ -19,6 +19,7 @@
  * CDDL HEADER END
  */
 /*
+ * Copyright 2023 Michael van der Westhuizen
  * Copyright 2017 Hayashi Naoyuki
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
@@ -51,6 +52,7 @@
 #include <sys/pg.h>
 #include <sys/kdi.h>
 #include <sys/cpupart.h>
+#include <sys/cpuinfo.h>
 
 #include <sys/debug.h>
 
@@ -196,6 +198,12 @@ mlsetup(struct regs *rp)
 	/* Get value of boot_ncpus. */
 	boot_ncpus = NCPU;
 	max_ncpus = boot_max_ncpus = boot_ncpus;
+
+	/*
+	 * Initialise CPU info for the boot processor and fill in accurate
+	 * values for boot_ncpus, boot_max_ncpus and max_ncpus.
+	 */
+	cpuinfo_bootstrap(CPU);
 
 	/*
 	 * lgroup framework initialization. This must be done prior

--- a/usr/src/uts/armv8/os/startup.c
+++ b/usr/src/uts/armv8/os/startup.c
@@ -20,6 +20,7 @@
  */
 
 /*
+ * Copyright 2023 Michael van der Westhuizen
  * Copyright 2017 Hayashi Naoyuki
  * Copyright (c) 1992, 2010, Oracle and/or its affiliates. All rights reserved.
  */
@@ -86,6 +87,7 @@
 #include <sys/psci.h>
 #include <sys/controlregs.h>
 #include <sys/arch_timer.h>
+#include <sys/cpuinfo.h>
 
 extern void brand_init(void);
 extern void pcf_init(void);
@@ -1225,6 +1227,12 @@ startup_modules(void)
 	 * Initialize segment management stuff.
 	 */
 	seg_init();
+
+	/*
+	 * Gather CPU information
+	 */
+	if (cpuinfo_init() != 0)
+		halt("Can't initialize CPU information");
 
 	/*
 	 * Set up the interrupt controller for the primary CPU

--- a/usr/src/uts/armv8/sys/cpuinfo.h
+++ b/usr/src/uts/armv8/sys/cpuinfo.h
@@ -1,0 +1,139 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2023 Michael van der Westhuizen
+ */
+
+#ifndef _CPUINFO_H
+#define	_CPUINFO_H
+
+#include <sys/types.h>
+#include <sys/list.h>
+#include <sys/cpuvar.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define	CPUINFO_ENABLED				0x1
+#ifdef XXXARM
+/*
+ * XXXARM: See the "additional fields" comment below.
+ */
+#define	CPIINFO_PERF_VEC_MODE			0x2
+#define	CPUINFO_VGIC_VEC_MODE			0x4
+#endif
+#define	CPUINFO_ONLINE_CAPABLE			0x8
+
+typedef enum {
+	/*
+	 * PSCI CPU_ON.
+	 */
+	CPUINFO_ENABLE_METHOD_PSCI		= 0,
+	/*
+	 * XXXARM: we need support for the parking protocol referenced in the
+	 * ACPI specification (the referenced document is called
+	 * "Multiprocessor Startup for ARM Platforms").
+	 */
+	/*
+	 * U-boot style WFE spin table.
+	 */
+	CPUINFO_ENABLE_METHOD_SPINTABLE_SIMPLE	= 42,
+} cpuinfo_enable_method_t;
+
+struct cpuinfo {
+	list_node_t		ci_list_node;
+	/*
+	 * CPU index, 0 is always the boot processor.
+	 */
+	processorid_t		ci_id;
+	/*
+	 * GIC CPU Interface - as specified for ACPI and derived for FDT.
+	 *
+	 * Derivation is aligned with edk2.
+	 */
+	uint32_t		ci_cpuif;
+	/*
+	 * CPU flags - see CPUINFO_* above.
+	 * If CPUINFO_ENABLED is set, the processor is ready for use
+	 * immediately and CPUINFO_ONLINE_CAPABLE should be zero.. If
+	 * CPUINFO_ENABLED is clear and CPUINFO_ONLINE_CAPABLE is set, then the
+	 * processor can be enabled at runtime. If both are clear the processor
+	 * should be ignored.
+	 */
+	uint32_t		ci_flags;
+	/*
+	 * Implementred Parking protocol version, or 0 for PSCI.
+	 *
+	 * See https://uefi.org/acpi (search for "Multiprocessor Startup for
+	 * ARM Platforms") for parking protocol details.
+	 */
+	cpuinfo_enable_method_t	ci_ppver;
+	/*
+	 * ACPI Processor UID - used to match this informational object to a
+	 * processor object in the DSDT once the OSPM is up.
+	 *
+	 * Only relevant for ACPI-based systems.
+	 */
+	uint32_t		ci_uid;
+	/*
+	 * The 64-bit physical address of the processor's Parking Protocol
+	 * mailbox.
+	 */
+	uint64_t		ci_parked_addr;
+	/*
+	 * The Multiprocessor Identity Register, following the formatting of
+	 * the MPIDR register in the ARM architecture, but containing only the
+	 * affinity bits.
+	 * - Bits [63:40] Must be zero
+	 * - Bits [39:32] Aff3 : Match Aff3 of target processor MPIDR
+	 * - Bits [31:24] Must be zero
+	 * - Bits [23:16] Aff2 : Match Aff2 of target processor MPIDR
+	 * - Bits [15:8] Aff1 : Match Aff1 of target processor MPIDR
+	 * - Bits [7:0] Aff0 : Match Aff0 of target processor MPIDR
+	 */
+	uint64_t		ci_mpidr;
+
+	/*
+	 * The following additional fields are possible in an ACPI
+	 * implementation, as that is based on GICC structures in the MADT.
+	 *
+	 * Once GIC configuration is abstracted we'll come back and revisit
+	 * what could or should be derived for the CPU structure.
+	 *
+	 * uint32_t ci_perfmon_vec;
+	 * uint64_t ci_cpuif_addr;
+	 * uint64_t ci_gicv_addr;
+	 * uint64_t ci_gich_addr;
+	 * uint32_t ci_vgic_vec;
+	 * uint64_t ci_gicr_addr;
+	 * uint8_t  ci_efficiency_class;
+	 * uint16_t ci_spe_overflow_vec;
+	 * uint16_t ci_trbe_vec;
+	 */
+};
+
+extern void cpuinfo_bootstrap(cpu_t *cp);
+
+extern int cpuinfo_init(void);
+
+extern struct cpuinfo *cpuinfo_first(void);
+extern struct cpuinfo *cpuinfo_first_enabled(void);
+extern struct cpuinfo *cpuinfo_next(struct cpuinfo *ci);
+extern struct cpuinfo *cpuinfo_next_enabled(struct cpuinfo *ci);
+extern struct cpuinfo *cpuinfo_end(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _CPUINFO_H */

--- a/usr/src/uts/armv8/sys/machcpuvar.h
+++ b/usr/src/uts/armv8/sys/machcpuvar.h
@@ -25,6 +25,7 @@
  *
  * Copyright 2011 Joyent, Inc. All rights reserved.
  * Copyright 2017 Hayashi Naoyuki
+ * Copyright 2023 Michael van der Westhuizen
  */
 
 #ifndef _SYS_MACHCPUVAR_H
@@ -64,6 +65,8 @@ struct	machcpu {
 	uint64_t	mcpu_revidr;
 
 	uint64_t	mcpu_boot_el;
+
+	struct cpuinfo	*mcpu_ci;
 };
 
 #ifndef NINTR_THREADS


### PR DESCRIPTION
Add a cpuinfo helper, based on the ACPI 6.5 GIC CPU Interface table structure as found in the ACPI MADT.  The idea behind this structure is modelled on a similarly named structure in NetBSD and has the goal of making CPU bringup firmware interface independent. Ultimately the same CPU oriented code paths should serve both FDT and ACPI machines. The approach of looking at firmware tables is similar to what's done in the i86pc code, which looks at the MADT for processor counts.

With a basic cpuinfo implementation in place, wire up the new implementation in both boot processor and application processor startup.

Testing output can be found at https://gist.github.com/r1mikey/688672d7baa1499764a275344c2aced0 - this test includes some additional output (line 95), showing the various CPU-related counts.

I've also cleaned up any remaining `pbchk` nits in the files I've touched.