### PR TITLE
Add a psciinfo helper

### DIFF
--- a/usr/src/uts/armv8/Makefile.files
+++ b/usr/src/uts/armv8/Makefile.files
@@ -25,7 +25,8 @@
 #
 
 CORE_OBJS_FDT =			\
-	cpuinfo_fdt.o
+	cpuinfo_fdt.o		\
+	psciinfo_fdt.o
 
 CORE_OBJS +=			\
 	aarch64_subr.o		\

--- a/usr/src/uts/armv8/os/mlsetup.c
+++ b/usr/src/uts/armv8/os/mlsetup.c
@@ -53,6 +53,8 @@
 #include <sys/kdi.h>
 #include <sys/cpupart.h>
 #include <sys/cpuinfo.h>
+#include <sys/psciinfo.h>
+#include <sys/psci.h>
 
 #include <sys/debug.h>
 
@@ -198,6 +200,12 @@ mlsetup(struct regs *rp)
 	/* Get value of boot_ncpus. */
 	boot_ncpus = NCPU;
 	max_ncpus = boot_max_ncpus = boot_ncpus;
+
+	/*
+	 * Gather PSCI configuration from the firmware and initialize PSCI.
+	 */
+	psciinfo_init();
+	psci_init();
 
 	/*
 	 * Initialise CPU info for the boot processor and fill in accurate

--- a/usr/src/uts/armv8/os/psciinfo_fdt.c
+++ b/usr/src/uts/armv8/os/psciinfo_fdt.c
@@ -1,0 +1,114 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2023 Michael van der Westhuizen
+ */
+
+#include <sys/types.h>
+#include <sys/psciinfo.h>
+#include <sys/systm.h>
+#include <sys/obpdefs.h>
+#include <sys/promif.h>
+
+#define	PSCI_CONDUIT_PROPNAME		"method"
+#define	PSCI_CONDUIT_PROPVAL_SMC	"smc"
+#define	PSCI_CONDUIT_PROPVAL_HVC	"hvc"
+
+#define	PSCI_CPU_SUSPEND_PROPNAME	"cpu_suspend"
+#define	PSCI_CPU_CPU_OFF_PROPNAME	"cpu_off"
+#define	PSCI_CPU_CPU_ON_PROPNAME	"cpu_on"
+#define	PSCI_CPU_MIGRATE_PROPNAME	"migrate"
+
+static struct psciinfo info = {
+	.pi_version			= PSCI_NOT_IMPLEMENTED,
+	.pi_conduit			= PSCI_CONDUIT_HVC,
+	.pi_cpu_suspend_id		= PSCI_CPU_SUSPEND_ID,
+	.pi_cpu_off_id			= PSCI_CPU_OFF_ID,
+	.pi_cpu_on_id			= PSCI_CPU_ON_ID,
+	.pi_migrate_id			= PSCI_MIGRATE_ID,
+};
+
+struct psci_scan {
+	const char			*compatible;
+	psci_version_t			psci_version;
+};
+
+static struct psci_scan scan_data[] = {
+	{ .compatible = "arm,psci-1.3", .psci_version = PSCI_VERSION_1_3, },
+	{ .compatible = "arm,psci-1.2", .psci_version = PSCI_VERSION_1_2, },
+	{ .compatible = "arm,psci-1.1", .psci_version = PSCI_VERSION_1_1, },
+	{ .compatible = "arm,psci-1.0", .psci_version = PSCI_VERSION_1_0, },
+	{ .compatible = "arm,psci-0.2", .psci_version = PSCI_VERSION_0_2, },
+	{ .compatible = "arm,psci", .psci_version = PSCI_VERSION_0_1, },
+	{ .compatible = NULL, .psci_version = PSCI_NOT_IMPLEMENTED, },
+};
+
+void
+psciinfo_init(void)
+{
+	pnode_t			node;
+	static struct psci_scan	*ps;
+	boolean_t		exists;
+	int			cv;
+	char			prop[OBP_STANDARD_MAXPROPNAME];
+
+	if (info.pi_version != PSCI_NOT_IMPLEMENTED)
+		return;
+
+	for (ps = &scan_data[0]; ps->compatible != NULL; ++ps) {
+		node = prom_find_compatible(prom_rootnode(), ps->compatible);
+		if (node > 0)
+			break;
+	}
+
+	/*
+	 * While a machine can theoretically operate without PSCI, illumos
+	 * will not do well without it.
+	 */
+	if (ps->compatible == NULL)
+		return;
+
+	exists = prom_node_has_property(node, PSCI_CONDUIT_PROPNAME);
+	if (exists != B_TRUE)
+		prom_panic("PSCI: no \"method\" property in PSCI node");
+
+	cv = prom_bounded_getprop(node, PSCI_CONDUIT_PROPNAME,
+	    prop, OBP_STANDARD_MAXPROPNAME - 1);
+	if (cv < 0)
+		prom_panic("PSCI: \"method\" property too long");
+
+	if (strcmp(prop, PSCI_CONDUIT_PROPVAL_SMC) == 0)
+		info.pi_conduit = PSCI_CONDUIT_SMC;
+	else if (strcmp(prop, PSCI_CONDUIT_PROPVAL_HVC) == 0)
+		info.pi_conduit = PSCI_CONDUIT_HVC;
+	else
+		prom_panic("PSCI: \"method\" property has unknown value");
+
+	if (ps->psci_version == PSCI_VERSION_0_1) {
+		info.pi_cpu_suspend_id = (uint32_t)prom_get_prop_int(node,
+		    PSCI_CPU_SUSPEND_PROPNAME, (int)PSCI_CPU_SUSPEND_ID);
+		info.pi_cpu_off_id = (uint32_t)prom_get_prop_int(node,
+		    PSCI_CPU_CPU_OFF_PROPNAME, (int)PSCI_CPU_OFF_ID);
+		info.pi_cpu_on_id = (uint32_t)prom_get_prop_int(node,
+		    PSCI_CPU_CPU_ON_PROPNAME, (int)PSCI_CPU_ON_ID);
+		info.pi_migrate_id = (uint32_t)prom_get_prop_int(node,
+		    PSCI_CPU_MIGRATE_PROPNAME, (int)PSCI_MIGRATE_ID);
+	}
+
+	info.pi_version = ps->psci_version;
+}
+
+const struct psciinfo *
+psciinfo_get(void)
+{
+	return (&info);
+}

