### PR TITLE
aarch64: Add more AdvSIMD opcodes to the disassembler

### DIFF
--- a/usr/src/lib/libdisasm/Makefile.com
+++ b/usr/src/lib/libdisasm/Makefile.com
@@ -47,22 +47,11 @@ COMDIR=		$(SRC)/lib/libdisasm/common
 #
 # Architecture-independent files
 #
-SRCS_common=		$(COMDIR)/libdisasm.c
-OBJECTS_common=		libdisasm.o
+OBJECTS_common=		libdisasm.o bitext.o
 
 #
 # Architecture-dependent disassembly files
 #
-SRCS_i386=		$(COMDIR)/dis_i386.c \
-			$(SRC)/common/dis/i386/dis_tables.c
-SRCS_sparc=		$(COMDIR)/dis_sparc.c \
-			$(COMDIR)/dis_sparc_fmt.c \
-			$(COMDIR)/dis_sparc_instr.c
-SRCS_s390x=		$(COMDIR)/dis_s390x.c
-SRCS_riscv=		$(COMDIR)/dis_riscv.c
-SRCS_arm=		$(COMDIR)/dis_arm_32.c \
-			$(COMDIR)/dis_arm_64.c
-
 OBJECTS_i386=		dis_i386.o \
 			dis_tables.o
 OBJECTS_sparc=		dis_sparc.o \
@@ -90,17 +79,6 @@ OBJECTS_standalone=	$(OBJECTS_common) \
 OBJECTS=		$(OBJECTS_$(CURTYPE))
 
 include $(SRC)/lib/Makefile.lib
-
-SRCS_library=		$(SRCS_common) \
-			$(SRCS_i386) \
-			$(SRCS_sparc) \
-			$(SRCS_s390x) \
-			$(SRCS_riscv) \
-			$(SRCS_arm) \
-			$(SRCS_aarch64) \
-SRCS_standalone=	$(SRCS_common) \
-			$(SRCS_$(MACH))
-SRCS=			$(SRCS_$(CURTYPE))
 
 #
 # Used to verify that the standalone doesn't have any unexpected external

--- a/usr/src/lib/libdisasm/Makefile.targ
+++ b/usr/src/lib/libdisasm/Makefile.targ
@@ -82,3 +82,7 @@ objs/%.o pics/%.o: $(COMDIR)/%.c
 objs/%.o pics/%.o: $(SRC)/common/dis/i386/%.c
 	$(COMPILE.c) -o $@ $<
 	$(POST_PROCESS_O)
+
+objs/%.o pics/%.o: $(SRC)/common/bitext/%.c
+	$(COMPILE.c) -o $@ $<
+	$(POST_PROCESS_O)


### PR DESCRIPTION
This updates them arm64 libdisasm module to support all of the remaining
opcodes from section 3.6 (Data processing - SIMD and floating point) of the
ARMv8 Architecture Reference Manual version A.a dated September 2013. This is
the latest version I could find that uses the same section numbering as
everything else already in that file, even version A.k has begun to renumber
things. I have clarified the reference in the file header but I am not going
through and renumbering things at this stage. The numbers are extremely useful
for cross reference with the spec so I have continued to use them around the
new code and tables.

With this change, I disassembled everything in `/usr/lib` and almost all of the
'invalid opcode' lines are gone - there are just a small number left in
libgcc_s.so, which are for SVE instructions and those from newer specs, and
aren't part of this change.

I've compared the output of this updated disassembler with the output of GNU
`objdump --disassemble` for several objects in /usr/lib and /usr/bin, and the
output is consistent between the two, so I have at least got most of this
right. I'm sure I've mishandled one opcode or another somewhere, we should add
a testsuite at some point.

I have also fixed some bugs in the existing output. For example, the `adrp`
instruction was mistakenly skipping calculations if the offset was zero, and
didn't properly sign extend negative values. While in there, I've extended the
crude `adrp/adr` handling (that I previously added) so that we get more symbol
references in the output - it previously only handled an `add` that occurred
immediately after the corresponding `adrp`.

