### PR TITLE
Don't rely on FDT for boot properties, clean up FDT prior to running unix

### DIFF
--- a/usr/src/psm/stand/boot/aarch64/meson-gxbb/machdep.c
+++ b/usr/src/psm/stand/boot/aarch64/meson-gxbb/machdep.c
@@ -19,9 +19,12 @@
  * CDDL HEADER END
  */
 /*
- * Copyright 2017 Hayashi Naoyuki
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ */
+/*
+ * Copyright 2024 Michael van der Westhuizen
+ * Copyright 2017 Hayashi Naoyuki
  */
 
 #include <sys/types.h>
@@ -55,7 +58,6 @@
 
 extern char _BootScratch[];
 extern char _RamdiskStart[];
-extern char _RamdiskStart[];
 extern char _RamdiskEnd[];
 extern char filename[];
 static struct xboot_info xboot_info;
@@ -79,6 +81,21 @@ extern int determine_fstype_and_mountroot(char *);
 extern	ssize_t xread(int, char *, size_t);
 extern	void _reset(void);
 extern	void init_physmem_common(void);
+extern void setenv(const char *name, const char *value);
+extern char envblock[];
+extern size_t envblock_len;
+
+#define	SI_HW_PROVIDER	"Amlogic Inc."
+#define	IMPL_ARCH_NAME	"AMLGC,meson-gxbb"
+#define	MFG_NAME	IMPL_ARCH_NAME
+
+static struct boot_modules boot_modules[MAX_BOOT_MODULES] = {
+	{ 0, 0, 0, BMT_ROOTFS },
+};
+
+static char cmdline[OBP_MAXPATHLEN] = {0};
+static char rootfs_name[] = "rootfs";
+static char environment_name[] = "environment";
 
 void
 setup_aux(void)
@@ -90,6 +107,7 @@ init_physmem(void)
 {
 	init_physmem_common();
 }
+
 void
 init_iolist(void)
 {
@@ -97,60 +115,58 @@ init_iolist(void)
 	memlist_add_span(gxbb_share_mem_out_base(), 0x1000, &plinearlistp);
 	memlist_add_span(gxbb_share_mem_in_base(), 0x1000, &plinearlistp);
 }
-void exitto(int (*entrypoint)())
+
+#define	MEMATTRS	(PTE_UXN | PTE_PXN | PTE_AF | PTE_SH_INNER |	\
+			PTE_AP_KRWUNA | PTE_ATTR_NORMEM)
+#define	PIOATTRS	(PTE_UXN | PTE_PXN | PTE_AF | PTE_SH_INNER |	\
+			PTE_AP_KRWUNA | PTE_ATTR_DEVICE)
+
+void
+exitto(int (*entrypoint)())
 {
 	for (struct memlist *ml = plinearlistp; ml != NULL; ml = ml->ml_next) {
 		uintptr_t pa = ml->ml_address;
 		uintptr_t sz = ml->ml_size;
-		map_phys(PTE_UXN | PTE_PXN | PTE_AF | PTE_SH_INNER | PTE_AP_KRWUNA | PTE_ATTR_NORMEM, (caddr_t)(SEGKPM_BASE + pa), pa, sz);
+		map_phys((MEMATTRS), (caddr_t)(SEGKPM_BASE + pa), pa, sz);
 	}
 	for (struct memlist *ml = piolistp; ml != NULL; ml = ml->ml_next) {
 		uintptr_t pa = ml->ml_address;
 		uintptr_t sz = ml->ml_size;
-		map_phys(PTE_UXN | PTE_PXN | PTE_AF | PTE_SH_INNER | PTE_AP_KRWUNA | PTE_ATTR_DEVICE, (caddr_t)(SEGKPM_BASE + pa), pa, sz);
+		map_phys((PIOATTRS), (caddr_t)(SEGKPM_BASE + pa), pa, sz);
 	}
 
-	uint64_t v;
-	const char *str;
+	xboot_info.bi_phys_avail = (uint64_t)pfreelistp;
+	xboot_info.bi_phys_installed = (uint64_t)pinstalledp;
+	xboot_info.bi_boot_scratch = (uint64_t)pscratchlistp;
 
-	v = htonll((uint64_t)_RamdiskStart);
-	prom_setprop(prom_chosennode(), "ramdisk_start", (caddr_t)&v, sizeof(v));
-	v = htonll((uint64_t)_RamdiskEnd);
-	prom_setprop(prom_chosennode(), "ramdisk_end", (caddr_t)&v, sizeof(v));
-	v = htonll((uint64_t)pfreelistp);
-	prom_setprop(prom_chosennode(), "phys-avail", (caddr_t)&v, sizeof(v));
-	v = htonll((uint64_t)pinstalledp);
-	prom_setprop(prom_chosennode(), "phys-installed", (caddr_t)&v, sizeof(v));
-	v = htonll((uint64_t)pscratchlistp);
-	prom_setprop(prom_chosennode(), "boot-scratch", (caddr_t)&v, sizeof(v));
-	if (bootp_response) {
-		uint_t blen = strlen(bootp_response) / 2;
-		char *pktbuf = __builtin_alloca(blen);
-		hexascii_to_octet(bootp_response, blen * 2, pktbuf, &blen);
-		prom_setprop(prom_chosennode(), "bootp-response", pktbuf, blen);
-	} else {
-	}
-	str = "";
-	prom_setprop(prom_chosennode(), "boot-args", (caddr_t)str, strlen(str) + 1);
-	str = "";
-	prom_setprop(prom_chosennode(), "bootargs", (caddr_t)str, strlen(str) + 1);
-	str = filename;
-	prom_setprop(prom_chosennode(), "whoami", (caddr_t)str, strlen(str) + 1);
-	str = filename;
-	prom_setprop(prom_chosennode(), "boot-file", (caddr_t)str, strlen(str) + 1);
+	if (bootp_response)
+		setenv("bootp-response", bootp_response);
 
-	if (prom_getproplen(prom_chosennode(), "impl-arch-name") < 0) {
-		str = "armv8";
-		prom_setprop(prom_chosennode(), "impl-arch-name", (caddr_t)str, strlen(str) + 1);
-	}
+	strncpy(cmdline, filename, sizeof (cmdline) - 1);
+	xboot_info.bi_cmdline = (uint64_t)cmdline;
 
-	str = get_mfg_name();
-	prom_setprop(prom_chosennode(), "mfg-name", (caddr_t)str, strlen(str) + 1);
-	str = "115200,8,n,1,-";
-	prom_setprop(prom_chosennode(), "ttya-mode", (caddr_t)str, strlen(str) + 1);
-	prom_setprop(prom_chosennode(), "ttyb-mode", (caddr_t)str, strlen(str) + 1);
+	setenv("ttya-mode", "115200,8,n,1,-");
+	setenv("ttyb-mode", "115200,8,n,1,-");
 
 	xboot_info.bi_fdt = SEGKPM_BASE + (uint64_t)get_fdtp();
+
+	/*
+	 * No calling setenv once our modules are set up.
+	 */
+	boot_modules[0].bm_type = BMT_ROOTFS;
+	boot_modules[0].bm_name = (uint64_t)rootfs_name;
+	boot_modules[0].bm_size =
+	    ((uint64_t)_RamdiskEnd - (uint64_t)_RamdiskStart);
+	boot_modules[0].bm_addr = (uint64_t)_RamdiskStart;
+
+	boot_modules[1].bm_type = BMT_ENV;
+	boot_modules[1].bm_name = (uint64_t)environment_name;
+	boot_modules[1].bm_size = (uint64_t)envblock_len;
+	boot_modules[1].bm_addr = (uint64_t)envblock;
+
+	xboot_info.bi_module_cnt = 2;
+	xboot_info.bi_modules = (uint64_t)&boot_modules[0];
+
 	entrypoint(&xboot_info);
 }
 
@@ -162,17 +178,15 @@ static void
 set_zfs_bootfs(void)
 {
 	get_boot_zpool(zfs_bootfs);
-	prom_setprop(prom_chosennode(), "zfs-bootfs", (caddr_t)zfs_bootfs, strlen(zfs_bootfs) + 1);
+	setenv("zfs-bootfs", zfs_bootfs);
 	prom_printf("zfs-bootfs=%s\n", zfs_bootfs);
 
 	get_boot_zpool_guid(zfs_boot_pool_guid);
-	prom_setprop(prom_chosennode(), "zfs-bootpool",
-	    (caddr_t)zfs_boot_pool_guid, strlen(zfs_boot_pool_guid) + 1);
+	setenv("zfs-bootpool", zfs_boot_pool_guid);
 	prom_printf("zfs-bootpool=%s\n", zfs_boot_pool_guid);
 
 	get_boot_vdev_guid(zfs_boot_vdev_guid);
-	prom_setprop(prom_chosennode(), "zfs-bootvdev",
-	    (caddr_t)zfs_boot_vdev_guid, strlen(zfs_boot_vdev_guid) + 1);
+	setenv("zfs-bootvdev", zfs_boot_vdev_guid);
 	prom_printf("zfs-bootvdev=%s\n", zfs_boot_vdev_guid);
 }
 
@@ -181,11 +195,9 @@ set_rootfs(char *bpath, char *fstype)
 {
 	char *str;
 	if (strcmp(fstype, "nfs") == 0) {
-		str = "nfsdyn";
-		prom_setprop(prom_chosennode(), "fstype", (caddr_t)str, strlen(str) + 1);
+		setenv("fstype", "nfsdyn");
 	} else {
-		str = fstype;
-		prom_setprop(prom_chosennode(), "fstype", (caddr_t)str, strlen(str) + 1);
+		setenv("fstype", fstype);
 		/*
 		 * We could set bootpath to the correct value here, but then
 		 * when we go to mount root we trust the config in the label
@@ -243,19 +255,7 @@ load_ramdisk(void *virt, const char *name)
 char *
 get_mfg_name(void)
 {
-	pnode_t n;
-	int len;
-
-	static char mfgname[MAXNMLEN];
-
-	if ((n = prom_rootnode()) != OBP_NONODE &&
-	    (len = prom_getproplen(n, "mfg-name")) > 0 && len < MAXNMLEN) {
-		(void) prom_getprop(n, "mfg-name", mfgname);
-		mfgname[len] = '\0'; /* broken clones don't terminate name */
-		return (mfgname);
-	}
-
-	return ("Unknown");
+	return (MFG_NAME);
 }
 
 static char *
@@ -279,7 +279,7 @@ get_node_name(pnode_t nodeid)
 			sprintf(name, "%lx", base);
 		}
 	}
-	return b;
+	return (b);
 }
 
 static void
@@ -307,26 +307,31 @@ get_default_bootpath(void)
 	static char def_bootpath[80];
 
 	prom_walk(get_bootpath_cb, def_bootpath);
-	return def_bootpath;
+	return (def_bootpath);
 }
 
-void _reset(void)
+void
+_reset(void)
 {
-	prom_printf("%s:%d\n",__func__,__LINE__);
+	prom_printf("%s:%d\n", __func__, __LINE__);
 	psci_system_reset();
 	for (;;) {}
 }
 
-void init_machdev(void)
+void
+init_machdev(void)
 {
-	char str[] = "AMLGC,meson-gxbb";
-	prom_setprop(prom_chosennode(), "impl-arch-name", (caddr_t)str, strlen(str) + 1);
-	prom_setprop(prom_rootnode(), "mfg-name", (caddr_t)str, strlen(str) + 1);
+	setenv("si-hw-provider", SI_HW_PROVIDER);
+	setenv("impl-arch-name", IMPL_ARCH_NAME);
+	setenv("mfg-name", MFG_NAME);
+
+	char str[] = IMPL_ARCH_NAME;
 	int namelen = prom_getproplen(prom_rootnode(), "compatible");
 	namelen += strlen(str) + 1;
 	char *compatible = __builtin_alloca(namelen);
 	strcpy(compatible, str);
-	prom_getprop(prom_rootnode(), "compatible", compatible + strlen(str) + 1);
+	prom_getprop(
+	    prom_rootnode(), "compatible", compatible + strlen(str) + 1);
 	prom_setprop(prom_rootnode(), "compatible", compatible, namelen);
 
 	init_arch_timer(TMR_PHYS);

--- a/usr/src/psm/stand/boot/aarch64/rpi4/machdep.c
+++ b/usr/src/psm/stand/boot/aarch64/rpi4/machdep.c
@@ -19,11 +19,13 @@
  * CDDL HEADER END
  */
 /*
- * Copyright 2020 Hayashi Naoyuki
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
-
+/*
+ * Copyright 2024 Michael van der Westhuizen
+ * Copyright 2020 Hayashi Naoyuki
+ */
 
 #include <sys/types.h>
 #include <sys/param.h>
@@ -65,7 +67,6 @@
 
 extern char _BootScratch[];
 extern char _RamdiskStart[];
-extern char _RamdiskStart[];
 extern char _RamdiskEnd[];
 extern char filename[];
 static struct xboot_info xboot_info;
@@ -89,6 +90,21 @@ extern int determine_fstype_and_mountroot(char *);
 extern	ssize_t xread(int, char *, size_t);
 extern	void _reset(void);
 extern	void init_physmem_common(void);
+extern void setenv(const char *name, const char *value);
+extern char envblock[];
+extern size_t envblock_len;
+
+#define	SI_HW_PROVIDER	"Raspberry Pi Foundation"
+#define	IMPL_ARCH_NAME	"RaspberryPi,4"
+#define	MFG_NAME	IMPL_ARCH_NAME
+
+static struct boot_modules boot_modules[MAX_BOOT_MODULES] = {
+	{ 0, 0, 0, BMT_ROOTFS },
+};
+
+static char cmdline[OBP_MAXPATHLEN] = {0};
+static char rootfs_name[] = "rootfs";
+static char environment_name[] = "environment";
 
 void
 setup_aux(void)
@@ -121,66 +137,73 @@ init_physmem(void)
 {
 	init_physmem_common();
 }
+
 void
 init_iolist(void)
 {
 	memlist_add_span(PERIPHERAL0_PHYS, PERIPHERAL0_SIZE, &piolistp);
 	memlist_add_span(PERIPHERAL1_PHYS, PERIPHERAL1_SIZE, &piolistp);
 }
-void exitto(int (*entrypoint)())
+
+#define	MEMATTRS	(PTE_UXN | PTE_PXN | PTE_AF | PTE_SH_INNER |	\
+			PTE_AP_KRWUNA | PTE_ATTR_NORMEM)
+#define	PIOATTRS	(PTE_UXN | PTE_PXN | PTE_AF | PTE_SH_INNER |	\
+			PTE_AP_KRWUNA | PTE_ATTR_DEVICE)
+
+void
+exitto(int (*entrypoint)())
 {
 	for (struct memlist *ml = plinearlistp; ml != NULL; ml = ml->ml_next) {
 		uintptr_t pa = ml->ml_address;
 		uintptr_t sz = ml->ml_size;
-		map_phys(PTE_UXN | PTE_PXN | PTE_AF | PTE_SH_INNER | PTE_AP_KRWUNA | PTE_ATTR_NORMEM, (caddr_t)(SEGKPM_BASE + pa), pa, sz);
+		map_phys((MEMATTRS), (caddr_t)(SEGKPM_BASE + pa), pa, sz);
 	}
 	for (struct memlist *ml = piolistp; ml != NULL; ml = ml->ml_next) {
 		uintptr_t pa = ml->ml_address;
 		uintptr_t sz = ml->ml_size;
-		map_phys(PTE_UXN | PTE_PXN | PTE_AF | PTE_SH_INNER | PTE_AP_KRWUNA | PTE_ATTR_DEVICE, (caddr_t)(SEGKPM_BASE + pa), pa, sz);
+		map_phys((PIOATTRS), (caddr_t)(SEGKPM_BASE + pa), pa, sz);
 	}
 
-	uint64_t v;
 	char *str;
 
-	v = htonll((uint64_t)_RamdiskStart);
-	prom_setprop(prom_chosennode(), "ramdisk_start", (caddr_t)&v, sizeof(v));
-	v = htonll((uint64_t)_RamdiskEnd);
-	prom_setprop(prom_chosennode(), "ramdisk_end", (caddr_t)&v, sizeof(v));
-	v = htonll((uint64_t)pfreelistp);
-	prom_setprop(prom_chosennode(), "phys-avail", (caddr_t)&v, sizeof(v));
-	v = htonll((uint64_t)pinstalledp);
-	prom_setprop(prom_chosennode(), "phys-installed", (caddr_t)&v, sizeof(v));
-	v = htonll((uint64_t)pscratchlistp);
-	prom_setprop(prom_chosennode(), "boot-scratch", (caddr_t)&v, sizeof(v));
-	if (bootp_response) {
-		uint_t blen = strlen(bootp_response) / 2;
-		char *pktbuf = __builtin_alloca(blen);
-		hexascii_to_octet(bootp_response, blen * 2, pktbuf, &blen);
-		prom_setprop(prom_chosennode(), "bootp-response", pktbuf, blen);
-	} else {
-	}
-	str = prom_bootargs(); //pass the bootargs from u-boot to illumos
+	xboot_info.bi_phys_avail = (uint64_t)pfreelistp;
+	xboot_info.bi_phys_installed = (uint64_t)pinstalledp;
+	xboot_info.bi_boot_scratch = (uint64_t)pscratchlistp;
+
+	if (bootp_response)
+		setenv("bootp-response", bootp_response);
+
+	strncpy(cmdline, filename, sizeof (cmdline) - 1);
+	str = prom_bootargs();
 	fix_boot_args(str);
-	prom_setprop(prom_chosennode(), "boot-args", (caddr_t)str, strlen(str) + 1);
-	prom_setprop(prom_chosennode(), "bootargs", (caddr_t)str, strlen(str) + 1);
-	str = filename;
-	prom_setprop(prom_chosennode(), "whoami", (caddr_t)str, strlen(str) + 1);
-	str = filename;
-	prom_setprop(prom_chosennode(), "boot-file", (caddr_t)str, strlen(str) + 1);
-
-	if (prom_getproplen(prom_chosennode(), "impl-arch-name") < 0) {
-		str = "armv8";
-		prom_setprop(prom_chosennode(), "impl-arch-name", (caddr_t)str, strlen(str) + 1);
+	if (strlen(str)) {
+		strncat(cmdline, " ", sizeof (cmdline) - strlen(cmdline) - 1);
+		strncat(cmdline, str, sizeof (cmdline) - strlen(cmdline) - 1);
 	}
+	xboot_info.bi_cmdline = (uint64_t)cmdline;
 
-	str = get_mfg_name();
-	prom_setprop(prom_chosennode(), "mfg-name", (caddr_t)str, strlen(str) + 1);
-	str = "115200,8,n,1,-";
-	prom_setprop(prom_chosennode(), "ttya-mode", (caddr_t)str, strlen(str) + 1);
-	prom_setprop(prom_chosennode(), "ttyb-mode", (caddr_t)str, strlen(str) + 1);
+	setenv("ttya-mode", "115200,8,n,1,-");
+	setenv("ttyb-mode", "115200,8,n,1,-");
 
 	xboot_info.bi_fdt = SEGKPM_BASE + (uint64_t)get_fdtp();
+
+	/*
+	 * No calling setenv once our modules are set up.
+	 */
+	boot_modules[0].bm_type = BMT_ROOTFS;
+	boot_modules[0].bm_name = (uint64_t)rootfs_name;
+	boot_modules[0].bm_size =
+	    ((uint64_t)_RamdiskEnd - (uint64_t)_RamdiskStart);
+	boot_modules[0].bm_addr = (uint64_t)_RamdiskStart;
+
+	boot_modules[1].bm_type = BMT_ENV;
+	boot_modules[1].bm_name = (uint64_t)environment_name;
+	boot_modules[1].bm_size = (uint64_t)envblock_len;
+	boot_modules[1].bm_addr = (uint64_t)envblock;
+
+	xboot_info.bi_module_cnt = 2;
+	xboot_info.bi_modules = (uint64_t)&boot_modules[0];
+
 	entrypoint(&xboot_info);
 }
 
@@ -192,17 +215,15 @@ static void
 set_zfs_bootfs(void)
 {
 	get_boot_zpool(zfs_bootfs);
-	prom_setprop(prom_chosennode(), "zfs-bootfs", (caddr_t)zfs_bootfs, strlen(zfs_bootfs) + 1);
+	setenv("zfs-bootfs", zfs_bootfs);
 	prom_printf("zfs-bootfs=%s\n", zfs_bootfs);
 
 	get_boot_zpool_guid(zfs_boot_pool_guid);
-	prom_setprop(prom_chosennode(), "zfs-bootpool",
-	    (caddr_t)zfs_boot_pool_guid, strlen(zfs_boot_pool_guid) + 1);
+	setenv("zfs-bootpool", zfs_boot_pool_guid);
 	prom_printf("zfs-bootpool=%s\n", zfs_boot_pool_guid);
 
 	get_boot_vdev_guid(zfs_boot_vdev_guid);
-	prom_setprop(prom_chosennode(), "zfs-bootvdev",
-	    (caddr_t)zfs_boot_vdev_guid, strlen(zfs_boot_vdev_guid) + 1);
+	setenv("zfs-bootvdev", zfs_boot_vdev_guid);
 	prom_printf("zfs-bootvdev=%s\n", zfs_boot_vdev_guid);
 }
 
@@ -211,11 +232,9 @@ set_rootfs(char *bpath, char *fstype)
 {
 	char *str;
 	if (strcmp(fstype, "nfs") == 0) {
-		str = "nfsdyn";
-		prom_setprop(prom_chosennode(), "fstype", (caddr_t)str, strlen(str) + 1);
+		setenv("fstype", "nfsdyn");
 	} else {
-		str = fstype;
-		prom_setprop(prom_chosennode(), "fstype", (caddr_t)str, strlen(str) + 1);
+		setenv("fstype", fstype);
 		/*
 		 * We could set bootpath to the correct value here, but then
 		 * when we go to mount root we trust the config in the label
@@ -273,19 +292,7 @@ load_ramdisk(void *virt, const char *name)
 char *
 get_mfg_name(void)
 {
-	pnode_t n;
-	int len;
-
-	static char mfgname[MAXNMLEN];
-
-	if ((n = prom_rootnode()) != OBP_NONODE &&
-	    (len = prom_getproplen(n, "mfg-name")) > 0 && len < MAXNMLEN) {
-		(void) prom_getprop(n, "mfg-name", mfgname);
-		mfgname[len] = '\0'; /* broken clones don't terminate name */
-		return (mfgname);
-	}
-
-	return ("Unknown");
+	return (MFG_NAME);
 }
 
 static char *
@@ -309,7 +316,7 @@ get_node_name(pnode_t nodeid)
 			sprintf(name, "%lx", base);
 		}
 	}
