### PR TITLE
locore: don't mess with CPUECTLR_EL1 except on Cortex-A53,-A57,-A72

### DIFF
--- a/usr/src/psm/stand/boot/aarch64/common/srt0.S
+++ b/usr/src/psm/stand/boot/aarch64/common/srt0.S
@@ -102,22 +102,22 @@ el2:
 
 	mrs	x0, midr_el1
 	mov	w0, w0
-	lsr	w1, w0, #24
-	cmp	w1, #0x41
+	lsr	w1, w0, #24	// Implementor
+	cmp	w1, #0x41	// ARM
 	b.ne	not_cortex_0
-	lsl	w1, w0, #(32 - (16 + 4))
-	lsr	w1, w1, #((32 - (16 + 4)) + 16)
+	ubfx	w1, w0, #16, #4	// Architecture
 	cmp	w1, #0xF
 	b.ne	not_cortex_0
-	lsl	w1, w0, #(32 - (4 + 12))
-	lsr	w1, w1, #((32 - (4 + 12)) + 4)
-	ldr	w2, =0xD07
-	cmp	w1, w2
+	ubfx	w1, w0, #4, #12	// Part
+	cmp	w1, #0xD08	// -A72
+	b.eq	cortex_a72_0
+	cmp	w1, #0xD07	// -A57
 	b.eq	cortex_a57_0
-	ldr	w2, =0xD03
-	cmp	w1, w2
+				// *not* -A55
+	cmp	w1, #0xD03	// -A53
 	b.eq	cortex_a53_0
 	b	not_cortex_0
+cortex_a72_0:
 cortex_a57_0:
 cortex_a53_0:
 	// access L2ACTLR L2ECTLR L2CTLR CPUECTLR CPUACTLR
@@ -147,29 +147,31 @@ el1:
 	dsb	sy
 	isb
 
-	// enable smp
+	// enable cache coherence on Cortex-A5x
 	mrs	x0, midr_el1
 	mov	w0, w0
-	lsr	w1, w0, #24
-	cmp	w1, #0x41
+	lsr	w1, w0, #24	// Implementor
+	cmp	w1, #0x41	// ARM Inc.
 	b.ne	not_cortex_1
-	lsl	w1, w0, #(32 - (16 + 4))
-	lsr	w1, w1, #((32 - (16 + 4)) + 16)
+	ubfx	w1, w0, #16, #4	// Architecture
 	cmp	w1, #0xF
 	b.ne	not_cortex_1
-	lsl	w1, w0, #(32 - (4 + 12))
-	lsr	w1, w1, #((32 - (4 + 12)) + 4)
-	ldr	w2, =0xD07
-	cmp	w1, w2
+	ubfx	w1, w0, #4, #12	// Part
+	// XXXARM: The -A72 TRM is wishy washy about whether this is
+	// necessary, but it is _possible_.
+	cmp	w1, #0xD08	// Cortex-A72
+	b.eq	cortex_a72_1
+	cmp	w1, #0xD07	// Cortex-A57
 	b.eq	cortex_a57_1
-	ldr	w2, =0xD03
-	cmp	w1, w2
+	// NB: Explicitly _not_ A55
+	cmp	w1, #0xD03	// Cortex-A53
 	b.eq	cortex_a53_1
 	b	not_cortex_1
+
+cortex_a72_1:
 cortex_a57_1:
 cortex_a53_1:
-
-	// cpuectlr SMPEN -> 0
+	// CPUECTLR_EL1.SMPEN -> 1 (enable cache coherence)
 	mrs	x0, s3_1_c15_c2_1
 	tbnz	x0, #6, not_cortex_1
 	orr	x0, x0, #(1<<6)
@@ -422,4 +424,3 @@ from_current_el_sync_handle:
 	bl	dump_exception
 0:	b	0b
 	SET_SIZE(exception_vector)
-

--- a/usr/src/uts/aarch64/asm/controlregs.h
+++ b/usr/src/uts/aarch64/asm/controlregs.h
@@ -643,20 +643,6 @@ write_cpuactlr_el1(uint64_t reg)
 }
 
 static __inline__ uint64_t