--- a/usr/src/uts/armv8/os/startup.c
+++ b/usr/src/uts/armv8/os/startup.c
@@ -1193,8 +1193,6 @@ startup_modules(void)
 	if (&set_platform_defaults)
 		set_platform_defaults();
 
-	psci_init();
-
 	/*
 	 * Read the GMT lag from /etc/rtc_config.
 	 */

--- a/usr/src/uts/armv8/sys/psci.h
+++ b/usr/src/uts/armv8/sys/psci.h
@@ -20,11 +20,12 @@
  * CDDL HEADER END
  */
 /*
+ * Copyright 2023 Michael van der Westhuizen
  * Copyright 2017 Hayashi Naoyuki
  */
 
 #ifndef _SYS_PSCI_H
-#define _SYS_PSCI_H
+#define	_SYS_PSCI_H
 
 #include <sys/types.h>
 
@@ -45,25 +46,30 @@ enum {
 	PSCI_INVALID_ADDRESS	= -9,
 };
 
-void psci_init(void);
-uint32_t psci_version(void);
-int32_t psci_cpu_suspend(uint32_t power_state, uint64_t entry_point_address, uint64_t context_id);
-int32_t psci_cpu_off(void);
-int32_t psci_cpu_on(uint64_t target_cpu, uint64_t entry_point_address, uint64_t context_id);
-int32_t psci_affinity_info(uint64_t target_affinity, uint32_t lowest_affinity_level);
-int32_t psci_migrate(uint64_t target_cpu);
-int32_t psci_migrate_info_type(void);
-uint64_t psci_migrate_info_up_cpu(void);
-void psci_system_off(void);
-void psci_system_reset(void);
-int32_t psci_features(uint32_t psci_func_id);
-int32_t psci_cpu_freeze(void);
-int32_t psci_cpu_default_suspend(uint64_t entry_point_address, uint64_t context_id);
-int32_t psci_node_hw_state(uint64_t target_cpu, uint32_t power_level);
-int32_t psci_system_suspend(uint64_t entry_point_address, uint64_t context_id);
-int32_t psci_set_suspend_mode(uint32_t mode);
-uint64_t psci_stat_residency(uint64_t target_cpu, uint32_t power_state);
-uint64_t psci_stat_count(uint64_t target_cpu, uint32_t power_state);
+extern void psci_init(void);
+extern uint32_t psci_version(void);
+extern int32_t psci_cpu_suspend(uint32_t power_state,
+	uint64_t entry_point_address, uint64_t context_id);
+extern int32_t psci_cpu_off(void);
+extern int32_t psci_cpu_on(uint64_t target_cpu,
+	uint64_t entry_point_address, uint64_t context_id);
+extern int32_t psci_affinity_info(uint64_t target_affinity,
+	uint32_t lowest_affinity_level);
+extern int32_t psci_migrate(uint64_t target_cpu);
+extern int32_t psci_migrate_info_type(void);
+extern uint64_t psci_migrate_info_up_cpu(void);
+extern void psci_system_off(void);
+extern void psci_system_reset(void);
+extern int32_t psci_features(uint32_t psci_func_id);
+extern int32_t psci_cpu_freeze(void);
+extern int32_t psci_cpu_default_suspend(uint64_t entry_point_address,
+	uint64_t context_id);
+extern int32_t psci_node_hw_state(uint64_t target_cpu, uint32_t power_level);
+extern int32_t psci_system_suspend(uint64_t entry_point_address,
+	uint64_t context_id);
+extern int32_t psci_set_suspend_mode(uint32_t mode);
+extern uint64_t psci_stat_residency(uint64_t target_cpu, uint32_t power_state);
+extern uint64_t psci_stat_count(uint64_t target_cpu, uint32_t power_state);
 
 #ifdef	__cplusplus
 }