-	return b;
+	return (b);
 }
 
 static void
@@ -337,26 +344,31 @@ get_default_bootpath(void)
 	static char def_bootpath[80];
 
 	prom_walk(get_bootpath_cb, def_bootpath);
-	return def_bootpath;
+	return (def_bootpath);
 }
 
-void _reset(void)
+void
+_reset(void)
 {
-	prom_printf("%s:%d\n",__func__,__LINE__);
+	prom_printf("%s:%d\n", __func__, __LINE__);
 	psci_system_reset();
 	for (;;) {}
 }
 
-void init_machdev(void)
+void
+init_machdev(void)
 {
-	char str[] = "RaspberryPi,4";
-	prom_setprop(prom_chosennode(), "impl-arch-name", (caddr_t)str, strlen(str) + 1);
-	prom_setprop(prom_rootnode(), "mfg-name", (caddr_t)str, strlen(str) + 1);
+	setenv("si-hw-provider", SI_HW_PROVIDER);
+	setenv("impl-arch-name", IMPL_ARCH_NAME);
+	setenv("mfg-name", MFG_NAME);
+
+	char str[] = IMPL_ARCH_NAME;
 	int namelen = prom_getproplen(prom_rootnode(), "compatible");
 	namelen += strlen(str) + 1;
 	char *compatible = __builtin_alloca(namelen);
 	strcpy(compatible, str);
-	prom_getprop(prom_rootnode(), "compatible", compatible + strlen(str) + 1);
+	prom_getprop(
+	    prom_rootnode(), "compatible", compatible + strlen(str) + 1);
 	prom_setprop(prom_rootnode(), "compatible", compatible, namelen);
 
 	init_arch_timer(TMR_PHYS);

--- a/usr/src/psm/stand/boot/aarch64/virt/machdep.c
+++ b/usr/src/psm/stand/boot/aarch64/virt/machdep.c
@@ -19,9 +19,12 @@
  * CDDL HEADER END
  */
 /*
- * Copyright 2020 Hayashi Naoyuki
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ */
+/*
+ * Copyright 2024 Michael van der Westhuizen
+ * Copyright 2020 Hayashi Naoyuki
  */
 
 #include <sys/types.h>
@@ -59,7 +62,6 @@
 
 extern char _BootScratch[];
 extern char _RamdiskStart[];
-extern char _RamdiskStart[];
 extern char _RamdiskEnd[];
 extern char filename[];
 static struct xboot_info xboot_info;
@@ -83,6 +85,21 @@ extern int determine_fstype_and_mountroot(char *);
 extern	ssize_t xread(int, char *, size_t);
 extern	void _reset(void);
 extern	void init_physmem_common(void);
+extern void setenv(const char *name, const char *value);
+extern char envblock[];
+extern size_t envblock_len;
+
+#define	SI_HW_PROVIDER	"QEMU"
+#define	IMPL_ARCH_NAME	"QEMU,virt-4.1"
+#define	MFG_NAME	IMPL_ARCH_NAME
+
+static struct boot_modules boot_modules[MAX_BOOT_MODULES] = {
+	{ 0, 0, 0, BMT_ROOTFS },
+};
+
+static char cmdline[OBP_MAXPATHLEN] = {0};
+static char rootfs_name[] = "rootfs";
+static char environment_name[] = "environment";
 
 void
 setup_aux(void)
@@ -92,24 +109,29 @@ setup_aux(void)
 static void
 add_iomap(pnode_t node, void *arg)
 {
-	if (prom_is_compatible(node, (const char *)arg)) {
-		int index = 0;
-		for (;;) {
-			uint64_t base;
-			uint64_t size;
-			if (prom_get_reg_address(node, index, &base) == 0 &&
-			    prom_get_reg_size(node, index, &size) == 0) {
-				uint64_t addr = rounddown(base, MMU_PAGESIZE);
-				uint64_t len = roundup(base + size, MMU_PAGESIZE) - addr;
-				if (!memlist_find(piolistp, addr)) {
-					prom_printf("add io %p %p for %s\n", addr, len, arg);
-					memlist_add_span(addr, len, &piolistp);
-				}
-			} else {
-				break;
+	int index;
+
+	if (!prom_is_compatible(node, (const char *)arg))
+		return;
+
+	index = 0;
+	for (;;) {
+		uint64_t base;
+		uint64_t size;
+		if (prom_get_reg_address(node, index, &base) == 0 &&
+		    prom_get_reg_size(node, index, &size) == 0) {
+			uint64_t addr = rounddown(base, MMU_PAGESIZE);
+			uint64_t len =
+			    roundup(base + size, MMU_PAGESIZE) - addr;
+			if (!memlist_find(piolistp, addr)) {
+				prom_printf(
+				    "add io %p %p for %s\n", addr, len, arg);
+				memlist_add_span(addr, len, &piolistp);
 			}
-			index++;
+		} else {
+			break;
 		}
+		index++;
 	}
 }
 
@@ -169,12 +191,12 @@ fixup_cpu(pnode_t node, void *arg)
 		return;
 
 	char psci[] = "psci";
-	prom_setprop(node, "enable-method", psci, sizeof(psci));
+	prom_setprop(node, "enable-method", psci, sizeof (psci));
 }
 
 /*
  * Remove -D and the path from the boot args, look for the next "-" char
-*/
+ */
 void
 fix_boot_args(char *str)
 {
@@ -192,12 +214,12 @@ fix_boot_args(char *str)
 	}
 }
 
-
 void
 init_physmem(void)
 {
 	init_physmem_common();
 }
+
 void
 init_iolist(void)
 {
@@ -207,64 +229,71 @@ init_iolist(void)
 	prom_walk(add_iomap, "virtio,mmio");
 	prom_walk(fixup_virtio, NULL);
 }
-void exitto(int (*entrypoint)())
+
+#define	MEMATTRS	(PTE_UXN | PTE_PXN | PTE_AF | PTE_SH_INNER |	\
+			PTE_AP_KRWUNA | PTE_ATTR_NORMEM)
+#define	PIOATTRS	(PTE_UXN | PTE_PXN | PTE_AF | PTE_SH_INNER |	\
+			PTE_AP_KRWUNA | PTE_ATTR_DEVICE)
+
+void
+exitto(int (*entrypoint)())
 {
 	prom_walk(fixup_cpu, NULL);
 	for (struct memlist *ml = plinearlistp; ml != NULL; ml = ml->ml_next) {
 		uintptr_t pa = ml->ml_address;
 		uintptr_t sz = ml->ml_size;
-		map_phys(PTE_UXN | PTE_PXN | PTE_AF | PTE_SH_INNER | PTE_AP_KRWUNA | PTE_ATTR_NORMEM, (caddr_t)(SEGKPM_BASE + pa), pa, sz);
+		map_phys((MEMATTRS), (caddr_t)(SEGKPM_BASE + pa), pa, sz);
 	}
 	for (struct memlist *ml = piolistp; ml != NULL; ml = ml->ml_next) {
 		uintptr_t pa = ml->ml_address;
 		uintptr_t sz = ml->ml_size;
-		map_phys(PTE_UXN | PTE_PXN | PTE_AF | PTE_SH_INNER | PTE_AP_KRWUNA | PTE_ATTR_DEVICE, (caddr_t)(SEGKPM_BASE + pa), pa, sz);
+		map_phys((PIOATTRS), (caddr_t)(SEGKPM_BASE + pa), pa, sz);
 	}
 
-	uint64_t v;
 	char *str;
 
-	v = htonll((uint64_t)_RamdiskStart);
-	prom_setprop(prom_chosennode(), "ramdisk_start", (caddr_t)&v, sizeof(v));
-	v = htonll((uint64_t)_RamdiskEnd);
-	prom_setprop(prom_chosennode(), "ramdisk_end", (caddr_t)&v, sizeof(v));
-	v = htonll((uint64_t)pfreelistp);
-	prom_setprop(prom_chosennode(), "phys-avail", (caddr_t)&v, sizeof(v));
-	v = htonll((uint64_t)pinstalledp);
-	prom_setprop(prom_chosennode(), "phys-installed", (caddr_t)&v, sizeof(v));
-	v = htonll((uint64_t)pscratchlistp);
-	prom_setprop(prom_chosennode(), "boot-scratch", (caddr_t)&v, sizeof(v));
-	if (bootp_response) {
-		uint_t blen = strlen(bootp_response) / 2;
-		char *pktbuf = __builtin_alloca(blen);
-		hexascii_to_octet(bootp_response, blen * 2, pktbuf, &blen);
-		prom_setprop(prom_chosennode(), "bootp-response", pktbuf, blen);
-	} else {
-	}
-	str = prom_bootargs(); //pass the bootargs from u-boot to illumos
+	xboot_info.bi_phys_avail = (uint64_t)pfreelistp;
+	xboot_info.bi_phys_installed = (uint64_t)pinstalledp;
+	xboot_info.bi_boot_scratch = (uint64_t)pscratchlistp;
+
+	if (bootp_response)
+		setenv("bootp-response", bootp_response);
+
+	strncpy(cmdline, filename, sizeof (cmdline) - 1);
+	str = prom_bootargs();
 	fix_boot_args(str);
-	prom_setprop(prom_chosennode(), "boot-args", (caddr_t)str, strlen(str) + 1);
-	prom_setprop(prom_chosennode(), "bootargs", (caddr_t)str, strlen(str) + 1);
-	str = filename;
-	prom_setprop(prom_chosennode(), "whoami", (caddr_t)str, strlen(str) + 1);
-	str = filename;
-	prom_setprop(prom_chosennode(), "boot-file", (caddr_t)str, strlen(str) + 1);
-
-	if (prom_getproplen(prom_chosennode(), "impl-arch-name") < 0) {
-		str = "armv8";
-		prom_setprop(prom_chosennode(), "impl-arch-name", (caddr_t)str, strlen(str) + 1);
+	if (strlen(str)) {
+		strncat(cmdline, " ", sizeof (cmdline) - strlen(cmdline) - 1);
+		strncat(cmdline, str, sizeof (cmdline) - strlen(cmdline) - 1);
 	}
+	xboot_info.bi_cmdline = (uint64_t)cmdline;
 
-	str = get_mfg_name();
-	prom_setprop(prom_chosennode(), "mfg-name", (caddr_t)str, strlen(str) + 1);
-	str = "115200,8,n,1,-";
-	prom_setprop(prom_chosennode(), "ttya-mode", (caddr_t)str, strlen(str) + 1);
-	prom_setprop(prom_chosennode(), "ttyb-mode", (caddr_t)str, strlen(str) + 1);
+	setenv("ttya-mode", "115200,8,n,1,-");
+	setenv("ttyb-mode", "115200,8,n,1,-");
 
-	str = "/pl011@9000000:115200n8";	// qemu
-	prom_setprop(prom_chosennode(), "stdout-path", (caddr_t)str, strlen(str) + 1);
+	str = "/pl011@9000000:115200n8";	/* qemu */
+	prom_setprop(prom_chosennode(), "stdout-path",
+	    (caddr_t)str, strlen(str) + 1);
 
 	xboot_info.bi_fdt = SEGKPM_BASE + (uint64_t)get_fdtp();
+
+	/*
+	 * No calling setenv once our modules are set up.
+	 */
+	boot_modules[0].bm_type = BMT_ROOTFS;
+	boot_modules[0].bm_name = (uint64_t)rootfs_name;
+	boot_modules[0].bm_size =
+	    ((uint64_t)_RamdiskEnd - (uint64_t)_RamdiskStart);
+	boot_modules[0].bm_addr = (uint64_t)_RamdiskStart;
+
+	boot_modules[1].bm_type = BMT_ENV;
+	boot_modules[1].bm_name = (uint64_t)environment_name;
+	boot_modules[1].bm_size = (uint64_t)envblock_len;
+	boot_modules[1].bm_addr = (uint64_t)envblock;
+
+	xboot_info.bi_module_cnt = 2;
+	xboot_info.bi_modules = (uint64_t)&boot_modules[0];
+
 	entrypoint(&xboot_info);
 }
 
@@ -276,30 +305,25 @@ static void
 set_zfs_bootfs(void)
 {
 	get_boot_zpool(zfs_bootfs);
-	prom_setprop(prom_chosennode(), "zfs-bootfs", (caddr_t)zfs_bootfs, strlen(zfs_bootfs) + 1);
+	setenv("zfs-bootfs", zfs_bootfs);
 	prom_printf("zfs-bootfs=%s\n", zfs_bootfs);
 
 	get_boot_zpool_guid(zfs_boot_pool_guid);
-	prom_setprop(prom_chosennode(), "zfs-bootpool",
-	    (caddr_t)zfs_boot_pool_guid, strlen(zfs_boot_pool_guid) + 1);
+	setenv("zfs-bootpool", zfs_boot_pool_guid);
 	prom_printf("zfs-bootpool=%s\n", zfs_boot_pool_guid);
 
 	get_boot_vdev_guid(zfs_boot_vdev_guid);
-	prom_setprop(prom_chosennode(), "zfs-bootvdev",
-	    (caddr_t)zfs_boot_vdev_guid, strlen(zfs_boot_vdev_guid) + 1);
+	setenv("zfs-bootvdev", zfs_boot_vdev_guid);
 	prom_printf("zfs-bootvdev=%s\n", zfs_boot_vdev_guid);
 }
 
 static void
 set_rootfs(char *bpath, char *fstype)
 {
-	char *str;
 	if (strcmp(fstype, "nfs") == 0) {
-		str = "nfsdyn";
-		prom_setprop(prom_chosennode(), "fstype", (caddr_t)str, strlen(str) + 1);
+		setenv("fstype", "nfsdyn");
 	} else {
-		str = fstype;
-		prom_setprop(prom_chosennode(), "fstype", (caddr_t)str, strlen(str) + 1);
+		setenv("fstype", fstype);
 		/*
 		 * We could set bootpath to the correct value here, but then
 		 * when we go to mount root we trust the config in the label
@@ -357,19 +381,7 @@ load_ramdisk(void *virt, const char *name)
 char *
 get_mfg_name(void)
 {
-	pnode_t n;
-	int len;
-
-	static char mfgname[MAXNMLEN];
-
-	if ((n = prom_rootnode()) != OBP_NONODE &&
-	    (len = prom_getproplen(n, "mfg-name")) > 0 && len < MAXNMLEN) {
-		(void) prom_getprop(n, "mfg-name", mfgname);
-		mfgname[len] = '\0'; /* broken clones don't terminate name */
-		return (mfgname);
-	}
-
-	return ("Unknown");
+	return (MFG_NAME);
 }
 
 static char *
@@ -393,7 +405,7 @@ get_node_name(pnode_t nodeid)
 			sprintf(name, "%lx", base);
 		}
 	}
