### PR TITLE
Refactor GICv2 and interrupt handling

### DIFF
--- a/usr/src/uts/aarch64/sys/gic.h
+++ b/usr/src/uts/aarch64/sys/gic.h
@@ -21,7 +21,7 @@
  */
 /*
  * Copyright 2017 Hayashi Naoyuki
- * Copyright 2023 Michael van der Westhuizen
+ * Copyright 2024 Michael van der Westhuizen
  */
 
 #ifndef _SYS_GIC_H
@@ -35,416 +35,54 @@
 extern "C" {
 #endif
 
-/*
- * All names/etc here are derived from:
- *
- * ARM® Generic Interrupt Controller Architecture Specification
- *    GIC architecture version 3.0 and version 4.0
- *
- * (XXXARM: despite us using the memory mapped cpuif right now)
- */
-
-struct gic_dist {
-	volatile uint32_t ctlr;
-	volatile uint32_t typer;
-	volatile uint32_t iidr;
-	volatile uint32_t resv0[29];
-	/* : 0x80 */
-	volatile uint32_t igroupr[32];
-	/* : 0x100 */
-	volatile uint32_t isenabler[32];
-	volatile uint32_t icenabler[32];
-	/* : 0x200 */
-	volatile uint32_t ispendr[32];
-	volatile uint32_t icpendr[32];
-	/* : 0x300 */
-	volatile uint32_t isactiver[32];
-	volatile uint32_t icactiver[32];
-	/* : 0x400 */
-	volatile uint32_t ipriorityr[256];
-	/* : 0x800 */
-	volatile uint32_t itargetsr[256];
-	/* : 0xc00 */
-	volatile uint32_t icfgr[64];
-	/* : 0xd00 */
-	volatile uint32_t resv1[64];
-	/* : 0xe00 */
-	volatile uint32_t nsacr[64];
-	/* : 0xf00 */
-	volatile uint32_t sgir;
-	volatile uint32_t resv2[3];
-	/* : 0xf10 */
-	volatile uint32_t cpendsgir[4];
-	/* : 0xf20 */
-	volatile uint32_t spendsgir[4];
-	/* : 0xf30 */
-	volatile uint32_t resv3[52];
-};
-
-struct gic_cpuif {
-	volatile uint32_t ctlr;
-	volatile uint32_t pmr;
-	volatile uint32_t bpr;
-	volatile uint32_t iar;
-	/* : 0x10 */
-	volatile uint32_t eoir;
-	volatile uint32_t rpr;
-	volatile uint32_t hppir;
-	volatile uint32_t abpr;
-	/* : 0x20 */
-	volatile uint32_t aiar;
-	volatile uint32_t aeoir;
-	volatile uint32_t ahppir;
-	/* : 0x2c */
-	volatile uint32_t resv0[41];
-	/* : 0xd0 */
-	volatile uint32_t apr[4];
-	/* : 0xe0 */
-	volatile uint32_t nsapr[4];
-	/* : 0xf0 */
-	volatile uint32_t resv1[3];
-	volatile uint32_t iidr;
-};
+extern int gic_init(void);
+extern void gic_cpu_init(cpu_t *cp);
+extern void gic_send_ipi(cpuset_t cpuset, int irq);
+extern void gic_config_irq(uint32_t irq, bool is_edge);
 
 /*
- * §2.2 INTIDs
- *
- * Interrupts are partitioned with a certain convention, older GIC interfaces
- * only support up to 1024
- *
- * XXXARM: In GICv2 compat mode we only support 1024.  When we change to
- * modern GIC the max must be changed.
+ * For interrupt handling.
  */
-#define	GIC_INTID_MIN		0	/* Min Interrupt */
-#define	GIC_INTID_MIN_SGI	0	/* Min Software Generated Interrupt */
-#define	GIC_INTID_MAX_SGI	15	/* Max Software Generated Interrupt */
-#define	GIC_INTID_MIN_PPI	16	/* Min Private Peripheral Interrupt */
-#define	GIC_INTID_MAX_PPI	31	/* Max Private Peripheral Interrupt */
-#define	GIC_INTID_MIN_SPI	32	/* Min Shared Peripheral Interrupt */
-#define	GIC_INTID_MAX_SPI	1019	/* Max Shared Peripheral Interrupt */
-#define	GIC_INTID_MIN_SPECIAL	1020	/* Min "Special" Interrupt */
-#define	GIC_INTID_MAX_SPECIAL	1023	/* Max "Special" Interrupt */
-#define	GIC_INTID_MAX		1023	/* Max Interrupt (in compat mode) */
-
-#define	GIC_INTID_PERCPU_MIN	0	/* Start of cpu-local range */
-#define	GIC_INTID_PERCPU_MAX	31	/* End of cpu-local range */
+extern uint32_t gic_acknowledge(void);
+extern uint32_t gic_ack_to_vector(uint32_t ack);
+extern void gic_eoi(uint32_t ack);
+extern void gic_deactivate(uint32_t ack);
+extern int gic_vector_is_special(uint32_t intid);
 
 /*
- * §8.9.24 GICD_TYPER interrupt controller type register
+ * Types and data structure filled by GIC implementation modules
  */
-
-/* [25] 1 of N SPI interrupts supported? */
-#define	GICD_TYPER_NO1N_SHIFT	25
-#define	GICD_TYPER_NO1N_MASK	(0x1 << GICD_TYPER_NO1N_SHIFT)
-#define	GICD_TYPER_NO1N(typer)	((typer & GICD_TYPER_NO1N_MASK) >> \
-    GICD_TYPER_NO1N_SHIFT)
-
-/* [24] affinity 3 valid? */
-#define	GICD_TYPER_A3V_SHIFT	24
-#define	GICD_TYPER_A3V_MASK	(0x1 << GICD_TYPER_A3V_SHIFT)
-#define	GICD_TYPER_A3V(typer)	((typer & GICD_TYPER_A3V_MASK) >> \
-    GICD_TYPER_A3V_SHIFT)
-
-/* [23:19] number of interrupt ID bits supported - 1 */
-#define	GICD_TYPER_IDBITS_SHIFT		19
-#define	GICD_TYPER_IDBITS_MASK		(0x1f << GICD_TYPER_IDBITS_SHIFT)
-#define	GICD_TYPER_IDBITS(typer)	((typer & GICD_TYPER_IDBITS_MASK) >> \
-    GICD_TYPER_IDBITS_SHIFT)
-
-/* [18] supports Direct Virtual LPI injection? */
-#define	GICD_TYPER_DVIS_SHIFT	18
-#define	GICD_TYPER_DVIS_MASK	(0x1 << GICD_TYPER_DVIS_SHIFT)
-#define	GICD_TYPER_DVIS(typer)	((typer & GICD_TYPER_DVIS_MASK) >> \
-    GICD_TYPER_DVIS_SHIFT)
-
-/* [17] supports LPIs? */
-#define	GICD_TYPER_LPIS_SHIFT	17
-#define	GICD_TYPER_LPIS_MASK	(0x1 << GICD_TYPER_LPIS_SHIFT)
-#define	GICD_TYPER_LPIS(typer)	((typer & GICD_TYPER_LPIS_MASK) >> \
-    GICD_TYPER_LPIS_SHIFT)
-
-/* [16] supports message-based interrupts via distributor writes? */
-#define	GICD_TYPER_MBIS_SHIFT	16
-#define	GICD_TYPER_MBIS_MASK	(0x1 << GICD_TYPER_MBIS_SHIFT)
-#define	GICD_TYPER_MBIS(typer)	((typer & GICD_TYPER_MBIS_MASK) >> \
-    GICD_TYPE_MBIS_SHIFT)
-
-/* [10] supports two security states? */
-#define	GICD_TYPER_SECURITYEXTN_SHIFT	10
-#define	GICD_TYPER_SECURITYEXTN_MASK	(0x1 << GICD_TYPER_SECURITYEXTN_SHIFT)
-#define	GICD_TYPER_SECURITYEXTN(typer)	\
-	((typer & GICD_TYPER_SECURITYEXTN_MASK) >> \
-	GICD_TYPER_SECURITYEXTN_SHIFT)
-
-/* [7:5] number of cpus supported without affinity routing - 1 */
-#define	GICD_TYPER_CPUNUMBER_SHIFT	5
-#define	GICD_TYPER_CPUNUMBER_MASK	(0x7 << GICD_TYPER_CPUNUMBER_SHIFT)
-#define	GICD_TYPER_CPUNUMBER(typer)	\
-	((typer & GICD_TYPER_CPUNUMBER_MASK) >> GICD_TYPER_CPUNUMBER_SHIFT)
-
-/* [4:0] maximum SPI INTID, for value N maximum is (32*(N+1))-1 */
-#define	GICD_TYPER_ITLINESNUMBER_SHIFT	0
-#define	GICD_TYPER_ITLINESNUMBER_MASK	0x1f
-#define	GICD_TYPER_ITLINESNUMBER(typer)	\
-	((typer & GICD_TYPER_ITLINESNUMBER_MASK) >> \
-	GICD_TYPER_ITLINESNUMBER_SHIFT)
-
-/*
- * 8.9.4 GICD_CTLR, Distributor Control Register
- */
-
-/* [31] is a register write still propagating? */
-#define	GICD_CTLR_RWP_SHIFT	31
-#define	GICD_CTLR_RWP_MASK	(0x1 << GICD_CTLR_RWP_SHIFT)
-#define	GICD_CTLR_RWP(ctlr)	((ctlr & GICD_CTLR_RWP_MASK) >> \
-    GICD_CTLR_RWP_SHIFT)
-
-/* [7] enable 1 of N wakeup? */
-#define	GICD_CTLR_E1NWF_SHIFT	7
-#define	GICD_CTLR_E1NWF_MASK	(0x1 << GICD_CTLR_E1NWF_SHIFT)
-#define	GICD_CTLR_E1NWF(ctlr)	((ctlr & GICD_CTLR_E1NWF_MASK) >> \
-    GICD_CTLR_E1NWF_SHIFT)
-
-/* [6] disable security? */
-#define	GICD_CTLR_DS_SHIFT	6
-#define	GICD_CTLR_DS_MASK	(0x1 << GICD_CTLR_DS_SHIFT)
-#define	GICD_CTLR_DS(ctlr)	((ctlr & GICD_CTLR_DS_MASK) >> \
-    GICD_CTLR_DS_SHIFT)
-
-/* [5] enable affinity routing (for non secure state)? */
-#define	GICD_CTLR_ARENS_SHIFT	5
-#define	GICD_CTLR_ARENS_MASK	(0x1 << GICD_CTLR_ARENS_SHIFT)
-#define	GICD_CTLR_ARENS(ctlr)	((ctlr & GICD_CTLR_ARENS_MASK) >> \
-    GICD_CTLR_ARENS_SHIFT)
-
-/* [4] enable affinity routing (for secure state)? */
-#define	GICD_CTLR_ARES_SHIFT	4
-#define	GICD_CTLR_ARES_MASK	(0x1 << GICD_CTLR_ARES_SHIFT)
-#define	GICD_CTLR_ARES(ctlr)	((ctlr & GICD_CTLR_ARES_MASK) >> \
-    GICD_CTLR_ARES_SHIFT)
-
-/* [2] enable secure group 1 interrupts? */
-#define	GICD_CTLR_ENABLEGRP1S_SHIFT	2
-#define	GICD_CTLR_ENABLEGRP1S_MASK	(0x1 << GICD_CTLR_ENABLEGRP1S_SHIFT)
-#define	GICD_CTLR_ENABLEGRP1S(ctlr)	\
-	((ctlr & GICD_CTLR_ENABLEGRP1S_MASK) >> GICD_CTLR_ENABLEGRP1S_SHIFT)
-
-/* [1] enable non-secure group 1 interrupts?  */
-#define	GICD_CTLR_ENABLEGRP1NS_SHIFT	1
-#define	GICD_CTLR_ENABLEGRP1NS_MASK	(0x1 << GICD_CTLR_ENABLEGRP1NS_SHIFT)
-#define	GICD_CTLR_ENABLEGRP1NS(ctlr)	\
-	((ctlr & GICD_CTLR_ENABLEGRP1NS_MASK) >> GICD_CTLR_ENABLEGRP1NS_SHIFT)
-
-/* [0] enable group 0 interrupts? */
-#define	GICD_CTLR_ENABLEGRP0_SHIFT	0
-#define	GICD_CTLR_ENABLEGRP0_MASK	(0x1 << GICD_CTLR_ENABLEGRP0_SHIFT)
-#define	GICD_CTLR_ENABLEGRP0(ctlr)	((ctlr & GICD_CTLR_ENABLEGRP0_MASK) >> \
-    GICD_CTLR_ENABLEGRP0_SHIFT)
-
-#define	GICD_CTLR_ENABLE_GROUP0	GICD_CTLR_ENABLEGRP0_MASK
-
-/*
- * §8.13.7 GICC_CTLR, CPU Interface Control Register
- *
- * NB: This register changes form depending on the value of GICD_CTLR.DS We
- * always establish this as 0, and these values assume it GICD_CTLR.DS==0
- */
-
-/* [10] non-secure EOI behaviour.  If 1 only does pri drop, not deactivate */
-#define	GICC_CTLR_EOIMODENS_SHIFT	10
-#define	GICC_CTLR_EOIMODENS_MASK	(0x1 << GICC_CTLR_EOIMODENS_SHIFT)
-#define	GICC_CTLR_EOIMODENS(ctlr)	((ctlr & GICC_CTLR_EOIMODENS_MASK) >> \
-    GICC_CTLR_EOIMODENS_SHIFT)
-
-/* [9] secure EOI behaviour.  If 1 only does pri drop, not deactivate */
-#define	GICC_CTLR_EOIMODES_SHIFT	9
-#define	GICC_CTLR_EOIMODES_MASK		(0x1 << GICC_CTLR_EOIMODES_SHIFT)
-#define	GICC_CTLR_EOIMODES(ctlr)	((ctlr & GICC_CTLR_EOIMODES_MASK) >> \
-    GICC_CTLR_EOIMODES_SHIFT)
-
-/* [8] disable bypass signal for irq group 1? */
-#define	GICC_CTLR_IRQBYPDISGRP1_SHIFT	8
-#define	GICC_CTLR_IRQBYPDISGRP1_MASK	(0x1 << GICC_CTLR_IRQBYPDISGRP1_SHIFT)
-#define	GICC_CTLR_IRQBYPDISGRP1(ctlr)	\
-	((ctlr & GICC_CTLR_IRQBYPDISGRP1_MASK) >> GICC_CTLR_IRQBYPDISGRP1_SHIFT)
-
-/* [7] disable bypass signal for fiq group 1? */
-#define	GICC_CTLR_FIQBYPDISGRP1_SHIFT	7
-#define	GICC_CTLR_FIQBYPDISGRP1_MASK	(0x1 << GICC_CTLR_FIQBYPDISGRP1_SHIFT)
-#define	GICC_CTLR_FIQBYPDISGRP1(ctlr)	\
-	((ctlr & GICC_CTLR_FIQBYPDISGRP1_MASK) >> GICC_CTLR_FIQBYPDISGRP1_SHIFT)
-
-/* [6] disable bypass signal for irq group 0 */
-#define	GICC_CTLR_IRQBYPDISGRP0_SHIFT	6
-#define	GICC_CTLR_IRQBYPDISGRP0_MASK	(0x1 << GICC_CTLR_IRQBYPDISGRP0_SHIFT)
-#define	GICC_CTLR_IRQBYPDISGRP0(ctlr)	\
-	((ctlr & GICC_CTLR_IRQBYPDISGRP0_MASK) >> GICC_CTLR_IRQBYPDISGRP0_SHIFT)
-
-/* [5] disable bypass signal for fiq group 1? */
-#define	GICC_CTLR_FIQBYPDISGRP0_SHIFT	5
-#define	GICC_CTLR_FIQBYPDISGRP0_MASK	(0x1 << GICC_CTLR_FIQBYPDISGRP0_SHIFT)
-#define	GICC_CTLR_FIQBYPDISGRP0(ctlr)	\
-	((ctlr & GICC_CTLR_FIQBYPDISGRP0_MASK) >> GICC_CTLR_FIQBYPDISGRP0_SHIFT)
-
-/* [4] GICC_BPR contrlors both group 0 and group 1? */
-#define	GICC_CTLR_CBPR_SHIFT	4
-#define	GICC_CTLR_CBPR_MASK	(0x1 << GICC_CTLR_CBPR_SHIFT)
-#define	GICC_CTLR_CBPR(ctlr)	((ctlr & GICC_CTLR_CBPR_MASK) >> \
-    GICC_CTLR_CBPR_SHIFT)
-
-/* [3] group 0 interrupts via FIQ? */
-#define	GICC_CTLR_FIQEN_SHIFT	3
-#define	GICC_CTLR_FIQEN_MASK	(0x1 << GICC_CTLR_FIQEN_SHIFT)
-#define	GICC_CTLR_FIQEN(ctlr)	((ctlr & GICC_CTLR_FIQEN_MASK) >> \
-    GICC_CTLR_FIQEN_SHIFT)
-
-/* [1] enable group 1? */
-#define	GICC_CTLR_ENABLEGRP1_SHIFT	1
-#define	GICC_CTLR_ENABLEGRP1_MASK	(0x1 << GICC_CTLR_ENABLEGRP1_SHIFT)
-#define	GICC_CTLR_ENABLEGRP1(ctlr)	((ctlr & GICC_CTLR_ENABLEGRP1_MASK) >> \
-    GICC_CTLR_ENABLEGRP1_SHIFT)
-
-/* [0] enable group 1? */
-#define	GICC_CTLR_ENABLEGRP0_SHIFT	0
-#define	GICC_CTLR_ENABLEGRP0_MASK	(0x1 << GICC_CTLR_ENABLEGRP0_SHIFT)
-#define	GICC_CTLR_ENABLEGRP0(ctlr)	((ctlr & GICC_CTLR_ENABLEGRP0_MASK) >> \
-    GICC_CTLR_ENABLEGRP0_SHIFT)
-
-#define	GICC_CTLR_ENABLE_GROUP0		GICC_CTLR_ENABLEGRP0_MASK
-#define	GICC_CTLR_ENABLE_GROUP1		GICC_CTLR_ENABLEGRP1_MASK
-
-/*
- * §8.13.11 GICC_IAR CPU Interface Interrupt Acknowledge Register
- *
- * Note that this differs when affinity routing is enabled to a mask of 0x3fffff
- * Without affinity routing bits [23:13] are also reserved, and bits [12:10]
- * indicate the source of an SGI or are otherwise reserved.
- *
- * This leaves us with [9:0] as intid.
- *
- * NB: The bits that become reserved _do not necessarily become 0_, we must
- * adjust the masking.
- */
-#define	GICC_IAR_INTID_SHIFT	0
-#define	GICC_IAR_INTID_MASK	(0x3ff << GICC_IAR_INTID_SHIFT)
-#define	GICC_IAR_INTID(iar)	((iar & GICC_IAR_INTID_MASK) >> \
-    GICC_IAR_INTID_SHIFT)
-
-/* Map IRQ to GICD_IPRIORITYR<n> */
-#define	GICD_IRQ_TO_IPRIORITYR(irq)	((irq) / 4)
-
-/* Map IRQ to GICD_IRPRIORITYR<n>.INTR (the 8 bit field within each register) */
-#define	GICD_IRQ_TO_IPRIORITYR_FIELD(irq, val)	(val << (8 * (irq % 4)))
-
-/* Map IRQ to GICD_ITARGETSR<n> */
-#define	GICD_IRQ_TO_ITARGETSR(irq)	((irq) / 4)
-
-/* Map IRQ to GICD_ITARGETSR<n>.INTR (the 8 bit field within each register) */
-#define	GICD_IRQ_TO_ITARGETSR_FIELD(irq, val)	(val << (8 * (irq % 4)))
-
-/* Map IRQ to GICD_ISENABLER<n> */
-#define	GICD_IRQ_TO_ISENABLER(irq)	((irq) / 32)
-
-/* Map IRQ to GICD_ISENABLER<n>.INTR */
-#define	GICD_IRQ_TO_ISENABLER_FIELD(irq)	(1 << ((irq) % 32))
-
-/* Map IRQ to GICD_ICFGR<n> */
-#define	GICD_IRQ_TO_ICFGR(irq)	((irq) / 16)
-
-/* Map IRQ to GICD_ICFGR<n>.INTR */
-#define	GICD_IRQ_TO_ICFGR_FIELD(irq, val)	(val << (((irq) % 16) * 2))
-
-/*
- * §8.9.21 GICD_SGIR, Software Generated Interrupt Register
- */
-/*
- * [24:23] determine how SGI is forwarded
- * 00 - forward to all in TARGETS
- * 01 - forward the interrupt to all cpus except this one
- * 10 - forward to the cpu that requested the interrupt
- * 11 - Reserved.
- */
-#define	GICD_SGIR_TARGETFILTER_SHIFT	24
-#define	GICD_SGIR_TARGETFILTER_MASK	(0x3 << GICD_SGIR_TARGETFILTER_SHIFT)
-/*
- * [23:16] target list, set bit for each cpu to receive
- * (XXXARM: GICv2/8 cpu limit)
- */
-#define	GICD_SGIR_TARGETS_SHIFT		16
-#define	GICD_SGIR_TARGETS_MASK		(0xff << GICD_SGIR_TARGETS_SHIFT)
-
-/* [15] forward to cpu only if group 1 on that cpu */
-#define	GICD_SGIR_NSATT_SHIFT		15
-#define	GICD_SGIR_NSATT_MASK		(1 << GICD_SGIR_NSATT_SHIFT)
-
-/* [3:0] SGI INTID to send */
-#define	GICD_SGIR_INTID_SHIFT		0
-#define	GICD_SGIR_INTID_MASK		(0xf << GICD_SGIR_INTID_SHIFT)
-
-#define	GICD_SGIR(filter, targets, nsatt, intid)			\
-	(((filter << GICD_SGIR_TARGETFILTER_SHIFT) &			\
-	GICD_SGIR_TARGETFILTER_MASK) |					\
-	((targets << GICD_SGIR_TARGETS_SHIFT) &				\
-	GICD_SGIR_TARGETS_MASK) |					\
-	((nsatt << GICD_SGIR_NSATT_SHIFT) & GICD_SGIR_NSATT_MASK) |	\
-	((intid << GICD_SGIR_INTID_SHIFT) & GICD_SGIR_INTID_MASK))
-
-/*
- * GIC supports at least 16 levels, which is what we need, so we only use
- * those 16.
- *
- * See §4.8 Interrupt Prioritization
- * for a description of how these priorities are arranged within a byte
- *
- * In short, we count down from 240 (ipl 0) to 0 (ipl 15) in steps of 16.
- */
-#define	GIC_IPL_TO_PRI(ipl)	((0xF & ~(ipl)) << 4)
-
-void gic_mask_level_irq(int irq);
-void gic_unmask_level_irq(int irq);
-
-void gic_send_ipi(cpuset_t cpuset, int irq);
-int gic_init(void);
-void gic_init_primary(void);
-void gic_init_secondary(int);
-void gic_config_irq(uint32_t irq, bool is_edge);
-int gic_num_cpus(void);
-
-/*
- * Types and data structure filled by GIC implementation modukles
- */
-typedef void (*mask_level_irq_t)(int irq);
-typedef void (*unmask_level_irq_t)(int irq);
-typedef void (*send_ipi_t)(cpuset_t cpuset, int irq);
-typedef void (*init_primary_t)(void);
-typedef void (*init_secondary_t)(int id);
-typedef void (*config_irq_t)(uint32_t irq, bool is_edge);
-typedef int (*num_cpus_t)(void);
-typedef int (*addspl_t)(int irq, int ipl, int min_ipl, int max_ipl);
-typedef int (*delspl_t)(int irq, int ipl, int min_ipl, int max_ipl);
-typedef int (*setlvl_t)(int irq);
-typedef void (*setlvlx_t)(int ipl, int irq);
+typedef void (*gic_send_ipi_t)(cpuset_t cpuset, int irq);
+typedef int (*gic_init_t)(void);
+typedef void (*gic_cpu_init_t)(cpu_t *cp);
+typedef void (*gic_config_irq_t)(uint32_t irq, bool is_edge);
+typedef int (*gic_addspl_t)(int irq, int ipl, int min_ipl, int max_ipl);
+typedef int (*gic_delspl_t)(int irq, int ipl, int min_ipl, int max_ipl);
+typedef int (*gic_setlvl_t)(int irq);
+typedef void (*gic_setlvlx_t)(int ipl);
+typedef uint32_t (*gic_acknowledge_t)(void);
+typedef uint32_t (*gic_ack_to_vector_t)(uint32_t ack);
+typedef void (*gic_eoi_t)(uint32_t ack);
+typedef void (*gic_deactivate_t)(uint32_t ack);
+typedef int (*gic_vector_is_special_t)(uint32_t intid);
 
 typedef struct gic_ops {
-	mask_level_irq_t	mask_level_irq;
-	unmask_level_irq_t	unmask_level_irq;
-	send_ipi_t		send_ipi;
-	init_primary_t		init_primary;
-	init_secondary_t	init_secondary;
-	config_irq_t		config_irq;
-	num_cpus_t		num_cpus;
-	addspl_t		addspl;
-	delspl_t		delspl;
-	setlvl_t		setlvl;
-	setlvlx_t		setlvlx;
+	gic_send_ipi_t		go_send_ipi;
+	gic_init_t		go_init;
+	gic_cpu_init_t		go_cpu_init;
+	gic_config_irq_t	go_config_irq;
+	gic_addspl_t		go_addspl;
+	gic_delspl_t		go_delspl;
+	gic_setlvl_t		go_setlvl;
+	gic_setlvlx_t		go_setlvlx;
+	gic_acknowledge_t	go_acknowledge;
+	gic_ack_to_vector_t	go_ack_to_vector;
+	gic_eoi_t		go_eoi;
+	gic_deactivate_t	go_deactivate;
+	gic_vector_is_special_t	go_vector_is_special;
 } gic_ops_t;
 
 extern gic_ops_t gic_ops;
