### PR TITLE
libm: expose __logl 'private' symbol which is consumed by LLVM

### DIFF
--- a/usr/src/contrib/msun/src/e_log.c
+++ b/usr/src/contrib/msun/src/e_log.c
@@ -145,3 +145,4 @@ __ieee754_log(double x)
 #if (LDBL_MANT_DIG == 53)
 __weak_reference(log, logl);
 #endif
+__weak_reference(log, __logl);

--- a/usr/src/lib/libm_aarch64/src/mapfile-vers
+++ b/usr/src/lib/libm_aarch64/src/mapfile-vers
@@ -72,6 +72,9 @@ global:
 	__ldexpl { FLAGS = NODYNSORT };
 	__powl;
 
+	# LLVM consumes this symbol so it needs to stay around
+	__logl;
+
 	acos;
 	acosf;
 	acosh;


### PR DESCRIPTION
LLVM seems to consume this "private" symbol so we should make it public?

```
[3190/3313] Linking CXX executable bin/llvm-profdata
FAILED: bin/llvm-profdata
: && /opt/cross/aarch64/bin/aarch64-unknown-solaris2.11-g++ -ffunction-sections -fdata-sections -fPIC -mno-outline-atomics -mtls-dialect=trad -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden -Werror=date-time -fno-lifetime-dse -w -fdiagnostics-color -ffunction-sections -fdata-sections -O3 -DNDEBUG  tools/llvm-profdata/CMakeFiles/llvm-profdata.dir/llvm-profdata.cpp.o tools/llvm-profdata/CMakeFiles/llvm-profdata.dir/llvm-profdata-driver.cpp.o -o bin/llvm-profdata  -Wl,-R"\$ORIGIN/../lib:"  lib/libLLVMCore.a  lib/libLLVMObject.a  lib/libLLVMProfileData.a  lib/libLLVMSupport.a  lib/libLLVMSymbolize.a  lib/libLLVMDebugInfoPDB.a  lib/libLLVMDebugInfoMSF.a  lib/libLLVMDebugInfoBTF.a  lib/libLLVMDebugInfoDWARF.a  lib/libLLVMObject.a  lib/libLLVMIRReader.a  lib/libLLVMBitReader.a  lib/libLLVMAsmParser.a  lib/libLLVMCore.a  lib/libLLVMRemarks.a  lib/libLLVMBitstreamReader.a  lib/libLLVMMCParser.a  lib/libLLVMMC.a  lib/libLLVMDebugInfoCodeView.a  lib/libLLVMTextAPI.a  lib/libLLVMBinaryFormat.a  lib/libLLVMTargetParser.a  lib/libLLVMSupport.a  lib/libLLVMDemangle.a  -lrt  -ldl  -lm  -lsocket  -lkstat && :
Undefined                       first referenced
 symbol                             in file
__logl                              lib/libLLVMSupport.a(BalancedPartitioning.cpp.o)
```