-	return b;
+	return (b);
 }
 
 static void
@@ -421,26 +433,31 @@ get_default_bootpath(void)
 	static char def_bootpath[80];
 
 	prom_walk(get_bootpath_cb, def_bootpath);
-	return def_bootpath;
+	return (def_bootpath);
 }
 
-void _reset(void)
+void
+_reset(void)
 {
-	prom_printf("%s:%d\n",__func__,__LINE__);
+	prom_printf("%s:%d\n", __func__, __LINE__);
 	psci_system_reset();
 	for (;;) {}
 }
 
-void init_machdev(void)
+void
+init_machdev(void)
 {
-	char str[] = "QEMU,virt-4.1";
-	prom_setprop(prom_chosennode(), "impl-arch-name", (caddr_t)str, strlen(str) + 1);
-	prom_setprop(prom_rootnode(), "mfg-name", (caddr_t)str, strlen(str) + 1);
+	setenv("si-hw-provider", SI_HW_PROVIDER);
+	setenv("impl-arch-name", IMPL_ARCH_NAME);
+	setenv("mfg-name", MFG_NAME);
+
+	char str[] = IMPL_ARCH_NAME;
 	int namelen = prom_getproplen(prom_rootnode(), "compatible");
 	namelen += strlen(str) + 1;
 	char *compatible = __builtin_alloca(namelen);
 	strcpy(compatible, str);
-	prom_getprop(prom_rootnode(), "compatible", compatible + strlen(str) + 1);
+	prom_getprop(
+	    prom_rootnode(), "compatible", compatible + strlen(str) + 1);
 	prom_setprop(prom_rootnode(), "compatible", compatible, namelen);
 
 	init_arch_timer(TMR_PHYS);

--- a/usr/src/psm/stand/boot/port/boot_plat.c
+++ b/usr/src/psm/stand/boot/port/boot_plat.c
@@ -19,9 +19,12 @@
  * CDDL HEADER END
  */
 /*
- * Copyright 2017 Hayashi Naoyuki
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ */
+/*
+ * Copyright 2024 Michael van der Westhuizen
+ * Copyright 2017 Hayashi Naoyuki
  */
 
 #include <sys/param.h>
@@ -66,6 +69,7 @@ extern	struct	bootops bootops;
 extern	void exitto(int (*entrypoint)());
 extern	int openfile(char *filename);
 extern int determine_fstype_and_mountroot(char *);
+extern void prom_node_late_init(void);
 
 int pagesize = PAGESIZE;
 char filename[MAXPATHLEN];
@@ -159,7 +163,7 @@ init_bootargs()
 	char *str;
 	static char buf[OBP_MAXPATHLEN];
 	int len = prom_getproplen(chosen, "bootargs");
-	if (0 < len && len < sizeof(buf)) {
+	if (0 < len && len < sizeof (buf)) {
 		prom_getprop(chosen, "bootargs", buf);
 		struct gos_params params;
 		params.gos_opts = "D:";
@@ -169,9 +173,11 @@ init_bootargs()
 		while ((c = getoptstr(&params)) != -1) {
 			switch (c) {
 			case 'D':
-				buf[params.gos_optargp - buf + params.gos_optarglen] = 0;
+				buf[params.gos_optargp - buf +
+				    params.gos_optarglen] = 0;
 				str = &buf[params.gos_optargp - buf];
-				prom_setprop(chosen, "__bootpath", (caddr_t)str, strlen(str) + 1);
+				prom_setprop(chosen, "__bootpath",
+				    (caddr_t)str, strlen(str) + 1);
 				break;
 			default:
 				break;
@@ -180,7 +186,8 @@ init_bootargs()
 	}
 	if (prom_getproplen(chosen, "__bootpath") <= 0) {
 		str = get_default_bootpath();
-		prom_setprop(chosen, "__bootpath", (caddr_t)str, strlen(str) + 1);
+		prom_setprop(chosen, "__bootpath",
+		    (caddr_t)str, strlen(str) + 1);
 	}
 }
 
@@ -200,6 +207,7 @@ main()
 	init_memlists();
 	prom_node_init();
 	init_memory();
+	prom_node_late_init();
 
 	init_machdev();
 	init_ramdisk();
@@ -210,11 +218,12 @@ main()
 	prom_printf("bootargs=%s\n", bargs);
 	prom_printf("bootpath=%s\n", bpath);
 
-	caddr_t virt = create_ramdisk(RD_ROOTFS, (uintptr_t)_RamdiskEnd - (uintptr_t)_RamdiskStart, NULL);
+	caddr_t virt = create_ramdisk(RD_ROOTFS,
+	    (uintptr_t)_RamdiskEnd - (uintptr_t)_RamdiskStart, NULL);
 	load_ramdisk(virt, def_boot_archive);
 
 	if (determine_fstype_and_mountroot(RD_ROOTFS) != VFS_SUCCESS) {
-		return -1;
+		return (-1);
 	}
 
 	dprintf("\nboot: V%d /boot interface.\n", BO_VERSION);
@@ -224,5 +233,5 @@ main()
 	strcpy(filename, kernname);
 	post_mountroot(filename);
 
-	return 0;
+	return (0);
 }

--- a/usr/src/uts/aarch64/sys/bootconf.h
+++ b/usr/src/uts/aarch64/sys/bootconf.h
@@ -20,6 +20,7 @@
  * CDDL HEADER END
  */
 /*
+ * Copyright 2024 Michael van der Westhuizen
  * Copyright 2017 Hayashi Naoyuki
  */
 
@@ -41,6 +42,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#define	BP_MAX_STRLEN	32
 
 /*
  * masks to hand to bsys_alloc memory allocator
@@ -90,7 +93,7 @@ typedef struct bootops {
 	/*
 	 * to find the size of the buffer to allocate
 	 */
-	int	(*bsys_getproplen)(struct bootops *, const char *);
+	ssize_t	(*bsys_getproplen)(struct bootops *, const char *);
 
 	/*
 	 * get the value associated with this name
@@ -106,7 +109,7 @@ typedef struct bootops {
 	/*
 	 * print formatted output
 	 */
-	void	(*bsys_printf)(void *, const char *, ...);
+	void	(*bsys_printf)(void *, const char *, ...) __PRINTFLIKE(2);
 
 	/* end of bootops which exist if (bootops-extensions >= 1) */
 } bootops_t;
@@ -190,9 +193,9 @@ extern char *netdev_path;
 
 extern void bop_no_more_mem(void);
 
-extern void bop_printf(void *, const char *, ...);
-extern void vbop_printf(void *ops, const char *fmt, va_list);
-extern void bop_panic(const char *, ...);
+extern void bop_printf(void *, const char *, ...) __PRINTFLIKE(2);
+extern void vbop_printf(void *ops, const char *fmt, va_list) __VPRINTFLIKE(2);
+extern void bop_panic(const char *, ...) __PRINTFLIKE(1);
 
 extern void read_bootenvrc(void);
 
@@ -200,8 +203,9 @@ extern int bootprop_getval(const char *, u_longlong_t *);
 struct xboot_info;
 void bop_init(struct xboot_info *xbp);
 
-extern int do_bsys_getproplen(bootops_t *, const char *);
+extern ssize_t do_bsys_getproplen(bootops_t *, const char *);
 extern int do_bsys_getprop(bootops_t *, const char *, void *);
+extern int do_bsys_getproptype(bootops_t *, const char *);
 
 #endif /* _KERNEL && !_BOOT */
 

--- a/usr/src/uts/aarch64/sys/bootinfo.h
+++ b/usr/src/uts/aarch64/sys/bootinfo.h
@@ -24,6 +24,11 @@
  * Use is subject to license terms.
  */
 
+/*
+ * Copyright 2024 Michael van der Westhuizen
+ * Copyright 2020 Joyent, Inc.
+ */
+
 #ifndef	_SYS_BOOTINFO_H
 #define	_SYS_BOOTINFO_H
 
@@ -33,19 +38,44 @@ extern "C" {
 
 #define	MAX_BOOT_MODULES	99
 
+typedef enum boot_module_type {
+	BMT_ROOTFS,
+	BMT_FILE,
+	BMT_HASH,
+	BMT_ENV,
+	BMT_FONT
+} boot_module_type_t;
+
 /*
  * The kernel needs to know how to find its modules.
  */
 struct boot_modules {
-	uint64_t	bm_addr;
-	uint64_t	bm_size;
+	uint64_t		bm_addr;
+	uint64_t		bm_name;
+	uint64_t		bm_hash;
+	uint64_t		bm_size;
+	boot_module_type_t	bm_type;
 };
+
+/* To help to identify UEFI system. */
+typedef enum uefi_arch_type {
+	XBI_UEFI_ARCH_NONE,
+	XBI_UEFI_ARCH_32,
+	XBI_UEFI_ARCH_64
+} uefi_arch_type_t;
 
 /*
  *
  */
 struct xboot_info {
-	uint64_t	bi_fdt;
+	uint64_t		bi_fdt;
+	uint64_t		bi_cmdline;
+	uint64_t		bi_modules;
+	uint64_t		bi_phys_avail;
+	uint64_t		bi_phys_installed;
+	uint64_t		bi_boot_scratch;
+	uint32_t		bi_module_cnt;
+	uint32_t		bi_pad1;
 };
 
 #ifdef	__cplusplus

--- a/usr/src/uts/armv8/Makefile.files
+++ b/usr/src/uts/armv8/Makefile.files
@@ -67,6 +67,7 @@ CORE_OBJS +=			\
 	dtrace_subr.o		\
 	mach_sysconfig.o	\
 	fakebop.o		\
+	boot_console.o		\
 	cpc_subr.o		\
 	ibft.o			\
 	mp_call.o		\

--- a/usr/src/uts/armv8/os/boot_console.c
+++ b/usr/src/uts/armv8/os/boot_console.c
@@ -1,0 +1,266 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright (c) 2012 Gary Mills
+ * Copyright 2020 Joyent, Inc.
+ *
+ * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+ * Use is subject to license terms.
+ */
+
+/*
+ * XXXARM: boot_console is not yet implemented for aarch64, so this file
+ * contains only the functions needed to support fakebop.
+ */
+
+#include <sys/types.h>
+#include <sys/systm.h>
+#include <sys/archsystm.h>
+#include <sys/boot_console.h>
+#include <sys/ctype.h>
+
+#include <sys/bootconf.h>
+
+static char *boot_line;
+static struct boot_env {
+	char	*be_env;	/* ends with double ascii nul */
+	size_t	be_size;	/* size of the environment, including nul */
+} boot_env;
+
+/* Advance str pointer past white space */
+#define	EAT_WHITE_SPACE(str)	{			\
+	while ((*str != '\0') && ISSPACE(*str))		\
+		str++;					\
+}
+
+/*
+ * boot_line is set when we call here.  Search it for the argument name,
+ * and if found, return a pointer to it.
+ */
+static char *
+find_boot_line_prop(const char *name)
+{
+	char *ptr;
+	char *ret = NULL;
+	char end_char;
+	size_t len;
+
+	if (boot_line == NULL)
+		return (NULL);
+
+	len = strlen(name);
+
+	/*
+	 * We have two nested loops here: the outer loop discards all options
+	 * except -B, and the inner loop parses the -B options looking for
+	 * the one we're interested in.
+	 */
+	for (ptr = boot_line; *ptr != '\0'; ptr++) {
+		EAT_WHITE_SPACE(ptr);
+
+		if (*ptr == '-') {
+			ptr++;
+			while ((*ptr != '\0') && (*ptr != 'B') &&
+			    !ISSPACE(*ptr))
+				ptr++;
+			if (*ptr == '\0')
+				goto out;
+			else if (*ptr != 'B')
+				continue;
+		} else {
+			while ((*ptr != '\0') && !ISSPACE(*ptr))
+				ptr++;
+			if (*ptr == '\0')
+				goto out;
+			continue;
+		}
+
+		do {
+			ptr++;
+			EAT_WHITE_SPACE(ptr);
+
+			if ((strncmp(ptr, name, len) == 0) &&
+			    (ptr[len] == '=')) {
+				ptr += len + 1;
+				if ((*ptr == '\'') || (*ptr == '"')) {
+					ret = ptr + 1;
+					end_char = *ptr;
+					ptr++;
+				} else {
+					ret = ptr;
+					end_char = ',';
+				}
+				goto consume_property;
+			}
+
+			/*
+			 * We have a property, and it's not the one we're
+			 * interested in.  Skip the property name.  A name
+			 * can end with '=', a comma, or white space.
+			 */
+			while ((*ptr != '\0') && (*ptr != '=') &&
+			    (*ptr != ',') && (!ISSPACE(*ptr)))
+				ptr++;
+
+			/*
+			 * We only want to go through the rest of the inner
+			 * loop if we have a comma.  If we have a property
+			 * name without a value, either continue or break.
+			 */
+			if (*ptr == '\0')
+				goto out;
+			else if (*ptr == ',')
+				continue;
+			else if (ISSPACE(*ptr))
+				break;
+			ptr++;
+
+			/*
+			 * Is the property quoted?
+			 */
+			if ((*ptr == '\'') || (*ptr == '"')) {
+				end_char = *ptr;
+				ptr++;
+			} else {
+				/*
+				 * Not quoted, so the string ends at a comma
+				 * or at white space.  Deal with white space
+				 * later.
+				 */
+				end_char = ',';
+			}
+
+			/*
+			 * Now, we can ignore any characters until we find
+			 * end_char.
+			 */
+consume_property:
+			for (; (*ptr != '\0') && (*ptr != end_char); ptr++) {
+				if ((end_char == ',') && ISSPACE(*ptr))
+					break;
+			}
+			if (*ptr && (*ptr != ',') && !ISSPACE(*ptr))
+				ptr++;
+		} while (*ptr == ',');
+	}
+out:
+	return (ret);
+}
+
+/*
+ * Find prop from boot env module. The data in module is list of C strings
+ * name=value, the list is terminated by double nul.
+ */
+static const char *
+find_boot_env_prop(const char *name)
+{
+	char *ptr;
+	size_t len;
+	uintptr_t size;
+
+	if (boot_env.be_env == NULL)
+		return (NULL);
+
+	ptr = boot_env.be_env;
+	len = strlen(name);
+
+	/*
+	 * Make sure we have at least len + 2 bytes in the environment.
+	 * We are looking for name=value\0 constructs, and the environment
+	 * itself is terminated by '\0'.
+	 */
+	if (boot_env.be_size < len + 2)
+		return (NULL);
+
+	do {
+		if ((strncmp(ptr, name, len) == 0) && (ptr[len] == '=')) {
+			ptr += len + 1;
+			return (ptr);
+		}
+		/* find the first '\0' */
+		while (*ptr != '\0') {
+			ptr++;
+			size = (uintptr_t)ptr - (uintptr_t)boot_env.be_env;
+			if (size > boot_env.be_size)
+				return (NULL);
+		}
+		ptr++;
+
+		/* If the remainder is shorter than name + 2, get out. */
+		size = (uintptr_t)ptr - (uintptr_t)boot_env.be_env;
+		if (boot_env.be_size - size < len + 2)
+			return (NULL);
+	} while (*ptr != '\0');
+	return (NULL);
+}
+
+/*
+ * Get prop value from either command line or boot environment.
+ * We always check kernel command line first, as this will keep the
+ * functionality and will allow user to override the values in environment.
+ */
+const char *
+find_boot_prop(const char *name)
+{
+	const char *value = find_boot_line_prop(name);
+
+	if (value == NULL)
+		value = find_boot_env_prop(name);
+	return (value);
+}
+
+static void
+bcons_init_env(struct xboot_info *xbi)
+{
+	uint32_t i;
+	struct boot_modules *modules;
+
+	modules = (struct boot_modules *)(uintptr_t)xbi->bi_modules;
+	for (i = 0; i < xbi->bi_module_cnt; i++) {
+		if (modules[i].bm_type == BMT_ENV)
+			break;
+	}
+	if (i == xbi->bi_module_cnt)
+		return;
+
+	boot_env.be_env = (char *)(uintptr_t)modules[i].bm_addr;
+	boot_env.be_size = modules[i].bm_size;
+}
+
+void
+bcons_init(struct xboot_info *xbi)
+{
+	const char *cons_str;
+#if !defined(_BOOT)
+	static char console_text[] = "text";
+	extern int post_fastreboot;
+#endif
+
+	/* Set up data to fetch properties from commad line and boot env. */
+	boot_line = (char *)(uintptr_t)xbi->bi_cmdline;
+	bcons_init_env(xbi);
+}
+
+void
+bcons_post_bootenvrc(char *inputdev, char *outputdev, char *consoledev)
+{
+	/* nothing for now */
+}

--- a/usr/src/uts/armv8/os/ddi_impl.c
+++ b/usr/src/uts/armv8/os/ddi_impl.c
@@ -20,9 +20,17 @@
  */
 
 /*
- * Copyright 2017 Hayashi Naoyuki
+ * Copyright (c) 1992, 2010, Oracle and/or its affiliates. All rights reserved.
+ *
  * Copyright 2006 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ *
+ * Copyright 2012 Garrett D'Amore <garrett@damore.org>
+ * Copyright 2014 Pluribus Networks, Inc.
+ * Copyright 2016 Nexenta Systems, Inc.
+ * Copyright 2017 Hayashi Naoyuki
+ * Copyright 2018 Joyent, Inc.
+ * Copyright 2024 Michael van der Westhuizen
  */
 
 #include <sys/types.h>
@@ -95,566 +103,840 @@ uint8_t
 i_ddi_get8(ddi_acc_impl_t *hdlp, uint8_t *addr)
 {
 	uint8_t x;
-	__asm__ volatile ("ldrb %w0, %1" : "=r" (x) : "Q" (*addr) : "memory");
-	return x;
+	__asm__ volatile("ldrb %w0, %1" : "=r" (x) : "Q" (*addr) : "memory");
+	return (x);
 }
 
 uint16_t
 i_ddi_get16(ddi_acc_impl_t *hdlp, uint16_t *addr)
 {
 	uint16_t x;
-	__asm__ volatile ("ldrh %w0, %1" : "=r" (x) : "Q" (*addr) : "memory");
-	return x;
+	__asm__ volatile("ldrh %w0, %1" : "=r" (x) : "Q" (*addr) : "memory");
+	return (x);
 }
 
 uint32_t
 i_ddi_get32(ddi_acc_impl_t *hdlp, uint32_t *addr)
 {
 	uint32_t x;
-	__asm__ volatile ("ldr %w0, %1" : "=r" (x) : "Q" (*addr) : "memory");
-	return x;
+	__asm__ volatile("ldr %w0, %1" : "=r" (x) : "Q" (*addr) : "memory");
+	return (x);
 }
 
 uint64_t
 i_ddi_get64(ddi_acc_impl_t *hdlp, uint64_t *addr)
 {
 	uint64_t x;
-	__asm__ volatile ("ldr %0, %1" : "=r" (x) : "Q" (*addr) : "memory");
-	return x;
+	__asm__ volatile("ldr %0, %1" : "=r" (x) : "Q" (*addr) : "memory");
+	return (x);
 }
 
 void
 i_ddi_put8(ddi_acc_impl_t *hdlp, uint8_t *addr, uint8_t value)
 {
-	__asm__ volatile ("strb %w1, %0" : "=Q" (*addr) : "r"(value) : "memory");
+	__asm__ volatile("strb %w1, %0" : "=Q" (*addr) : "r"(value) : "memory");
 }
 
 void
 i_ddi_put16(ddi_acc_impl_t *hdlp, uint16_t *addr, uint16_t value)
 {
-	__asm__ volatile ("strh %w1, %0" : "=Q" (*addr) : "r"(value) : "memory");
+	__asm__ volatile("strh %w1, %0" : "=Q" (*addr) : "r"(value) : "memory");
 }
 
 void
 i_ddi_put32(ddi_acc_impl_t *hdlp, uint32_t *addr, uint32_t value)
 {
-	__asm__ volatile ("str %w1, %0" : "=Q" (*addr) : "r"(value) : "memory");
+	__asm__ volatile("str %w1, %0" : "=Q" (*addr) : "r"(value) : "memory");
 }
 
 void
 i_ddi_put64(ddi_acc_impl_t *hdlp, uint64_t *addr, uint64_t value)
 {
-	__asm__ volatile ("str %1, %0" : "=Q" (*addr) : "r"(value) : "memory");
+	__asm__ volatile("str %1, %0" : "=Q" (*addr) : "r"(value) : "memory");
 }
 
 void
-i_ddi_rep_get8(ddi_acc_impl_t *hdlp, uint8_t *host_addr, uint8_t *dev_addr, size_t repcount, uint_t flags)
+i_ddi_rep_get8(ddi_acc_impl_t *hdlp, uint8_t *host_addr, uint8_t *dev_addr,
+    size_t repcount, uint_t flags)
 {
 	if (flags == DDI_DEV_AUTOINCR)
 		while (repcount--)
-			__asm__ volatile ("ldrb %w0, %1" : "=r" (*(host_addr++)) : "Q" (*(dev_addr++)) : "memory");
+			__asm__ volatile("ldrb %w0, %1"
+			    : "=r" (*(host_addr++))
+			    : "Q" (*(dev_addr++))
+			    : "memory");
 	else
 		while (repcount--)
-			__asm__ volatile ("ldrb %w0, %1" : "=r" (*(host_addr++)) : "Q" (*(dev_addr)) : "memory");
+			__asm__ volatile("ldrb %w0, %1"
+			    : "=r" (*(host_addr++))
+			    : "Q" (*(dev_addr))
+			    : "memory");
 }
 
 void
-i_ddi_rep_get16(ddi_acc_impl_t *hdlp, uint16_t *host_addr, uint16_t *dev_addr, size_t repcount, const uint_t flags)
+i_ddi_rep_get16(ddi_acc_impl_t *hdlp, uint16_t *host_addr, uint16_t *dev_addr,
+    size_t repcount, const uint_t flags)
 {
 	if (flags == DDI_DEV_AUTOINCR)
 		while (repcount--)
-			__asm__ volatile ("ldrh %w0, %1" : "=r" (*(host_addr++)) : "Q" (*(dev_addr++)) : "memory");
+			__asm__ volatile("ldrh %w0, %1"
+			    : "=r" (*(host_addr++))
+			    : "Q" (*(dev_addr++))
+			    : "memory");
 	else
 		while (repcount--)
-			__asm__ volatile ("ldrh %w0, %1" : "=r" (*(host_addr++)) : "Q" (*(dev_addr)) : "memory");
+			__asm__ volatile("ldrh %w0, %1"
+			    : "=r" (*(host_addr++))
+			    : "Q" (*(dev_addr))
+			    : "memory");
 }
 
 void
-i_ddi_rep_get32(ddi_acc_impl_t *hdlp, uint32_t *host_addr, uint32_t *dev_addr, size_t repcount, uint_t flags)
+i_ddi_rep_get32(ddi_acc_impl_t *hdlp, uint32_t *host_addr, uint32_t *dev_addr,
+    size_t repcount, uint_t flags)
 {
 	if (flags == DDI_DEV_AUTOINCR)
 		while (repcount--)
-			__asm__ volatile ("ldr %w0, %1" : "=r" (*(host_addr++)) : "Q" (*(dev_addr++)) : "memory");
+			__asm__ volatile("ldr %w0, %1"
+			    : "=r" (*(host_addr++))
+			    : "Q" (*(dev_addr++))
+			    : "memory");
 	else
 		while (repcount--)
-			__asm__ volatile ("ldr %w0, %1" : "=r" (*(host_addr++)) : "Q" (*(dev_addr)) : "memory");
+			__asm__ volatile("ldr %w0, %1"
+			    : "=r" (*(host_addr++))
+			    : "Q" (*(dev_addr))
+			    : "memory");
 }
 
 void
-i_ddi_rep_get64(ddi_acc_impl_t *hdlp, uint64_t *host_addr, uint64_t *dev_addr, size_t repcount, uint_t flags)
+i_ddi_rep_get64(ddi_acc_impl_t *hdlp, uint64_t *host_addr, uint64_t *dev_addr,
+    size_t repcount, uint_t flags)
 {
 	if (flags == DDI_DEV_AUTOINCR)
 		while (repcount--)
-			__asm__ volatile ("ldr %0, %1" : "=r" (*(host_addr++)) : "Q" (*(dev_addr++)) : "memory");
+			__asm__ volatile("ldr %0, %1"
+			    : "=r" (*(host_addr++))
+			    : "Q" (*(dev_addr++))
+			    : "memory");
 	else
 		while (repcount--)
-			__asm__ volatile ("ldr %0, %1" : "=r" (*(host_addr++)) : "Q" (*(dev_addr)) : "memory");
+			__asm__ volatile("ldr %0, %1"
+			    : "=r" (*(host_addr++))
+			    : "Q" (*(dev_addr))
+			    : "memory");
 }
 
 void
-i_ddi_rep_put8(ddi_acc_impl_t *hdlp, uint8_t *host_addr, uint8_t *dev_addr, size_t repcount, uint_t flags)
+i_ddi_rep_put8(ddi_acc_impl_t *hdlp, uint8_t *host_addr, uint8_t *dev_addr,
+    size_t repcount, uint_t flags)
 {
 	if (flags == DDI_DEV_AUTOINCR)
 		while (repcount--)
-			__asm__ volatile ("strb %w1, %0" : "=Q" (*(dev_addr++)) : "r"(*(host_addr++)) : "memory");
+			__asm__ volatile("strb %w1, %0"
+			    : "=Q" (*(dev_addr++))
+			    : "r"(*(host_addr++))
+			    : "memory");
 	else
 		while (repcount--)
-			__asm__ volatile ("strb %w1, %0" : "=Q" (*(dev_addr)) : "r"(*(host_addr++)) : "memory");
+			__asm__ volatile("strb %w1, %0"
+			    : "=Q" (*(dev_addr))
+			    : "r"(*(host_addr++))
+			    : "memory");
 }
 
 void
-i_ddi_rep_put16(ddi_acc_impl_t *hdlp, uint16_t *host_addr, uint16_t *dev_addr, size_t repcount, uint_t flags)
+i_ddi_rep_put16(ddi_acc_impl_t *hdlp, uint16_t *host_addr, uint16_t *dev_addr,
+    size_t repcount, uint_t flags)
 {
 	if (flags == DDI_DEV_AUTOINCR)
 		while (repcount--)
-			__asm__ volatile ("strh %w1, %0" : "=Q" (*(dev_addr++)) : "r"(*(host_addr++)) : "memory");
+			__asm__ volatile("strh %w1, %0"
+			    : "=Q" (*(dev_addr++))
+			    : "r"(*(host_addr++))
+			    : "memory");
 	else
 		while (repcount--)
-			__asm__ volatile ("strh %w1, %0" : "=Q" (*(dev_addr)) : "r"(*(host_addr++)) : "memory");
+			__asm__ volatile("strh %w1, %0"
+			    : "=Q" (*(dev_addr))
+			    : "r"(*(host_addr++))
+			    : "memory");
 }
 
 void
-i_ddi_rep_put32(ddi_acc_impl_t *hdlp, uint32_t *host_addr, uint32_t *dev_addr, size_t repcount, uint_t flags)
+i_ddi_rep_put32(ddi_acc_impl_t *hdlp, uint32_t *host_addr, uint32_t *dev_addr,
+    size_t repcount, uint_t flags)
 {
 	if (flags == DDI_DEV_AUTOINCR)
 		while (repcount--)
-			__asm__ volatile ("str %w1, %0" : "=Q" (*(dev_addr++)) : "r"(*(host_addr++)) : "memory");
+			__asm__ volatile("str %w1, %0"
+			    : "=Q" (*(dev_addr++))
+			    : "r"(*(host_addr++))
+			    : "memory");
 	else
 		while (repcount--)
-			__asm__ volatile ("str %w1, %0" : "=Q" (*(dev_addr)) : "r"(*(host_addr++)) : "memory");
+			__asm__ volatile("str %w1, %0"
+			    : "=Q" (*(dev_addr))
+			    : "r"(*(host_addr++))
+			    : "memory");
 }
 
 void
-i_ddi_rep_put64(ddi_acc_impl_t *hdlp, uint64_t *host_addr, uint64_t *dev_addr, size_t repcount, uint_t flags)
+i_ddi_rep_put64(ddi_acc_impl_t *hdlp, uint64_t *host_addr, uint64_t *dev_addr,
+    size_t repcount, uint_t flags)
 {
 	if (flags == DDI_DEV_AUTOINCR)
 		while (repcount--)
-			__asm__ volatile ("str %1, %0" : "=Q" (*(dev_addr++)) : "r"(*(host_addr++)) : "memory");
+			__asm__ volatile("str %1, %0"
+			    : "=Q" (*(dev_addr++))
+			    : "r"(*(host_addr++))
+			    : "memory");
 	else
 		while (repcount--)
-			__asm__ volatile ("str %1, %0" : "=Q" (*(dev_addr)) : "r"(*(host_addr++)) : "memory");
+			__asm__ volatile("str %1, %0"
+			    : "=Q" (*(dev_addr))
+			    : "r"(*(host_addr++))
+			    : "memory");
 }
 
 uint16_t
 i_ddi_swap_get16(ddi_acc_impl_t *hdlp, uint16_t *addr)
 {
 	uint16_t x;
-	__asm__ volatile ("ldrh %w0, %1" : "=r" (x) : "Q" (*addr) : "memory");
-	return __builtin_bswap16(x);
+	__asm__ volatile("ldrh %w0, %1"
+	    : "=r" (x)
+	    : "Q" (*addr)
+	    : "memory");
+	return (__builtin_bswap16(x));
 }
 
 uint32_t
 i_ddi_swap_get32(ddi_acc_impl_t *hdlp, uint32_t *addr)
 {
 	uint32_t x;
-	__asm__ volatile ("ldr %w0, %1" : "=r" (x) : "Q" (*addr) : "memory");
-	return __builtin_bswap32(x);
+	__asm__ volatile("ldr %w0, %1"
+	    : "=r" (x)
+	    : "Q" (*addr)
+	    : "memory");
+	return (__builtin_bswap32(x));
 }
 
 uint64_t
 i_ddi_swap_get64(ddi_acc_impl_t *hdlp, uint64_t *addr)
 {
 	uint64_t x;
-	__asm__ volatile ("ldr %0, %1" : "=r" (x) : "Q" (*addr) : "memory");
-	return __builtin_bswap64(x);
+	__asm__ volatile("ldr %0, %1"
+	    : "=r" (x)
+	    : "Q" (*addr)
+	    : "memory");
+	return (__builtin_bswap64(x));
 }
 
 void
 i_ddi_swap_put16(ddi_acc_impl_t *hdlp, uint16_t *addr, uint16_t value)
 {
-	__asm__ volatile ("strh %w1, %0" : "=Q" (*addr) : "r"(__builtin_bswap16(value)) : "memory");
+	__asm__ volatile("strh %w1, %0"
+	    : "=Q" (*addr)
+	    : "r"(__builtin_bswap16(value))
+	    : "memory");
 }
 
 void
 i_ddi_swap_put32(ddi_acc_impl_t *hdlp, uint32_t *addr, uint32_t value)
 {
-	__asm__ volatile ("str %w1, %0" : "=Q" (*addr) : "r"(__builtin_bswap32(value)) : "memory");
+	__asm__ volatile("str %w1, %0"
+	    : "=Q" (*addr)
+	    : "r"(__builtin_bswap32(value))
+	    : "memory");
 }
 
 void
 i_ddi_swap_put64(ddi_acc_impl_t *hdlp, uint64_t *addr, uint64_t value)
 {
-	__asm__ volatile ("str %1, %0" : "=Q" (*addr) : "r"(__builtin_bswap64(value)) : "memory");
+	__asm__ volatile("str %1, %0"
+	    : "=Q" (*addr)
+	    : "r"(__builtin_bswap64(value))
+	    : "memory");
 }
 
 void
-i_ddi_swap_rep_get16(ddi_acc_impl_t *hdlp, uint16_t *host_addr, uint16_t *dev_addr, size_t repcount, const uint_t flags)
+i_ddi_swap_rep_get16(ddi_acc_impl_t *hdlp, uint16_t *host_addr,
+    uint16_t *dev_addr, size_t repcount, const uint_t flags)
 {
 	uint16_t x;
 	if (flags == DDI_DEV_AUTOINCR)
 		while (repcount--) {
-			__asm__ volatile ("ldrh %w0, %1" : "=r" (x) : "Q" (*(dev_addr++)) : "memory");
+			__asm__ volatile("ldrh %w0, %1"
+			    : "=r" (x)
+			    : "Q" (*(dev_addr++))
+			    : "memory");
 			*host_addr++ = __builtin_bswap16(x);
 		}
 	else
 		while (repcount--) {
-			__asm__ volatile ("ldrh %w0, %1" : "=r" (x) : "Q" (*(dev_addr)) : "memory");
+			__asm__ volatile("ldrh %w0, %1"
+			    : "=r" (x)
+			    : "Q" (*(dev_addr))
+			    : "memory");
 			*host_addr++ = __builtin_bswap16(x);
 		}
 }
 
 void
-i_ddi_swap_rep_get32(ddi_acc_impl_t *hdlp, uint32_t *host_addr, uint32_t *dev_addr, size_t repcount, uint_t flags)
+i_ddi_swap_rep_get32(ddi_acc_impl_t *hdlp, uint32_t *host_addr,
+    uint32_t *dev_addr, size_t repcount, uint_t flags)
 {
 	uint32_t x;
 	if (flags == DDI_DEV_AUTOINCR)
 		while (repcount--) {
-			__asm__ volatile ("ldr %w0, %1" : "=r" (x) : "Q" (*(dev_addr++)) : "memory");
+			__asm__ volatile("ldr %w0, %1"
+			    : "=r" (x)
+			    : "Q" (*(dev_addr++))
+			    : "memory");
 			*host_addr++ = __builtin_bswap32(x);
 		}
 	else
 		while (repcount--) {
-			__asm__ volatile ("ldr %w0, %1" : "=r" (x) : "Q" (*(dev_addr)) : "memory");
+			__asm__ volatile("ldr %w0, %1"
+			    : "=r" (x)
+			    : "Q" (*(dev_addr))
+			    : "memory");
 			*host_addr++ = __builtin_bswap32(x);
 		}
 }
 
 void
-i_ddi_swap_rep_get64(ddi_acc_impl_t *hdlp, uint64_t *host_addr, uint64_t *dev_addr, size_t repcount, uint_t flags)
+i_ddi_swap_rep_get64(ddi_acc_impl_t *hdlp, uint64_t *host_addr,
+    uint64_t *dev_addr, size_t repcount, uint_t flags)
 {
 	uint64_t x;
 	if (flags == DDI_DEV_AUTOINCR)
 		while (repcount--) {
-			__asm__ volatile ("ldr %0, %1" : "=r" (x) : "Q" (*(dev_addr++)) : "memory");
+			__asm__ volatile("ldr %0, %1"
+			    : "=r" (x)
+			    : "Q" (*(dev_addr++))
+			    : "memory");
 			*host_addr++ = __builtin_bswap64(x);
 		}
 	else
 		while (repcount--) {
-			__asm__ volatile ("ldr %0, %1" : "=r" (x) : "Q" (*(dev_addr)) : "memory");
+			__asm__ volatile("ldr %0, %1"
+			    : "=r" (x)
+			    : "Q" (*(dev_addr))
+			    : "memory");
 			*host_addr++ = __builtin_bswap64(x);
 		}
 }
 
 void
-i_ddi_swap_rep_put16(ddi_acc_impl_t *hdlp, uint16_t *host_addr, uint16_t *dev_addr, size_t repcount, uint_t flags)
+i_ddi_swap_rep_put16(ddi_acc_impl_t *hdlp, uint16_t *host_addr,
+    uint16_t *dev_addr, size_t repcount, uint_t flags)
 {
 	if (flags == DDI_DEV_AUTOINCR)
 		while (repcount--)
-			__asm__ volatile ("strh %w1, %0" : "=Q" (*(dev_addr++)) : "r"(__builtin_bswap16(*(host_addr++))) : "memory");
+			__asm__ volatile("strh %w1, %0"
+			    : "=Q" (*(dev_addr++))
+			    : "r"(__builtin_bswap16(*(host_addr++)))
+			    : "memory");
 	else
 		while (repcount--)
-			__asm__ volatile ("strh %w1, %0" : "=Q" (*(dev_addr)) : "r"(__builtin_bswap16(*(host_addr++))) : "memory");
+			__asm__ volatile("strh %w1, %0"
+			    : "=Q" (*(dev_addr))
+			    : "r"(__builtin_bswap16(*(host_addr++)))
+			    : "memory");
 }
 
 void
-i_ddi_swap_rep_put32(ddi_acc_impl_t *hdlp, uint32_t *host_addr, uint32_t *dev_addr, size_t repcount, uint_t flags)
+i_ddi_swap_rep_put32(ddi_acc_impl_t *hdlp, uint32_t *host_addr,
+    uint32_t *dev_addr, size_t repcount, uint_t flags)
 {
 	if (flags == DDI_DEV_AUTOINCR)
 		while (repcount--)
-			__asm__ volatile ("str %w1, %0" : "=Q" (*(dev_addr++)) : "r"(__builtin_bswap32(*(host_addr++))) : "memory");
+			__asm__ volatile("str %w1, %0"
+			    : "=Q" (*(dev_addr++))
+			    : "r"(__builtin_bswap32(*(host_addr++)))
+			    : "memory");
 	else
 		while (repcount--)
-			__asm__ volatile ("str %w1, %0" : "=Q" (*(dev_addr)) : "r"(__builtin_bswap32(*(host_addr++))) : "memory");
+			__asm__ volatile("str %w1, %0"
+			    : "=Q" (*(dev_addr))
+			    : "r"(__builtin_bswap32(*(host_addr++)))
+			    : "memory");
 }
 
 void
-i_ddi_swap_rep_put64(ddi_acc_impl_t *hdlp, uint64_t *host_addr, uint64_t *dev_addr, size_t repcount, uint_t flags)
+i_ddi_swap_rep_put64(ddi_acc_impl_t *hdlp, uint64_t *host_addr,
+    uint64_t *dev_addr, size_t repcount, uint_t flags)
 {
 	if (flags == DDI_DEV_AUTOINCR)
 		while (repcount--)
-			__asm__ volatile ("str %1, %0" : "=Q" (*(dev_addr++)) : "r"(__builtin_bswap64(*(host_addr++))) : "memory");
+			__asm__ volatile("str %1, %0"
+			    : "=Q" (*(dev_addr++))
+			    : "r"(__builtin_bswap64(*(host_addr++)))
+			    : "memory");
 	else
 		while (repcount--)
-			__asm__ volatile ("str %1, %0" : "=Q" (*(dev_addr)) : "r"(__builtin_bswap64(*(host_addr++))) : "memory");
+			__asm__ volatile("str %1, %0"
+			    : "=Q" (*(dev_addr))
+			    : "r"(__builtin_bswap64(*(host_addr++)))
+			    : "memory");
 }
 
 uint8_t
 i_ddi_io_get8(ddi_acc_impl_t *hdlp, uint8_t *addr)
 {
-	uint8_t *io_addr = (uint8_t *)((uintptr_t)addr + hdlp->ahi_io_port_base);
+	uint8_t *io_addr =
+	    (uint8_t *)((uintptr_t)addr + hdlp->ahi_io_port_base);
 	uint8_t x;
-	__asm__ volatile ("ldrb %w0, %1" : "=r" (x) : "Q" (*io_addr) : "memory");
-	return x;
+	__asm__ volatile("ldrb %w0, %1" : "=r" (x) : "Q" (*io_addr) : "memory");
+	return (x);
 }
 
 uint16_t
 i_ddi_io_get16(ddi_acc_impl_t *hdlp, uint16_t *addr)
 {
-	uint16_t *io_addr = (uint16_t *)((uintptr_t)addr + hdlp->ahi_io_port_base);
+	uint16_t *io_addr =
+	    (uint16_t *)((uintptr_t)addr + hdlp->ahi_io_port_base);
 	uint16_t x;
-	__asm__ volatile ("ldrh %w0, %1" : "=r" (x) : "Q" (*io_addr) : "memory");
-	return x;
+	__asm__ volatile("ldrh %w0, %1" : "=r" (x) : "Q" (*io_addr) : "memory");
+	return (x);
 }
 
 uint32_t
 i_ddi_io_get32(ddi_acc_impl_t *hdlp, uint32_t *addr)
 {
-	uint32_t *io_addr = (uint32_t *)((uintptr_t)addr + hdlp->ahi_io_port_base);
+	uint32_t *io_addr =
+	    (uint32_t *)((uintptr_t)addr + hdlp->ahi_io_port_base);
 	uint32_t x;
-	__asm__ volatile ("ldr %w0, %1" : "=r" (x) : "Q" (*io_addr) : "memory");
-	return x;
+	__asm__ volatile("ldr %w0, %1" : "=r" (x) : "Q" (*io_addr) : "memory");
+	return (x);
 }
 
 uint64_t
 i_ddi_io_get64(ddi_acc_impl_t *hdlp, uint64_t *addr)
 {
-	uint64_t *io_addr = (uint64_t *)((uintptr_t)addr + hdlp->ahi_io_port_base);
+	uint64_t *io_addr =
+	    (uint64_t *)((uintptr_t)addr + hdlp->ahi_io_port_base);
 	uint64_t x;
-	__asm__ volatile ("ldr %0, %1" : "=r" (x) : "Q" (*io_addr) : "memory");
-	return x;
+	__asm__ volatile("ldr %0, %1" : "=r" (x) : "Q" (*io_addr) : "memory");
+	return (x);
 }
 
 void
 i_ddi_io_put8(ddi_acc_impl_t *hdlp, uint8_t *addr, uint8_t value)
 {
-	uint8_t *io_addr = (uint8_t *)((uintptr_t)addr + hdlp->ahi_io_port_base);
-	__asm__ volatile ("strb %w1, %0" : "=Q" (*io_addr) : "r"(value) : "memory");
+	uint8_t *io_addr =
+	    (uint8_t *)((uintptr_t)addr + hdlp->ahi_io_port_base);
+	__asm__ volatile("strb %w1, %0"
+	    : "=Q" (*io_addr)
+	    : "r"(value)
+	    : "memory");
 }
 
 void
 i_ddi_io_put16(ddi_acc_impl_t *hdlp, uint16_t *addr, uint16_t value)
 {
-	uint16_t *io_addr = (uint16_t *)((uintptr_t)addr + hdlp->ahi_io_port_base);
-	__asm__ volatile ("strh %w1, %0" : "=Q" (*io_addr) : "r"(value) : "memory");
+	uint16_t *io_addr =
+	    (uint16_t *)((uintptr_t)addr + hdlp->ahi_io_port_base);
+	__asm__ volatile("strh %w1, %0"
+	    : "=Q" (*io_addr)
+	    : "r"(value)
+	    : "memory");
 }
 
 void
 i_ddi_io_put32(ddi_acc_impl_t *hdlp, uint32_t *addr, uint32_t value)
 {
-	uint32_t *io_addr = (uint32_t *)((uintptr_t)addr + hdlp->ahi_io_port_base);
-	__asm__ volatile ("str %w1, %0" : "=Q" (*io_addr) : "r"(value) : "memory");
+	uint32_t *io_addr =
+	    (uint32_t *)((uintptr_t)addr + hdlp->ahi_io_port_base);
+	__asm__ volatile("str %w1, %0"
+	    : "=Q" (*io_addr)
+	    : "r"(value)
+	    : "memory");
 }
 
 void
 i_ddi_io_put64(ddi_acc_impl_t *hdlp, uint64_t *addr, uint64_t value)
 {
-	uint64_t *io_addr = (uint64_t *)((uintptr_t)addr + hdlp->ahi_io_port_base);
-	__asm__ volatile ("str %1, %0" : "=Q" (*io_addr) : "r"(value) : "memory");
+	uint64_t *io_addr =
+	    (uint64_t *)((uintptr_t)addr + hdlp->ahi_io_port_base);
+	__asm__ volatile("str %1, %0"
+	    : "=Q" (*io_addr)
+	    : "r"(value)
+	    : "memory");
 }
 
 void
-i_ddi_io_rep_get8(ddi_acc_impl_t *hdlp, uint8_t *host_addr, uint8_t *dev_addr, size_t repcount, uint_t flags)
+i_ddi_io_rep_get8(ddi_acc_impl_t *hdlp, uint8_t *host_addr,
+    uint8_t *dev_addr, size_t repcount, uint_t flags)
 {
-	uint8_t *io_dev_addr = (uint8_t *)((uintptr_t)dev_addr + hdlp->ahi_io_port_base);
+	uint8_t *io_dev_addr =
+	    (uint8_t *)((uintptr_t)dev_addr + hdlp->ahi_io_port_base);
 	if (flags == DDI_DEV_AUTOINCR)
 		while (repcount--)
-			__asm__ volatile ("ldrb %w0, %1" : "=r" (*(host_addr++)) : "Q" (*(io_dev_addr++)) : "memory");
+			__asm__ volatile("ldrb %w0, %1"
+			    : "=r" (*(host_addr++))
+			    : "Q" (*(io_dev_addr++))
+			    : "memory");
 	else
 		while (repcount--)
-			__asm__ volatile ("ldrb %w0, %1" : "=r" (*(host_addr++)) : "Q" (*(io_dev_addr)) : "memory");
+			__asm__ volatile("ldrb %w0, %1"
+			    : "=r" (*(host_addr++))
+			    : "Q" (*(io_dev_addr))
+			    : "memory");
 }
 
 void
-i_ddi_io_rep_get16(ddi_acc_impl_t *hdlp, uint16_t *host_addr, uint16_t *dev_addr, size_t repcount, const uint_t flags)
+i_ddi_io_rep_get16(ddi_acc_impl_t *hdlp, uint16_t *host_addr,
+    uint16_t *dev_addr, size_t repcount, const uint_t flags)
 {
-	uint16_t *io_dev_addr = (uint16_t *)((uintptr_t)dev_addr + hdlp->ahi_io_port_base);
+	uint16_t *io_dev_addr =
+	    (uint16_t *)((uintptr_t)dev_addr + hdlp->ahi_io_port_base);
 	if (flags == DDI_DEV_AUTOINCR)
 		while (repcount--)
-			__asm__ volatile ("ldrh %w0, %1" : "=r" (*(host_addr++)) : "Q" (*(io_dev_addr++)) : "memory");
+			__asm__ volatile("ldrh %w0, %1"
+			    : "=r" (*(host_addr++))
+			    : "Q" (*(io_dev_addr++))
+			    : "memory");
 	else
 		while (repcount--)
-			__asm__ volatile ("ldrh %w0, %1" : "=r" (*(host_addr++)) : "Q" (*(io_dev_addr)) : "memory");
+			__asm__ volatile("ldrh %w0, %1"
+			    : "=r" (*(host_addr++))
+			    : "Q" (*(io_dev_addr))
+			    : "memory");
 }
 
 void
-i_ddi_io_rep_get32(ddi_acc_impl_t *hdlp, uint32_t *host_addr, uint32_t *dev_addr, size_t repcount, uint_t flags)
+i_ddi_io_rep_get32(ddi_acc_impl_t *hdlp, uint32_t *host_addr,
+    uint32_t *dev_addr, size_t repcount, uint_t flags)
 {
-	uint32_t *io_dev_addr = (uint32_t *)((uintptr_t)dev_addr + hdlp->ahi_io_port_base);
+	uint32_t *io_dev_addr =
+	    (uint32_t *)((uintptr_t)dev_addr + hdlp->ahi_io_port_base);
 	if (flags == DDI_DEV_AUTOINCR)
 		while (repcount--)
-			__asm__ volatile ("ldr %w0, %1" : "=r" (*(host_addr++)) : "Q" (*(io_dev_addr++)) : "memory");
+			__asm__ volatile("ldr %w0, %1"
+			    : "=r" (*(host_addr++))
+			    : "Q" (*(io_dev_addr++))
+			    : "memory");
 	else
 		while (repcount--)
-			__asm__ volatile ("ldr %w0, %1" : "=r" (*(host_addr++)) : "Q" (*(io_dev_addr)) : "memory");
+			__asm__ volatile("ldr %w0, %1"
+			    : "=r" (*(host_addr++))
+			    : "Q" (*(io_dev_addr))
+			    : "memory");
 }
 
 void
-i_ddi_io_rep_get64(ddi_acc_impl_t *hdlp, uint64_t *host_addr, uint64_t *dev_addr, size_t repcount, uint_t flags)
+i_ddi_io_rep_get64(ddi_acc_impl_t *hdlp, uint64_t *host_addr,
+    uint64_t *dev_addr, size_t repcount, uint_t flags)
 {
-	uint64_t *io_dev_addr = (uint64_t *)((uintptr_t)dev_addr + hdlp->ahi_io_port_base);
+	uint64_t *io_dev_addr =
+	    (uint64_t *)((uintptr_t)dev_addr + hdlp->ahi_io_port_base);
 	if (flags == DDI_DEV_AUTOINCR)
 		while (repcount--)
-			__asm__ volatile ("ldr %0, %1" : "=r" (*(host_addr++)) : "Q" (*(io_dev_addr++)) : "memory");
+			__asm__ volatile("ldr %0, %1"
+			    : "=r" (*(host_addr++))
+			    : "Q" (*(io_dev_addr++))
+			    : "memory");
 	else
 		while (repcount--)
-			__asm__ volatile ("ldr %0, %1" : "=r" (*(host_addr++)) : "Q" (*(io_dev_addr)) : "memory");
+			__asm__ volatile("ldr %0, %1"
+			    : "=r" (*(host_addr++))
+			    : "Q" (*(io_dev_addr))
+			    : "memory");
 }
 
 void
-i_ddi_io_rep_put8(ddi_acc_impl_t *hdlp, uint8_t *host_addr, uint8_t *dev_addr, size_t repcount, uint_t flags)
+i_ddi_io_rep_put8(ddi_acc_impl_t *hdlp, uint8_t *host_addr,
+    uint8_t *dev_addr, size_t repcount, uint_t flags)
 {
-	uint8_t *io_dev_addr = (uint8_t *)((uintptr_t)dev_addr + hdlp->ahi_io_port_base);
+	uint8_t *io_dev_addr =
+	    (uint8_t *)((uintptr_t)dev_addr + hdlp->ahi_io_port_base);
 	if (flags == DDI_DEV_AUTOINCR)
 		while (repcount--)
-			__asm__ volatile ("strb %w1, %0" : "=Q" (*(io_dev_addr++)) : "r"(*(host_addr++)) : "memory");
+			__asm__ volatile("strb %w1, %0"
+			    : "=Q" (*(io_dev_addr++))
+			    : "r"(*(host_addr++))
+			    : "memory");
 	else
 		while (repcount--)
-			__asm__ volatile ("strb %w1, %0" : "=Q" (*(io_dev_addr)) : "r"(*(host_addr++)) : "memory");
+			__asm__ volatile("strb %w1, %0"
+			    : "=Q" (*(io_dev_addr))
+			    : "r"(*(host_addr++))
+			    : "memory");
 }
 
 void
-i_ddi_io_rep_put16(ddi_acc_impl_t *hdlp, uint16_t *host_addr, uint16_t *dev_addr, size_t repcount, uint_t flags)
+i_ddi_io_rep_put16(ddi_acc_impl_t *hdlp, uint16_t *host_addr,
+    uint16_t *dev_addr, size_t repcount, uint_t flags)
 {
-	uint16_t *io_dev_addr = (uint16_t *)((uintptr_t)dev_addr + hdlp->ahi_io_port_base);
+	uint16_t *io_dev_addr =
+	    (uint16_t *)((uintptr_t)dev_addr + hdlp->ahi_io_port_base);
 	if (flags == DDI_DEV_AUTOINCR)
 		while (repcount--)
-			__asm__ volatile ("strh %w1, %0" : "=Q" (*(io_dev_addr++)) : "r"(*(host_addr++)) : "memory");
+			__asm__ volatile("strh %w1, %0"
+			    : "=Q" (*(io_dev_addr++))
+			    : "r"(*(host_addr++))
+			    : "memory");
 	else
 		while (repcount--)
-			__asm__ volatile ("strh %w1, %0" : "=Q" (*(io_dev_addr)) : "r"(*(host_addr++)) : "memory");
+			__asm__ volatile("strh %w1, %0"
+			    : "=Q" (*(io_dev_addr))
+			    : "r"(*(host_addr++))
+			    : "memory");
 }
 
 void
-i_ddi_io_rep_put32(ddi_acc_impl_t *hdlp, uint32_t *host_addr, uint32_t *dev_addr, size_t repcount, uint_t flags)
+i_ddi_io_rep_put32(ddi_acc_impl_t *hdlp, uint32_t *host_addr,
+    uint32_t *dev_addr, size_t repcount, uint_t flags)
 {
-	uint32_t *io_dev_addr = (uint32_t *)((uintptr_t)dev_addr + hdlp->ahi_io_port_base);
+	uint32_t *io_dev_addr =
+	    (uint32_t *)((uintptr_t)dev_addr + hdlp->ahi_io_port_base);
 	if (flags == DDI_DEV_AUTOINCR)
 		while (repcount--)
-			__asm__ volatile ("str %w1, %0" : "=Q" (*(io_dev_addr++)) : "r"(*(host_addr++)) : "memory");
+			__asm__ volatile("str %w1, %0"
+			    : "=Q" (*(io_dev_addr++))
+			    : "r"(*(host_addr++))
+			    : "memory");
 	else
 		while (repcount--)
-			__asm__ volatile ("str %w1, %0" : "=Q" (*(io_dev_addr)) : "r"(*(host_addr++)) : "memory");
+			__asm__ volatile("str %w1, %0"
+			    : "=Q" (*(io_dev_addr))
+			    : "r"(*(host_addr++))
+			    : "memory");
 }
 
 void
-i_ddi_io_rep_put64(ddi_acc_impl_t *hdlp, uint64_t *host_addr, uint64_t *dev_addr, size_t repcount, uint_t flags)
+i_ddi_io_rep_put64(ddi_acc_impl_t *hdlp, uint64_t *host_addr,
+    uint64_t *dev_addr, size_t repcount, uint_t flags)
 {
-	uint64_t *io_dev_addr = (uint64_t *)((uintptr_t)dev_addr + hdlp->ahi_io_port_base);
+	uint64_t *io_dev_addr =
+	    (uint64_t *)((uintptr_t)dev_addr + hdlp->ahi_io_port_base);
 	if (flags == DDI_DEV_AUTOINCR)
 		while (repcount--)
-			__asm__ volatile ("str %1, %0" : "=Q" (*(io_dev_addr++)) : "r"(*(host_addr++)) : "memory");
+			__asm__ volatile("str %1, %0"
+			    : "=Q" (*(io_dev_addr++))
+			    : "r"(*(host_addr++))
+			    : "memory");
 	else
 		while (repcount--)
-			__asm__ volatile ("str %1, %0" : "=Q" (*(io_dev_addr)) : "r"(*(host_addr++)) : "memory");
+			__asm__ volatile("str %1, %0"
+			    : "=Q" (*(io_dev_addr))
+			    : "r"(*(host_addr++))
+			    : "memory");
 }
 
 uint16_t
 i_ddi_io_swap_get16(ddi_acc_impl_t *hdlp, uint16_t *addr)
 {
-	uint16_t *io_addr = (uint16_t *)((uintptr_t)addr + hdlp->ahi_io_port_base);
+	uint16_t *io_addr =
+	    (uint16_t *)((uintptr_t)addr + hdlp->ahi_io_port_base);
 	uint16_t x;
-	__asm__ volatile ("ldrh %w0, %1" : "=r" (x) : "Q" (*io_addr) : "memory");
-	return __builtin_bswap16(x);
+	__asm__ volatile("ldrh %w0, %1"
+	    : "=r" (x)
+	    : "Q" (*io_addr)
+	    : "memory");
+	return (__builtin_bswap16(x));
 }
 
 uint32_t
 i_ddi_io_swap_get32(ddi_acc_impl_t *hdlp, uint32_t *addr)
 {
-	uint32_t *io_addr = (uint32_t *)((uintptr_t)addr + hdlp->ahi_io_port_base);
+	uint32_t *io_addr =
+	    (uint32_t *)((uintptr_t)addr + hdlp->ahi_io_port_base);
 	uint32_t x;
-	__asm__ volatile ("ldr %w0, %1" : "=r" (x) : "Q" (*io_addr) : "memory");
-	return __builtin_bswap32(x);
+	__asm__ volatile("ldr %w0, %1"
+	    : "=r" (x)
+	    : "Q" (*io_addr)
+	    : "memory");
+	return (__builtin_bswap32(x));
 }
 
 uint64_t
 i_ddi_io_swap_get64(ddi_acc_impl_t *hdlp, uint64_t *addr)
 {
-	uint64_t *io_addr = (uint64_t *)((uintptr_t)addr + hdlp->ahi_io_port_base);
+	uint64_t *io_addr =
+	    (uint64_t *)((uintptr_t)addr + hdlp->ahi_io_port_base);
 	uint64_t x;
-	__asm__ volatile ("ldr %0, %1" : "=r" (x) : "Q" (*io_addr) : "memory");
-	return __builtin_bswap64(x);
+	__asm__ volatile("ldr %0, %1"
+	    : "=r" (x)
+	    : "Q" (*io_addr)
+	    : "memory");
+	return (__builtin_bswap64(x));
 }
 
 void
 i_ddi_io_swap_put16(ddi_acc_impl_t *hdlp, uint16_t *addr, uint16_t value)
 {
-	uint16_t *io_addr = (uint16_t *)((uintptr_t)addr + hdlp->ahi_io_port_base);
-	__asm__ volatile ("strh %w1, %0" : "=Q" (*io_addr) : "r"(__builtin_bswap16(value)) : "memory");
+	uint16_t *io_addr =
+	    (uint16_t *)((uintptr_t)addr + hdlp->ahi_io_port_base);
+	__asm__ volatile("strh %w1, %0"
+	    : "=Q" (*io_addr)
+	    : "r"(__builtin_bswap16(value))
+	    : "memory");
 }
 
 void
 i_ddi_io_swap_put32(ddi_acc_impl_t *hdlp, uint32_t *addr, uint32_t value)
 {
-	uint32_t *io_addr = (uint32_t *)((uintptr_t)addr + hdlp->ahi_io_port_base);
-	__asm__ volatile ("str %w1, %0" : "=Q" (*io_addr) : "r"(__builtin_bswap32(value)) : "memory");
+	uint32_t *io_addr =
+	    (uint32_t *)((uintptr_t)addr + hdlp->ahi_io_port_base);
+	__asm__ volatile("str %w1, %0"
+	    : "=Q" (*io_addr)
+	    : "r"(__builtin_bswap32(value))
+	    : "memory");
 }
 
 void
 i_ddi_io_swap_put64(ddi_acc_impl_t *hdlp, uint64_t *addr, uint64_t value)
 {
-	uint64_t *io_addr = (uint64_t *)((uintptr_t)addr + hdlp->ahi_io_port_base);
-	__asm__ volatile ("str %1, %0" : "=Q" (*io_addr) : "r"(__builtin_bswap64(value)) : "memory");
+	uint64_t *io_addr =
+	    (uint64_t *)((uintptr_t)addr + hdlp->ahi_io_port_base);
+	__asm__ volatile("str %1, %0"
+	    : "=Q" (*io_addr)
+	    : "r"(__builtin_bswap64(value))
+	    : "memory");
 }
 
 void
-i_ddi_io_swap_rep_get16(ddi_acc_impl_t *hdlp, uint16_t *host_addr, uint16_t *dev_addr, size_t repcount, const uint_t flags)
+i_ddi_io_swap_rep_get16(ddi_acc_impl_t *hdlp, uint16_t *host_addr,
+    uint16_t *dev_addr, size_t repcount, const uint_t flags)
 {
-	uint16_t *io_dev_addr = (uint16_t *)((uintptr_t)dev_addr + hdlp->ahi_io_port_base);
+	uint16_t *io_dev_addr =
+	    (uint16_t *)((uintptr_t)dev_addr + hdlp->ahi_io_port_base);
 	uint16_t x;
 	if (flags == DDI_DEV_AUTOINCR)
 		while (repcount--) {
-			__asm__ volatile ("ldrh %w0, %1" : "=r" (x) : "Q" (*(io_dev_addr++)) : "memory");
+			__asm__ volatile("ldrh %w0, %1"
+			    : "=r" (x)
+			    : "Q" (*(io_dev_addr++))
+			    : "memory");
 			*host_addr++ = __builtin_bswap16(x);
 		}
 	else
 		while (repcount--) {
-			__asm__ volatile ("ldrh %w0, %1" : "=r" (x) : "Q" (*(io_dev_addr)) : "memory");
+			__asm__ volatile("ldrh %w0, %1"
+			    : "=r" (x)
+			    : "Q" (*(io_dev_addr))
+			    : "memory");
 			*host_addr++ = __builtin_bswap16(x);
 		}
 }
 
 void
-i_ddi_io_swap_rep_get32(ddi_acc_impl_t *hdlp, uint32_t *host_addr, uint32_t *dev_addr, size_t repcount, uint_t flags)
+i_ddi_io_swap_rep_get32(ddi_acc_impl_t *hdlp, uint32_t *host_addr,
+    uint32_t *dev_addr, size_t repcount, uint_t flags)
 {
-	uint32_t *io_dev_addr = (uint32_t *)((uintptr_t)dev_addr + hdlp->ahi_io_port_base);
+	uint32_t *io_dev_addr =
+	    (uint32_t *)((uintptr_t)dev_addr + hdlp->ahi_io_port_base);
 	uint32_t x;
 	if (flags == DDI_DEV_AUTOINCR)
 		while (repcount--) {
-			__asm__ volatile ("ldr %w0, %1" : "=r" (x) : "Q" (*(io_dev_addr++)) : "memory");
+			__asm__ volatile("ldr %w0, %1"
+			    : "=r" (x)
+			    : "Q" (*(io_dev_addr++))
+			    : "memory");
 			*host_addr++ = __builtin_bswap32(x);
 		}
 	else
 		while (repcount--) {
-			__asm__ volatile ("ldr %w0, %1" : "=r" (x) : "Q" (*(io_dev_addr)) : "memory");
+			__asm__ volatile("ldr %w0, %1"
+			    : "=r" (x)
+			    : "Q" (*(io_dev_addr))
+			    : "memory");
 			*host_addr++ = __builtin_bswap32(x);
 		}
 }
 
 void
-i_ddi_io_swap_rep_get64(ddi_acc_impl_t *hdlp, uint64_t *host_addr, uint64_t *dev_addr, size_t repcount, uint_t flags)
+i_ddi_io_swap_rep_get64(ddi_acc_impl_t *hdlp, uint64_t *host_addr,
+    uint64_t *dev_addr, size_t repcount, uint_t flags)
 {
-	uint64_t *io_dev_addr = (uint64_t *)((uintptr_t)dev_addr + hdlp->ahi_io_port_base);
+	uint64_t *io_dev_addr =
+	    (uint64_t *)((uintptr_t)dev_addr + hdlp->ahi_io_port_base);
 	uint64_t x;
 	if (flags == DDI_DEV_AUTOINCR)
 		while (repcount--) {
-			__asm__ volatile ("ldr %0, %1" : "=r" (x) : "Q" (*(io_dev_addr++)) : "memory");
+			__asm__ volatile("ldr %0, %1"
+			    : "=r" (x)
+			    : "Q" (*(io_dev_addr++))
+			    : "memory");
 			*host_addr++ = __builtin_bswap64(x);
 		}
 	else
 		while (repcount--) {
-			__asm__ volatile ("ldr %0, %1" : "=r" (x) : "Q" (*(io_dev_addr)) : "memory");
+			__asm__ volatile("ldr %0, %1"
+			    : "=r" (x)
+			    : "Q" (*(io_dev_addr))
+			    : "memory");
 			*host_addr++ = __builtin_bswap64(x);
 		}
 }
 
 void
-i_ddi_io_swap_rep_put16(ddi_acc_impl_t *hdlp, uint16_t *host_addr, uint16_t *dev_addr, size_t repcount, uint_t flags)
+i_ddi_io_swap_rep_put16(ddi_acc_impl_t *hdlp, uint16_t *host_addr,
+    uint16_t *dev_addr, size_t repcount, uint_t flags)
 {
-	uint16_t *io_dev_addr = (uint16_t *)((uintptr_t)dev_addr + hdlp->ahi_io_port_base);
+	uint16_t *io_dev_addr =
+	    (uint16_t *)((uintptr_t)dev_addr + hdlp->ahi_io_port_base);
 	if (flags == DDI_DEV_AUTOINCR)
 		while (repcount--)
-			__asm__ volatile ("strh %w1, %0" : "=Q" (*(io_dev_addr++)) : "r"(__builtin_bswap16(*(host_addr++))) : "memory");
+			__asm__ volatile("strh %w1, %0"
+			    : "=Q" (*(io_dev_addr++))
+			    : "r"(__builtin_bswap16(*(host_addr++)))
+			    : "memory");
 	else
 		while (repcount--)
-			__asm__ volatile ("strh %w1, %0" : "=Q" (*(io_dev_addr)) : "r"(__builtin_bswap16(*(host_addr++))) : "memory");
+			__asm__ volatile("strh %w1, %0"
+			    : "=Q" (*(io_dev_addr))
+			    : "r"(__builtin_bswap16(*(host_addr++)))
+			    : "memory");
 }
 
 void
-i_ddi_io_swap_rep_put32(ddi_acc_impl_t *hdlp, uint32_t *host_addr, uint32_t *dev_addr, size_t repcount, uint_t flags)
+i_ddi_io_swap_rep_put32(ddi_acc_impl_t *hdlp, uint32_t *host_addr,
+    uint32_t *dev_addr, size_t repcount, uint_t flags)
 {
-	uint32_t *io_dev_addr = (uint32_t *)((uintptr_t)dev_addr + hdlp->ahi_io_port_base);
+	uint32_t *io_dev_addr =
+	    (uint32_t *)((uintptr_t)dev_addr + hdlp->ahi_io_port_base);
 	if (flags == DDI_DEV_AUTOINCR)
 		while (repcount--)
-			__asm__ volatile ("str %w1, %0" : "=Q" (*(io_dev_addr++)) : "r"(__builtin_bswap32(*(host_addr++))) : "memory");
+			__asm__ volatile("str %w1, %0"
+			    : "=Q" (*(io_dev_addr++))
+			    : "r"(__builtin_bswap32(*(host_addr++)))
+			    : "memory");
 	else
 		while (repcount--)
-			__asm__ volatile ("str %w1, %0" : "=Q" (*(io_dev_addr)) : "r"(__builtin_bswap32(*(host_addr++))) : "memory");
+			__asm__ volatile("str %w1, %0"
+			    : "=Q" (*(io_dev_addr))
+			    : "r"(__builtin_bswap32(*(host_addr++)))
+			    : "memory");
 }
 
 void
-i_ddi_io_swap_rep_put64(ddi_acc_impl_t *hdlp, uint64_t *host_addr, uint64_t *dev_addr, size_t repcount, uint_t flags)
+i_ddi_io_swap_rep_put64(ddi_acc_impl_t *hdlp, uint64_t *host_addr,
+    uint64_t *dev_addr, size_t repcount, uint_t flags)
 {
-	uint64_t *io_dev_addr = (uint64_t *)((uintptr_t)dev_addr + hdlp->ahi_io_port_base);
+	uint64_t *io_dev_addr =
+	    (uint64_t *)((uintptr_t)dev_addr + hdlp->ahi_io_port_base);
 	if (flags == DDI_DEV_AUTOINCR)
 		while (repcount--)
-			__asm__ volatile ("str %1, %0" : "=Q" (*(io_dev_addr++)) : "r"(__builtin_bswap64(*(host_addr++))) : "memory");
+			__asm__ volatile("str %1, %0"
+			    : "=Q" (*(io_dev_addr++))
+			    : "r"(__builtin_bswap64(*(host_addr++)))
+			    : "memory");
 	else
 		while (repcount--)
-			__asm__ volatile ("str %1, %0" : "=Q" (*(io_dev_addr)) : "r"(__builtin_bswap64(*(host_addr++))) : "memory");
+			__asm__ volatile("str %1, %0"
+			    : "=Q" (*(io_dev_addr))
+			    : "r"(__builtin_bswap64(*(host_addr++)))
+			    : "memory");
 }
 
 static void
-i_ddi_caut_getput_ctlops(ddi_acc_impl_t *hp, uint64_t host_addr, uint64_t dev_addr, size_t size, size_t repcount, uint_t flags, ddi_ctl_enum_t cmd)
+i_ddi_caut_getput_ctlops(ddi_acc_impl_t *hp, uint64_t host_addr,
+    uint64_t dev_addr, size_t size, size_t repcount,
+    uint_t flags, ddi_ctl_enum_t cmd)
 {
 	peekpoke_ctlops_t	cautacc_ctlops_arg;
 
@@ -665,14 +947,16 @@ i_ddi_caut_getput_ctlops(ddi_acc_impl_t *hp, uint64_t host_addr, uint64_t dev_ad
 	cautacc_ctlops_arg.repcount = repcount;
 	cautacc_ctlops_arg.flags = flags;
 
-	(void) ddi_ctlops(hp->ahi_common.ah_dip, hp->ahi_common.ah_dip, cmd, &cautacc_ctlops_arg, NULL);
+	(void) ddi_ctlops(hp->ahi_common.ah_dip, hp->ahi_common.ah_dip,
+	    cmd, &cautacc_ctlops_arg, NULL);
 }
 
 uint8_t
 i_ddi_caut_get8(ddi_acc_impl_t *hp, uint8_t *addr)
 {
 	uint8_t value;
-	i_ddi_caut_getput_ctlops(hp, (uintptr_t)&value, (uintptr_t)addr, sizeof (uint8_t), 1, 0, DDI_CTLOPS_PEEK);
+	i_ddi_caut_getput_ctlops(hp, (uintptr_t)&value, (uintptr_t)addr,
+	    sizeof (uint8_t), 1, 0, DDI_CTLOPS_PEEK);
 
 	return (value);
 }
@@ -681,7 +965,8 @@ uint16_t
 i_ddi_caut_get16(ddi_acc_impl_t *hp, uint16_t *addr)
 {
 	uint16_t value;
-	i_ddi_caut_getput_ctlops(hp, (uintptr_t)&value, (uintptr_t)addr, sizeof (uint16_t), 1, 0, DDI_CTLOPS_PEEK);
+	i_ddi_caut_getput_ctlops(hp, (uintptr_t)&value, (uintptr_t)addr,
+	    sizeof (uint16_t), 1, 0, DDI_CTLOPS_PEEK);
 
 	return (value);
 }
@@ -690,7 +975,8 @@ uint32_t
 i_ddi_caut_get32(ddi_acc_impl_t *hp, uint32_t *addr)
 {
 	uint32_t value;
-	i_ddi_caut_getput_ctlops(hp, (uintptr_t)&value, (uintptr_t)addr, sizeof (uint32_t), 1, 0, DDI_CTLOPS_PEEK);
+	i_ddi_caut_getput_ctlops(hp, (uintptr_t)&value, (uintptr_t)addr,
+	    sizeof (uint32_t), 1, 0, DDI_CTLOPS_PEEK);
 
 	return (value);
 }
@@ -699,7 +985,8 @@ uint64_t
 i_ddi_caut_get64(ddi_acc_impl_t *hp, uint64_t *addr)
 {
 	uint64_t value;
-	i_ddi_caut_getput_ctlops(hp, (uintptr_t)&value, (uintptr_t)addr, sizeof (uint64_t), 1, 0, DDI_CTLOPS_PEEK);
+	i_ddi_caut_getput_ctlops(hp, (uintptr_t)&value, (uintptr_t)addr,
+	    sizeof (uint64_t), 1, 0, DDI_CTLOPS_PEEK);
 
 	return (value);
 }
@@ -707,73 +994,93 @@ i_ddi_caut_get64(ddi_acc_impl_t *hp, uint64_t *addr)
 void
 i_ddi_caut_put8(ddi_acc_impl_t *hp, uint8_t *addr, uint8_t value)
 {
-	i_ddi_caut_getput_ctlops(hp, (uintptr_t)&value, (uintptr_t)addr, sizeof (uint8_t), 1, 0, DDI_CTLOPS_POKE);
+	i_ddi_caut_getput_ctlops(hp, (uintptr_t)&value, (uintptr_t)addr,
+	    sizeof (uint8_t), 1, 0, DDI_CTLOPS_POKE);
 }
 
 void
 i_ddi_caut_put16(ddi_acc_impl_t *hp, uint16_t *addr, uint16_t value)
 {
-	i_ddi_caut_getput_ctlops(hp, (uintptr_t)&value, (uintptr_t)addr, sizeof (uint16_t), 1, 0, DDI_CTLOPS_POKE);
+	i_ddi_caut_getput_ctlops(hp, (uintptr_t)&value, (uintptr_t)addr,
+	    sizeof (uint16_t), 1, 0, DDI_CTLOPS_POKE);
 }
 
 void
 i_ddi_caut_put32(ddi_acc_impl_t *hp, uint32_t *addr, uint32_t value)
 {
-	i_ddi_caut_getput_ctlops(hp, (uintptr_t)&value, (uintptr_t)addr, sizeof (uint32_t), 1, 0, DDI_CTLOPS_POKE);
+	i_ddi_caut_getput_ctlops(hp, (uintptr_t)&value, (uintptr_t)addr,
+	    sizeof (uint32_t), 1, 0, DDI_CTLOPS_POKE);
 }
 
 void
 i_ddi_caut_put64(ddi_acc_impl_t *hp, uint64_t *addr, uint64_t value)
 {
-	i_ddi_caut_getput_ctlops(hp, (uintptr_t)&value, (uintptr_t)addr, sizeof (uint64_t), 1, 0, DDI_CTLOPS_POKE);
+	i_ddi_caut_getput_ctlops(hp, (uintptr_t)&value, (uintptr_t)addr,
+	    sizeof (uint64_t), 1, 0, DDI_CTLOPS_POKE);
 }
 
 void
-i_ddi_caut_rep_get8(ddi_acc_impl_t *hp, uint8_t *host_addr, uint8_t *dev_addr, size_t repcount, uint_t flags)
+i_ddi_caut_rep_get8(ddi_acc_impl_t *hp, uint8_t *host_addr,
+    uint8_t *dev_addr, size_t repcount, uint_t flags)
 {
-	i_ddi_caut_getput_ctlops(hp, (uintptr_t)host_addr, (uintptr_t)dev_addr, sizeof (uint8_t), repcount, flags, DDI_CTLOPS_PEEK);
+	i_ddi_caut_getput_ctlops(hp, (uintptr_t)host_addr, (uintptr_t)dev_addr,
+	    sizeof (uint8_t), repcount, flags, DDI_CTLOPS_PEEK);
 }
 
 void
-i_ddi_caut_rep_get16(ddi_acc_impl_t *hp, uint16_t *host_addr, uint16_t *dev_addr, size_t repcount, uint_t flags)
+i_ddi_caut_rep_get16(ddi_acc_impl_t *hp, uint16_t *host_addr,
+    uint16_t *dev_addr, size_t repcount, uint_t flags)
 {
-	i_ddi_caut_getput_ctlops(hp, (uintptr_t)host_addr, (uintptr_t)dev_addr, sizeof (uint16_t), repcount, flags, DDI_CTLOPS_PEEK);
+	i_ddi_caut_getput_ctlops(hp, (uintptr_t)host_addr, (uintptr_t)dev_addr,
+	    sizeof (uint16_t), repcount, flags, DDI_CTLOPS_PEEK);
 }
 
 void
-i_ddi_caut_rep_get32(ddi_acc_impl_t *hp, uint32_t *host_addr, uint32_t *dev_addr, size_t repcount, uint_t flags)
+i_ddi_caut_rep_get32(ddi_acc_impl_t *hp, uint32_t *host_addr,
+    uint32_t *dev_addr, size_t repcount, uint_t flags)
 {
-	i_ddi_caut_getput_ctlops(hp, (uintptr_t)host_addr, (uintptr_t)dev_addr, sizeof (uint32_t), repcount, flags, DDI_CTLOPS_PEEK);
+	i_ddi_caut_getput_ctlops(hp, (uintptr_t)host_addr, (uintptr_t)dev_addr,
+	    sizeof (uint32_t), repcount, flags, DDI_CTLOPS_PEEK);
 }
 
 void
-i_ddi_caut_rep_get64(ddi_acc_impl_t *hp, uint64_t *host_addr, uint64_t *dev_addr, size_t repcount, uint_t flags)
+i_ddi_caut_rep_get64(ddi_acc_impl_t *hp, uint64_t *host_addr,
+    uint64_t *dev_addr, size_t repcount, uint_t flags)
 {
-	i_ddi_caut_getput_ctlops(hp, (uintptr_t)host_addr, (uintptr_t)dev_addr, sizeof (uint64_t), repcount, flags, DDI_CTLOPS_PEEK);
+	i_ddi_caut_getput_ctlops(hp, (uintptr_t)host_addr, (uintptr_t)dev_addr,
+	    sizeof (uint64_t), repcount, flags, DDI_CTLOPS_PEEK);
 }
 
 void
-i_ddi_caut_rep_put8(ddi_acc_impl_t *hp, uint8_t *host_addr, uint8_t *dev_addr, size_t repcount, uint_t flags)
+i_ddi_caut_rep_put8(ddi_acc_impl_t *hp, uint8_t *host_addr,
+    uint8_t *dev_addr, size_t repcount, uint_t flags)
 {
-	i_ddi_caut_getput_ctlops(hp, (uintptr_t)host_addr, (uintptr_t)dev_addr, sizeof (uint8_t), repcount, flags, DDI_CTLOPS_POKE);
+	i_ddi_caut_getput_ctlops(hp, (uintptr_t)host_addr, (uintptr_t)dev_addr,
+	    sizeof (uint8_t), repcount, flags, DDI_CTLOPS_POKE);
 }
 
 void
-i_ddi_caut_rep_put16(ddi_acc_impl_t *hp, uint16_t *host_addr, uint16_t *dev_addr, size_t repcount, uint_t flags)
+i_ddi_caut_rep_put16(ddi_acc_impl_t *hp, uint16_t *host_addr,
+    uint16_t *dev_addr, size_t repcount, uint_t flags)
 {
-	i_ddi_caut_getput_ctlops(hp, (uintptr_t)host_addr, (uintptr_t)dev_addr, sizeof (uint16_t), repcount, flags, DDI_CTLOPS_POKE);
+	i_ddi_caut_getput_ctlops(hp, (uintptr_t)host_addr, (uintptr_t)dev_addr,
+	    sizeof (uint16_t), repcount, flags, DDI_CTLOPS_POKE);
 }
 
 void
-i_ddi_caut_rep_put32(ddi_acc_impl_t *hp, uint32_t *host_addr, uint32_t *dev_addr, size_t repcount, uint_t flags)
+i_ddi_caut_rep_put32(ddi_acc_impl_t *hp, uint32_t *host_addr,
+    uint32_t *dev_addr, size_t repcount, uint_t flags)
 {
-	i_ddi_caut_getput_ctlops(hp, (uintptr_t)host_addr, (uintptr_t)dev_addr, sizeof (uint32_t), repcount, flags, DDI_CTLOPS_POKE);
+	i_ddi_caut_getput_ctlops(hp, (uintptr_t)host_addr, (uintptr_t)dev_addr,
+	    sizeof (uint32_t), repcount, flags, DDI_CTLOPS_POKE);
 }
 
 void
-i_ddi_caut_rep_put64(ddi_acc_impl_t *hp, uint64_t *host_addr, uint64_t *dev_addr, size_t repcount, uint_t flags)
+i_ddi_caut_rep_put64(ddi_acc_impl_t *hp, uint64_t *host_addr,
+    uint64_t *dev_addr, size_t repcount, uint_t flags)
 {
-	i_ddi_caut_getput_ctlops(hp, (uintptr_t)host_addr, (uintptr_t)dev_addr, sizeof (uint64_t), repcount, flags, DDI_CTLOPS_POKE);
+	i_ddi_caut_getput_ctlops(hp, (uintptr_t)host_addr, (uintptr_t)dev_addr,
+	    sizeof (uint64_t), repcount, flags, DDI_CTLOPS_POKE);
 }
 
 int
@@ -862,9 +1169,10 @@ i_ddi_get_intx_nintrs(dev_info_t *dip)
 	    DDI_PROP_CANSLEEP,
 	    "interrupts", (caddr_t)&ip, &intrlen) == DDI_SUCCESS) {
 
-		intr_sz = ddi_getprop(DDI_DEV_T_ANY, dip, 0, "#interrupt-cells", 1);
+		intr_sz = ddi_getprop(DDI_DEV_T_ANY, dip,
+		    0, "#interrupt-cells", 1);
 		/* adjust for number of bytes */
-		intr_sz *= sizeof(int32_t);
+		intr_sz *= sizeof (int32_t);
 
 		ret = intrlen / intr_sz;
 
@@ -876,7 +1184,9 @@ i_ddi_get_intx_nintrs(dev_info_t *dip)
 
 void
 i_ddi_intr_redist_all_cpus()
-{}
+{
+	/* nothing (yet) */
+}
 
 uint_t
 impl_assign_instance(dev_info_t *dip)
@@ -903,8 +1213,11 @@ impl_check_cpu(dev_info_t *devi)
 }
 
 void
