### PR TITLE
Clean up direct PSTATE DAIF flags manipulation

### DIFF
--- a/usr/src/uts/aarch64/asm/controlregs.h
+++ b/usr/src/uts/aarch64/asm/controlregs.h
@@ -560,7 +560,7 @@ write_cpacr_el1(uint64_t reg)
 #define	DAIF_SERROR	(1 << 8)
 #define	DAIF_DEBUG	(1 << 9)
 
-static inline uint64_t
+extern __GNU_INLINE uint64_t
 read_daif(void)
 {
 	uint64_t reg;
@@ -568,19 +568,19 @@ read_daif(void)
 	return (reg);
 }
 
-static inline void
+extern __GNU_INLINE void
 write_daif(uint64_t reg)
 {
 	__asm__ __volatile__("msr daif, %0"::"r"(reg):"memory");
 }
 
-static inline void
+extern __GNU_INLINE void
 set_daif(uint64_t val)
 {
 	__asm__ __volatile__("msr DAIFSet, %0"::"I"(val):"memory");
 }
 
-static inline void
+extern __GNU_INLINE void
 clear_daif(uint64_t val)
 {
 	__asm__ __volatile__("msr DAIFClr, %0"::"I"(val):"memory");

--- a/usr/src/uts/armv8/os/gicv2.c
+++ b/usr/src/uts/armv8/os/gicv2.c
@@ -68,6 +68,7 @@
 #include <sys/sunddi.h>
 #include <sys/promif.h>
 #include <sys/smp_impldefs.h>
+#include <sys/archsystm.h>
 
 extern char *gic_module_name;
 
@@ -187,14 +188,12 @@ static uint32_t gicv2_prio_pmr_mask;
 #undef GIC_IPL_TO_PRIO
 #define	GIC_IPL_TO_PRIO(v)		(gicv2_prio_map[((v) & 0xF)])
 
-#define	GICV2_GICD_LOCK_INIT_HELD()	uint64_t old_daif = read_daif(); \
-					set_daif(DAIF_SETCLEAR_IRQ); \
+#define	GICV2_GICD_LOCK_INIT_HELD()	uint64_t __s = disable_interrupts(); \
 					LOCK_INIT_HELD(&conf.gc_lock)
-#define	GICV2_GICD_LOCK()		uint64_t old_daif = read_daif(); \
-					set_daif(DAIF_SETCLEAR_IRQ); \
+#define	GICV2_GICD_LOCK()		uint64_t __s = disable_interrupts(); \
 					lock_set(&conf.gc_lock)
 #define	GICV2_GICD_UNLOCK()		lock_clear(&conf.gc_lock); \
-					write_daif(old_daif)
+					restore_interrupts(__s)
 #define	GICV2_ASSERT_GICD_LOCK_HELD()	ASSERT(LOCK_HELD(&conf.gc_lock))
 
 static inline uint32_t

--- a/usr/src/uts/armv8/os/mp_machdep.c
+++ b/usr/src/uts/armv8/os/mp_machdep.c
@@ -20,7 +20,7 @@
  * CDDL HEADER END
  */
 /*
- * Copyright 2023 Michael van der Westhuizen
+ * Copyright 2024 Michael van der Westhuizen
  * Copyright 2017 Hayashi Naoyuki
  * Copyright (c) 1992, 2010, Oracle and/or its affiliates. All rights reserved.
  */
@@ -288,21 +288,19 @@ cpu_halt(void)
 	 * which returns useful cycles to the peer hardware strand
 	 * that shares the pipeline.
 	 */
-	s = read_daif();
-	set_daif(DAIF_SETCLEAR_IRQ);
+	s = disable_interrupts();
 	while (*p == 0 &&
 	    ((hset_update && bitset_in_set(&cp->cp_haltset, cpu_sid)) ||
 	    (!hset_update && (CPU->cpu_flags & CPU_OFFLINE)))) {
 		__asm__ volatile("wfi");
-		write_daif(s);
-		s = read_daif();
-		set_daif(DAIF_SETCLEAR_IRQ);
+		restore_interrupts(s);
+		s = disable_interrupts();
 	}
 
 	/*
 	 * We're no longer halted
 	 */
-	write_daif(s);
+	restore_interrupts(s);
 	if (hset_update) {
 		cpup->cpu_disp_flags &= ~CPU_DISP_HALTED;
 		bitset_atomic_del(&cp->cp_haltset, cpu_sid);

--- a/usr/src/uts/armv8/os/trap.c
+++ b/usr/src/uts/armv8/os/trap.c
@@ -23,6 +23,7 @@
  * Copyright (c) 2004, 2010, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, Joyent, Inc.  All rights reserverd.
  * Copyright 2017 Hayashi Naoyuki
+ * Copyright 2024 Michael van der Westhuizen
  */
 
 #include <sys/cpuvar.h>
@@ -482,7 +483,7 @@ trap(uint16_t ec, uint64_t esr, caddr_t addr, struct regs *rp)
 	/*
 	 * XXXARM: Why are these DTrace bits handled here?
 	 */
-	ASSERT((read_daif() & DAIF_IRQ) != 0);
+	ASSERT(interrupts_disabled());
 
 	if (DTRACE_CPUFLAG_ISSET(CPU_DTRACE_NOFAULT)) {
 		ASSERT(!USERMODE(rp->r_spsr));
@@ -516,7 +517,7 @@ trap(uint16_t ec, uint64_t esr, caddr_t addr, struct regs *rp)
 		}
 	}
 
-	clear_daif(DAIF_SETCLEAR_IRQ);
+	(void) enable_interrupts();
 
 	ASSERT_STACK_ALIGNED();
 
@@ -1051,7 +1052,7 @@ kpreempt(int asyncspl)
 			kpreempt_cnts.kpc_prilevel++;
 			return;
 		}
-		if (!interrupts_enabled()) {
+		if (interrupts_disabled()) {
 			/*
 			 * Can't preempt while running with ints disabled
 			 */


### PR DESCRIPTION
There's a fair amount of cognitive overhead to direct manipulation of the PSTATE DAIF bits. We also only every manipulate the I (IRQ) flag.

Add a set of static inline functions to manipulate, restore and query interrupt state, then refactor all callsites to use the new functions.

Boot tested on:
* Raspberry Pi4: https://gist.github.com/r1mikey/18dde4136f46e148354aac4e87fd94e0
* Qemu: https://gist.github.com/r1mikey/4389fd4f0cea7ba9dcabe54818a1ecd3

This is part of a set of small changes leading up to GICv3, which can be previewed at https://github.com/r1mikey/illumos-gate/commits/gicv3/.