### PR TITLE
aarch64: smatch fixes

### DIFF
--- a/usr/src/cmd/mdb/aarch64/kmdb/kaif.c
+++ b/usr/src/cmd/mdb/aarch64/kmdb/kaif.c
@@ -415,7 +415,7 @@ kaif_wapt_match(kmdb_wapt_t *wp)
 
 	ASSERT(BT_TEST(&kaif_waptmap, hwid));
 
-	kmdb_dpi_get_register("far", &far);
+	(void) kmdb_dpi_get_register("far", &far);
 
 	for (i = 0; i < kmdb_kdi_num_wapts(); i++) {
 		kdi_waptreg_t kw;
@@ -440,14 +440,14 @@ kaif_step(void)
 	 * set single-step, disable interrupts, and clear PSTATE.D when we
 	 * resume.
 	 */
-	kmdb_dpi_get_register("spsr", &spsr);
-	kmdb_dpi_set_register("spsr", (spsr | PSR_SS | PSR_I) & ~PSR_D);
+	(void) kmdb_dpi_get_register("spsr", &spsr);
+	(void) kmdb_dpi_set_register("spsr", (spsr | PSR_SS | PSR_I) & ~PSR_D);
 	write_mdscr_el1(read_mdscr_el1() | MDSCR_SS);
 
 	kmdb_dpi_resume_master(); /* Run the next instruction and come back */
 
 	/* restore the single step setting and mask settings */
-	kmdb_dpi_set_register("spsr", spsr);
+	(void) kmdb_dpi_set_register("spsr", spsr);
 	write_mdscr_el1(read_mdscr_el1() & ~MDSCR_SS);
 
 	return (0);

--- a/usr/src/cmd/mdb/aarch64/kmdb/kvm_isadep.c
+++ b/usr/src/cmd/mdb/aarch64/kmdb/kvm_isadep.c
@@ -173,7 +173,7 @@ aarch64_el_name(uint_t el)
 		[PSR_M_EL0t] = "0t"
 	};
 
-	if ((el > ARRAY_SIZE(elnames)) || elnames[el] == NULL)
+	if ((el >= ARRAY_SIZE(elnames)) || elnames[el] == NULL)
 		return ("unknown");
 
 	return (elnames[el]);

--- a/usr/src/cmd/ps/Makefile
+++ b/usr/src/cmd/ps/Makefile
@@ -69,6 +69,8 @@ $(DCFILE): $(PROG).c
 	$(SED) -e '/^domain/d' messages.po > $@
 	$(RM) messages.po
 
+SMOFF += indenting
+
 include ../Makefile.targ
 
 FRC:


### PR DESCRIPTION
This is everything needed to get a clean smatch build of aarch64 on aarch64.