-impl_fix_props(dev_info_t *dip, dev_info_t *ch_dip, char *name, int len, caddr_t buffer)
-{}
+impl_fix_props(dev_info_t *dip, dev_info_t *ch_dip, char *name,
+    int len, caddr_t buffer)
+{
+	/* nothing (yet) */
+}
 
 static int
 get_prop_int_array(dev_info_t *di, char *pname, int **pval, uint_t *plen)
@@ -924,7 +1237,8 @@ impl_sunbus_name_child(dev_info_t *child, char *name, int namelen)
 {
 	name[0] = '\0';
 	if (ddi_get_parent_data(child) == NULL) {
-		struct ddi_parent_private_data *pdptr = kmem_zalloc(sizeof (*pdptr), KM_SLEEP);
+		struct ddi_parent_private_data *pdptr =
+		    kmem_zalloc(sizeof (*pdptr), KM_SLEEP);
 		ddi_set_parent_data(child, pdptr);
 	}
 
@@ -939,7 +1253,7 @@ impl_sunbus_name_child(dev_info_t *child, char *name, int namelen)
 		}
 	}
 
-	return DDI_SUCCESS;
+	return (DDI_SUCCESS);
 }
 
 int
@@ -989,40 +1303,64 @@ impl_ddi_sunbus_removechild(dev_info_t *dip)
 	impl_rem_dev_props(dip);
 }
 