-
-/*
- * Populated when MMIO access to the CPU interface is needed.
- */
-extern volatile struct gic_cpuif *gic_cpuif;
 
 #ifdef __cplusplus
 }

--- a/usr/src/uts/aarch64/sys/gic_reg.h
+++ b/usr/src/uts/aarch64/sys/gic_reg.h
@@ -1,0 +1,829 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2024 Michael van der Westhuizen
+ */
+
+#ifndef _GIC_REG_H
+#define	_GIC_REG_H
+
+/*
+ * Arm Generic Interrupt Controller registers
+ *
+ * Covers GICv2 and GICv3+.
+ *
+ * Where secure and non-secure versions of the registers are available we only
+ * capture the non-secure versions of the registers (since we expect to run in
+ * the non-secure world).
+ *
+ * There are 32 per-CPU interrupts, half of which are software generated and
+ * the other half are for per-CPU IP blocks (such as timers). These are broken
+ * down into ranges: Software Generated Interrupts (SGI) and Private Peripheral
+ * Interrupts (PPI). Arm recommends that half the SGI range is reserved for use
+ * by the secure world.
+ *
+ * We then have Shared Peripheral Interrupts. In GICv2 these run up to 1023,
+ * with 1020-1023 as special interrupts.
+ *
+ * In a GICv3.1 implementation the interrupt space is extended significantly,
+ * introducing additional space for both PPI and SPI interrupts.
+ *
+ * Finally, Locality-specific Peripheral Interrupts (LPI) get a separate range
+ * of their own. LPI was introduced in GICv3. If LPIs are supported there will
+ * be at least 8192 LPIs available.
+ *
+ *    0 -    7: SGI for the non-secure world
+ *    8 -   15: SGI or the secure world
+ *   16 -   31: PPI
+ *   32 - 1019: SPI
+ * 1020 - 1023: Special
+ * 1056 - 1119: Extended PPI (GICv3.1+)
+ * 4096 - 5119: Extended SPI (GICv3.1+)
+ * 8192 -     : LPI (max is at least 16384)
+ *
+ * From the point of view of an operating system, special interrupt 1023
+ * indicates that the interrupt acknowledge is spurious, which can happen
+ * when GIC maintenance operations race with interrupt handling or when the
+ * non-secure world performs an interrupt acknowledge while the highest
+ * priority pending interrupt is a group 0 (secure world) interrupt.
+ *
+ * The SGI split (0-7 for NS, 8-15 for S) comes from IHI0048 $2.2.1 and
+ * IHI0069 $2.2, where it is stated that:
+ *   Arm strongly recommends that software reserves:
+ *   - INTID0 - INTID7 for Non-secure interrupts.
+ *   - INTID8 - INTID15 for Secure interrupts.
+ *
+ * It is possible (and likely) that not all INTIDs in the SPI, Extended PPI and
+ * Extended SPI space are implemented. When this is the case, the documentation
+ * states:
+ *   Arm strongly recommends that implemented interrupts are grouped to use
+ *   the lowest INTID numbers and as small a range of INTIDs as possible. This
+ *   reduces the size of the associated tables in memory that must be
+ *   implemented, and that discovery routines must check.
+ *
+ * Document references:
+ * IHI0069: Arm® Generic Interrupt Controller Architecture Specification
+ *          GIC architecture version 3 and version 4
+ * IHI0048: ARM® Generic Interrupt Controller Architecture version 2.0
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define	GIC_INTID_MIN		0
+#define	GIC_INTID_SGI_MIN	0
+#define	GIC_INTID_SGI_NS_MIN	0
+#define	GIC_INTID_SGI_NS_MAX	7
+#define	GIC_INTID_SGI_S_MIN	8
+#define	GIC_INTID_SGI_S_MAX	15
+#define	GIC_INTID_SGI_MAX	15
+#define	GIC_INTID_PPI_MIN	16
+#define	GIC_INTID_PPI_MAX	31
+#define	GIC_INTID_SPI_MIN	32
+#define	GIC_INTID_SPI_MAX	1019
+#define	GIC_INTID_SPECIAL_MIN	1020
+#define	GIC_INTID_SPURIOUS	1023
+#define	GIC_INTID_SPECIAL_MAX	1023
+#define	GIC_INTID_EPPI_MIN	1056
+#define	GIC_INTID_EPPI_MAX	1119
+#define	GIC_INTID_ESPI_MIN	4096
+#define	GIC_INTID_ESPI_MAX	5119
+#define	GIC_INTID_LPI_MIN	8192
+
+#define	GIC_INTID_IS_SGI(v)	((v) <= (GIC_INTID_SGI_MAX))
+#define	GIC_INTID_IS_PPI(v)	((v) >= (GIC_INTID_PPI_MIN) && \
+				(v) <= (GIC_INTID_PPI_MAX))
+#define	GIC_INTID_IS_SPI(v)	((v) >= (GIC_INTID_SPI_MIN) && \
+				(v) <= (GIC_INTID_SPI_MAX))
+#define	GIC_INTID_IS_SPECIAL(v)	((v) >= (GIC_INTID_SPECIAL_MIN) && \
+				(v) <= (GIC_INTID_SPECIAL_MAX))
+#define	GIC_INTID_IS_EPPI(v)	((v) >= (GIC_INTID_EPPI_MIN) && \
+				(v) <= (GIC_INTID_EPPI_MAX))
+#define	GIC_INTID_IS_ESPI(v)	((v) >= (GIC_INTID_ESPI_MIN) && \
+				(v) <= (GIC_INTID_ESPI_MAX))
+#define	GIC_INTID_IS_LPI(v)	((v) >= (GIC_INTID_LPI_MIN))
+#define	GIC_INTID_IS_ANY_PPI(v)	(GIC_INTID_IS_PPI((v)) || \
+				GIC_INTID_IS_EPPI((v)))
+#define	GIC_INTID_IS_ANY_SPI(v)	(GIC_INTID_IS_SPI((v)) || \
+				GIC_INTID_IS_ESPI((v)))
+#define	GIC_INTID_IS_PERCPU(v)	((v) <= (GIC_INTID_PPI_MAX))
+
+/*
+ * GIC Distributor Interface
+ */
+
+/*
+ * Distributor Control Register
+ */
+#define	GICD_CTLR				0x0000
+#define	GICD_CTLR_RWP				0x80000000
+#define	GICD_CTLR_ARE_NS			0x00000010
+#define	GICD_CTLR_EnableGrp1A			0x00000002
+#define	GICD_CTLR_EnableGrp1			0x00000001
+
+/*
+ * Interrupt Controller Type Register
+ */
+#define	GICD_TYPER				0x0004
+#define	GICD_TYPER_ESPI_range			0xF8000000
+#define	GICD_TYPER_RSS				0x04000000
+#define	GICD_TYPER_No1N				0x02000000
+#define	GICD_TYPER_A3V				0x01000000
+#define	GICD_TYPER_IDbits			0x00F80000
+#define	GICD_TYPER_DVIS				0x00040000
+#define	GICD_TYPER_LPIS				0x00020000
+#define	GICD_TYPER_MBIS				0x00010000
+#define	GICD_TYPER_num_LPIs			0x0000F800
+/* [10] Indicates that the GIC supports two security states */
+#define	GICD_TYPER_SecurityExtn			0x00000400
+#define	GICD_TYPER_NMI				0x00000200
+#define	GICD_TYPER_ESPI				0x00000100
+#define	GICD_TYPER_CPUNumber			0x000000E0
+#define	GICD_TYPER_CPUNumber_SHIFT		5
+#define	GICD_TYPER_ITLinesNumber		0x0000001F
+#define	GICD_TYPER_LINES(n)			MIN(((32*(((n)&0x1F)+1))-1), \
+						1020)
+
+#define	GICD_TYPER_CPUNUMBER(n)			(((n)&(GICD_TYPER_CPUNumber)) \
+						>> (GICD_TYPER_CPUNumber_SHIFT))
+
+#define	GICD_IIDR				0x0008
+#define	GICD_IIDR_ProductID			0xFF000000
+#define	GICD_IIDR_Variant			0x000F0000
+#define	GICD_IIDR_Revision			0x0000F000
+#define	GICD_IIDR_Implementer			0x00000FFF
+
+#define	GICD_TYPER2				0x000c
+#define	GICD_TYPER2_nASSGIcap			0x00000100
+#define	GICD_TYPER2_VIL				0x00000080
+#define	GICD_TYPER2_VID				0x0000001F
+
+#define	GICD_STATUSR				0x0010
+#define	GICD_STATUSR_WROD			0x00000008
+#define	GICD_STATUSR_RWOD			0x00000004
+#define	GICD_STATUSR_WRD			0x00000002
+#define	GICD_STATUSR_RRD			0x00000001
+
+#define	GICD_SETSPI_NSR				0x0040
+#define	GICD_SETSPI_NSR_INTID			0x00001FFF
+
+#define	GICD_CLRSPI_NSR				0x0048
+#define	GICD_CLRSPI_NSR_INTID			0x00001FFF
+
+#define	GICD_SETSPI_SR				0x0050
+#define	GICD_SETSPI_SR_INTID			0x00001FFF
+
+#define	GICD_CLRSPI_SR				0x0058
+#define	GICD_CLRSPI_SR_INTID			0x00001FFF
+
+#define	GICD_IGROUPRn(n)			(0x0080+(4*(n)))
+#define	GICD_IGROUPR_REGNUM(v)			((v)>>5)
+#define	GICD_IGROUPR_REGBIT(v)			(1U<<((v)&0x1F))
+
+#define	GICD_ISENABLERn(n)			(0x0100+(4*(n)))
+#define	GICD_ICENABLERn(n)			(0x0180+(4*(n)))
+#define	GICD_IENABLER_REGNUM(v)			(GICD_IGROUPR_REGNUM((v)))
+#define	GICD_IENABLER_REGBIT(v)			(GICD_IGROUPR_REGBIT((v)))
+
+#define	GICD_ISPENDRn(n)			(0x0200+(4*(n)))
+#define	GICD_ICPENDRn(n)			(0x0280+(4*(n)))
+#define	GICD_IPENDR_REGNUM(v)			(GICD_IGROUPR_REGNUM((v)))
+#define	GICD_IPENDR_REGBIT(v)			(GICD_IGROUPR_REGBIT((v)))
+
+#define	GICD_ISACTIVERn(n)			(0x0300+(4*(n)))
+#define	GICD_ICACTIVERn(n)			(0x0380+(4*(n)))
+#define	GICD_IACTIVER_REGNUM(v)			(GICD_IGROUPR_REGNUM((v)))
+#define	GICD_IACTIVER_REGBIT(v)			(GICD_IGROUPR_REGBIT((v)))
+
+#define	GICD_IPRIORITYRn(n)			(0x0400+(4*(n)))
+#define	GICD_IPRIORITY_REGMASK			0xff
+#define	GICD_IPRIORITY_REGNUM(n)		((n) >> 2)
+#define	GICD_IPRIORITY_REGVAL(n, v)		(((v) & 0xff) << \
+						(((n) & 0x3) << 3))
+#define	GICD_IPRIORITY_SETPRIO(val, n, v)	(((val) & \
+						~(GICD_IPRIORITY_REGVAL((n), \
+						0xFF))) | \
+						(GICD_IPRIORITY_REGVAL((n), \
+						(v))))
+/*
+ * We only support a GIC that has at least 32 levels of priority, as the
+ * non-secure world (where we run) will then have 16 levels available.
+ *
+ * See §4.8 Interrupt Prioritization
+ * for a description of how these priorities are arranged within a byte
+ *
+ * In short, we count down from 248 (ipl 0) to 128 (ipl 15) in steps of 8.
+ */
+#define	GIC_IPL_TO_PRIO(ipl)			(0xF8 - ((ipl) << 3))
+
+#define	GICD_ITARGETSRn(n)			(0x0800+(4*(n)))
+#define	GICD_ITARGETSR_REGMASK			0xFF
+#define	GICD_ITARGETSR_REGNUM(n)		((n) >> 2)
+#define	GICD_ITARGETSR_REGVAL(n, v)		(((v) & 0xff) << \
+						(((n) & 0x3) << 3))
+#define	GICD_ITARGETSR_SETTARGETS(val, n, v)	(((val) & \
+						~(GICD_ITARGETSR_REGVAL((n), \
+						0xFF))) | \
+						(GICD_ITARGETSR_REGVAL((n), \
+						(v))))
+
+#define	GICD_ICFGRn(n)				(0x0c00+(4*(n)))
+#define	GICD_ICFGR_INT_CONFIG_MASK		0x3
+#define	GICD_ICFGR_INT_CONFIG_LEVEL		0x0
+#define	GICD_ICFGR_INT_CONFIG_EDGE		0x2
+#define	GICD_ICFGR_REGNUM(irq)			((irq) >> 4)
+#define	GICD_ICFGR_REGOFF(irq)			(((irq) & 0xf) << 1)
+#define	GICD_ICFGR_REGVAL(irq, v)		(((v) & 0x3) << \
+						(((irq) & 0xf) << 1))
+#define	GICD_ICFGR_SETVAL(val, irq, v)		(((val) & \
+						~(GICD_ICFGR_REGVAL((irq), \
+						(GICD_ICFGR_INT_CONFIG_MASK))))\
+						| (GICD_ICFGR_REGVAL((irq), \
+						(v))))
+
+/* GICv3+ only */
+#define	GICD_IGRPMODRn(n)			(0x0d00+(4*(n)))
+
+#define	GICD_NSACRn(n)				(0x0e00+(4*(n)))
+
+#define	GICD_SGIR				0x0f00
+#define	GICD_SGIR_TargetListFilter		0x03000000
+#define	GICD_SGIR_TargetListSpecified		0x0
+#define	GICD_SGIR_TargetListAllButMe		0x1
+#define	GICD_SGIR_TargetListOnlyMe		0x2
+#define	GICD_SGIR_TargetListReserved		0x3
+#define	GICD_SGIR_TargetList_MASK		0x3
+#define	GICD_SGIR_TargetList_SHIFT		24
+#define	GICD_SGIR_CPUTargetList			0x00FF0000
+#define	GICD_SGIR_CPUTargetList_MASK		0xFF
+#define	GICD_SGIR_CPUTargetList_SHIFT		16
+/*
+ * This field is writable only by a Secure access. Any Non-secure write to the
+ * GICD_SGIR generates an SGI only if the specified SGI is programmed as
+ * Group 1, regardless of the value of bit[15] of the write.
+ */
+#define	GICD_SGIR_NSATT				0x00008000
+#define	GICD_SGIR_NSATT_MASK			0x1
+#define	GICD_SGIR_NSATT_SHIFT			15
+#define	GICD_SGIR_INTID				0x0000000F
+#define	GICD_SGIR_INTID_MASK			0xF
+#define	GICD_SGIR_INTID_SHIFT			0
+
+/*
+ * Make the target list component of the software generated interrupt register.
+ */
+#define	GICD_MAKE_SGIR_TLF(f)			(((f) & \
+						(GICD_SGIR_TargetList_MASK)) \
+						<< (GICD_SGIR_TargetList_SHIFT))
+/*
+ * Make the CPU target list component of the software generated interrupt
+ * register.
+ */
+#define	GICD_MAKE_SGIR_CTL(t)			(((t) & \
+						(GICD_SGIR_CPUTargetList_MASK))\
+						<< \
+						(GICD_SGIR_CPUTargetList_SHIFT))
+/*
+ * Make the non-secure attribute component of the software generated interrupt
+ * register.
+ */
+#define	GICD_MAKE_SGIR_NSATT(n)			(((n) & (GICD_SGIR_NSATT_MASK))\
+						<< (GICD_SGIR_NSATT_SHIFT))
+/*
+ * Make the INTID component of the software generated interrupt register.
+ */
+#define	GICD_MAKE_SGIR_INTID(i)			((i) & (GICD_SGIR_INTID_MASK))
+/*
+ * Create the register value to write to the software generated interrupt
+ * register.
+ */
+#define	GICD_MAKE_SGIR_REGVAL(f, t, n, i)	((GICD_MAKE_SGIR_TLF((f))) | \
+						(GICD_MAKE_SGIR_CTL((t))) | \
+						(GICD_MAKE_SGIR_NSATT((n))) | \
+						(GICD_MAKE_SGIR_INTID((i))))
+
+#define	GICD_CPENDSGIRn(n)			(0x0f10+(4*(n)))
+#define	GICD_SPENDSGIRn(n)			(0x0f20+(4*(n)))
+
+/* GICv3+ only (until GICD_PIDR2) */
+#define	GICD_INMIRn(n)				(0x0f80+(4*(n)))
+#define	GICD_IGROUPRnE(n)			(0x1000+(4*(n)))
+#define	GICD_ISENABLERnE(n)			(0x1200+(4*(n)))
+#define	GICD_ICENABLERnE(n)			(0x1400+(4*(n)))
+#define	GICD_ISPENDRnE(n)			(0x1600+(4*(n)))
+#define	GICD_ICPENDRnE(n)			(0x1800+(4*(n)))
+#define	GICD_ISACTIVERnE(n)			(0x1a00+(4*(n)))
+#define	GICD_ICACTIVERnE(n)			(0x1c00+(4*(n)))
+#define	GICD_IPRIORITYRnE(n)			(0x2000+(4*(n)))
+#define	GICD_ICFGRnE(n)				(0x3000+(4*(n)))
+#define	GICD_IGRPMODRnE(n)			(0x3400+(4*(n)))
+#define	GICD_NSACRnE(n)				(0x3600+(4*(n)))
+#define	GICD_INMIRnE(n)				(0x3b00+(4*(n)))
+#define	GICD_IROUTERn(n)			(0x6100+(8*(n)))
+#define	GICD_IROUTERnE(n)			(0x8000+(8*(n)))
+
+#define	GICD_PIDR2				0xffe8
+#define	GICD_PIDR2_ArchRev			0x000000F0
+
+/*
+ * GIC Redistributor Interface
+ *
+ * The redistributor was introduced in GICv3.
+ */
+#define	GICR_CTLR				0x0000
+#define	GICR_CTLR_UWP				0x80000000
+#define	GICR_CTLR_DPG1S				0x04000000
+#define	GICR_CTLR_DPG1NS			0x02000000
+#define	GICR_CTLR_DPG0				0x01000000
+#define	GICR_CTLR_RWP				0x00000008
+#define	GICR_CTLR_IR				0x00000004
+#define	GICR_CTLR_CES				0x00000002
+#define	GICR_CTLR_EnableLPIs			0x00000001
+
+#define	GICR_IIDR				0x0004
+#define	GICR_IIDR_ProductID			0xFF000000
+#define	GICR_IIDR_Variant			0x000F0000
+#define	GICR_IIDR_Revision			0x0000F000
+#define	GICR_IIDR_Implementer			0x00000FFF
+
+#define	GICR_TYPER				0x0008
+#define	GICR_TYPER_Affinity_Value		0xFFFFFFFF00000000
+#define	GICR_TYPER_Affinity_Value_Aff3		0xFF00000000000000
+#define	GICR_TYPER_Affinity_Value_Aff2		0x00FF000000000000
+#define	GICR_TYPER_Affinity_Value_Aff1		0x0000FF0000000000
+#define	GICR_TYPER_Affinity_Value_Aff0		0x000000FF00000000
+#define	GICR_TYPER_PPInum			0xF8000000
+#define	GICR_TYPER_VSGI				0x04000000
+#define	GICR_TYPER_CommonLPIAff			0x03000000
+#define	GICR_TYPER_Processor_Number		0x00FFFF00
+#define	GICR_TYPER_RVPEID			0x00000080
+#define	GICR_TYPER_MPAM				0x00000040
+#define	GICR_TYPER_DPGS				0x00000020
+#define	GICR_TYPER_Last				0x00000010
+#define	GICR_TYPER_DirectLPI			0x00000008
+#define	GICR_TYPER_Dirty			0x00000004
+#define	GICR_TYPER_VLPIS			0x00000002
+#define	GICR_TYPER_PLPIS			0x00000001
+
+#define	GICR_STATUSR				0x0010
+#define	GICR_STATUSR_WROD			0x00000008
+#define	GICR_STATUSR_RWOD			0x00000004
+#define	GICR_STATUSR_WRD			0x00000002
+#define	GICR_STATUSR_RRD			0x00000001
+
+#define	GICR_WAKER				0x0014
+#define	GICR_WAKER_ChildrenAsleep		0x00000004
+#define	GICR_WAKER_ProcessorSleep		0x00000002
+
+#define	GICR_MPAMIDR				0x0018
+#define	GICR_MPAMIDR_PMGmax			0x00FF0000
+#define	GICR_MPAMIDR_PARTIDmax			0x0000FFFF
+
+#define	GICR_PARTIDR				0x001c
+#define	GICR_PARTIDR_PMG			0x00FF0000
+#define	GICR_PARTIDR_PARTID			0x0000FFFF
+
+#define	GICR_SETLPIR				0x0040
+#define	GICR_SETLPIR_pINTID			0xffffffff
+
+#define	GICR_CLRLPIR				0x0048
+#define	GICR_CLRLPIR_pINTID			0xffffffff
+
+#define	GICR_PROPBASER				0x0070
+#define	GICR_PROPBASER_OuterCache		0x0700000000000000
+#define	GICR_PROPBASER_Physical_Address		0x000FFFFFFFFFF000
+#define	GICR_PROPBASER_Shareability		0x0000000000000C00
+#define	GICR_PROPBASER_InnerCache		0x0000000000000380
+#define	GICR_PROPBASER_IDbits			0x000000000000001F
+
+#define	GICR_PENDBASER				0x0078
+#define	GICR_PENDBASER_PTZ			0x4000000000000000
+#define	GICR_PENDBASER_OuterCache		0x0700000000000000
+#define	GICR_PENDBASER_Physical_Address		0x000FFFFFFFFF0000
+#define	GICR_PENDBASER_Shareability		0x0000000000000C00
+#define	GICR_PENDBASER_InnerCache		0x0000000000000380
+
+#define	GICR_INVLPIR				0x00a0
+#define	GICR_INVLPIR_V				0x8000000000000000
+#define	GICR_INVLPIR_vPEID			0x0000FFFF00000000
+#define	GICR_INVLPIR_INTID			0x00000000FFFFFFFF
+
+#define	GICR_INVALLR				0x00b0
+#define	GICR_INVALLR_V				0x8000000000000000
+#define	GICR_INVALLR_vPEID			0x0000FFFF00000000
+
+#define	GICR_SYNCR				0x00c0
+#define	GICR_SYNCR_Busy				0x00000001
+
+#define	GICR_PIDR2				0xffe8
+#define	GICR_PIDR2_ArchRev			0x000000F0
+
+#define	GICR_IGROUPR0				0x0080
+#define	GICR_IGROUPRnE(n)			(0x0084+(4*(n)))
+#define	GICR_ISENABLER0				0x0100
+#define	GICR_ISENABLERnE(n)			(0x0104+(4*(n)))
+#define	GICR_ICENABLERnE(n)			(0x0184+(4*(n)))
+#define	GICR_ICENABLER0				0x0180
+#define	GICR_ISPENDR0				0x0200
+#define	GICR_ISPENDRnE(n)			(0x0204+(4*(n)))
+#define	GICR_ICPENDR0				0x0280
+#define	GICR_ICPENDRnE(n)			(0x0284+(4*(n)))
+#define	GICR_ISACTIVER0				0x0300
+#define	GICR_ISACTIVERnE(n)			(0x0304+(4*(n)))
+#define	GICR_ICACTIVER0				0x0380
+#define	GICR_ICACTIVERnE(n)			(0x0384+(4*(n)))
+#define	GICR_IPRIORITYRn(n)			(0x0400+(4*(n)))
+#define	GICR_IPRIORITYRnE(n)			(0x0420+(4*(n)))
+#define	GICR_ICFGR0				0x0c00
+#define	GICR_ICFGR1				0x0c04
+#define	GICR_ICFGRn(n)				((GICR_ICFGR0)+(4*(n)))
+#define	GICR_ICFGRnE(n)				(0x0c08+(4*(n)))
+#define	GICR_IGRPMODR0				0x0d00
+#define	GICR_IGRPMODRnE(n)			(0x0d04+(4*(n)))
+#define	GICR_NSACR				0x0e00
+#define	GICR_INMIR0				0x0f80
+#define	GICR_INMIRnE(n)				(0x0f84+(4*(n)))
+
+#define	GICR_VPROPBASER				0x0070
+#define	GICR_VPROPBASER_OuterCache		0x0700000000000000
+#define	GICR_VPROPBASER_Physical_Address	0x000FFFFFFFFFF000
+#define	GICR_VPROPBASER_Shareability		0x0000000000000C00
+#define	GICR_VPROPBASER_InnerCache		0x0000000000000380
+#define	GICR_VPROPBASER_IDbits			0x000000000000001F
+
+#define	GICR_VPENDBASER				0x0078
+/* Both FEAT_GICv4 and FEAT_GICv4p1 */
+#define	GICR_VPENDBASER_Valid			0x8000000000000000
+/* FEAT_GICv4 only */
+#define	GICR_VPENDBASER_IDAI			0x4000000000000000
+/* FEAT_GICv4p1 only */
+#define	GICR_VPENDBASER_Doorbell		0x4000000000000000
+/* Both FEAT_GICv4 and FEAT_GICv4p1 */
+#define	GICR_VPENDBASER_PendingLast		0x2000000000000000
+/* Both FEAT_GICv4 and FEAT_GICv4p1 */
+#define	GICR_VPENDBASER_Dirty			0x1000000000000000
+/* FEAT_GICv4p1 only */
+#define	GICR_VPENDBASER_VGrp0En			0x0800000000000000
+/* FEAT_GICv4p1 only */
+#define	GICR_VPENDBASER_VGrp1En			0x0400000000000000
+/* FEAT_GICv4 only */
+#define	GICR_VPENDBASER_OuterCache		0x0700000000000000
+/* FEAT_GICv4 only */
+#define	GICR_VPENDBASER_Physical_Address	0x000FFFFFFFFF0000
+/* FEAT_GICv4 only */
+#define	GICR_VPENDBASER_Shareability		0x0000000000000C00
+/* FEAT_GICv4 only */
+#define	GICR_VPENDBASER_InnerCache		0x0000000000000380
+/* FEAT_GICv4p1 only */
+#define	GICR_VPENDBASER_vPEID			0x000000000000FFFF
+
+#define	GICR_VSGIR				0x0080
+#define	GICR_VSGIR_vPEID			0x0000FFFF
+
+#define	GICR_VSGIPENDR				0x0088
+#define	GICR_VSGIPENDR_Busy			0x80000000
+#define	GICR_VSGIPENDR_Pending			0x0000FFFF
+
+/*
+ * GIC CPU Interface
+ *
+ * On GICv3 platforms these are commonly accesswed via the System Register
+ * interface, but on GICv2 they are accessed via the MMIO interface.
+ */
+
+/*
+ * CPU Interface Control Register
+ */
+#define	GICC_CTLR				0x0000
+/* [9] if set EOI does priority drop and DIR is needed for deactivation */
+#define	GICC_CTLR_EOImodeNS			0x00000200
+#define	GICC_CTLR_IRQBypDisGrp1			0x00000040
+#define	GICC_CTLR_FIQBypDisGrp1			0x00000020
+/* [0] Enable signalling of group 1 interrupts to the PE */
+#define	GICC_CTLR_EnableGrp1			0x00000001
+
+#define	GICC_PMR				0x0004
+/* If this bit is set the priority applies to non-secure accesses */
+#define	GICC_PMR_NONSECURE			0x00000080
+#define	GICC_PMR_Priority			0x000000FF
+
+#define	GICC_BPR				0x0008
+#define	GICC_BPR_Binary_Point			0x00000007
+
+#define	GICC_IAR				0x000c
+#define	GICC_IAR_CPUID				0x00001C00
+#define	GICC_IAR_CPUID_MASK			0x00000007
+#define	GICC_IAR_CPUID_SHIFT			10
+#define	GICC_IAR_INTID_NO_ARE			0x000003FF
+#define	GICC_IAR_INTID_NO_ARE_MASK		0x000003FF
+#define	GICC_IAR_INTID_NO_ARE_SHIFT		0
+#define	GICC_IAR_INTID				0x00FFFFFF
+#define	GICC_IAR_INTID_MASK			0x00FFFFFF
+#define	GICC_IAR_INTID_SHIFT			0
+
+#define	GICC_EOIR				0x0010
+#define	GICC_EOIR_INTID				0x00FFFFFF
+
+#define	GICC_RPR				0x0014
+#define	GICC_RPR_Priority			0x000000FF
+
+#define	GICC_HPPIR				0x0018
+#define	GICC_HPPIR_INTID			0x00FFFFFF
+
+#define	GICC_ABPR				0x001c
+#define	GICC_ABPR_Binary_Point			0x00000007
+
+#define	GICC_AIAR				0x0020
+#define	GICC_AIAR_INTID				0x00FFFFFF
+
+#define	GICC_AEOIR				0x0024
+#define	GICC_AEOIR_INTID			0x00FFFFFF
+
+#define	GICC_AHPPIR				0x0028
+#define	GICC_AHPPIR_INTID			0x00FFFFFF
+
+/* GICv3+ only */
+#define	GICC_STATUSR				0x002c
+#define	GICC_STATUSR_ASV			0x00000010
+#define	GICC_STATUSR_WROD			0x00000008
+#define	GICC_STATUSR_RWOD			0x00000004
+#define	GICC_STATUSR_WRD			0x00000002
+#define	GICC_STATUSR_RRD			0x00000001
+
+#define	GICC_APRn(n)				(0x00d0+(4*(n)))
+#define	GICC_NSAPRn(n)				(0x00e0+(4*(n)))
+
+#define	GICC_IIDR				0x00fc
+#define	GICC_IIDR_ProductID			0xFF000000
+#define	GICC_IIDR_Architecture_version		0x000F0000
+#define	GICC_IIDR_Revision			0x0000F000
+#define	GICC_IIDR_Implementer			0x00000FFF
+
+#define	GICC_DIR				0x1000
+#define	GICC_DIR_INTID				0x00FFFFFF
+
+/*
+ * GIC System Register CPU Interface
+ *
+ * The System Register interface was introduced with GICv3.
+ */
+#define	ICC_CTLR_EL1_ExtRange			0x0000000000080000
+#define	ICC_CTLR_EL1_RSS			0x0000000000040000
+#define	ICC_CTLR_EL1_A3V			0x0000000000008000
+#define	ICC_CTLR_EL1_SEIS			0x0000000000004000
+#define	ICC_CTLR_EL1_IDbits			0x0000000000003800
+#define	ICC_CTLR_EL1_PRIbits			0x0000000000000700
+#define	ICC_CTLR_EL1_PMHE			0x0000000000000040
+#define	ICC_CTLR_EL1_EOImode			0x0000000000000002
+#define	ICC_CTLR_EL1_CBPR			0x0000000000000001
+
+#define	ICC_SGI0R_EL1_Aff3			0x00ff000000000000
+#define	ICC_SGI0R_EL1_RS			0x0000f00000000000
+#define	ICC_SGI0R_EL1_IRM			0x0000010000000000
+#define	ICC_SGI0R_EL1_Aff2			0x000000ff00000000
+#define	ICC_SGI0R_EL1_INTID			0x000000000f000000
+#define	ICC_SGI0R_EL1_Aff1			0x0000000000ff0000
+#define	ICC_SGI0R_EL1_TargetList		0x000000000000ffff
+
+#define	ICC_SGI1R_EL1_Aff3			0x00ff000000000000
+#define	ICC_SGI1R_EL1_RS			0x0000f00000000000
+#define	ICC_SGI1R_EL1_IRM			0x0000010000000000
+#define	ICC_SGI1R_EL1_Aff2			0x000000ff00000000
+#define	ICC_SGI1R_EL1_INTID			0x000000000f000000
+#define	ICC_SGI1R_EL1_Aff1			0x0000000000ff0000
+#define	ICC_SGI1R_EL1_TargetList		0x000000000000ffff
+
+#define	ICC_SRE_EL1_DIB				0x0000000000000004
+#define	ICC_SRE_EL1_DFB				0x0000000000000002
+#define	ICC_SRE_EL1_SRE				0x0000000000000001
+
+#define	ICC_IGRPEN0_EL1_Enable			0x0000000000000001
+
+#define	ICC_IGRPEN1_EL1_Enable			0x0000000000000001
+
+/*
+ * GIC Virtual CPU Interface
+ */
+#define	GICV_CTLR				0x0000
+#define	GICV_CTLR_EOImode			0x00000200
+#define	GICV_CTLR_CBPR				0x00000010
+#define	GICV_CTLR_FIQEn				0x00000008
+#define	GICV_CTLR_AckCtl			0x00000004
+#define	GICV_CTLR_EnableGrp1			0x00000002
+#define	GICV_CTLR_EnableGrp0			0x00000001
+
+#define	GICV_PMR				0x0004
+#define	GICV_PMR_Priority			0x000000FF
+
+#define	GICV_BPR				0x0008
+#define	GICV_BPR_Binary_Point			0x00000007
+
+#define	GICV_IAR				0x000c
+#define	GICV_IAR_INTID				0x00FFFFFF
+
+#define	GICV_EOIR				0x0010
+#define	GICV_EOIR_INTID				0x00FFFFFF
+
+#define	GICV_RPR				0x0014
+#define	GICV_RPR_Priority			0x000000FF
+
+#define	GICV_HPPIR				0x0018
+#define	GICV_HPPIR_INTID			0x00FFFFFF
+
+#define	GICV_ABPR				0x001c
+#define	GICV_ABPR_Binary_Point			0x00000007
+
+#define	GICV_AIAR				0x0020
+#define	GICV_AIAR_INTID				0x00FFFFFF
+
+#define	GICV_AEOIR				0x0024
+#define	GICV_AEOIR_INTID			0x00FFFFFF
+
+#define	GICV_AHPPIR				0x0028
+#define	GICV_AHPPIR_INTID			0x00FFFFFF
+
+#define	GICV_STATUSR				0x002c
+#define	GICV_STATUSR_WROD			0x00000008
+#define	GICV_STATUSR_RWOD			0x00000004
+#define	GICV_STATUSR_WRD			0x00000002
+#define	GICV_STATUSR_RRD			0x00000001
+
+#define	GICV_APRn(n)				(0x00d0+(4*(n)))
+
+#define	GICV_IIDR				0x00fc
+#define	GICC_IIDR_ProductID			0xFF000000
+#define	GICC_IIDR_Architecture_version		0x000F0000
+#define	GICC_IIDR_Revision			0x0000F000
+#define	GICC_IIDR_Implementer			0x00000FFF
+
+#define	GICV_DIR				0x1000
+#define	GICV_DIR_INTID				0x00FFFFFF
+
+/*
+ * GIC Virtual Interface Control
+ */
+#define	GICH_HCR				0x0000
+#define	GICH_HCR_EOICount			0xF8000000
+#define	GICH_HCR_VGrp1DIE			0x00000080
+#define	GICH_HCR_VGrp1EIE			0x00000040
+#define	GICH_HCR_VGrp0DIE			0x00000020
+#define	GICH_HCR_VGrp0EIE			0x00000010
+#define	GICH_HCR_NPIE				0x00000008
+#define	GICH_HCR_LRENPIE			0x00000004
+#define	GICH_HCR_UIE				0x00000002
+#define	GICH_HCR_En				0x00000001
+
+#define	GICH_VTR				0x0004
+#define	GICH_VTR_PRIbits			0xE0000000
+#define	GICH_VTR_PREbits			0x1C000000
+#define	GICH_VTR_IDbits				0x03800000
+#define	GICH_VTR_SEIS				0x00400000
+#define	GICH_VTR_A3V				0x00200000
+#define	GICH_VTR_ListRegs			0x0000001F
+
+#define	GICH_VMCR				0x0008
+#define	GICH_VMCR_VPMR				0xFF000000
+#define	GICH_VMCR_VBPR0				0x00E00000
+#define	GICH_VMCR_VBPR1				0x001C0000
+#define	GICH_VMCR_VEOIM				0x00000200
+#define	GICH_VMCR_VCBPR				0x00000010
+#define	GICH_VMCR_VFIQEn			0x00000008
+#define	GICH_VMCR_VAckCtl			0x00000004
+#define	GICH_VMCR_VENG1				0x00000002
+#define	GICH_VMCR_VENG0				0x00000001
+
+#define	GICH_MISR				0x0010
+#define	GICH_MISR_VGrp1D			0x00000080
+#define	GICH_MISR_VGrp1E			0x00000040
+#define	GICH_MISR_VGrp0D			0x00000020
+#define	GICH_MISR_VGrp0E			0x00000010
+#define	GICH_MISR_NP				0x00000008
+#define	GICH_MISR_LRENP				0x00000004
+#define	GICH_MISR_U				0x00000002
+#define	GICH_MISR_EOI				0x00000001
+
+#define	GICH_EISR				0x0020
+#define	GICH_ELRSR				0x0030
+#define	GICH_APRn(n)				(0x00f0+(4*(n)))
+
+#define	GICH_LRn(n)				(0x0100+(4*(n)))
+#define	GICH_LRn_HW				0x80000000
+#define	GICH_LRn_Group				0x40000000
+#define	GICH_LRn_State				0x30000000
+#define	GICH_LRn_Priority			0x0F800000
+#define	GICH_LRn_pINTID				0x000FFC00
+#define	GICH_LRn_vINTID				0x000003FF
+
+/*
+ * GIC Interrupt Translation Service Interface
+ *
+ * The ITS was introduced with GICv3.
+ */
+#define	GITS_CTLR				0x0000
+#define	GITS_CTLR_Quiescent			0x80000000
+#define	GITS_CTLR_UMSIirq			0x00000100
+#define	GITS_CTLR_ITS_Number			0x000000F0
+#define	GITS_CTLR_ImDe				0x00000002
+#define	GITS_CTLR_Enabled			0x00000001
+
+#define	GITS_IIDR				0x0004
+#define	GITS_IIDR_ProductID			0xFF000000
+#define	GITS_IIDR_Variant			0x000F0000
+#define	GITS_IIDR_Revision			0x0000F000
+#define	GITS_IIDR_Implementer			0x00000FFF
+
+#define	GITS_TYPER				0x0008
+#define	GITS_TYPER_INV				0x0000400000000000
+#define	GITS_TYPER_UMSIirq			0x0000200000000000
+#define	GITS_TYPER_UMSI				0x0000100000000000
+#define	GITS_TYPER_nID				0x0000080000000000
+#define	GITS_TYPER_SVPET			0x0000060000000000
+#define	GITS_TYPER_VMAPP			0x0000010000000000
+#define	GITS_TYPER_VSGI				0x0000008000000000
+#define	GITS_TYPER_MPAM				0x0000004000000000
+#define	GITS_TYPER_VMOVP			0x0000002000000000
+#define	GITS_TYPER_CIL				0x0000001000000000
+#define	GITS_TYPER_CIDbits			0x0000000F00000000
+#define	GITS_TYPER_HCC				0x00000000FF000000
+#define	GITS_TYPER_PTA				0x0000000000080000
+#define	GITS_TYPER_SEIS				0x0000000000040000
+#define	GITS_TYPER_Devbits			0x000000000003E000
+#define	GITS_TYPER_ID_bits			0x0000000000001F00
+#define	GITS_TYPER_ITT_entry_size		0x00000000000000F0
+#define	GITS_TYPER_CCT				0x0000000000000004
+#define	GITS_TYPER_Virtual			0x0000000000000002
+#define	GITS_TYPER_Physical			0x0000000000000001
+
+#define	GITS_MPAMIDR				0x0010
+#define	GITS_MPAMIDR_PMGmax			0x00FF0000
+#define	GITS_MPAMIDR_PARTIDmax			0x0000FFFF
+
+#define	GITS_PARTIDR				0x0014
+#define	GITS_PARTIDR_PMG			0x00FF0000
+#define	GITS_PARTIDR_PARTID			0x0000FFFF
+
+#define	GITS_MPIDR				0x0018
+#define	GITS_MPIDR_Affinity			0xFFFFFF00
+#define	GITS_MPIDR_Affinity_Aff3		0xFF000000
+#define	GITS_MPIDR_Affinity_Aff2		0x00FF0000
+#define	GITS_MPIDR_Affinity_Aff1		0x0000FF00
+
+#define	GITS_STATUSR				0x0040
+#define	GITS_STATUSR_Syndrome			0x000003C0
+#define	GITS_STATUSR_Overflow			0x00000020
+#define	GITS_STATUSR_UMSI			0x00000010
+#define	GITS_STATUSR_WROD			0x00000008
+#define	GITS_STATUSR_RWOD			0x00000004
+#define	GITS_STATUSR_WRD			0x00000002
+#define	GITS_STATUSR_RRD			0x00000001
+
+#define	GITS_UMSIR				0x0048
+#define	GITS_UMSIR_DeviceID			0xFFFFFFFF00000000
+#define	GITS_UMSIR_EventID			0x00000000FFFFFFFF
+
+#define	GITS_CBASER				0x0080
+#define	GITS_CBASER_Valid			0x8000000000000000
+#define	GITS_CBASER_InnerCache			0x3800000000000000
+#define	GITS_CBASER_OuterCache			0x00E0000000000000
+#define	GITS_CBASER_Physical_Address		0x000FFFFFFFFFF000
+#define	GITS_CBASER_Shareability		0x0000000000000C00
+#define	GITS_CBASER_Size			0x00000000000000FF
+
+#define	GITS_CWRITER				0x0088
+#define	GITS_CWRITER_Offset			0x00000000000FFFE0
+#define	GITS_CWRITER_Retry			0x0000000000000001
+
+#define	GITS_CREADR				0x0090
+#define	GITS_CREADR_Offset			0x00000000000FFFE0
+#define	GITS_CREADR_Stalled			0x0000000000000001
+
+#define	GITS_BASERn(n)				(0x0100+(4*(n)))
+#define	GITS_BASERn_Valid			0x8000000000000000
+#define	GITS_BASERn_Indirect			0x4000000000000000
+#define	GITS_BASERn_InnerCache			0x3800000000000000
+#define	GITS_BASERn_Type			0x0700000000000000
+#define	GITS_BASERn_OuterCache			0x00E0000000000000
+#define	GITS_BASERn_Entry_Size			0x001F000000000000
+#define	GITS_BASERn_Physical_Address		0x0000FFFFFFFFF000
+#define	GITS_BASERn_Shareability		0x0000000000000C00
+#define	GITS_BASERn_Page_Size			0x0000000000000300
+#define	GITS_BASERn_Size			0x00000000000000FF
+
+#define	GITS_PIDR2				0xffe8
+#define	GITS_PIDR2_ArchRev			0x000000F0
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _GIC_REG_H */

