### PR TITLE
Use device arena mapping for the GICv2 implementation

### DIFF
--- a/usr/src/uts/armv8/Makefile.files
+++ b/usr/src/uts/armv8/Makefile.files
@@ -20,7 +20,7 @@
 #
 
 #
-# Copyright 2023 Michael van der Westhuizen
+# Copyright 2024 Michael van der Westhuizen
 # Copyright 2017 Hayashi Naoyuki
 #
 
@@ -74,6 +74,7 @@ CORE_OBJS +=			\
 	ssp.o			\
 	psci.o			\
 	arch_timer.o		\
+	earlybsa.o		\
 	$(CORE_OBJS_FDT)
 
 CORE_OBJS += $(PCI_STRING_OBJS)

--- a/usr/src/uts/armv8/os/earlybsa.c
+++ b/usr/src/uts/armv8/os/earlybsa.c
@@ -1,0 +1,85 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
+ * Use is subject to license terms.
+ * Copyright 2020 Oxide Computer Company
+ * Copyright 2024 Michael van der Westhuizen
+ */
+
+/*
+ * Routines used by pre-rootnex Base System Architecture hardware support.
+ */
+
+#include <sys/types.h>
+#include <sys/null.h>
+#include <sys/machparam.h>
+#include <sys/param.h>
+#include <sys/vmem.h>
+#include <vm/hat.h>
+#include <vm/seg_kmem.h>
+#include <sys/smp_impldefs.h>
+
+/*
+ * from startup.c - kernel VA range allocator for device mappings
+ */
+extern void *device_arena_alloc(size_t size, int vm_flag);
+extern void device_arena_free(void * vaddr, size_t size);
+
+caddr_t
+psm_map_phys(paddr_t addr, size_t len, int prot)
+{
+	uint_t pgoffset;
+	paddr_t base;
+	pgcnt_t npages;
+	caddr_t cvaddr;
+
+	if (len == 0)
+		return (NULL);
+
+	pgoffset = addr & MMU_PAGEOFFSET;
+	base = addr;
+
+	npages = mmu_btopr(len + pgoffset);
+	cvaddr = device_arena_alloc(ptob(npages), VM_NOSLEEP);
+	if (cvaddr == NULL)
+		return (NULL);
+	hat_devload(kas.a_hat, cvaddr, mmu_ptob(npages), mmu_btop(base),
+	    prot, HAT_LOAD_LOCK);
+	return (cvaddr + pgoffset);
+}
+
+void
+psm_unmap_phys(caddr_t addr, size_t len)
+{
+	uint_t pgoffset;
+	caddr_t base;
+	pgcnt_t npages;
+
+	if (len == 0)
+		return;
+
+	pgoffset = (uintptr_t)addr & MMU_PAGEOFFSET;
+	base = addr - pgoffset;
+	npages = mmu_btopr(len + pgoffset);
+	hat_unload(kas.a_hat, base, ptob(npages), HAT_UNLOAD_UNLOCK);
+	device_arena_free(base, ptob(npages));
+}

--- a/usr/src/uts/armv8/sys/smp_impldefs.h
+++ b/usr/src/uts/armv8/sys/smp_impldefs.h
@@ -59,16 +59,7 @@ extern void av_set_softint_pending();	/* set software interrupt pending */
 extern void kdi_av_set_softint_pending(); /* kmdb private entry point */
 
 /* map physical address							*/
-
-/*
- * XX64: Changing psm_map_phys() to take a paddr_t rather than a uint32_t
- * will be a flag day.  Other drivers in the WOS use the psm_map()
- * interface, so we need this hack to get them to coexist for
- * pre-integration testing.
- */
-extern caddr_t psm_map_phys_new(paddr_t, size_t, int);
-#define	psm_map_phys psm_map_phys_new
-
+extern caddr_t psm_map_phys(paddr_t, size_t, int);
 /* unmap the physical address given in psm_map_phys() from the addr	*/
 extern void psm_unmap_phys(caddr_t, size_t);
 


### PR DESCRIPTION
The original port relies on device mappings set up by `inetboot` relative to `SEGKPM`. Use device arena mappings to reduce coupling.

There are three changes here:
1. Port `psm_map_phys` and `psm_unmap_phys` from the i86pc PSM code.
2. Implement `prom_get_reg_size`, which was declared but never defined.
3. Use (1) and (2) to map the GIC frames into the device arena from the GICv2 implementation.

Testing:
* Boot on Raspberry Pi 4: https://gist.github.com/r1mikey/ae499bf928b73cbfa29ff3ee0ee1d4bf
* Boot on qemu virt: https://gist.github.com/r1mikey/4cf1052a451ee92e9505a88248d1f0fb