For example, here's part of libcrypto.so.3 showing the mishandling of
`adrp x2, #0`, and that we now have a couple of extra labels.

```diff
-    ossl_config_add_ssl_module:      02 00 00 90  adrp x2, 0x0
-    ossl_config_add_ssl_module+0x4:  01 00 00 90  adrp x1, 0x0
-    ossl_config_add_ssl_module+0x8:  42 10 30 91  add x2, x2, #0xc04
-    ossl_config_add_ssl_module+0xc:  21 80 30 91  add x1, x1, #0xc20
+    ossl_config_add_ssl_module:      02 00 00 90  adrp x2, 0x191000
+    ossl_config_add_ssl_module+0x4:  01 00 00 90  adrp x1, 0x191000
+    ossl_config_add_ssl_module+0x8:  42 10 30 91  add x2, x2, #0xc04    <ssl_module_free>
+    ossl_config_add_ssl_module+0xc:  21 80 30 91  add x1, x1, #0xc20    <ssl_module_init>
```

and here's another showing the sign extension problem:

```diff
-    ASN1_mbstring_ncopy+0x1f8:            f6 ff ff f0  adrp x22, 0x100128000
-    ASN1_mbstring_ncopy+0x1fc:            d6 c2 3b 91  add x22, x22, #0xef0
+    ASN1_mbstring_ncopy+0x1f8:            f6 ff ff f0  adrp x22, 0x128000
+    ASN1_mbstring_ncopy+0x1fc:            d6 c2 3b 91  add x22, x22, #0xef0	<cpy_asc>
```

