### PR TITLE
aarch64: Use the virtual counter in the virt bootloader

### DIFF
--- a/usr/src/psm/stand/boot/aarch64/virt/machdep.c
+++ b/usr/src/psm/stand/boot/aarch64/virt/machdep.c
@@ -474,7 +474,7 @@ init_machdev(void)
 	    prom_rootnode(), "compatible", compatible + strlen(str) + 1);
 	prom_setprop(prom_rootnode(), "compatible", compatible, namelen);
 
-	init_arch_timer(TMR_PHYS);
+	init_arch_timer(TMR_VIRT);
 	init_virtnet();
 	init_virtblk();
 }


### PR DESCRIPTION
I hadn't actually updated the `inetboot.bin` file that I've been using to test aarch64 illumos on a Macbook M2 since July!

I updated it today after the boot property change, and started seeing very early crashes. I traced these to:

```
dump_exception
pc  = 00000000400bec54
esr = 0000000002000000
far = 0000000000000000
x0 = ffffffffffffffff

Dump of assembler code for function write_cntp_cval:
   0x00000000400bec54 <+0>:	msr	cntp_cval_el0, x0
   0x00000000400bec58 <+4>:	isb
   0x00000000400bec5c <+8>:	ret
```

We're trying to use the physical counter. The change that introduced this is quite old - 362ddb68db741830659e72691f6023625cb7be16 and contained this comment:

> For now the bootloader is fixed to the physical counter regardless
> of EL (this mirrors behavior seen in other bootloaders like u-boot).

However, this definitely appears to upset qemu+hvf, as you might imagine.

With this change I can boot again with HVF, and I also tested with TCG on the same Mac.