### PR TITLE
Increase the width of acknowledged interrupts

### DIFF
--- a/usr/src/uts/aarch64/sys/gic.h
+++ b/usr/src/uts/aarch64/sys/gic.h
@@ -43,10 +43,10 @@ extern void gic_config_irq(uint32_t irq, bool is_edge);
 /*
  * For interrupt handling.
  */
-extern uint32_t gic_acknowledge(void);
-extern uint32_t gic_ack_to_vector(uint32_t ack);
-extern void gic_eoi(uint32_t ack);
-extern void gic_deactivate(uint32_t ack);
+extern uint64_t gic_acknowledge(void);
+extern uint32_t gic_ack_to_vector(uint64_t ack);
+extern void gic_eoi(uint64_t ack);
+extern void gic_deactivate(uint64_t ack);
 extern int gic_vector_is_special(uint32_t intid);
 
 /*
@@ -60,10 +60,10 @@ typedef int (*gic_addspl_t)(int irq, int ipl, int min_ipl, int max_ipl);
 typedef int (*gic_delspl_t)(int irq, int ipl, int min_ipl, int max_ipl);
 typedef int (*gic_setlvl_t)(int irq);
 typedef void (*gic_setlvlx_t)(int ipl);
-typedef uint32_t (*gic_acknowledge_t)(void);
-typedef uint32_t (*gic_ack_to_vector_t)(uint32_t ack);
-typedef void (*gic_eoi_t)(uint32_t ack);
-typedef void (*gic_deactivate_t)(uint32_t ack);
+typedef uint64_t (*gic_acknowledge_t)(void);
+typedef uint32_t (*gic_ack_to_vector_t)(uint64_t ack);
+typedef void (*gic_eoi_t)(uint64_t ack);
+typedef void (*gic_deactivate_t)(uint64_t ack);
 typedef int (*gic_vector_is_special_t)(uint32_t intid);
 
 typedef struct gic_ops {

--- a/usr/src/uts/armv8/ml/exceptions.S
+++ b/usr/src/uts/armv8/ml/exceptions.S
@@ -492,7 +492,7 @@ _sys_rtt_preempt:
 	 * - w20: old pri
 	 * - w21: new pri
 	 * - w22: INTID (vector)
-	 * - w23: IAR value (to use for priority drop and deactivation)
+	 * - x23: IAR value (to use for priority drop and deactivation)
 	 * - x24: old SP (when switching stacks)
 	 * - w25: st_pending (used in softint processing)
 	 * - w26: used temporarily (for new pri) in priority drop
@@ -517,7 +517,7 @@ _sys_rtt_preempt:
 	ldr	w20, [x19, #CPU_PRI]		/* x20 <- old (current) pri */
 
 	bl	gic_acknowledge			/* read interrupt acknowledge */
-	mov	w23, w0				/* w23 <- acked IRQ */
+	mov	x23, x0				/* x23 <- acked IRQ */
 	bl	gic_ack_to_vector		/* extract vector (INTID) */
 	mov	w22, w0				/* x22 <- vector */
 
@@ -561,7 +561,7 @@ _sys_rtt_preempt:
 	mov	w0, w22				/* slew to the irq prio */
 	bl	setlvl				/* returns new_prio in w0 */
 	mov	w26, w0				/* stash new-pri temporarily */
-	mov	w0, w23
+	mov	x0, x23
 	bl	gic_eoi				/* priority drop */
 	cbnz	w26, 1f				/* skip to normal processing */
 
@@ -569,7 +569,7 @@ _sys_rtt_preempt:
 	 * In the "skip to softint" case we deactivate the interrupt and skip
 	 * the hardware interrupt processing.
 	 */
-	mov	w0, w23
+	mov	x0, x23
 	bl	gic_deactivate			/* deactivate the interrupt */
 	b	check_softint
 
@@ -614,7 +614,7 @@ _sys_rtt_preempt:
 	mov	x0, x19				/* CPU */
 	mov	w1, w21				/* new pri */
 	mov	w2, w20				/* old pri */
-	mov	w3, w23				/* acknowledge value */
+	mov	x3, x23				/* acknowledge value */
 	bl	hilevel_intr_epilog		/* sends eoi */
 	b	check_softint			/* process softints */
 
@@ -646,7 +646,7 @@ intr_thread:
 	msr	DAIFSet, #DAIF_SETCLEAR_IRQ	/* mask interrupts */
 
 	mov	x0, x19				/* CPU */
