### PR TITLE
aarch64: do not zero the addend for R_AARCH64_RELATIVE relocations

### DIFF
--- a/usr/src/cmd/sgs/libld/common/machrel.aarch64.c
+++ b/usr/src/cmd/sgs/libld/common/machrel.aarch64.c
@@ -333,13 +333,6 @@ ld_perform_outreloc(Rel_desc *orsp, Ofl_desc *ofl, Boolean *remain_seen)
 	value = sdp->sd_sym->st_value;
 
 	if (orsp->rel_flags & FLG_REL_GOT) {
-		/*
-		 * Note: for GOT relative relocations on AArch64
-		 *	 we discard the addend.  It was relevant
-		 *	 to the reference - not to the data item
-		 *	 being referenced (ie: that -4 thing).
-		 */
-		raddend = 0;
 		osp = ofl->ofl_osgot;
 		roffset = ld_calc_got_offset(orsp, ofl);
 	} else if (orsp->rel_flags & FLG_REL_PLT) {


### PR DESCRIPTION
This appears to be a mistake, the `addend` is required for the output
entry in order to find the data being sought.

Zeroing this out caused some hand-rolled aarch64 assembly code in
libgmp to use the wrong address for its data table, resulting in
a range of issues, including that gcc would not properly compile
C code containing float immediates.

In fact, it appears to have only been libgmp that was affected amongst the
libraries on my test machine.

```
root@braich:~# for l in /lib/*.so /usr/lib/*.so; do
    elfdump -r $l | awk '$1=="R_AARCH64_RELATIVE" && $3==0 {print; exit 1}' || echo $l
done
  R_AARCH64_RELATIVE                  0x79a70                  0  .SUNW_reloc
/usr/lib/libgmp.so
```

With this patch applied to libld.so, the `addend` field is preserved, and
the `libgmp` testsuite passes successfully.

```
Relocation Section:  .SUNW_reloc
    type                               offset             addend  section        symbol
   R_AARCH64_RELATIVE                  0x79a70            0x68950  .SUNW_reloc
```

A wsdiff with this applied contains only:

```
# This file was produced by wsdiff
# 2024-05-07 at 11:41:00
Old proto area: /root/illumos-gate/proto.old/root_aarch64/
New proto area: /root/illumos-gate/proto/root_aarch64/
Results file: wsdiff.out

lib/libld.so.4
NOTE: ELF .text difference detected.

@@ -147,7 +147,7 @@
     do32_reloc_ld_sparc+0x124: c0 04 00 54  b.eq 0x1e780       <do32_reloc_ld_sparc+0x1bc>
     do32_reloc_ld_sparc+0x128: 3b 00 00 14  b 0x1e7d8  <do32_reloc_ld_sparc+0x214>
     do32_reloc_ld_sparc+0x12c: 00 e9 8f 52  mov w0, #0x7f48
-    do32_reloc_ld_sparc+0x130: 3e 3e 00 94  bl 0x2dfec <_libld_msg>
+    do32_reloc_ld_sparc+0x130: 3d 3e 00 94  bl 0x2dfe8 <_libld_msg>
     do32_reloc_ld_sparc+0x134: f3 03 00 aa  mov x19, x0
     do32_reloc_ld_sparc+0x138: e0 03 15 aa  mov x0, x21
     do32_reloc_ld_sparc+0x13c: e0 02 3f d6  blr x23
@@ -154,7 +154,7 @@
     do32_reloc_ld_sparc+0x140: a0 01 00 b4  cbz x0, 0x1e738    <do32_reloc_ld_sparc+0x174>
     do32_reloc_ld_sparc+0x144: e0 03 15 aa  mov x0, x21
     do32_reloc_ld_sparc+0x148: e0 02 3f d6  blr x23
-    do32_reloc_ld_sparc+0x14c: 41 3e 00 94  bl 0x2e014 <demangle>
+    do32_reloc_ld_sparc+0x14c: 40 3e 00 94  bl 0x2e010 <demangle>
     do32_reloc_ld_sparc+0x150: e4 03 00 aa  mov x4, x0
     do32_reloc_ld_sparc+0x154: e5 03 16 2a  mov w5, w22
     do32_reloc_ld_sparc+0x158: e3 03 18 aa  mov x3, x24
@@ -165,7 +165,7 @@
     do32_reloc_ld_sparc+0x16c: fa 03 14 2a  mov w26, w20
     do32_reloc_ld_sparc+0x170: fb 00 00 14  b 0x1eb20  <do32_reloc_ld_sparc+0x55c>
     do32_reloc_ld_sparc+0x174: 60 3a 88 52  mov w0, #0x41d3
-    do32_reloc_ld_sparc+0x178: 2c 3e 00 94  bl 0x2dfec <_libld_msg>
+    do32_reloc_ld_sparc+0x178: 2b 3e 00 94  bl 0x2dfe8 <_libld_msg>
     do32_reloc_ld_sparc+0x17c: e4 03 00 aa  mov x4, x0
     do32_reloc_ld_sparc+0x180: f5 ff ff 17  b 0x1e718  <do32_reloc_ld_sparc+0x154>
     do32_reloc_ld_sparc+0x184: 81 00 80 52  mov w1, #0x4
@@ -205,12 +205,12 @@
     do32_reloc_ld_sparc+0x20c: 7f 06 40 f2  tst x19, #0x3
     do32_reloc_ld_sparc+0x210: 60 fd ff 54  b.eq 0x1e780       <do32_reloc_ld_sparc+0x1bc>
     do32_reloc_ld_sparc+0x214: 20 57 83 52  mov w0, #0x1ab9
-    do32_reloc_ld_sparc+0x218: 04 3e 00 94  bl 0x2dfec <_libld_msg>
+    do32_reloc_ld_sparc+0x218: 03 3e 00 94  bl 0x2dfe8 <_libld_msg>
     do32_reloc_ld_sparc+0x21c: f4 03 00 aa  mov x20, x0
     do32_reloc_ld_sparc+0x220: 02 00 80 52  mov w2, #0x0
     do32_reloc_ld_sparc+0x224: e1 03 16 2a  mov w1, w22
     do32_reloc_ld_sparc+0x228: 00 05 80 52  mov w0, #0x28
-    do32_reloc_ld_sparc+0x22c: 0e 09 02 94  bl 0xa0c28 <conv_reloc_type_static>
+    do32_reloc_ld_sparc+0x22c: 0d 09 02 94  bl 0xa0c24 <conv_reloc_type_static>
     do32_reloc_ld_sparc+0x230: f6 03 00 aa  mov x22, x0
     do32_reloc_ld_sparc+0x234: e0 03 15 aa  mov x0, x21
     do32_reloc_ld_sparc+0x238: e0 02 3f d6  blr x23
@@ -217,7 +217,7 @@
     do32_reloc_ld_sparc+0x23c: a0 01 00 b4  cbz x0, 0x1e834    <do32_reloc_ld_sparc+0x270>
     do32_reloc_ld_sparc+0x240: e0 03 15 aa  mov x0, x21
     do32_reloc_ld_sparc+0x244: e0 02 3f d6  blr x23
-    do32_reloc_ld_sparc+0x248: 02 3e 00 94  bl 0x2e014 <demangle>
+    do32_reloc_ld_sparc+0x248: 01 3e 00 94  bl 0x2e010 <demangle>
     do32_reloc_ld_sparc+0x24c: e5 03 00 aa  mov x5, x0
     do32_reloc_ld_sparc+0x250: e6 03 13 aa  mov x6, x19
     do32_reloc_ld_sparc+0x254: e4 03 18 aa  mov x4, x24
@@ -228,7 +228,7 @@
     do32_reloc_ld_sparc+0x268: f1 f8 ff 97  bl 0x1cbf0
     do32_reloc_ld_sparc+0x26c: bc 00 00 14  b 0x1eb20  <do32_reloc_ld_sparc+0x55c>
     do32_reloc_ld_sparc+0x270: 60 3a 88 52  mov w0, #0x41d3
-    do32_reloc_ld_sparc+0x274: ed 3d 00 94  bl 0x2dfec <_libld_msg>
+    do32_reloc_ld_sparc+0x274: ec 3d 00 94  bl 0x2dfe8 <_libld_msg>
     do32_reloc_ld_sparc+0x278: e5 03 00 aa  mov x5, x0
     do32_reloc_ld_sparc+0x27c: f5 ff ff 17  b 0x1e814  <do32_reloc_ld_sparc+0x250>
     do32_reloc_ld_sparc+0x280: c8 00 00 54  b.hi 0x1e85c       <do32_reloc_ld_sparc+0x298>
@@ -238,12 +238,12 @@
     do32_reloc_ld_sparc+0x290: 3f 00 03 ea  tst x1, x3
     do32_reloc_ld_sparc+0x294: 41 f9 ff 54  b.ne 0x1e780       <do32_reloc_ld_sparc+0x1bc>
     do32_reloc_ld_sparc+0x298: 20 f2 8f 52  mov w0, #0x7f91
-    do32_reloc_ld_sparc+0x29c: e3 3d 00 94  bl 0x2dfec <_libld_msg>
+    do32_reloc_ld_sparc+0x29c: e2 3d 00 94  bl 0x2dfe8 <_libld_msg>
     do32_reloc_ld_sparc+0x2a0: f3 03 00 aa  mov x19, x0
     do32
... truncated due to length: use -v to override ...


etc/versions/build
NOTE: ASCII difference detected.

@@ -1,1 +1,1 @@
-heads/arm64-gate-0-g7ec80d894a
+heads/arm64-gate-0-g7ec80d894a-dirty


platform/RaspberryPi,4/inetboot
NOTE: ASCII difference detected.

@@ -1,5 +1,5 @@
-0000000   ' 005 031   V 353   C 357  \f   f   : 003 351  \0  \n   ' 020
-        56190527 0cef43eb e9033a66 10270a00
+0000000   ' 005 031   V 351 347   - 331   f   : 020   b  \0  \n   ' 020
+        56190527 d92de7e9 62103a66 10270a00
 0000020  \0  \b  \0  \0  \0  \b  \0  \0   '   6 247 273 005 026 002  \0
         00000800 00000800 bba73627 00021605
 0000040   i   l   l   u   m   o   s  \0  \0  \0  \0  \0  \0  \0  \0  \0


platform/Amlogic,meson-gxbb/inetboot
NOTE: ASCII difference detected.

@@ -1,5 +1,5 @@
-0000000   ' 005 031   V 200   8 365   J   f   : 003 347  \0  \n   <   X
-        56190527 4af53880 e7033a66 583c0a00
+0000000   ' 005 031   V 342 250   ~   P   f   : 020   `  \0  \n   <   X
+        56190527 507ea8e2 60103a66 583c0a00
 0000020 021  \0  \0  \0 021  \0  \0  \0 313   = 363 277 005 026 002  \0
         00000011 00000011 bff33dcb 00021605
 0000040   i   l   l   u   m   o   s  \0  \0  \0  \0  \0  \0  \0  \0  \0
```
