### PR TITLE
Reintroduce xc_levels.h

### DIFF
--- a/usr/src/pkg/manifests/system-header.p5m
+++ b/usr/src/pkg/manifests/system-header.p5m
@@ -1504,7 +1504,6 @@ file path=usr/include/sys/wait.h
 file path=usr/include/sys/waitq.h
 file path=usr/include/sys/watchpoint.h
 $(i386_ONLY)file path=usr/include/sys/x86_archext.h
-$(aarch64_ONLY)file path=usr/include/sys/x_call.h
 $(i386_ONLY)file path=usr/include/sys/xen_errno.h
 file path=usr/include/sys/xti_inet.h
 file path=usr/include/sys/xti_osi.h
@@ -1603,6 +1602,8 @@ $(aarch64_ONLY)file path=usr/platform/armv8/include/sys/sbd_ioctl.h
 $(aarch64_ONLY)file path=usr/platform/armv8/include/sys/smp_impldefs.h
 $(aarch64_ONLY)file path=usr/platform/armv8/include/sys/smt.h
 $(aarch64_ONLY)file path=usr/platform/armv8/include/sys/vm_machparam.h
+$(aarch64_ONLY)file path=usr/platform/armv8/include/sys/x_call.h
+$(aarch64_ONLY)file path=usr/platform/armv8/include/sys/xc_levels.h
 $(i386_ONLY)dir path=usr/platform/i86pc group=sys
 $(i386_ONLY)dir path=usr/platform/i86pc/include
 $(i386_ONLY)dir path=usr/platform/i86pc/include/sys

--- a/usr/src/uts/aarch64/sys/Makefile
+++ b/usr/src/uts/aarch64/sys/Makefile
@@ -69,8 +69,7 @@ HDRS	=			\
 	trap.h			\
 	ucontext.h		\
 	utrap.h			\
-	vmparam.h		\
-	x_call.h
+	vmparam.h
 
 ROOTDIR=	$(ROOT)/usr/include/sys
 SCSIDIR=	$(ROOTDIR)/scsi

--- a/usr/src/uts/armv8/io/cbe.c
+++ b/usr/src/uts/armv8/io/cbe.c
@@ -30,6 +30,7 @@
 #include <sys/cyclic_impl.h>
 #include <sys/spl.h>
 #include <sys/x_call.h>
+#include <sys/xc_levels.h>
 #include <sys/kmem.h>
 #include <sys/machsystm.h>
 #include <sys/smp_impldefs.h>

--- a/usr/src/uts/armv8/os/intr.c
+++ b/usr/src/uts/armv8/os/intr.c
@@ -54,6 +54,7 @@
 #include <sys/promif.h>
 #include <sys/gic.h>
 #include <sys/x_call.h>
+#include <sys/xc_levels.h>
 #include <sys/arch_timer.h>
 
 /*

--- a/usr/src/uts/armv8/os/machdep.c
+++ b/usr/src/uts/armv8/os/machdep.c
@@ -52,6 +52,7 @@
 #include <sys/callb.h>
 #include <sys/controlregs.h>
 #include <sys/x_call.h>
+#include <sys/xc_levels.h>
 #include <sys/consdev.h>
 #include <sys/arch_timer.h>
 

--- a/usr/src/uts/armv8/os/mp_call.c
+++ b/usr/src/uts/armv8/os/mp_call.c
@@ -32,6 +32,7 @@
 #include <sys/irq.h>
 #include <sys/spl.h>
 #include <sys/x_call.h>
+#include <sys/xc_levels.h>
 #include <sys/machsystm.h>
 
 void

--- a/usr/src/uts/armv8/os/trap.c
+++ b/usr/src/uts/armv8/os/trap.c
@@ -62,6 +62,7 @@
 #include <sys/frame.h>
 #include <sys/dtrace.h>
 #include <sys/x_call.h>
+#include <sys/xc_levels.h>
 #include <sys/spl.h>
 
 extern void print_msg_hwerr(ctid_t ct_id, proc_t *p);

--- a/usr/src/uts/armv8/os/x_call.c
+++ b/usr/src/uts/armv8/os/x_call.c
@@ -30,6 +30,7 @@
 #include <sys/thread.h>
 #include <sys/cpuvar.h>
 #include <sys/x_call.h>
+#include <sys/xc_levels.h>
 #include <sys/cpu.h>
 #include <sys/psw.h>
 #include <sys/sunddi.h>

--- a/usr/src/uts/armv8/sys/Makefile
+++ b/usr/src/uts/armv8/sys/Makefile
@@ -45,7 +45,9 @@ HDRS= \
 	smp_impldefs.h \
 	smt.h \
 	ddi_subrdefs.h \
-	vm_machparam.h
+	vm_machparam.h \
+	x_call.h \
+	xc_levels.h
 
 ROOTHDRS= $(HDRS:%=$(USR_PSM_ISYS_DIR)/%)
 

--- a/usr/src/uts/armv8/sys/x_call.h
+++ b/usr/src/uts/armv8/sys/x_call.h
@@ -1,0 +1,64 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+ * Use is subject to license terms.
+ */
+
+#ifndef _SYS_X_CALL_H
+#define	_SYS_X_CALL_H
+
+#include <sys/cpuvar.h>
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+#ifndef _ASM
+
+typedef uintptr_t xc_arg_t;
+typedef int (*xc_func_t)(xc_arg_t, xc_arg_t, xc_arg_t);
+
+/*
+ * Cross-call routines.
+ */
+#if defined(_KERNEL)
+
+#if defined(_MACHDEP)
+/* XXXARM: this whole file needs to be closer to Intel */
+#define	CPUSET2BV(set)	(set)
+extern void	xc_init(void);
+extern void	xc_call(xc_arg_t, xc_arg_t, xc_arg_t, cpuset_t set, xc_func_t);
+extern void	xc_sync(xc_arg_t, xc_arg_t, xc_arg_t, cpuset_t set, xc_func_t);
+extern void	xc_call_nowait(xc_arg_t, xc_arg_t, xc_arg_t, cpuset_t set,
+    xc_func_t);
+#endif
+
+#endif	/* _KERNEL */
+
+#endif	/* !_ASM */
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif	/* _SYS_X_CALL_H */