-	mov	w1, w23				/* acknowledge value */
+	mov	x1, x23				/* acknowledge value */
 	mov	w2, w20				/* old pri */
 	bl	intr_thread_epilog
 	mov	sp, x24				/* restore sp (after epilog) */

--- a/usr/src/uts/armv8/os/gic.c
+++ b/usr/src/uts/armv8/os/gic.c
@@ -117,26 +117,26 @@ setlvlx(int ipl)
 	gic_ops.go_setlvlx(ipl);
 }
 
-uint32_t
+uint64_t
 gic_acknowledge(void)
 {
 	return (gic_ops.go_acknowledge());
 }
 
 uint32_t
-gic_ack_to_vector(uint32_t ack)
+gic_ack_to_vector(uint64_t ack)
 {
 	return (gic_ops.go_ack_to_vector(ack));
 }
 
 void
-gic_eoi(uint32_t ack)
+gic_eoi(uint64_t ack)
 {
 	gic_ops.go_eoi(ack);
 }
 
 void
-gic_deactivate(uint32_t ack)
+gic_deactivate(uint64_t ack)
 {
 	gic_ops.go_deactivate(ack);
 }

--- a/usr/src/uts/armv8/os/gicv2.c
+++ b/usr/src/uts/armv8/os/gicv2.c
@@ -469,28 +469,28 @@ gicv2_send_ipi(cpuset_t cpuset, int irq)
 	GICV2_GICD_UNLOCK();
 }
 
-static uint32_t
+static uint64_t
 gicv2_acknowledge(void)
 {
-	return (gicc_read(&conf, GICC_IAR));
+	return ((uint64_t)gicc_read(&conf, GICC_IAR));
 }
 
 static uint32_t
-gicv2_ack_to_vector(uint32_t ack)
+gicv2_ack_to_vector(uint64_t ack)
 {
-	return (ack & GICC_IAR_INTID_NO_ARE);
+	return ((uint32_t)(ack & GICC_IAR_INTID_NO_ARE));
 }
 
 static void
-gicv2_eoi(uint32_t ack)
+gicv2_eoi(uint64_t ack)
 {
-	gicc_write(&conf, GICC_EOIR, ack);
+	gicc_write(&conf, GICC_EOIR, (uint32_t)(ack & 0xFFFFFFFF));
 }
 
 static void
-gicv2_deactivate(uint32_t ack)
+gicv2_deactivate(uint64_t ack)
 {
-	gicc_write(&conf, GICC_DIR, ack);
+	gicc_write(&conf, GICC_DIR, (uint32_t)(ack & 0xFFFFFFFF));
 }
 
 /*

--- a/usr/src/uts/armv8/os/intr.c
+++ b/usr/src/uts/armv8/os/intr.c
@@ -175,7 +175,7 @@ hilevel_intr_prolog(struct cpu *cpu, uint_t pil, uint_t oldpil, struct regs *rp)
  * Called with interrupts masked
  */
 int
-hilevel_intr_epilog(struct cpu *cpu, uint_t pil, uint_t oldpil, uint32_t ack)
+hilevel_intr_epilog(struct cpu *cpu, uint_t pil, uint_t oldpil, uint64_t ack)
 {
 	struct machcpu *mcpu = &cpu->cpu_m;
 	uint_t mask;
@@ -312,7 +312,7 @@ int intr_thread_cnt;
  * Called with interrupts disabled
  */
 void
-intr_thread_epilog(struct cpu *cpu, uint32_t ack, uint_t oldpil)
+intr_thread_epilog(struct cpu *cpu, uint64_t ack, uint_t oldpil)
 {
 	struct machcpu *mcpu = &cpu->cpu_m;
 	kthread_t *t;


### PR DESCRIPTION
GICv3 uses 64 bit registers for IAR, EOI and DIR. Update the abstraction layer to avoid losing the extra width and update the GICv2 implementation to match.

This is part of a series of small changes that prepare for GICv3, a preview of which can be found at https://github.com/r1mikey/illumos-gate/commits/gicv3/.

Booted tested on:
* Raspberry Pi4: https://gist.github.com/r1mikey/2daf72442a28f357d346888ac0972749
* Qemu: https://gist.github.com/r1mikey/53f499b4f9483c53546789f5dd85bf7b