--- a/usr/src/uts/armv8/sys/psciinfo.h
+++ b/usr/src/uts/armv8/sys/psciinfo.h
@@ -1,0 +1,111 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2023 Michael van der Westhuizen
+ */
+
+#ifndef _PSCIINFO_H
+#define	_PSCIINFO_H
+
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Default PSCI function identifiers for PSCI 0.2 and later.
+ */
+#define	PSCI_CPU_SUSPEND_ID	0xC4000001
+#define	PSCI_CPU_OFF_ID		0x84000002
+#define	PSCI_CPU_ON_ID		0xC4000003
+#define	PSCI_MIGRATE_ID		0xC4000005
+
+typedef enum {
+	/*
+	 * Used internally to indicate that the PSCI information has not
+	 * been initialised or was not found (or explicitly marked as not
+	 * implemented) in the firmware tables.
+	 *
+	 * In devicetree there would simply be no PSCI node if PSCI was not
+	 * implemented, while in ACPI the Arm Boot Architecture Flags would
+	 * not have the PSCI_COMPLIANT bit set.
+	 */
+	PSCI_NOT_IMPLEMENTED	= 0,
+	/*
+	 * In the ACPI world the PSCI version can only be determined at runtime
+	 * by calling the PSCI_VERSION function.
+	 */
+	PSCI_VERSION_DEFERRED	= 1,
+	/*
+	 * PSCI 0.1 will contain function identifier values for the four
+	 * supported functions.
+	 *
+	 * There is no support for overriding function identifier values in
+	 * ACPI.
+	 */
+	PSCI_VERSION_0_1	= 2,
+	/*
+	 * PSCI 0.2 and later do not allow function identifier value overrides.
+	 */
+	PSCI_VERSION_0_2	= 3,
+	PSCI_VERSION_1_0	= 4,
+	PSCI_VERSION_1_1	= 5,
+	PSCI_VERSION_1_2	= 6,
+	/*
+	 * PSCI 1.3 is still being standardized (as of 2023-12-18).
+	 */
+	PSCI_VERSION_1_3	= 7,
+} psci_version_t;
+
+/*
+ * The PSCI conduit indicates the trap type that the PSCI code should use to
+ * access PSCI.
+ *
+ * We use these values to choose between Hypervisor calls (HVC) and Secure
+ * Monitor calls (SMC).  The conduit is always provided by firmware, either
+ * through the mandatory method property in the PSCI devicetree node or via the
+ * PSCI_USE_HVC bit in the Arm Boot Architecture Flags (these are in the FADT
+ * field called ARM_BOOT_ARCH).
+ */
+typedef enum {
+	/*
+	 * PSCI calls are made via "hvc #0".
+	 */
+	PSCI_CONDUIT_HVC	= 0,
+	/*
+	 * PSCI calls are made via "smc #0".
+	 */
+	PSCI_CONDUIT_SMC	= 1,
+} psci_conduit_t;
+
+struct psciinfo {
+	psci_version_t		pi_version;
+	psci_conduit_t		pi_conduit;
+	/*
+	 * Only populated from firmware in the PSCI 0.1 case and onlu ever on
+	 * devicetree machines.
+	 */
+	uint32_t		pi_cpu_suspend_id;
+	uint32_t		pi_cpu_off_id;
+	uint32_t		pi_cpu_on_id;
+	uint32_t		pi_migrate_id;
+};
+
+extern void psciinfo_init(void);
+extern const struct psciinfo *psciinfo_get(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _PSCIINFO_H */


### PR DESCRIPTION
Add a helper for gathering PSCI information from firmware, then tweak the PSCI code to use the new helper and initialise much earlier in the boot process, allowing early reboot to work as expected.

Similarly to the cpuinfo change in #58 the goal of this work is to make startup firmware independent.

Tests performed (all on qemu with the `virt` machine):
* Boot and shutdown: https://gist.github.com/r1mikey/4b352a704b1c036097a92101cfb18ac8
* Boot and reboot: https://gist.github.com/r1mikey/35ab035532be523efc108d0669308204
* Crash before any PSCI info or PSCI initialisation: https://gist.github.com/r1mikey/6f425031f772bf8c57f02c4befc99ae3
* Crash between PSCI info initialisation and PSCI initialisation: https://gist.github.com/r1mikey/dc4cbeb1da8ac60f3468ecdae07016d2
* Crash immediately after PSCI is up: https://gist.github.com/r1mikey/405789deb94a41b46921fcac6d76842f