### PR TITLE
Add PROM property retrieval helpers for uint32_t and uint64_t values

### DIFF
--- a/usr/src/uts/aarch64/promif/prom_utils.c
+++ b/usr/src/uts/aarch64/promif/prom_utils.c
@@ -19,6 +19,7 @@
  * CDDL HEADER END
  */
 /*
+ * Copyright 2024 Michael van der Westhuizen
  * Copyright 2017 Hayashi Naoyuki
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
@@ -70,6 +71,34 @@ prom_get_prop_int(pnode_t node, const char *name, int def)
 		node = prom_parentnode(node);
 	}
 	return value;
+}
+
+uint64_t
+prom_get_prop_u64(pnode_t node, const char *name, uint64_t def)
+{
+	uint64_t prop;
+	uint64_t value = def;
+
+	if (node > 0 && prom_getproplen(node, name) == sizeof(uint64_t)) {
+		prom_getprop(node, name, (caddr_t)&prop);
+		value = ntohll(prop);
+	}
+
+	return (value);
+}
+
+uint32_t
+prom_get_prop_u32(pnode_t node, const char *name, uint32_t def)
+{
+	uint32_t prop;
+	uint32_t value = def;
+
+	if (node > 0 && prom_getproplen(node, name) == sizeof(uint32_t)) {
+		prom_getprop(node, name, (caddr_t)&prop);
+		value = ntohl(prop);
+	}
+
+	return (value);
 }
 
 int prom_get_reset(pnode_t node, int index, struct prom_hwreset *reset)

--- a/usr/src/uts/aarch64/promif/prom_utils.c
+++ b/usr/src/uts/aarch64/promif/prom_utils.c
@@ -44,12 +44,12 @@ prom_get_prop_index(pnode_t node, const char *prop_name, const char *name)
 		int index = 0;
 		while (offeset < len) {
 			if (strcmp(name, prop + offeset) == 0)
-				return index;
+				return (index);
 			offeset += strlen(prop + offeset) + 1;
 			index++;
 		}
 	}
-	return -1;
+	return (-1);
 }
 
 int
@@ -59,7 +59,7 @@ prom_get_prop_int(pnode_t node, const char *name, int def)
 
 	while (node > 0) {
 		int len = prom_getproplen(node, name);
-		if (len == sizeof(int)) {
+		if (len == sizeof (int)) {
 			int prop;
 			prom_getprop(node, name, (caddr_t)&prop);
 			value = ntohl(prop);
@@ -70,7 +70,7 @@ prom_get_prop_int(pnode_t node, const char *name, int def)
 		}
 		node = prom_parentnode(node);
 	}
-	return value;
+	return (value);
 }
 
 uint64_t
@@ -79,7 +79,7 @@ prom_get_prop_u64(pnode_t node, const char *name, uint64_t def)
 	uint64_t prop;
 	uint64_t value = def;
 
-	if (node > 0 && prom_getproplen(node, name) == sizeof(uint64_t)) {
+	if (node > 0 && prom_getproplen(node, name) == sizeof (uint64_t)) {
 		prom_getprop(node, name, (caddr_t)&prop);
 		value = ntohll(prop);
 	}
@@ -93,7 +93,7 @@ prom_get_prop_u32(pnode_t node, const char *name, uint32_t def)
 	uint32_t prop;
 	uint32_t value = def;
 
-	if (node > 0 && prom_getproplen(node, name) == sizeof(uint32_t)) {
+	if (node > 0 && prom_getproplen(node, name) == sizeof (uint32_t)) {
 		prom_getprop(node, name, (caddr_t)&prop);
 		value = ntohl(prop);
 	}
@@ -101,11 +101,12 @@ prom_get_prop_u32(pnode_t node, const char *name, uint32_t def)
 	return (value);
 }
 
-int prom_get_reset(pnode_t node, int index, struct prom_hwreset *reset)
+int
+prom_get_reset(pnode_t node, int index, struct prom_hwreset *reset)
 {
 	int len = prom_getproplen(node, "resets");
 	if (len <= 0)
-		return -1;
+		return (-1);
 
 	uint32_t *resets = __builtin_alloca(len);
 	prom_getprop(node, "resets", (caddr_t)resets);
@@ -113,39 +114,43 @@ int prom_get_reset(pnode_t node, int index, struct prom_hwreset *reset)
 	pnode_t reset_node;
 	reset_node = prom_findnode_by_phandle(htonl(resets[0]));
 	if (reset_node < 0)
-		return -1;
+		return (-1);
 
 	int reset_cells = prom_get_prop_int(reset_node, "#reset-cells", 1);
 	if (reset_cells != 1)
-		return -1;
+		return (-1);
 
-	if ((len % (sizeof(uint32_t) * (reset_cells + 1))) != 0)
-		return -1;
-	if (len <= index * (sizeof(uint32_t) * (reset_cells + 1)))
-		return -1;
+	if ((len % (sizeof (uint32_t) * (reset_cells + 1))) != 0)
+		return (-1);
+	if (len <= index * (sizeof (uint32_t) * (reset_cells + 1)))
+		return (-1);
 
-	reset_node = prom_findnode_by_phandle(htonl(resets[index * (reset_cells + 1)]));
+	reset_node =
+	    prom_findnode_by_phandle(htonl(resets[index * (reset_cells + 1)]));
 	if (reset_node < 0)
-		return -1;
+		return (-1);
 	reset->node = reset_node;
 	reset->id = htonl(resets[index * (reset_cells + 1) + 1]);
 
-	return 0;
+	return (0);
 }
 
-int prom_get_reset_by_name(pnode_t node, const char *name, struct prom_hwreset *reset)
+int
+prom_get_reset_by_name(pnode_t node,
+    const char *name, struct prom_hwreset *reset)
 {
 	int index = prom_get_prop_index(node, "reset-names", name);
 	if (index >= 0)
-		return prom_get_reset(node, index, reset);
-	return -1;
+		return (prom_get_reset(node, index, reset));
+	return (-1);
 }
 
-int prom_get_clock(pnode_t node, int index, struct prom_hwclock *clock)
+int
+prom_get_clock(pnode_t node, int index, struct prom_hwclock *clock)
 {
 	int len = prom_getproplen(node, "clocks");
 	if (len <= 0)
-		return -1;
+		return (-1);
 
 	uint32_t *clocks = __builtin_alloca(len);
 	prom_getprop(node, "clocks", (caddr_t)clocks);
@@ -153,42 +158,48 @@ int prom_get_clock(pnode_t node, int index, struct prom_hwclock *clock)
 	pnode_t clock_node;
 	clock_node = prom_findnode_by_phandle(htonl(clocks[0]));
 	if (clock_node < 0)
-		return -1;
+		return (-1);
 
 	int clock_cells = prom_get_prop_int(clock_node, "#clock-cells", 1);
 	if (clock_cells != 0 && clock_cells != 1)
-		return -1;
+		return (-1);
 
-	if ((len % (sizeof(uint32_t) * (clock_cells + 1))) != 0)
-		return -1;
-	if (len <= index * (sizeof(uint32_t) * (clock_cells + 1)))
-		return -1;
+	if ((len % (sizeof (uint32_t) * (clock_cells + 1))) != 0)
+		return (-1);
+	if (len <= index * (sizeof (uint32_t) * (clock_cells + 1)))
+		return (-1);
 
-	clock_node = prom_findnode_by_phandle(htonl(clocks[index * (clock_cells + 1)]));
+	clock_node =
+	    prom_findnode_by_phandle(htonl(clocks[index * (clock_cells + 1)]));
 	if (clock_node < 0)
-		return -1;
+		return (-1);
 	clock->node = clock_node;
-	clock->id = (clock_cells == 0? 0: htonl(clocks[index * (clock_cells + 1) + 1]));
+	clock->id = (clock_cells == 0 ? 0:
+	    htonl(clocks[index * (clock_cells + 1) + 1]));
 
-	return 0;
+	return (0);
 }
 
-int prom_get_clock_by_name(pnode_t node, const char *name, struct prom_hwclock *clock)
+int
+prom_get_clock_by_name(pnode_t node,
+    const char *name, struct prom_hwclock *clock)
 {
 	int index = prom_get_prop_index(node, "clock-names", name);
 	if (index >= 0)
-		return prom_get_clock(node, index, clock);
-	return -1;
+		return (prom_get_clock(node, index, clock));
+	return (-1);
 }
 
-int prom_get_address_cells(pnode_t node)
+int
+prom_get_address_cells(pnode_t node)
 {
-	return prom_get_prop_int(prom_parentnode(node), "#address-cells", 2);
+	return (prom_get_prop_int(prom_parentnode(node), "#address-cells", 2));
 }
 
-int prom_get_size_cells(pnode_t node)
+int
+prom_get_size_cells(pnode_t node)
 {
-	return prom_get_prop_int(prom_parentnode(node), "#size-cells", 2);
+	return (prom_get_prop_int(prom_parentnode(node), "#size-cells", 2));
 }
 
 static int
@@ -206,7 +217,7 @@ prom_get_reg_bounds(pnode_t node, int index, uint64_t *base, uint64_t *size)
 	int size_cells = prom_get_size_cells(node);
 
 	if (((address_cells + size_cells) * index + address_cells + size_cells)
-	    * sizeof(uint32_t) > len)
+	    * sizeof (uint32_t) > len)
 		return (-1);
 
 	if (address_cells < 1 || address_cells > 2 ||
@@ -263,51 +274,70 @@ prom_get_reg_address(pnode_t node, int index, uint64_t *reg)
 {
 	uint64_t addr;
 	if (prom_get_reg(node, index, &addr) != 0)
-		return -1;
+		return (-1);
 
 	pnode_t parent = prom_parentnode(node);
 	while (parent > 0) {
-		if (prom_is_compatible(parent, "simple-bus")) {
-			int len = prom_getproplen(parent, "ranges");
-			if (len > 0) {
-				int address_cells = prom_get_prop_int(parent, "#address-cells", 2);
-				int size_cells = prom_get_prop_int(parent, "#size-cells", 2);
-				int parent_address_cells  = prom_get_prop_int(prom_parentnode(parent), "#address-cells", 2);
+		if (!prom_is_compatible(parent, "simple-bus")) {
+			parent = prom_parentnode(parent);
+			continue;
+		}
 
-				if ((len % (sizeof(uint32_t) * (address_cells + parent_address_cells + size_cells))) == 0) {
-					uint32_t *ranges = __builtin_alloca(len);
-					prom_getprop(parent, "ranges", (caddr_t)ranges);
-					int ranges_cells = (address_cells + parent_address_cells + size_cells);
+		int len = prom_getproplen(parent, "ranges");
+		if (len <= 0) {
+			parent = prom_parentnode(parent);
+			continue;
+		}
 
-					for (int i = 0; i < len / (sizeof(uint32_t) * ranges_cells); i++) {
-						uint64_t base = 0;
-						uint64_t target = 0;
-						uint64_t size = 0;
-						for (int j = 0; j < address_cells; j++) {
-							base <<= 32;
-							base += htonl(ranges[ranges_cells * i + j]);
-						}
-						for (int j = 0; j < parent_address_cells; j++) {
-							target <<= 32;
-							target += htonl(ranges[ranges_cells * i + address_cells + j]);
-						}
-						for (int j = 0; j < size_cells; j++) {
-							size <<= 32;
-							size += htonl(ranges[ranges_cells * i + address_cells + parent_address_cells + j]);
-						}
+		int address_cells =
+		    prom_get_prop_int(parent, "#address-cells", 2);
+		int size_cells = prom_get_prop_int(parent, "#size-cells", 2);
+		int parent_address_cells = prom_get_prop_int(
+		    prom_parentnode(parent), "#address-cells", 2);
 
-						if (base <= addr && addr <= base + size - 1) {
-							addr = (addr - base) + target;
-							break;
-						}
-					}
-				}
+		if ((len % (sizeof (uint32_t) * (
+		    address_cells + parent_address_cells + size_cells))) != 0) {
+			parent = prom_parentnode(parent);
+			continue;
+		}
+
+		uint32_t *ranges = __builtin_alloca(len);
+		prom_getprop(parent, "ranges", (caddr_t)ranges);
+		int ranges_cells =
+		    (address_cells + parent_address_cells + size_cells);
+
+		for (int i = 0;
+		    i < len / (sizeof (uint32_t) * ranges_cells); i++) {
+			uint64_t base = 0;
+			uint64_t target = 0;
+			uint64_t size = 0;
+			for (int j = 0; j < address_cells; j++) {
+				base <<= 32;
+				base += htonl(ranges[ranges_cells * i + j]);
+			}
+			for (int j = 0; j < parent_address_cells; j++) {
+				target <<= 32;
+				target += htonl(ranges[
+				    ranges_cells * i + address_cells + j]);
+			}
+			for (int j = 0; j < size_cells; j++) {
+				size <<= 32;
+				size += htonl(ranges[
+				    ranges_cells * i + address_cells +
+				    parent_address_cells + j]);
+			}
+
+			if (base <= addr && addr <= base + size - 1) {
+				addr = (addr - base) + target;
+				break;
 			}
 		}
+
 		parent = prom_parentnode(parent);
 	}
+
 	*reg = addr;
-	return 0;
+	return (0);
 }
 
 int
@@ -316,8 +346,8 @@ prom_get_reg_by_name(pnode_t node, const char *name, uint64_t *base)
 	int index = prom_get_prop_index(node, "reg-names", name);
 
 	if (index >= 0)
-		return prom_get_reg(node, index, base);
-	return -1;
+		return (prom_get_reg(node, index, base));
+	return (-1);
 }
 
 boolean_t

--- a/usr/src/uts/aarch64/sys/promif.h
+++ b/usr/src/uts/aarch64/sys/promif.h
@@ -24,7 +24,7 @@
  * Use is subject to license terms.
  *
  * Copyright 2017 Hayashi Naoyuki
- * Copyright 2023 Michael van der Westhuizen
+ * Copyright 2024 Michael van der Westhuizen
  */
 
 #ifndef _SYS_PROMIF_H
@@ -245,6 +245,8 @@ struct prom_compat {
 };
 
 extern int prom_get_prop_int(pnode_t node, const char *name, int def);
+extern uint64_t prom_get_prop_u64(pnode_t node, const char *name, uint64_t def);
+extern uint32_t prom_get_prop_u32(pnode_t node, const char *name, uint32_t def);
 extern int prom_get_reg(pnode_t node, int index, uint64_t *base);
 extern int prom_get_reg_by_name(pnode_t node, const char *name, uint64_t *base);
 extern int prom_get_address_cells(pnode_t node);


### PR DESCRIPTION
The current PROM property retrieval functions deal only in (signed) integers, which is not enough for implementing GICv3.

Add helpers to retrieve 32 bit and 64 bit unsigned integers.

This is part of a series of preparatory PRs for GICv3 support (which uses this diff, in this case). A preview of the GICv3 work can be found at https://github.com/r1mikey/illumos-gate/commits/gicv3/.

Boot tested on:
* Raspberry Pi4: https://gist.github.com/r1mikey/1734eae95518443f2a05bf10cc0df998
* Qemu: https://gist.github.com/r1mikey/cf3d73a2fbb4180bdfe741973cd32683