### PR TITLE
ld(1): Fix manual page comments from andyf

### DIFF
--- a/usr/src/man/man1/ld.1
+++ b/usr/src/man/man1/ld.1
@@ -109,9 +109,7 @@
 .Op Fl z Cm sysroot= Ns Ar directory
 .Op Fl z Cm target= Ns Cm sparc Ns | Ns Cm x86 Ns | Ns Cm aarch64
 .Op Fl z Cm text | Fl z Cm textwarn | Fl z Cm textoff
-.Sm off
-.Op Fl z\~ Cm type= Cm exec | kmod | reloc | shared
-.Sm on
+.Op Fl z Cm type= Ns Cm exec Ns | Ns Cm kmod Ns | Ns Cm reloc Ns | Ns Cm shared
 .Op Fl z Cm verbose
 .Op Fl z Cm wrap= Ns Ar symbol
 .Ar filename Ns No \&...
@@ -669,9 +667,11 @@ in
 .Pp
 If path begins with the string
 .Va $SYSROOT/
-(for compatibility with Solaris) or
+.Pq for compatibility with Solaris
+or
 .Va =/
-(for compatibility with GNU), this token is replaced with the system root
+.Pq for compatibility with GNU
+this token is replaced with the system root
 specified with
 .Fl z Cm sysroot
 or the default, the root filesystem
@@ -920,11 +920,13 @@ is a colon-separated path list.
 .Pp
 If the paths in this list begin with the string
 .Va $SYSROOT/
-(for compatibility with Solaris) or
+.Pq for compatibility with Solaris
+or
 .Va =/
-(for compatibility with GNU), this token is replaced with the system root
+.Pq for compatibility with GNU
+this token is replaced with the system root
 specified with
-.Fl z Ar sysroot
+.Fl z Cm sysroot
 or the root filesystem
 .Pa / .
 .Pp
@@ -1580,7 +1582,9 @@ At runtime, the global symbol will be bound to the corresponding implementation
 that is appropriate based on the capabilities of the system.
 .Pp
 .It Fl z Cm sysroot= Ns Ar directory
-Specifies a directory to use as if it were the system root directory (/) when
+Specifies a directory to use as if it were the system root directory
+.Pq /
+when
 searching for libraries along the default search paths, or if specified to do
 so in the
 .Fl L


### PR DESCRIPTION
I think this covers up the notes you had Andy, and makes clear the comment I had about `-z type`.