and another extract from libcrypto.so.3 showing a few more instructions being
decoded:
```diff
-    added_obj_hash+0xcc:                                            26 1e b1 4e  *** invalid opcode ***
+    added_obj_hash+0xcc:                                            26 1e b1 4e  mov v6.16b, v17.16b
     added_obj_hash+0xd0:                                            02 04 c1 3c  ldr q2, [x0], #16
-    added_obj_hash+0xd4:                                            31 86 b6 4e  *** invalid opcode ***
-    added_obj_hash+0xd8:                                            c3 84 b5 4e  *** invalid opcode ***
-    added_obj_hash+0xdc:                                            c0 54 21 4f  *** invalid opcode ***
-    added_obj_hash+0xe0:                                            c1 84 b4 4e  *** invalid opcode ***
-    added_obj_hash+0xe4:                                            44 a4 08 2f  *** invalid opcode ***
-    added_obj_hash+0xe8:                                            77 54 21 4f  *** invalid opcode ***
-    added_obj_hash+0xec:                                            00 84 a6 4e  *** invalid opcode ***
-    added_obj_hash+0xf0:                                            27 54 21 4f  *** invalid opcode ***
-    added_obj_hash+0xf4:                                            c6 84 b3 4e  *** invalid opcode ***
-    added_obj_hash+0xf8:                                            e3 86 a3 4e  *** invalid opcode ***
-    added_obj_hash+0xfc:                                            18 c0 a5 4e  *** invalid opcode ***
-    added_obj_hash+0x100:                                           1a c0 a5 0e  *** invalid opcode ***
-    added_obj_hash+0x104:                                           e7 84 a1 4e  *** invalid opcode ***
-    added_obj_hash+0x108:                                           79 c0 a5 0e  *** invalid opcode ***
-    added_obj_hash+0x10c:                                           61 c0 a5 4e  *** invalid opcode ***
-    added_obj_hash+0x110:                                           5a 5b 98 4e  uzp2 v26.4s, v26.4s, v24.4s
-    added_obj_hash+0x114:                                           97 a4 10 2f  *** invalid opcode ***
-    added_obj_hash+0x118:                                           f8 c0 a5 0e  *** invalid opcode ***
-    added_obj_hash+0x11c:                                           39 5b 81 4e  uzp2 v25.4s, v25.4s, v1.4s
-    added_obj_hash+0x120:                                           5a 07 3e 4f  *** invalid opcode ***
-    added_obj_hash+0x124:                                           fb c0 a5 4e  *** invalid opcode ***
-    added_obj_hash+0x128:                                           c1 54 21 4f  *** invalid opcode ***
-    added_obj_hash+0x12c:                                           39 07 3e 4f  *** invalid opcode ***
-    added_obj_hash+0x130:                                           40 97 b0 6e  *** invalid opcode ***
-    added_obj_hash+0x134:                                           84 a4 10 6f  *** invalid opcode ***
-    added_obj_hash+0x138:                                           26 84 a6 4e  *** invalid opcode ***
+    added_obj_hash+0xd4:                                            31 86 b6 4e  add v17.4s, v17.4s, v22.4s
+    added_obj_hash+0xd8:                                            c3 84 b5 4e  add v3.4s, v6.4s, v21.4s
+    added_obj_hash+0xdc:                                            c0 54 21 4f  shl v0.4s, v6.4s, #1
+    added_obj_hash+0xe0:                                            c1 84 b4 4e  add v1.4s, v6.4s, v20.4s
+    added_obj_hash+0xe4:                                            44 a4 08 2f  ushll v4.8h, v2.8b, #0
+    added_obj_hash+0xe8:                                            77 54 21 4f  shl v23.4s, v3.4s, #1
+    added_obj_hash+0xec:                                            00 84 a6 4e  add v0.4s, v0.4s, v6.4s
+    added_obj_hash+0xf0:                                            27 54 21 4f  shl v7.4s, v1.4s, #1
+    added_obj_hash+0xf4:                                            c6 84 b3 4e  add v6.4s, v6.4s, v19.4s
+    added_obj_hash+0xf8:                                            e3 86 a3 4e  add v3.4s, v23.4s, v3.4s
+    added_obj_hash+0xfc:                                            18 c0 a5 4e  smull2 v24.2d, v0.4s, v5.4s
+    added_obj_hash+0x100:                                           1a c0 a5 0e  smull v26.2d, v0.2s, v5.2s
+    added_obj_hash+0x104:                                           e7 84 a1 4e  add v7.4s, v7.4s, v1.4s
+    added_obj_hash+0x108:                                           79 c0 a5 0e  smull v25.2d, v3.2s, v5.2s
+    added_obj_hash+0x10c:                                           61 c0 a5 4e  smull2 v1.2d, v3.4s, v5.4s
+    added_obj_hash+0x110:                                           5a 5b 98 4e  uzp2 v26.4s, v26.4s, v24.4s
+    added_obj_hash+0x114:                                           97 a4 10 2f  ushll v23.4s, v4.4h, #0
+    added_obj_hash+0x118:                                           f8 c0 a5 0e  smull v24.2d, v7.2s, v5.2s
+    added_obj_hash+0x11c:                                           39 5b 81 4e  uzp2 v25.4s, v25.4s, v1.4s
+    added_obj_hash+0x120:                                           5a 07 3e 4f  sshr v26.4s, v26.4s, #2
+    added_obj_hash+0x124:                                           fb c0 a5 4e  smull2 v27.2d, v7.4s, v5.4s
+    added_obj_hash+0x128:                                           c1 54 21 4f  shl v1.4s, v6.4s, #1
+    added_obj_hash+0x12c:                                           39 07 3e 4f  sshr v25.4s, v25.4s, #2
+    added_obj_hash+0x130:                                           40 97 b0 6e  mls v0.4s, v26.4s, v16.4s
+    added_obj_hash+0x134:                                           84 a4 10 6f  ushll2 v4.4s, v4.8h, #0
+    added_obj_hash+0x138:                                           26 84 a6 4e  add v6.4s, v1.4s, v6.4s
```