--- a/usr/src/uts/armv8/sys/xc_levels.h
+++ b/usr/src/uts/armv8/sys/xc_levels.h
@@ -24,10 +24,8 @@
  * Use is subject to license terms.
  */
 
-#ifndef _SYS_X_CALL_H
-#define	_SYS_X_CALL_H
-
-#include <sys/cpuvar.h>
+#ifndef _SYS_XC_LEVELS_H
+#define	_SYS_XC_LEVELS_H
 
 #ifdef	__cplusplus
 extern "C" {
@@ -39,32 +37,8 @@ extern "C" {
 #define	XC_HI_PIL	15	/* cross call with service function */
 #define	XCALL_PIL	XC_HI_PIL /* alias for XC_HI_PIL */
 
-#ifndef _ASM
-
-typedef uintptr_t xc_arg_t;
-typedef int (*xc_func_t)(xc_arg_t, xc_arg_t, xc_arg_t);
-
-/*
- * Cross-call routines.
- */
-#if defined(_KERNEL)
-
-#if defined(_MACHDEP)
-/* XXXARM: this whole file needs to be closer to Intel */
-#define	CPUSET2BV(set)	(set)
-extern void	xc_init(void);
-extern void	xc_call(xc_arg_t, xc_arg_t, xc_arg_t, cpuset_t set, xc_func_t);
-extern void	xc_sync(xc_arg_t, xc_arg_t, xc_arg_t, cpuset_t set, xc_func_t);
-extern void	xc_call_nowait(xc_arg_t, xc_arg_t, xc_arg_t, cpuset_t set,
-    xc_func_t);
-#endif
-
-#endif	/* _KERNEL */
-
-#endif	/* !_ASM */
-
 #ifdef	__cplusplus
 }
 #endif
 
-#endif	/* _SYS_X_CALL_H */
+#endif	/* _SYS_XC_LEVELS_H */

--- a/usr/src/uts/common/os/cap_util.c
+++ b/usr/src/uts/common/os/cap_util.c
@@ -124,7 +124,7 @@
 #include <sys/archsystm.h>
 #include <sys/promif.h>
 
-#if defined(__x86)
+#if defined(__x86) || defined(__aarch64__)
 #include <sys/xc_levels.h>
 #endif
 

--- a/usr/src/uts/common/os/kcpc.c
+++ b/usr/src/uts/common/os/kcpc.c
@@ -46,6 +46,8 @@
 #include <sys/cap_util.h>
 #if defined(__x86)
 #include <asm/clock.h>
+#endif
+#if defined(__x86) || defined(__aarch64__)
 #include <sys/xc_levels.h>
 #endif
 


### PR DESCRIPTION
As a step towards making the aarch64 x-call infrastructure look more like i86pc, split xc_levels.h from x_call.h and move both files to armv8, much like they are in i86pc.

There are still significant differences in the implementations that need to be examined and resolved if the implementation is inappropriate.

There is no functional change in this diff, it's just a bit of housecleaning.

Some background: this is extracted from a set of changes I'm working on to move IRQ handling into a PSM (armbsa), but it's an isolated change, so I thought I'd get it into the tree now.

A nightly build is clean: https://gist.github.com/r1mikey/4308c99b8e5fff428042245f96051e98

Boot tested on qemu: https://gist.github.com/r1mikey/ee54256dbfd678359c44f6a068064760