### PR TITLE
Rework IRQ handling from assembler to C

### DIFF
--- a/usr/src/uts/aarch64/sys/archsystm.h
+++ b/usr/src/uts/aarch64/sys/archsystm.h
@@ -60,8 +60,8 @@ extern void tenmicrosec(void);
 extern void bind_hwcap(void);
 extern void av_dispatch_autovect(uint_t);
 extern void av_dispatch_softvect(uint_t);
-extern void switch_sp_and_call(void *, void (*)(uint_t, uint_t),
-    uint_t, uint_t);
+extern void switch_sp_and_call(uint64_t, uint64_t,
+    void (*)(uint64_t, uint64_t), void *);
 extern void fakesoftint(void);
 
 extern void __adj_hrestime(void);

--- a/usr/src/uts/aarch64/sys/gic.h
+++ b/usr/src/uts/aarch64/sys/gic.h
@@ -47,7 +47,7 @@ extern uint64_t gic_acknowledge(void);
 extern uint32_t gic_ack_to_vector(uint64_t ack);
 extern void gic_eoi(uint64_t ack);
 extern void gic_deactivate(uint64_t ack);
-extern int gic_vector_is_special(uint32_t intid);
+extern int gic_is_spurious(uint32_t intid);
 
 /*
  * Types and data structure filled by GIC implementation modules
@@ -64,7 +64,7 @@ typedef uint64_t (*gic_acknowledge_t)(void);
 typedef uint32_t (*gic_ack_to_vector_t)(uint64_t ack);
 typedef void (*gic_eoi_t)(uint64_t ack);
 typedef void (*gic_deactivate_t)(uint64_t ack);
-typedef int (*gic_vector_is_special_t)(uint32_t intid);
+typedef int (*gic_is_spurious_t)(uint32_t intid);
 
 typedef struct gic_ops {
 	gic_send_ipi_t		go_send_ipi;
@@ -79,7 +79,7 @@ typedef struct gic_ops {
 	gic_ack_to_vector_t	go_ack_to_vector;
 	gic_eoi_t		go_eoi;
 	gic_deactivate_t	go_deactivate;
-	gic_vector_is_special_t	go_vector_is_special;
+	gic_is_spurious_t	go_is_spurious;
 } gic_ops_t;
 
 extern gic_ops_t gic_ops;

--- a/usr/src/uts/armv8/ml/aarch64_subr.S
+++ b/usr/src/uts/armv8/ml/aarch64_subr.S
@@ -19,6 +19,7 @@
  * CDDL HEADER END
  */
 /*
+ * Copyright 2024 Michael van der Westhuizen
  * Copyright 2017 Hayashi Naoyuki
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
@@ -316,3 +317,27 @@
 	b.gt	0b
 4:	ret
 	SET_SIZE(clean_data_cache_all)
+
+	/*
+	 * void
+	 * switch_sp_and_call(uint64_t a0, uint64_t a1,
+	 *     void (*func)(uint64_t a0, uint64_t a1), void *newsp);
+	 */
+	ENTRY(switch_sp_and_call)
+	stp	fp, lr, [sp, #-16]!
+	mov	fp, sp
+	/*
+	 * Set up the new stack - the old is in fp.
+	 */
+	mov	sp, x3
+	/*
+	 * Call the function
+	 *
+	 * argument a0 is already in x0
+	 * argument a1 is already in x1
+	 */
+	blr	x2
+	mov	sp, fp
+	ldp	fp, lr, [sp], #16
+	ret
+	SET_SIZE(switch_sp_and_call)

--- a/usr/src/uts/armv8/ml/exceptions.S
+++ b/usr/src/uts/armv8/ml/exceptions.S
@@ -124,7 +124,9 @@ ALTENTRY(from_current_el_irq)
 	clrex
 	__SAVE_REGS
 	__SAVE_FRAME
-	b	irq_handler
+	mov	x0, sp
+	bl	do_interrupt
+	b	_sys_rtt
 	CHECK_VECTOR_ENTRY(from_current_el_irq)
 SET_SIZE(from_current_el_irq)
 
@@ -166,7 +168,9 @@ ALTENTRY(from_lower_el_aarch64_irq)
 	clrex
 	__SAVE_REGS
 	__TERMINATE_FRAME
-	b	irq_handler
+	mov	x0, sp
+	bl	do_interrupt
+	b	_sys_rtt
 	CHECK_VECTOR_ENTRY(from_lower_el_aarch64_irq)
 SET_SIZE(from_lower_el_aarch64_irq)
 
@@ -479,230 +483,6 @@ _sys_rtt_preempt:
 	strb	wzr, [x20, #T_PREEMPT_LK]
 	b	_sys_rtt_preempt_ret
 	SET_SIZE(_sys_rtt)
-
-	/*
-	 * IRQ Handler
-	 *
-	 * This routine uses [wx]19-[wx]26 to keep state, as these are
-	 * callee-saved registers and will be restored by the called C code
-	 * prior to returning.
-	 *
-	 * Assignment is as follows:
-	 * - x19: CPU
-	 * - w20: old pri
-	 * - w21: new pri
-	 * - w22: INTID (vector)
-	 * - x23: IAR value (to use for priority drop and deactivation)
-	 * - x24: old SP (when switching stacks)
-	 * - w25: st_pending (used in softint processing)
-	 * - w26: used temporarily (for new pri) in priority drop
-	 *
-	 * This is all eerily similar to do_interrupt in
-	 * usr/src/uts/i86pc/os/intr.c, but it's done in assembly so we can
-	 * fully unwind the stack between calls to C code. There's some dubious
-	 * passing of the regs struct that's later used as a stack pointer
-	 * where needed, and I don't have the brain power to determine if
-	 * that's safe or it'll trash the (in use, in C) stack.
-	 *
-	 * NOTE: we're still missing a way to implement fakesoftint processing
-	 * in do_splx and splr as is done in i86pc. This could be useful, but
-	 * would require some refactoring here (and possibly reserving a fake
-	 * vector to trigger that path).
-	 */
-	ENTRY(irq_handler)
-	mov	w0, #CPU_IDLE_CB_FLAG_INTR
-	bl	cpu_idle_exit
-
-	CPUP(x19)				/* x19 <- CPU */
-	ldr	w20, [x19, #CPU_PRI]		/* x20 <- old (current) pri */
-
-	bl	gic_acknowledge			/* read interrupt acknowledge */
-	mov	x23, x0				/* x23 <- acked IRQ */
-	bl	gic_ack_to_vector		/* extract vector (INTID) */
-	mov	w22, w0				/* x22 <- vector */
-
-	/*
-	 * If we get a "special" interrupt it means that the highest priority
-	 * pending interrupt is for the other (secure) world, and we're
-	 * supposed to just return.
-	 *
-	 * See IHI0048, 1.4.4 Spurious interrupts and
-	 * IHI0048, 3.2.5 Special interrupt numbers
-	 */
-	bl	gic_is_spurious			/* w0 is the still the vector */
-	cbnz	w0, _sys_rtt			/* non-zero means special */
-
-	/*
-	 * Set our priority to that of the interrupt.
-	 *
-	 * The running priority has been set for us by the hardware, and can
-	 * be found in the running priority register (GICC_RPR, ICC_RPR). The
-	 * idea is that the priority mask of the CPU interface is:
-	 *   MAX(GICC_PMR, GICC_RPR)
-	 * Since we're doing split end-of-interrupt to safely support threaded
-	 * interrupts we need to do the running priority drop (caused by EOI)
-	 * early.
-	 *
-	 * To make this safe, we first set our priority mask register (via
-	 * setlvl) to that of the received interrupt, then send the EOI (which
-	 * drops the running priority). This ensures that we don't leave a
-	 * window where the distributor might determine that an inapproriate
-	 * interrupt should be forwarded to us.
-	 *
-	 * If setlvl returns zero we've hit a race, where somebody else has
-	 * disestablished the interrupt while we're processing it. In this case
-	 * we deactivate the interrupt and skip to softint processing. Note
-	 * that in this case we just leave the priority as-is (as setlvl will
-	 * have refused to change the priority mask register).
-	 *
-	 * In the nominal case the hardware interrupt processing is responsible
-	 * for deactivating the interrupt in the relevant epilog function.
-	 */
-	mov	w0, w22				/* slew to the irq prio */
-	bl	setlvl				/* returns new_prio in w0 */
-	mov	w26, w0				/* stash new-pri temporarily */
-	mov	x0, x23
-	bl	gic_eoi				/* priority drop */
-	cbnz	w26, 1f				/* skip to normal processing */
-
-	/*
-	 * In the "skip to softint" case we deactivate the interrupt and skip
-	 * the hardware interrupt processing.
-	 */
-	mov	x0, x23
-	bl	gic_deactivate			/* deactivate the interrupt */
-	b	check_softint
-
-1:
-	mov	w21, w26			/* w21 <- new pri */
-	str	w21, [x19, #CPU_PRI]		/* update our CPU's pri */
-
-	cmp	w21, #LOCK_LEVEL
-	b.le	intr_thread			/* threaded interrupt needed */
-
-	/*
-	 * High-level interrupt handling is as one might expect:
-	 * - Call the prolog
-	 * - If the prolog indicated that a stack switch is necessary, do it
-	 * - allow interrupts
-	 * - dispatch the vector
-	 * - disable interrupts
-	 * - restore the stack
-	 * - call the epilog, which deactivates the interrupt
-	 * - move on to softint processing
-	 *
-	 * Note that high-level interrupts restore the stack pointer *before*
-	 * calling the epilog, as they cannot switch away.
-	 */
-	mov	x0, x19				/* CPU */
-	mov	w1, w21				/* new pri */
-	mov	w2, w20				/* old pri */
-	mov	x3, sp				/* regs */
-	bl	hilevel_intr_prolog		/* returns new stack in x0 */
-	mov	x24, sp				/* x24 <- old sp */
-	cbnz	x0, 2f				/* need to switch stacks? */
-
-	ldr	x0, [x19, #CPU_INTR_STACK]	/* load up the irq stack */
-	mov	sp, x0				/* switch the the new stack */
-2:
-	msr	DAIFClr, #DAIF_SETCLEAR_IRQ	/* unmask interrupts */
-	mov	w0, w22				/* vector <- w22 */
-	bl	av_dispatch_autovect
-	msr	DAIFSet, #DAIF_SETCLEAR_IRQ	/* mask interrupts */
-
-	mov	sp, x24				/* restore sp (maybe noop) */
-	mov	x0, x19				/* CPU */
-	mov	w1, w21				/* new pri */
-	mov	w2, w20				/* old pri */
-	mov	x3, x23				/* acknowledge value */
-	bl	hilevel_intr_epilog		/* sends eoi */
-	b	check_softint			/* process softints */
-
-	/*
-	 * Threaded interrupt handling is slightly different:
-	 * - Call the prolog, this returns the stack pointer to use
-	 * - Switch to the new stack
-	 * - allow interrupts
-	 * - dispatch the vector (will switch away if needed and resume here)
-	 * - disable interrupts
-	 * - call the epilog, which deactivates the interrupt
-	 * - restore the stack
-	 * - move on to softint processing
-	 *
-	 * Note that threaded interrupts restore the stack pointer *after*
-	 * calling the epilog, as they may have switched away.
-	 */
-intr_thread:
-	mov	x0, x19				/* CPU */
-	mov	x1, sp				/* stackptr */
-	mov	w2, w21				/* new pri */
-	bl	intr_thread_prolog		/* returns new stack in x0 */
-	mov	x24, sp				/* x24 <- old sp */
-	mov	sp, x0				/* switch the the new stack */
-
-	msr	DAIFClr, #DAIF_SETCLEAR_IRQ	/* unmask interrupts */
-	mov	w0, w22				/* vector <- w22 */
-	bl	av_dispatch_autovect
-	msr	DAIFSet, #DAIF_SETCLEAR_IRQ	/* mask interrupts */
-
-	mov	x0, x19				/* CPU */
-	mov	x1, x23				/* acknowledge value */
-	mov	w2, w20				/* old pri */
-	bl	intr_thread_epilog
-	mov	sp, x24				/* restore sp (after epilog) */
-						/* fall through to softints */
-
-	/*
-	 * This label simply drives processing of softints - if st_pending
-	 * is non-zero we run the softints logic, which keeps coming back here.
-	 *
-	 * If/when st_pending gets to 0, we're done - return from the trap.
-	 */
-check_softint:
-	ldr	w25, [x19, #CPU_SOFTINFO]	/* load fresh st_pending */
-	cbnz	w25, dosoftint			/* work to do, get to it */
-	b	_sys_rtt			/* no work, we're done */
-
-	/*
-	 * Soft interrupt handling is, again, different:
-	 * - Call the prolog, this returns the stack pointer to use or NULL
-	 * - If the prolog returned NULL there are no softints of suitable
-	 *   priority available, so we're done (return from the trap)
-	 * - Switch to the new stack
-	 * - allow interrupts
-	 * - dispatch the softints for the pil
-	 * - disable interrupts
-	 * - call the epilog (tweaks the pil)
-	 * - restore the stack
-	 * - check for more softints (see the check_softint label above)
-	 *
-	 * Note that soft interrupts restore the stack pointer *after* calling
-	 * the epilog as they may have switched away.
-	 */
-dosoftint:
-	mov	x0, x19				/* CPU */
-	mov	x1, sp				/* stackptr */
-	mov	w2, w25				/* st_pending */
-	mov	w3, w20				/* old pri */
-	bl	dosoftint_prolog		/* x0 == 0 iff none suitable */
-	cbz	x0, _sys_rtt			/* no more? we're done */
-
-	mov	x24, sp				/* x24 <- old sp */
-	mov	sp, x0				/* switch the the new stack */
-
-	msr	DAIFClr, #DAIF_SETCLEAR_IRQ	/* unmask interrupts */
-	THREADP(x0)
-	ldrb	w0, [x0, #T_PIL]		/* load up the PIL */
-	bl	av_dispatch_softvect		/* run the softints */
-	msr	DAIFSet, #DAIF_SETCLEAR_IRQ	/* mask interrupts */
-
-	mov	x0, x19				/* CPU */
-	mov	w1, w20				/* old pri */
-	bl	dosoftint_epilog
-	mov	sp, x24				/* restore sp (after epilog) */
-	b	check_softint			/* check for more work */
-	SET_SIZE(irq_handler)
-
 
 	ENTRY(lwp_rtt_initial)
 	THREADP(x0)

--- a/usr/src/uts/armv8/ml/exceptions.S
+++ b/usr/src/uts/armv8/ml/exceptions.S
@@ -529,7 +529,7 @@ _sys_rtt_preempt:
 	 * See IHI0048, 1.4.4 Spurious interrupts and
 	 * IHI0048, 3.2.5 Special interrupt numbers
 	 */
-	bl	gic_vector_is_special		/* w0 is the still the vector */
+	bl	gic_is_spurious			/* w0 is the still the vector */
 	cbnz	w0, _sys_rtt			/* non-zero means special */
 
 	/*

--- a/usr/src/uts/armv8/os/gic.c
+++ b/usr/src/uts/armv8/os/gic.c
@@ -43,7 +43,7 @@ gic_ops_t gic_ops = {
 	.go_ack_to_vector	= (gic_ack_to_vector_t)stub_not_config,
 	.go_eoi			= (gic_eoi_t)stub_not_config,
 	.go_deactivate		= (gic_deactivate_t)stub_not_config,
-	.go_vector_is_special	= (gic_vector_is_special_t)NULL
+	.go_is_spurious		= (gic_is_spurious_t)NULL
 };
 
 static void
@@ -142,10 +142,10 @@ gic_deactivate(uint64_t ack)
 }
 
 int
-gic_vector_is_special(uint32_t intid)
+gic_is_spurious(uint32_t intid)
 {
-	if (gic_ops.go_vector_is_special != NULL)
-		return (gic_ops.go_vector_is_special(intid));
+	if (gic_ops.go_is_spurious != NULL)
+		return (gic_ops.go_is_spurious(intid));
 
 	if (GIC_INTID_IS_SPECIAL(intid))
 		return (1);

--- a/usr/src/uts/armv8/os/gicv2.c
+++ b/usr/src/uts/armv8/os/gicv2.c
@@ -835,7 +835,7 @@ _init(void)
 		/*
 		 * Explicitly use the default "is special" handler.
 		 */
-		gic_ops.go_vector_is_special = (gic_vector_is_special_t)NULL;
+		gic_ops.go_is_spurious = (gic_is_spurious_t)NULL;
 	}
 
 	return (mod_install(&modlinkage));

--- a/usr/src/uts/armv8/os/gicv3.c
+++ b/usr/src/uts/armv8/os/gicv3.c
@@ -1169,7 +1169,7 @@ _init(void)
 		/*
 		 * Explicitly use the default "is special" handler.
 		 */
-		gic_ops.go_vector_is_special = (gic_vector_is_special_t)NULL;
+		gic_ops.go_is_spurious = (gic_is_spurious_t)NULL;
 	}
 
 	return (mod_install(&modlinkage));


### PR DESCRIPTION
The `irq_handler` function for aarch64 was completely implemented in assembler, which the corresponding trap handlers for sun4 and i86pc are implemented in C. Rework the aarch64 version to C, based on the i86pc version, after auditing the various resume functions to ensure that their stack usage makes sense.

Raspberry Pi4 boot: https://gist.github.com/r1mikey/299feb62b41f4a80326ad0613a5e6e4f
Qemu boot: https://gist.github.com/r1mikey/6d100340d5299d209037a1f019ea12dc

Transferred a 10MiB file to, and then from, the Pi4 250 times per test, 8 tests in parallel (for a total of 20G of upload, 20G of download) using the script in https://gist.github.com/r1mikey/eb3a453eadb6aa4302aa043d5c3be985. No corruption observed and no crashes on the Pi4. Did a similar test against qemu (with two CPUs), transferring 1G total (it's just too slow to do much more).