+/*
+ * Copy name to property_name, since name
+ * is in the low address range below kernelbase.
+ */
+static void
+copy_boot_str(const char *boot_str, char *kern_str, int len)
+{
+	int i = 0;
+
+	while (i < len - 1 && boot_str[i] != '\0') {
+		kern_str[i] = boot_str[i];
+		i++;
+	}
+
+	kern_str[i] = 0;	/* null terminate */
+	if (boot_str[i] != '\0')
+		cmn_err(CE_WARN,
+		    "boot property string is truncated to %s", kern_str);
+}
+
 static void
 get_boot_properties(void)
 {
 	extern char hw_provider[];
 	dev_info_t *devi;
 	char *name;
-	int length;
-	char property_name[OBP_MAXPROPNAME], property_val[50];
+	int length, flags;
+	char property_name[50], property_val[50];
 	void *bop_staging_area;
 
 	bop_staging_area = kmem_zalloc(MMU_PAGESIZE, KM_NOSLEEP);
 
+	/*
+	 * Import "root" properties from the boot.
+	 *
+	 * We do this by invoking BOP_NEXTPROP until the list
+	 * is completely copied in.
+	 */
+
 	devi = ddi_root_node();
-	property_name[0] = '\0';
-	for (name = BOP_NEXTPROP(bootops, property_name);	/* get first */
-	    name && strlen(name) > 0;				/* NULL => DONE */
-	    name = BOP_NEXTPROP(bootops, property_name)) {	/* get next */
+	for (name = BOP_NEXTPROP(bootops, "");		/* get first */
+	    name;					/* NULL => DONE */
+	    name = BOP_NEXTPROP(bootops, name)) {	/* get next */
 
-		if (strlen(name) >= OBP_MAXPROPNAME) {
-			cmn_err(CE_NOTE,
-			    "boot property name %s longer than 0x%lx\n",
-			    name, sizeof(property_name));
-			break;
-		}
+		/* copy string to memory above kernelbase */
+		copy_boot_str(name, property_name, 50);
 
-		strcpy(property_name, name);
-
+		/*
+		 * Skip vga properties. They will be picked up later
+		 * by get_vga_properties.
+		 */
 		if (strcmp(property_name, "display-edif-block") == 0 ||
 		    strcmp(property_name, "display-edif-id") == 0) {
 			continue;
 		}
 
 		length = BOP_GETPROPLEN(bootops, property_name);
-		if (length == 0)
+		if (length < 0)
 			continue;
 		if (length > MMU_PAGESIZE) {
 			cmn_err(CE_NOTE,
@@ -1031,31 +1369,85 @@ get_boot_properties(void)
 			continue;
 		}
 		BOP_GETPROP(bootops, property_name, bop_staging_area);
+		flags = do_bsys_getproptype(bootops, property_name);
 
-		if (strcmp(property_name, "si-machine") == 0) {
-			(void) strncpy(utsname.machine, bop_staging_area, SYS_NMLN);
-			utsname.machine[SYS_NMLN - 1] = 0;
-		} else if (strcmp(property_name, "si-hw-provider") == 0) {
+		/*
+		 * special properties:
+		 * si-machine, si-hw-provider
+		 *	goes to kernel data structures.
+		 * bios-boot-device and stdout
+		 *	goes to hardware property list so it may show up
+		 *	in the prtconf -vp output. This is needed by
+		 *	Install/Upgrade. Once we fix install upgrade,
+		 *	this can be taken out.
+		 * XXXARM: It's unclear whether we need bios-boot-device.
+		 */
+		if (strcmp(name, "si-machine") == 0) {
+			(void) strncpy(utsname.machine, bop_staging_area,
+			    SYS_NMLN);
+			utsname.machine[SYS_NMLN - 1] = '\0';
+			continue;
+		}
+		if (strcmp(name, "si-hw-provider") == 0) {
 			(void) strncpy(hw_provider, bop_staging_area, SYS_NMLN);
-			hw_provider[SYS_NMLN - 1] = 0;
-		} else if (strcmp(property_name, "bios-boot-device") == 0) {
-			if (length >= sizeof(property_val)) {
-				cmn_err(CE_NOTE,
-				    "boot property %s longer than 0x%lx, ignored\n",
-				    property_name, MMU_PAGESIZE);
-			}
-			bcopy(bop_staging_area, property_val, length);
+			hw_provider[SYS_NMLN - 1] = '\0';
+			continue;
+		}
+		if (strcmp(name, "bios-boot-device") == 0) {
+			copy_boot_str(bop_staging_area, property_val, 50);
 			(void) ndi_prop_update_string(DDI_DEV_T_NONE, devi,
 			    property_name, property_val);
-		} else if (strcmp(property_name, "stdout") == 0) {
+			continue;
+		}
+		if (strcmp(name, "stdout") == 0) {
 			(void) ndi_prop_update_int(DDI_DEV_T_NONE, devi,
 			    property_name, *((int *)bop_staging_area));
-		} else if (strcmp(property_name, "ramdisk_start") == 0) {
-		} else if (strcmp(property_name, "ramdisk_end") == 0) {
-		} else if (strcmp(property_name, "ramdisk_end") == 0) {
-		} else {
+			continue;
+		}
+
+		/* Boolean property */
+		if (length == 0) {
+			(void) e_ddi_prop_create(DDI_DEV_T_NONE, devi,
+			    DDI_PROP_CANSLEEP, property_name, NULL, 0);
+			continue;
+		}
+
+		/* Now anything else based on type. */
+		switch (flags) {
+		case DDI_PROP_TYPE_INT:
+			if (length == sizeof (int)) {
+				(void) e_ddi_prop_update_int(DDI_DEV_T_NONE,
+				    devi, property_name,
+				    *((int *)bop_staging_area));
+			} else {
+				(void) e_ddi_prop_update_int_array(
+				    DDI_DEV_T_NONE, devi, property_name,
+				    bop_staging_area, length / sizeof (int));
+			}
+			break;
+		case DDI_PROP_TYPE_STRING:
+			(void) e_ddi_prop_update_string(DDI_DEV_T_NONE, devi,
+			    property_name, bop_staging_area);
+			break;
+		case DDI_PROP_TYPE_BYTE:
+			(void) e_ddi_prop_update_byte_array(DDI_DEV_T_NONE,
+			    devi, property_name, bop_staging_area, length);
+			break;
+		case DDI_PROP_TYPE_INT64:
+			if (length == sizeof (int64_t)) {
+				(void) e_ddi_prop_update_int64(DDI_DEV_T_NONE,
+				    devi, property_name,
+				    *((int64_t *)bop_staging_area));
+			} else {
+				(void) e_ddi_prop_update_int64_array(
+				    DDI_DEV_T_NONE, devi, property_name,
+				    bop_staging_area,
+				    length / sizeof (int64_t));
+			}
+			break;
+		default:
 			/* Property type unknown, use old prop interface */
-			e_ddi_prop_create(DDI_DEV_T_NONE, devi,
+			(void) e_ddi_prop_create(DDI_DEV_T_NONE, devi,
 			    DDI_PROP_CANSLEEP, property_name, bop_staging_area,
 			    length);
 		}
@@ -1071,11 +1463,10 @@ impl_setup_ddi(void)
 	rd_existing_t rd_mem_prop;
 	int err;
 
-	ndi_devi_alloc_sleep(ddi_root_node(), "ramdisk", (pnode_t)DEVI_SID_NODEID, &xdip);
+	ndi_devi_alloc_sleep(
+	    ddi_root_node(), "ramdisk", (pnode_t)DEVI_SID_NODEID, &xdip);
 	(void) BOP_GETPROP(bootops, "ramdisk_start", (void *)&ramdisk_start);
 	(void) BOP_GETPROP(bootops, "ramdisk_end", (void *)&ramdisk_end);
-	ramdisk_start = ntohll(ramdisk_start);
-	ramdisk_end = ntohll(ramdisk_end);
 
 	rd_mem_prop.phys = ramdisk_start;
 	rd_mem_prop.size = ramdisk_end - ramdisk_start + 1;
@@ -1529,7 +1920,7 @@ contig_free(void *addr, size_t size)
  */
 static void *
 kalloca(size_t size, size_t align, int cansleep, int physcontig,
-	ddi_dma_attr_t *attr)
+    ddi_dma_attr_t *attr)
 {
 	size_t *addr, *raddr, rsize;
 	size_t hdrsize = 4 * sizeof (size_t);	/* must be power of 2 */
@@ -1713,7 +2104,7 @@ get_address_cells(pnode_t node)
 	while (node > 0) {
 		int len = prom_getproplen(node, "#address-cells");
 		if (len > 0) {
-			ASSERT(len == sizeof(int));
+			ASSERT(len == sizeof (int));
 			int prop;
 			prom_getprop(node, "#address-cells", (caddr_t)&prop);
 			address_cells = ntohl(prop);
@@ -1721,7 +2112,7 @@ get_address_cells(pnode_t node)
 		}
 		node = prom_parentnode(node);
 	}
-	return address_cells;
+	return (address_cells);
 }
 
 static int
@@ -1732,7 +2123,7 @@ get_size_cells(pnode_t node)
 	while (node > 0) {
 		int len = prom_getproplen(node, "#size-cells");
 		if (len > 0) {
-			ASSERT(len == sizeof(int));
+			ASSERT(len == sizeof (int));
 			int prop;
 			prom_getprop(node, "#size-cells", (caddr_t)&prop);
 			size_cells = ntohl(prop);
@@ -1740,7 +2131,7 @@ get_size_cells(pnode_t node)
 		}
 		node = prom_parentnode(node);
 	}
-	return size_cells;
+	return (size_cells);
 }
 
 struct dma_range
@@ -1778,7 +2169,9 @@ get_dma_ranges(dev_info_t *dip, struct dma_range **range, int *nrange)
 
 		parent = prom_parentnode(node);
 		if (parent <= 0) {
-			cmn_err(CE_WARN, "%s: root node has a dma-ranges property.", __func__);
+			cmn_err(CE_WARN,
+			    "%s: root node has a dma-ranges property.",
+			    __func__);
 			goto err_exit;
 		}
 
@@ -1787,27 +2180,34 @@ get_dma_ranges(dev_info_t *dip, struct dma_range **range, int *nrange)
 		parent_address_cells = get_address_cells(parent);
 
 		int len = prom_getproplen(node, "dma-ranges");
-		if (len % (sizeof(uint32_t) * (bus_address_cells + parent_address_cells + bus_size_cells)) != 0) {
-			cmn_err(CE_WARN, "%s: dma-ranges property length is invalid\n"
+		if (len % (sizeof (uint32_t) * (bus_address_cells +
+		    parent_address_cells + bus_size_cells)) != 0) {
+			cmn_err(CE_WARN,
+			    "%s: dma-ranges property length is invalid\n"
 			    "bus_address_cells %d\n"
 			    "parent_address_cells %d\n"
 			    "bus_size_cells %d\n"
-			    "len %d\n"
-			    , __func__, bus_address_cells, parent_address_cells, bus_size_cells, len);
+			    "len %d\n",
+			    __func__, bus_address_cells, parent_address_cells,
+			    bus_size_cells, len);
 			ret = DDI_FAILURE;
 			goto err_exit;
 		}
-		int num = len / (sizeof(uint32_t) * (bus_address_cells + parent_address_cells + bus_size_cells));
+		int num = len / (sizeof (uint32_t) * (
+		    bus_address_cells + parent_address_cells + bus_size_cells));
 		uint32_t *cells = __builtin_alloca(len);
 		prom_getprop(node, "dma-ranges", (caddr_t)cells);
 
 		boolean_t first = (dma_ranges == NULL);
 		if (first) {
 			dma_range_num = num;
-			dma_ranges = kmem_zalloc(sizeof(struct dma_range) * dma_range_num, KM_SLEEP);
-			update = kmem_zalloc(sizeof(boolean_t) * dma_range_num, KM_SLEEP);
+			dma_ranges = kmem_zalloc(
+			    sizeof (struct dma_range) * dma_range_num,
+			    KM_SLEEP);
+			update = kmem_zalloc(
+			    sizeof (boolean_t) * dma_range_num, KM_SLEEP);
 		} else {
-			memset(update, 0, sizeof(boolean_t) * dma_range_num);
+			memset(update, 0, sizeof (boolean_t) * dma_range_num);
 		}
 
 		for (int i = 0; i < num; i++) {
@@ -1816,15 +2216,23 @@ get_dma_ranges(dev_info_t *dip, struct dma_range **range, int *nrange)
 			uint64_t bus_size = 0;
 			for (int j = 0; j < bus_address_cells; j++) {
 				bus_address <<= 32;
-				bus_address += ntohl(cells[(bus_address_cells + parent_address_cells + bus_size_cells) * i + j]);
+				bus_address += ntohl(cells[(
+				    bus_address_cells + parent_address_cells +
+				    bus_size_cells) * i + j]);
 			}
 			for (int j = 0; j < parent_address_cells; j++) {
 				parent_address <<= 32;
-				parent_address += ntohl(cells[(bus_address_cells + parent_address_cells + bus_size_cells) * i + bus_address_cells + j]);
+				parent_address += ntohl(
+				    cells[(bus_address_cells +
+				    parent_address_cells + bus_size_cells) *
+				    i + bus_address_cells + j]);
 			}
 			for (int j = 0; j < bus_size_cells; j++) {
 				bus_size <<= 32;
-				bus_size += ntohl(cells[(bus_address_cells + parent_address_cells + bus_size_cells) * i + bus_address_cells + parent_address_cells + j]);
+				bus_size += ntohl(cells[(bus_address_cells +
+				    parent_address_cells + bus_size_cells) *
+				    i + bus_address_cells +
+				    parent_address_cells + j]);
 			}
 
 			if (first) {
@@ -1834,8 +2242,14 @@ get_dma_ranges(dev_info_t *dip, struct dma_range **range, int *nrange)
 				update[i] = B_TRUE;
 			} else {
 				for (int j = 0; j < dma_range_num; j++) {
-					if (bus_address <= dma_ranges[j].cpu_addr && dma_ranges[j].cpu_addr + dma_ranges[j].size - 1 <= bus_address + bus_size - 1) {
-						dma_ranges[j].cpu_addr += (parent_address - bus_address);
+					if (bus_address <=
+					    dma_ranges[j].cpu_addr &&
+					    dma_ranges[j].cpu_addr +
+					    dma_ranges[j].size - 1 <=
+					    bus_address + bus_size - 1) {
+						dma_ranges[j].cpu_addr +=
+						    (parent_address -
+						    bus_address);
 						update[j] = B_TRUE;
 						break;
 					}
@@ -1844,7 +2258,9 @@ get_dma_ranges(dev_info_t *dip, struct dma_range **range, int *nrange)
 		}
 		for (int i = 0; i < dma_range_num; i++) {
 			if (!update[i]) {
-				cmn_err(CE_WARN, "%s: dma-ranges property is invalid", __func__);
+				cmn_err(CE_WARN,
+				    "%s: dma-ranges property is invalid",
+				    __func__);
 				ret = DDI_FAILURE;
 				goto err_exit;
 			}
@@ -1855,44 +2271,54 @@ get_dma_ranges(dev_info_t *dip, struct dma_range **range, int *nrange)
 	*range = dma_ranges;
 err_exit:
 	if (ret != DDI_SUCCESS && dma_ranges) {
-		kmem_free(dma_ranges, sizeof(struct dma_range) * dma_range_num);
+		kmem_free(
+		    dma_ranges, sizeof (struct dma_range) * dma_range_num);
 	}
 	if (update) {
-		kmem_free(update, sizeof(boolean_t) * dma_range_num);
+		kmem_free(update, sizeof (boolean_t) * dma_range_num);
 	}
-	return ret;
+	return (ret);
 }
 
 int
-i_ddi_convert_dma_attr(ddi_dma_attr_t *dst, dev_info_t *dip, const ddi_dma_attr_t *src)
+i_ddi_convert_dma_attr(
+    ddi_dma_attr_t *dst, dev_info_t *dip, const ddi_dma_attr_t *src)
 {
 	*dst = *src;
 
 	int dma_range_num = 0;
 	struct dma_range *dma_ranges = NULL;
-	int ret= get_dma_ranges(dip, &dma_ranges, &dma_range_num);
+	int ret = get_dma_ranges(dip, &dma_ranges, &dma_range_num);
 	if (ret != DDI_SUCCESS)
-		return DDI_FAILURE;
+		return (DDI_FAILURE);
 
 	if (dma_range_num > 0) {
 		int i;
 		for (i = 0; i < dma_range_num; i++) {
-			if (dma_ranges[i].bus_addr <= dst->dma_attr_addr_lo && dst->dma_attr_addr_hi <= dma_ranges[i].bus_addr + dma_ranges[i].size - 1) {
-				dst->dma_attr_addr_lo += (dma_ranges[i].cpu_addr - dma_ranges[i].bus_addr);
-				dst->dma_attr_addr_hi += (dma_ranges[i].cpu_addr - dma_ranges[i].bus_addr);
+			if (dma_ranges[i].bus_addr <= dst->dma_attr_addr_lo &&
+			    dst->dma_attr_addr_hi <=
+			    dma_ranges[i].bus_addr + dma_ranges[i].size - 1) {
+				dst->dma_attr_addr_lo +=
+				    (dma_ranges[i].cpu_addr -
+				    dma_ranges[i].bus_addr);
+				dst->dma_attr_addr_hi +=
+				    (dma_ranges[i].cpu_addr -
+				    dma_ranges[i].bus_addr);
 				break;
 			}
 		}
 		if (i == dma_range_num) {
-			cmn_err(CE_WARN, "%s: ddi_dma_attr_t is invalid range", __func__);
+			cmn_err(CE_WARN,
+			    "%s: ddi_dma_attr_t is invalid range", __func__);
 			ret = DDI_FAILURE;
 		}
 	}
 
 	if (dma_ranges) {
-		kmem_free(dma_ranges, sizeof(struct dma_range) * dma_range_num);
+		kmem_free(
+		    dma_ranges, sizeof (struct dma_range) * dma_range_num);
 	}
-	return ret;
+	return (ret);
 }
 
 int
@@ -1900,29 +2326,33 @@ i_ddi_update_dma_attr(dev_info_t *dip, ddi_dma_attr_t *attr)
 {
 	int dma_range_num = 0;
 	struct dma_range *dma_ranges = NULL;
-	int ret= get_dma_ranges(dip, &dma_ranges, &dma_range_num);
+	int ret = get_dma_ranges(dip, &dma_ranges, &dma_range_num);
 	if (ret != DDI_SUCCESS)
-		return DDI_FAILURE;
+		return (DDI_FAILURE);
 
 	if (dma_range_num > 0) {
 		int dma_range_index = 0;
 		for (int i = 0; i < dma_range_num; i++) {
-			if (dma_ranges[i].cpu_addr < dma_ranges[dma_range_index].cpu_addr) {
+			if (dma_ranges[i].cpu_addr <
+			    dma_ranges[dma_range_index].cpu_addr) {
 				dma_range_index = i;
 			}
 		}
 
 		attr->dma_attr_addr_lo = dma_ranges[dma_range_index].bus_addr;
-		attr->dma_attr_addr_hi = dma_ranges[dma_range_index].bus_addr + dma_ranges[dma_range_index].size - 1;
+		attr->dma_attr_addr_hi =
+		    dma_ranges[dma_range_index].bus_addr +
+		    dma_ranges[dma_range_index].size - 1;
 	} else {
 		ret = DDI_FAILURE;
 	}
 
 	if (dma_ranges) {
-		kmem_free(dma_ranges, sizeof(struct dma_range) * dma_range_num);
+		kmem_free(
+		    dma_ranges, sizeof (struct dma_range) * dma_range_num);
 	}
 
-	return ret;
+	return (ret);
 }
 
 /*
@@ -1937,9 +2367,9 @@ i_ddi_update_dma_attr(dev_info_t *dip, ddi_dma_attr_t *attr)
 /*ARGSUSED*/
 int
 i_ddi_mem_alloc(dev_info_t *dip, ddi_dma_attr_t *oattr,
-	size_t length, int cansleep, int flags,
-	ddi_device_acc_attr_t *accattrp, caddr_t *kaddrp,
-	size_t *real_length, ddi_acc_hdl_t *ap)
+    size_t length, int cansleep, int flags,
+    ddi_device_acc_attr_t *accattrp, caddr_t *kaddrp,
+    size_t *real_length, ddi_acc_hdl_t *ap)
 {
 	caddr_t a;
 	int iomin;
@@ -2272,19 +2702,23 @@ poke_mem(peekpoke_ctlops_t *in_args)
 	if (!on_trap(&otd, OT_DATA_ACCESS)) {
 		switch (in_args->size) {
 		case sizeof (uint8_t):
-			*(uint8_t *)(in_args->dev_addr) = *(uint8_t *)in_args->host_addr;
+			*(uint8_t *)(in_args->dev_addr) =
+			    *(uint8_t *)in_args->host_addr;
 			break;
 
 		case sizeof (uint16_t):
-			*(uint16_t *)(in_args->dev_addr) = *(uint16_t *)in_args->host_addr;
+			*(uint16_t *)(in_args->dev_addr) =
+			    *(uint16_t *)in_args->host_addr;
 			break;
 
 		case sizeof (uint32_t):
-			*(uint32_t *)(in_args->dev_addr) = *(uint32_t *)in_args->host_addr;
+			*(uint32_t *)(in_args->dev_addr) =
+			    *(uint32_t *)in_args->host_addr;
 			break;
 
 		case sizeof (uint64_t):
-			*(uint64_t *)(in_args->dev_addr) = *(uint64_t *)in_args->host_addr;
+			*(uint64_t *)(in_args->dev_addr) =
+			    *(uint64_t *)in_args->host_addr;
 			break;
 
 		default:
@@ -2309,19 +2743,23 @@ peek_mem(peekpoke_ctlops_t *in_args)
 	if (!on_trap(&otd, OT_DATA_ACCESS)) {
 		switch (in_args->size) {
 		case sizeof (uint8_t):
-			*(uint8_t *)in_args->host_addr = *(uint8_t *)in_args->dev_addr;
+			*(uint8_t *)in_args->host_addr =
+			    *(uint8_t *)in_args->dev_addr;
 			break;
 
 		case sizeof (uint16_t):
-			*(uint16_t *)in_args->host_addr = *(uint16_t *)in_args->dev_addr;
+			*(uint16_t *)in_args->host_addr =
+			    *(uint16_t *)in_args->dev_addr;
 			break;
 
 		case sizeof (uint32_t):
-			*(uint32_t *)in_args->host_addr = *(uint32_t *)in_args->dev_addr;
+			*(uint32_t *)in_args->host_addr =
+			    *(uint32_t *)in_args->dev_addr;
 			break;
 
 		case sizeof (uint64_t):
-			*(uint64_t *)in_args->host_addr = *(uint64_t *)in_args->dev_addr;
+			*(uint64_t *)in_args->host_addr =
+			    *(uint64_t *)in_args->dev_addr;
 			break;
 
 		default:
@@ -2379,8 +2817,8 @@ print_dip(dev_info_t *dip, void *arg)
 {
 	char *model_str;
 	prom_printf("%s: dip=%p\n", __FUNCTION__, dip);
-	if (ddi_prop_lookup_string(DDI_DEV_T_ANY, dip, 0,
-		    "name", &model_str) != DDI_SUCCESS)
+	if (ddi_prop_lookup_string(
+	    DDI_DEV_T_ANY, dip, 0, "name", &model_str) != DDI_SUCCESS)
 		return (DDI_WALK_CONTINUE);
 	prom_printf("%s: name=%s\n", __FUNCTION__, model_str);
 	ddi_prop_free(model_str);

--- a/usr/src/uts/armv8/sys/boot_console.h
+++ b/usr/src/uts/armv8/sys/boot_console.h
@@ -1,0 +1,54 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright (c) 2012 Gary Mills
+ * Copyright 2020 Joyent, Inc.
+ *
+ * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
+ * Use is subject to license terms.
+ */
+
+/*
+ * XXXARM: boot_console is not yet implemented for aarch64, and contains
+ * only the functions needed to support fakebop.
+ */
+
+#ifndef _BOOT_CONSOLE_H
+#define	_BOOT_CONSOLE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <sys/bootinfo.h>
+
+/* Read property from command line or environment. */
+extern const char *find_boot_prop(const char *);
+
+extern void bcons_init(struct xboot_info *);
+
+extern void bcons_post_bootenvrc(char *, char *, char *);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _BOOT_CONSOLE_H */

--- a/usr/src/uts/common/krtld/bootrd.c
+++ b/usr/src/uts/common/krtld/bootrd.c
@@ -175,12 +175,6 @@ kobj_boot_mountroot()
 		return (-1);
 	}
 
-	/* XXXARM: Why do this, and not just not swap it in the first place? */
-#if defined(__aarch64__)
-	rd_start = ntohll(rd_start);
-	rd_end = ntohll(rd_end);
-#endif
-
 #ifdef KOBJ_DEBUG
 	_kobj_printf(ops,
 	    "ramdisk range: 0x%llx-%llx\n", rd_start, rd_end);


### PR DESCRIPTION
To make the startup code reusable between devicetree and ACPI we need to reduce our dependency on FDT for communicating boot properties between inteboot (or any loader shim) and the kernel boot code.

Use a combination of xboot_info and boot modules to disentangle this part of the codebase.

Since the illumos FDT integration requires a phandle for all nodes, and libfdt only insists on phandle for referenced nodes, have the `inetboot` shims tweak the FDT before passing it through to illumos.

Also have the `inetboot` shims ensure that well known pseudo-nodes exist before starting `unix`.

While I'm here, make all files touched pbchk clean.

This diff introduces a few new XXXARM blocks, which are in place to track places we need to adjust to get parity with i86pc.

Tested on both Qemu and Pi4 - Pi4 boot log and prtconf in https://gist.github.com/r1mikey/82e558bb3da5e57cdd492648e7bbcd58 (lightly edited to clean up some bootrd logspew so that it's small enough for a gist).