--- a/usr/src/uts/armv8/ml/exceptions.S
+++ b/usr/src/uts/armv8/ml/exceptions.S
@@ -23,6 +23,7 @@
  * Use is subject to license terms.
  *
  * Copyright 2017 Hayashi Naoyuki
+ * Copyright 2024 Michael van der Westhuizen
  */
 
 #include <sys/asm_linkage.h>
@@ -66,11 +67,12 @@ unexpected_exception:	.asciz "unexpected exception type"
 	bl panic
 
 /*
- * This is the AArch64 exception vector used by the hardware, each entry is 128 byte
- * aligned, and 32 instructions (128 bytes) long.
+ * This is the AArch64 exception vector used by the hardware, each entry is
+ * 128 byte aligned, and 32 instructions (128 bytes) long.
  *
- * We represent this as a single large function (exception_vector), which we can put in VBAR,
- * and a nested function per-entry to make things easier to refer to while debugging.
+ * We represent this as a single large function (exception_vector), which we
+ * can put in VBAR, and a nested function per-entry to make things easier to
+ * refer to while debugging.
  *
  * It is important that ALTENTRY is used, so alignment is not altered, and the
  * vector keeps it specified shape.
@@ -480,140 +482,225 @@ _sys_rtt_preempt:
 
 	/*
 	 * IRQ Handler
+	 *
+	 * This routine uses [wx]19-[wx]26 to keep state, as these are
+	 * callee-saved registers and will be restored by the called C code
+	 * prior to returning.
+	 *
+	 * Assignment is as follows:
+	 * - x19: CPU
+	 * - w20: old pri
+	 * - w21: new pri
+	 * - w22: INTID (vector)
+	 * - w23: IAR value (to use for priority drop and deactivation)
+	 * - x24: old SP (when switching stacks)
+	 * - w25: st_pending (used in softint processing)
+	 * - w26: used temporarily (for new pri) in priority drop
+	 *
+	 * This is all eerily similar to do_interrupt in
+	 * usr/src/uts/i86pc/os/intr.c, but it's done in assembly so we can
+	 * fully unwind the stack between calls to C code. There's some dubious
+	 * passing of the regs struct that's later used as a stack pointer
+	 * where needed, and I don't have the brain power to determine if
+	 * that's safe or it'll trash the (in use, in C) stack.
+	 *
+	 * NOTE: we're still missing a way to implement fakesoftint processing
+	 * in do_splx and splr as is done in i86pc. This could be useful, but
+	 * would require some refactoring here (and possibly reserving a fake
+	 * vector to trigger that path).
 	 */
 	ENTRY(irq_handler)