-read_cpuectlr_el1(void)
-{
-	uint64_t reg;
-	__asm__ __volatile__("mrs %0, s3_1_c15_c2_1":"=r"(reg)::"memory");
-	return (reg);
-}
-
-static __inline__ void
-write_cpuectlr_el1(uint64_t reg)
-{
-	__asm__ __volatile__("msr s3_1_c15_c2_1, %0"::"r"(reg):"memory");
-}
-
-static __inline__ uint64_t
 read_l2actlr_el1(void)
 {
 	uint64_t reg;

--- a/usr/src/uts/armv8/ml/genassym.cf
+++ b/usr/src/uts/armv8/ml/genassym.cf
@@ -21,6 +21,7 @@ include <sys/privregs.h>
 include <sys/kdi_machimpl.h>
 include <sys/kdi_regs.h>
 include <sys/kdi_svc.h>
+include <sys/cpuid.h>
 
 include <asm/controlregs.h>
 
@@ -181,6 +182,11 @@ define	LOCK_LEVEL		LOCK_LEVEL
 define	MMU_PAGESHIFT	MMU_PAGESHIFT
 define	DEFAULTSTKSZ	DEFAULTSTKSZ
 define	MMU_PAGESIZE	MMU_PAGESIZE
+
+define	MIDR_IMPL_ARM			MIDR_IMPL_ARM
+define	MIDR_PART_ARM_CORTEX_A53	MIDR_PART_ARM_CORTEX_A53
+define	MIDR_PART_ARM_CORTEX_A57	MIDR_PART_ARM_CORTEX_A57
+define	MIDR_PART_ARM_CORTEX_A72	MIDR_PART_ARM_CORTEX_A72
 
 define	TIMESPEC_SIZE	sizeof(timespec_t)
 define	TV_SEC		offsetof(timespec_t, tv_sec)

--- a/usr/src/uts/armv8/ml/locore.S
+++ b/usr/src/uts/armv8/ml/locore.S
@@ -58,25 +58,40 @@ t0:
 
 	SET_SIZE(_start)
 
-	.text
 	.balign 4096
-	.globl secondary_vec_start
-secondary_vec_start:
-	// disable smp
+	ENTRY(secondary_vec_start)
+	// enable SMP cache affinity
 	mrs	x0, midr_el1
 	mov	w0, w0
-	lsr	w1, w0, #24
-	cmp	w1, #0x41
-	b.ne	.Lnot_arm_core
+	lsr	w1, w0, #24	// Implementator
+	cmp	w1, #MIDR_IMPL_ARM
+	b.ne	not_cortex_1
+	ubfx	w1, w0, #16, #4	// Architecture
+	cmp	w1, #0xF
+	b.ne	not_cortex_1
+	ubfx	w1, w0, #4, #12	// Part
+	// XXXARM: The -A72 TRM is wishy washy about whether this is
+	// necessary, but it is _possible_.
+	cmp	w1, #MIDR_PART_ARM_CORTEX_A72
+	b.eq	cortex_a72_1
+	cmp	w1, #MIDR_PART_ARM_CORTEX_A57
+	b.eq	cortex_a57_1
+	// NB: Explicitly _not_ A55
+	cmp	w1, #MIDR_PART_ARM_CORTEX_A53
+	b.eq	cortex_a53_1
+	b	not_cortex_1
 
-	// cpuectlr SMPEN -> 1
+cortex_a72_1:
+cortex_a57_1:
+cortex_a53_1:
+	// CPUECTLR_EL1.SMPEN -> 1
 	mrs	x0, s3_1_c15_c2_1
-	tbnz	x0, #6, .Lnot_arm_core
-	orr	x1, x0, #(1 << 6)
+	tbnz	x0, #6, not_cortex_1
+	orr	x0, x0, #(1<<6)
 	msr	s3_1_c15_c2_1, x0
+	dsb	sy
 	isb
-
-.Lnot_arm_core:
+not_cortex_1:
 	// invalidate cache (data/inst)
 	bl	dcache_invalidate_all
 	ic	iallu
@@ -230,6 +245,5 @@ dcache_invalidate_all:
 
 	.globl secondary_vec_end
 secondary_vec_end:
-
 	.balign 4096
-	.size	secondary_vec_start, [.-secondary_vec_start]
+SET_SIZE(secondary_vec_start)


### PR DESCRIPTION
This should follow all the CPU manuals as to what we need to do (and not do) here, and do so tightly enough that qemu is happy with us now where it wasn't before.

@citrus-it @hadfl can you see how this goes on raspberry pi, and hvf?  It should be fine and/or invisibly better, I hope?  (it probably won't help showing your native CPU through qemu under hvf though, until we support the larger address space).