-	CPUP(x19)				// x19 <- CPU
-	ldr	w20, [x19, #CPU_PRI]		// x20 <- old pri
+	mov	w0, #CPU_IDLE_CB_FLAG_INTR
+	bl	cpu_idle_exit
 
-	ldr	x21, =gic_cpuif			// x21 <- gic_cpuif
-	ldr	x21, [x21]
-	ldr	w23, [x21, #GIC_CPUIF_IAR]	// x23 <- IAR, acknowledge receipt
-	and	w22, w23, #GICC_IAR_INTID_MASK	// x22 <- irq
-	// On receipt of a "special" interrupt, just return
-	// See ARM® Generic Interrupt Controller Architecture Specification
-	//    GIC architecture version 3.0 and version 4.0 §2.2.1 Special INTIDs
-	//
-	// XXXARM: This code needs changing to support LPIs in GICv3 and above
-	cmp	w22, #GIC_INTID_MIN_SPECIAL
-	b.ge	_sys_rtt
+	CPUP(x19)				/* x19 <- CPU */
+	ldr	w20, [x19, #CPU_PRI]		/* x20 <- old (current) pri */
 
-	// irq mask (Clear Enable)
-	mov	w0, w22
-	bl	gic_mask_level_irq
+	bl	gic_acknowledge			/* read interrupt acknowledge */
+	mov	w23, w0				/* w23 <- acked IRQ */
+	bl	gic_ack_to_vector		/* extract vector (INTID) */
+	mov	w22, w0				/* x22 <- vector */
 
-	// write the full GICC_IAR back to GICC_EOIR to acknowledge end of interrupt
-	str	w23, [x21, #GIC_CPUIF_EOIR]
+	/*
+	 * If we get a "special" interrupt it means that the highest priority
+	 * pending interrupt is for the other (secure) world, and we're
+	 * supposed to just return.
+	 *
+	 * See IHI0048, 1.4.4 Spurious interrupts and
+	 * IHI0048, 3.2.5 Special interrupt numbers
+	 */
+	bl	gic_vector_is_special		/* w0 is the still the vector */
+	cbnz	w0, _sys_rtt			/* non-zero means special */
 
-	// set pri
-	mov	w0, w22
-	bl	setlvl
-	cbnz	w0, 1f
+	/*
+	 * Set our priority to that of the interrupt.
+	 *
+	 * The running priority has been set for us by the hardware, and can
+	 * be found in the running priority register (GICC_RPR, ICC_RPR). The
+	 * idea is that the priority mask of the CPU interface is:
+	 *   MAX(GICC_PMR, GICC_RPR)
+	 * Since we're doing split end-of-interrupt to safely support threaded
+	 * interrupts we need to do the running priority drop (caused by EOI)
+	 * early.
+	 *
+	 * To make this safe, we first set our priority mask register (via
+	 * setlvl) to that of the received interrupt, then send the EOI (which
+	 * drops the running priority). This ensures that we don't leave a
+	 * window where the distributor might determine that an inapproriate
+	 * interrupt should be forwarded to us.
+	 *
+	 * If setlvl returns zero we've hit a race, where somebody else has
+	 * disestablished the interrupt while we're processing it. In this case
+	 * we deactivate the interrupt and skip to softint processing. Note
+	 * that in this case we just leave the priority as-is (as setlvl will
+	 * have refused to change the priority mask register).
+	 *
+	 * In the nominal case the hardware interrupt processing is responsible
+	 * for deactivating the interrupt in the relevant epilog function.
+	 */
+	mov	w0, w22				/* slew to the irq prio */
+	bl	setlvl				/* returns new_prio in w0 */
+	mov	w26, w0				/* stash new-pri temporarily */
+	mov	w0, w23
+	bl	gic_eoi				/* priority drop */
+	cbnz	w26, 1f				/* skip to normal processing */
 
-	// If ipl == 0
-	mov	w0, w22
-	bl	gic_unmask_level_irq
+	/*
+	 * In the "skip to softint" case we deactivate the interrupt and skip
+	 * the hardware interrupt processing.
+	 */
+	mov	w0, w23
+	bl	gic_deactivate			/* deactivate the interrupt */
 	b	check_softint
 
-	// Else (ipl != 0)
 1:
-	mov	w21, w0				// x21 <- new pri
-	str	w21, [x19, #CPU_PRI]
+	mov	w21, w26			/* w21 <- new pri */
+	str	w21, [x19, #CPU_PRI]		/* update our CPU's pri */
 
 	cmp	w21, #LOCK_LEVEL
-	b.le	intr_thread
+	b.le	intr_thread			/* threaded interrupt needed */
 
-	//	x19: CPU
-	//	x20: old pri
-	//	x21: new pri
-	//	x22: irq
+	/*
+	 * High-level interrupt handling is as one might expect:
+	 * - Call the prolog
+	 * - If the prolog indicated that a stack switch is necessary, do it
+	 * - allow interrupts
+	 * - dispatch the vector
+	 * - disable interrupts
+	 * - restore the stack
+	 * - call the epilog, which deactivates the interrupt
+	 * - move on to softint processing
+	 *
+	 * Note that high-level interrupts restore the stack pointer *before*
+	 * calling the epilog, as they cannot switch away.
+	 */
+	mov	x0, x19				/* CPU */
+	mov	w1, w21				/* new pri */
+	mov	w2, w20				/* old pri */
+	mov	x3, sp				/* regs */
+	bl	hilevel_intr_prolog		/* returns new stack in x0 */
+	mov	x24, sp				/* x24 <- old sp */
+	cbnz	x0, 2f				/* need to switch stacks? */
 
-	mov	x0, x19
-	mov	w1, w21
-	mov	w2, w20
-	mov	x3, sp
-	bl	hilevel_intr_prolog
-	cbnz	x0, 2f
-
-	mov	x23, sp				// x23 <- old sp
-	ldr	x0, [x19, #CPU_INTR_STACK]
-	mov	sp, x0
+	ldr	x0, [x19, #CPU_INTR_STACK]	/* load up the irq stack */
+	mov	sp, x0				/* switch the the new stack */
 2:
-
-	/* Dispatch interrupt handler. */
-	msr	DAIFClr, #DAIF_SETCLEAR_IRQ
-	mov	w0, w22
+	msr	DAIFClr, #DAIF_SETCLEAR_IRQ	/* unmask interrupts */
+	mov	w0, w22				/* vector <- w22 */
 	bl	av_dispatch_autovect
-	msr	DAIFSet, #DAIF_SETCLEAR_IRQ
+	msr	DAIFSet, #DAIF_SETCLEAR_IRQ	/* mask interrupts */
 
-	mov	x0, x19
-	mov	w1, w21
-	mov	w2, w20
-	mov	w3, w22
-	bl	hilevel_intr_epilog
-	cbnz	x0, check_softint
+	mov	sp, x24				/* restore sp (maybe noop) */
+	mov	x0, x19				/* CPU */
+	mov	w1, w21				/* new pri */
+	mov	w2, w20				/* old pri */
+	mov	w3, w23				/* acknowledge value */
+	bl	hilevel_intr_epilog		/* sends eoi */
+	b	check_softint			/* process softints */
 
-	mov	sp, x23
-	b	check_softint
-
+	/*
+	 * Threaded interrupt handling is slightly different:
+	 * - Call the prolog, this returns the stack pointer to use
+	 * - Switch to the new stack
+	 * - allow interrupts
+	 * - dispatch the vector (will switch away if needed and resume here)
+	 * - disable interrupts
+	 * - call the epilog, which deactivates the interrupt
+	 * - restore the stack
+	 * - move on to softint processing
+	 *
+	 * Note that threaded interrupts restore the stack pointer *after*
+	 * calling the epilog, as they may have switched away.
+	 */
 intr_thread:
-	//	x19: CPU
-	//	x20: old pri
-	//	x21: new pri
-	//	x22: irq
+	mov	x0, x19				/* CPU */
+	mov	x1, sp				/* stackptr */
+	mov	w2, w21				/* new pri */
+	bl	intr_thread_prolog		/* returns new stack in x0 */
+	mov	x24, sp				/* x24 <- old sp */
+	mov	sp, x0				/* switch the the new stack */
 
-	mov	x0, x19
-	mov	x1, sp
-	mov	w2, w21
-	bl	intr_thread_prolog
-	mov	x23, sp				// x23 <- old sp
-	mov	sp, x0
-
-	/* Dispatch interrupt handler. */
-	msr	DAIFClr, #DAIF_SETCLEAR_IRQ
-	mov	w0, w22
+	msr	DAIFClr, #DAIF_SETCLEAR_IRQ	/* unmask interrupts */
+	mov	w0, w22				/* vector <- w22 */
 	bl	av_dispatch_autovect
-	msr	DAIFSet, #DAIF_SETCLEAR_IRQ
+	msr	DAIFSet, #DAIF_SETCLEAR_IRQ	/* mask interrupts */
 
-	mov	x0, x19
-	mov	x1, x22
-	mov	x2, x20
+	mov	x0, x19				/* CPU */
+	mov	w1, w23				/* acknowledge value */
+	mov	w2, w20				/* old pri */
 	bl	intr_thread_epilog
+	mov	sp, x24				/* restore sp (after epilog) */
+						/* fall through to softints */
 
-	mov	sp, x23
-
+	/*
+	 * This label simply drives processing of softints - if st_pending
+	 * is non-zero we run the softints logic, which keeps coming back here.
+	 *
+	 * If/when st_pending gets to 0, we're done - return from the trap.
+	 */
 check_softint:
-	ldr	w22, [x19, #CPU_SOFTINFO]
-	cbnz	w22, dosoftint
-	b	_sys_rtt
+	ldr	w25, [x19, #CPU_SOFTINFO]	/* load fresh st_pending */
+	cbnz	w25, dosoftint			/* work to do, get to it */
+	b	_sys_rtt			/* no work, we're done */
 
+	/*
+	 * Soft interrupt handling is, again, different:
+	 * - Call the prolog, this returns the stack pointer to use or NULL
+	 * - If the prolog returned NULL there are no softints of suitable
+	 *   priority available, so we're done (return from the trap)
+	 * - Switch to the new stack
+	 * - allow interrupts
+	 * - dispatch the softints for the pil
+	 * - disable interrupts
+	 * - call the epilog (tweaks the pil)
+	 * - restore the stack
+	 * - check for more softints (see the check_softint label above)
+	 *
+	 * Note that soft interrupts restore the stack pointer *after* calling
+	 * the epilog as they may have switched away.
+	 */
 dosoftint:
-	//	x19: CPU
-	//	x20: old pri
-	//	x21: new pri
-	//	x22: st_pending
+	mov	x0, x19				/* CPU */
+	mov	x1, sp				/* stackptr */
+	mov	w2, w25				/* st_pending */
+	mov	w3, w20				/* old pri */
+	bl	dosoftint_prolog		/* x0 == 0 iff none suitable */
+	cbz	x0, _sys_rtt			/* no more? we're done */
 
-	mov	x0, x19
-	mov	x1, sp
-	mov	w2, w22
-	mov	w3, w20
-	bl	dosoftint_prolog
-	cbz	x0, _sys_rtt
+	mov	x24, sp				/* x24 <- old sp */
+	mov	sp, x0				/* switch the the new stack */
 
-	mov	x23, sp				// x23 <- old sp
-	mov	sp, x0
-
-	msr	DAIFClr, #DAIF_SETCLEAR_IRQ
+	msr	DAIFClr, #DAIF_SETCLEAR_IRQ	/* unmask interrupts */
 	THREADP(x0)
-	ldrb	w0, [x0, #T_PIL]
-	bl	av_dispatch_softvect
-	msr	DAIFSet, #DAIF_SETCLEAR_IRQ
+	ldrb	w0, [x0, #T_PIL]		/* load up the PIL */
+	bl	av_dispatch_softvect		/* run the softints */
+	msr	DAIFSet, #DAIF_SETCLEAR_IRQ	/* mask interrupts */
 
-	mov	x0, x19
-	mov	w1, w20
+	mov	x0, x19				/* CPU */
+	mov	w1, w20				/* old pri */
 	bl	dosoftint_epilog
-
-	mov	sp, x23
-	b	check_softint
+	mov	sp, x24				/* restore sp (after epilog) */
+	b	check_softint			/* check for more work */
 	SET_SIZE(irq_handler)
 
 

--- a/usr/src/uts/armv8/ml/genassym.cf
+++ b/usr/src/uts/armv8/ml/genassym.cf
@@ -2,6 +2,7 @@ include <sys/modctl.h>
 include <sys/cpu.h>
 include <sys/thread.h>
 include <sys/cpuvar.h>
+include <sys/cpu_event.h>
 include <sys/ontrap.h>
 include <sys/lockstat.h>
 include <sys/rwlock_impl.h>
@@ -15,9 +16,9 @@ include <sys/dditypes.h>
 include <sys/ddi.h>
 include <sys/ddi_isa.h>
 include <sys/systm.h>
-include <sys/gic.h>
 include <sys/dtrace.h>
 include <sys/privregs.h>
+include <asm/controlregs.h>
 
 define	MODS_SIZE		sizeof(struct mod_stub_info)
 define	MODS_INSTFCN		offsetof(struct mod_stub_info, mods_func_adr)
@@ -36,6 +37,8 @@ define	CPU_STATS_SYS_CPUMIGRATE	offsetof(cpu_t, cpu_stats.sys.cpumigrate)
 define	CPU_PRI			offsetof(cpu_t, cpu_pri)
 define	CPU_INTR_STACK		offsetof(cpu_t, cpu_intr_stack)
 define	CPU_SOFTINFO		offsetof(cpu_t, cpu_softinfo.st_pending)
+
+define	CPU_IDLE_CB_FLAG_INTR	CPU_IDLE_CB_FLAG_INTR
 
 define	OT_PROT			offsetof(struct on_trap_data, ot_prot)
 define	OT_TRAP			offsetof(struct on_trap_data, ot_trap)
@@ -169,12 +172,6 @@ define	CPACR_FPEN_EN		CPACR_FPEN_EN
 define	CPACR_FPEN_DIS		CPACR_FPEN_DIS
 
 define	LOCK_LEVEL		LOCK_LEVEL
-
-define	GIC_CPUIF_IAR		offsetof(struct gic_cpuif, iar)
-define	GIC_CPUIF_EOIR		offsetof(struct gic_cpuif, eoir)
-
-define	GIC_INTID_MIN_SPECIAL	GIC_INTID_MIN_SPECIAL
-define	GICC_IAR_INTID_MASK	GICC_IAR_INTID_MASK
 
 define	MMU_PAGESHIFT	MMU_PAGESHIFT
 define	DEFAULTSTKSZ	DEFAULTSTKSZ

--- a/usr/src/uts/armv8/os/mp_startup.c
+++ b/usr/src/uts/armv8/os/mp_startup.c
@@ -30,7 +30,7 @@
  * Copyright (c) 2012, Joyent, Inc.  All rights reserved.
  * Copyright 2013 Nexenta Systems, Inc.  All rights reserved.
  * Copyright 2017 Hayashi Naoyuki
- * Copyright 2023 Michael van der Westhuizen
+ * Copyright 2024 Michael van der Westhuizen
  */
 
 #include <sys/types.h>
@@ -352,10 +352,12 @@ mp_startup_boot(void)
 	/* Let the control CPU continue into tsc_sync_master() */
 	mp_startup_signal(&procset_slave, cp->cpu_id);
 
-	/* Set up the GIC for the new additional CPU */
-	gic_init_secondary(cp->cpu_id);
+	/* Set our exception vector base */
 	write_vbar((uintptr_t)exception_vector);
 	isb();
+
+	/* Set up the GIC for the new additional CPU */
+	gic_cpu_init(cp);
 
 	/*
 	 * Enable interrupts with spl set to LOCK_LEVEL. LOCK_LEVEL is the

--- a/usr/src/uts/armv8/os/startup.c
+++ b/usr/src/uts/armv8/os/startup.c
@@ -963,10 +963,6 @@ startup_end(void)
 	mach_init();
 
 	PRM_POINT("Enabling interrupts");
-#if 0
-	(*picinitf)();
-	sti();
-#endif
 	set_base_spl();
 	enable_irq();
 

--- a/usr/src/uts/armv8/sys/smp_impldefs.h
+++ b/usr/src/uts/armv8/sys/smp_impldefs.h
@@ -20,6 +20,7 @@
  */
 
 /*
+ * Copyright 2024 Michael van der Westhuizen
  * Copyright 2017 Hayashi Naoyuki
  * Copyright (c) 1993, 2010, Oracle and/or its affiliates. All rights reserved.
  */
@@ -36,30 +37,14 @@
 extern "C" {
 #endif
 
-#define	WARM_RESET_VECTOR	0x467	/* the ROM/BIOS vector for 	*/
-					/* starting up secondary cpu's	*/
-/* timer modes for clkinitf */
-#define	TIMER_ONESHOT		0x1
-#define	TIMER_PERIODIC		0x2
-
 /*
  *	External Reference Functions
  */
-extern void (*psminitf)();	/* psm init entry point			*/
-extern void (*picinitf)();	/* pic init entry point			*/
-extern int (*clkinitf)(int, int *);	/* clock init entry point	*/
-extern int (*ap_mlsetup)(); 	/* completes init of starting cpu	*/
-extern void (*send_dirintf)();	/* send interprocessor intr		*/
-extern hrtime_t (*gethrtimef)(); /* get high resolution timer value	*/
-extern hrtime_t (*gethrtimeunscaledf)(); /* get high res timer unscaled value */
-
-extern int (*slvltovect)(int);	/* ipl interrupt priority level		*/
-extern int setlvl(int); /* set intr pri represented by vect	*/
-extern void setlvlx(int, int); /* set intr pri to specified level	*/
-extern void (*setspl)(int);	/* mask intr below or equal given ipl	*/
-extern int (*addspl)(int, int, int, int); /* add intr mask of vector 	*/
-extern int (*delspl)(int, int, int, int); /* delete intr mask of vector */
-extern int (*get_pending_spl)(void);	/* get highest pending ipl */
+extern int (*slvltovect)(int);	/* ipl interrupt priority level */
+extern int setlvl(int);	/* set intr pri represented by vect */
+extern void setlvlx(int);	/* set intr pri to specified level */
+extern int (*addspl)(int, int, int, int);	/* add intr mask of vector  */
+extern int (*delspl)(int, int, int, int);	/* delete intr mask of vector */
 extern int (*addintr)(void *, int, avfunc, char *, int, caddr_t, caddr_t,
     uint64_t *, dev_info_t *);	/* replacement of add_avintr */
 extern void (*remintr)(void *, int, avfunc, int); /* replace of rem_avintr */
@@ -72,7 +57,6 @@ extern void (*kdisetsoftint)(int, struct av_softinfo *);
 
 extern void av_set_softint_pending();	/* set software interrupt pending */
 extern void kdi_av_set_softint_pending(); /* kmdb private entry point */
-extern void microfind(void);	/* initialize tenmicrosec		*/
 
 /* map physical address							*/
 
@@ -87,9 +71,6 @@ extern caddr_t psm_map_phys_new(paddr_t, size_t, int);
 
 /* unmap the physical address given in psm_map_phys() from the addr	*/
 extern void psm_unmap_phys(caddr_t, size_t);
-extern void psm_modloadonly(void);
-extern void psm_install(void);
-extern void psm_modload(void);
 
 /*
  *	External Reference Data


### PR DESCRIPTION
A few things about interrupt handling in the aarch64 port have made my spidey-senses tingle, so I went digging...

The first thing that jumped out to me was the "mask/unmask level interrupts" code called from the interrupt handler. A GIC keeps an internal state machine (described in IHI0048), and a kernel should be able to use only the GIC CPU interface to service interrupts. Masking and unmasking, however, hits the GIC distributor.

As it turns out, this seems to have been done to meet the ordering requirements for EOI, where GICC_EOI must be issued in reverse order of the acknowledgement of interrupts (GICC_IACK). This requirement presupposes that an operating system will not use threaded IRQs, since meeting this requirement gets very hard.

It seems as though masking the level IRQ was put in place so that the EOI can be issued _before_ dealing with the interrupt, then unmasking once the interrupt was dealt with.

Fortunately GICv2 addresses this problem by offering two EOI modes - the first (GICC_CTLR.EOImode=0) describes the behaviour above - issuing an end-of-interrupts both drops the running priority level and deactivates the interrupt. GICC_CTLR.EOImode=1 separates the running priority drop (happens at GICC_EOIR write) and interrupt deactivation (happens on a write to GICC_DIR). There are no ordering requirements on interrupt deactivation, only on running priority drop.

With this in hand, I refactored the irq_handler function to deal with GICC_CTLR.EOImode=1.

Since the memory mapped GIC CPU interface does not exist in GICv3 (other than in legacy mode), I also made the irq_handler call through the GIC abstraction to interact with the CPU interface.

The original port uses a lot of "cast this address to a volatile struct pointer, then dereference that when writing to registers" which does not really align with the way the kernel would like folks to use DDI. I've introduced a full set of register descriptions (from IHI0069 - the GICv3 and GOCv4 spec, cross-referenced against the GICv2 spec) and reworked the GICv2 implementation to use the DDI implementation functions (since we're up a bit too early for busses).

This allowed me to remove the CPU interface global (which had been used by the IRQ handler).

The GICv2 implementation seemed to think it was running in the secure world, trying to put everything into secure group 0. This probably simply silently didn't work, as the registers used to do that are secure world only, so everything ends up where the secure world originally put it, which is non-secure group one. I cleaned all of this up, but I think we could still do a bit better at recognising which vectors we can't touch.

Priority handling also has some confusion. The GICv2 spec states that a minimum of 16 priorities must be supported, which sound fine until one considers that the non-secure world (where we run) only owns those with the top bit set, so 8 of those 16. This is the case on Raspberry Pi4(!). A GICv3 will implement a minimum of 32 priorities in an implementation that supports two world (i.e. things we'll run on), so my handling of having too few hardware priority levels is scoped to the GICv2 implementation only.

I use the binary point register to map the  intermediate levels (those that don't directly map to hardware priorities) to prioritise interrupts that fall into those levels, hopefully mitigating some of the awfulness.

Distributor access was not properly protected from multiple processors writing to non-banked distributor registers in parallel.

There's quite a lot going on here, since this was done on top of work to avoid volatile structs for hardware access, but it would have ended up pretty large either way.

* Bootup/mpstat/shutdown on Raspberry Pi4: https://gist.github.com/r1mikey/0b2f1ed1a3b6d0d79e36113405c81655
* Bootup/mpstat/shutdown on qemu: https://gist.github.com/r1mikey/3a767898408b1c36ce95298fedfee37d

In addition to basic bootup and shutdown I used the script in https://gist.github.com/r1mikey/42b91be754ca4bc7c45e647513d70fb5 to run four sets of transfers/checks concurrently against the host. For example, four terminals running something similar to `./x-test.sh 192.168.1.239 25 3 ; echo $?`. That ends up in 1G of transfer to and from the machine, along with integrity checks.