### PR TITLE
byteswap prom values in the DDI layer

### DIFF
--- a/usr/src/uts/aarch64/os/ddi_arch.c
+++ b/usr/src/uts/aarch64/os/ddi_arch.c
@@ -302,7 +302,8 @@ i_ddi_map_fault(dev_info_t *dip, dev_info_t *rdip,
  * representation, which is big-endian, with no particular alignment
  * guarantees.  intp points to the OBP data, and n the number of bytes.
  *
- * Byte-swapping is needed on intel.
+ * Byte-swapping is needed on ARM, since devicetree is big-endian and the CPU
+ * is not.
  */
 int
 impl_ddi_prop_int_from_prom(uchar_t *intp, int n)
@@ -316,7 +317,7 @@ impl_ddi_prop_int_from_prom(uchar_t *intp, int n)
 		i = (i << 8) | *(--intp);
 	}
 
-	return (i);
+	return (ntohl(i));
 }
 
 

--- a/usr/src/uts/armv8/io/rootnex.c
+++ b/usr/src/uts/armv8/io/rootnex.c
@@ -815,13 +815,13 @@ rootnex_map(dev_info_t *dip, dev_info_t *rdip, ddi_map_req_t *mp, off_t offset,
 
 		for (int i = 0; i < addr_cells; i++) {
 			addr <<= 32;
-			addr |= ntohl(rp[(addr_cells + size_cells) *
-			    rnumber + i]);
+			addr |= rp[(addr_cells + size_cells) *
+			    rnumber + i];
 		}
 		for (int i = 0; i < size_cells; i++) {
 			size <<= 32;
-			size |= ntohl(rp[(addr_cells + size_cells) *
-			    rnumber + addr_cells + i]);
+			size |= rp[(addr_cells + size_cells) *
+			    rnumber + addr_cells + i];
 		}
 
 		ddi_prop_free(rp);
@@ -1189,21 +1189,17 @@ rootnex_intr_ops(dev_info_t *pdip, dev_info_t *rdip, ddi_intr_op_t intr_op,
 			switch (interrupt_cells) {
 			case 1:
 				grp = 0;
-				vec = ntohl((uint32_t)
-				    irupts_prop[interrupt_cells *
-				    hdlp->ih_inum + 0]);
+				vec = irupts_prop[interrupt_cells *
+				    hdlp->ih_inum + 0];
 				cfg = 4;
 				break;
 			case 3:
-				grp = ntohl((uint32_t)
-				    irupts_prop[interrupt_cells *
-				    hdlp->ih_inum + 0]);
-				vec = ntohl((uint32_t)
-				    irupts_prop[interrupt_cells *
-				    hdlp->ih_inum + 1]);
-				cfg = ntohl((uint32_t)irupts_prop[
-				    interrupt_cells *
-				    hdlp->ih_inum + 2]);
+				grp = irupts_prop[interrupt_cells *
+				    hdlp->ih_inum + 0];
+				vec = irupts_prop[interrupt_cells *
+				    hdlp->ih_inum + 1];
+				cfg = irupts_prop[interrupt_cells *
+				    hdlp->ih_inum + 2];
 				break;
 			default:
 				ddi_prop_free(irupts_prop);

--- a/usr/src/uts/armv8/io/rootnex.c
+++ b/usr/src/uts/armv8/io/rootnex.c
@@ -787,7 +787,7 @@ rootnex_map(dev_info_t *dip, dev_info_t *rdip, ddi_map_req_t *mp, off_t offset,
 	}
 
 	if (mp->map_type == DDI_MT_RNUMBER)  {
-		int reglen;
+		uint_t reglen;
 		int rnumber = mp->map_obj.rnumber;
 		uint32_t *rp;
 		int addr_cells = get_address_cells(ddi_get_nodeid(dip));
@@ -796,19 +796,17 @@ rootnex_map(dev_info_t *dip, dev_info_t *rdip, ddi_map_req_t *mp, off_t offset,
 		ASSERT(addr_cells == 1 || addr_cells == 2);
 		ASSERT(size_cells == 1 || size_cells == 2);
 
-		if ((ddi_getlongprop(DDI_DEV_T_ANY, rdip, DDI_PROP_DONTPASS,
-		    "reg", (caddr_t)&rp, &reglen) != DDI_SUCCESS) ||
+		if ((ddi_prop_lookup_int_array(DDI_DEV_T_ANY, rdip, DDI_PROP_DONTPASS,
+		    "reg", (int **)&rp, &reglen) != DDI_SUCCESS) ||
 		    reglen == 0) {
 			return (DDI_ME_RNUMBER_RANGE);
 		}
 
-		int n = reglen / (sizeof (uint32_t) *
-		    (addr_cells + size_cells));
-		ASSERT(reglen % (sizeof (uint32_t) *
-		    (addr_cells + size_cells)) == 0);
+		int n = reglen / addr_cells + size_cells;
+		ASSERT(reglen % (addr_cells + size_cells) == 0);
 
 		if (rnumber < 0 || rnumber >= n) {
-			kmem_free(rp, reglen);
+			ddi_prop_free(rp);
 			return (DDI_ME_RNUMBER_RANGE);
 		}
 
@@ -825,7 +823,9 @@ rootnex_map(dev_info_t *dip, dev_info_t *rdip, ddi_map_req_t *mp, off_t offset,
 			size |= ntohl(rp[(addr_cells + size_cells) *
 			    rnumber + addr_cells + i]);
 		}
-		kmem_free(rp, reglen);
+
+		ddi_prop_free(rp);
+
 		ASSERT((addr & 0xffff000000000000ul) == 0);
 		ASSERT((size & 0xffff000000000000ul) == 0);
 		reg.regspec_bustype = ((addr >> 32) & 0xffff);
@@ -1170,17 +1170,16 @@ rootnex_intr_ops(dev_info_t *pdip, dev_info_t *rdip, ddi_intr_op_t intr_op,
 			}
 
 			int *irupts_prop;
-			int irupts_len;
-			if ((ddi_getlongprop(DDI_DEV_T_ANY, rdip,
+			uint_t irupts_len;
+			if ((ddi_prop_lookup_int_array(DDI_DEV_T_ANY, rdip,
 			    DDI_PROP_DONTPASS, "interrupts",
-			    (caddr_t)&irupts_prop,
+			    &irupts_prop,
 			    &irupts_len) != DDI_SUCCESS) ||
 			    (irupts_len == 0)) {
 				return (DDI_FAILURE);
 			}
-			if (interrupt_cells * hdlp->ih_inum >=
-			    irupts_len * sizeof (int)) {
-				kmem_free(irupts_prop, irupts_len);
+			if ((interrupt_cells * hdlp->ih_inum) >= irupts_len) {
+				ddi_prop_free(irupts_prop);
 				return (DDI_FAILURE);
 			}
 
@@ -1207,10 +1206,10 @@ rootnex_intr_ops(dev_info_t *pdip, dev_info_t *rdip, ddi_intr_op_t intr_op,
 				    hdlp->ih_inum + 2]);
 				break;
 			default:
-				kmem_free(irupts_prop, irupts_len);
+				ddi_prop_free(irupts_prop);
 				return (DDI_FAILURE);
 			}
-			kmem_free(irupts_prop, irupts_len);
+			ddi_prop_free(irupts_prop);
 			switch (grp) {
 			case 1:
 				hdlp->ih_vector = vec + 16;

--- a/usr/src/uts/armv8/io/simple-bus.c
+++ b/usr/src/uts/armv8/io/simple-bus.c
@@ -291,11 +291,11 @@ smpl_bus_map(dev_info_t *dip, dev_info_t *rdip, ddi_map_req_t *mp, off_t offset,
 
 		for (int i = 0; i < addr_cells; i++) {
 			addr <<= 32;
-			addr |= ntohl(rp[(addr_cells + size_cells) * rnumber + i]);
+			addr |= rp[(addr_cells + size_cells) * rnumber + i];
 		}
 		for (int i = 0; i < size_cells; i++) {
 			size <<= 32;
-			size |= ntohl(rp[(addr_cells + size_cells) * rnumber + addr_cells + i]);
+			size |= rp[(addr_cells + size_cells) * rnumber + addr_cells + i];
 		}
 
 		ddi_prop_free(rp);
@@ -502,13 +502,17 @@ smpl_intr_ops(dev_info_t *pdip, dev_info_t *rdip, ddi_intr_op_t intr_op,
 			switch (interrupt_cells) {
 			case 1:
 				grp = 0;
-				vec = ntohl((uint32_t)irupts_prop[interrupt_cells * hdlp->ih_inum + 0]);
+				vec = irupts_prop[interrupt_cells *
+				    hdlp->ih_inum + 0];
 				cfg = 4;
 				break;
 			case 3:
-				grp = ntohl((uint32_t)irupts_prop[interrupt_cells * hdlp->ih_inum + 0]);
-				vec = ntohl((uint32_t)irupts_prop[interrupt_cells * hdlp->ih_inum + 1]);
-				cfg = ntohl((uint32_t)irupts_prop[interrupt_cells * hdlp->ih_inum + 2]);
+				grp = irupts_prop[(interrupt_cells *
+				    hdlp->ih_inum) + 0];
+				vec = irupts_prop[(interrupt_cells *
+				    hdlp->ih_inum) + 1];
+				cfg = irupts_prop[(interrupt_cells * hdlp->ih_inum)
+				    + 2];
 				break;
 			default:
 				ddi_prop_free(irupts_prop);

--- a/usr/src/uts/armv8/io/simple-bus.c
+++ b/usr/src/uts/armv8/io/simple-bus.c
@@ -252,33 +252,37 @@ smpl_bus_map(dev_info_t *dip, dev_info_t *rdip, ddi_map_req_t *mp, off_t offset,
 	struct rangespec range = {0};
 
 	uint32_t *rangep;
-	int rangelen;
+	uint_t rangelen;
 
-	if (ddi_getlongprop(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS, "ranges", (caddr_t)&rangep, &rangelen) != DDI_SUCCESS || rangelen == 0) {
+	if (ddi_prop_lookup_int_array(DDI_DEV_T_ANY, dip,
+	    DDI_PROP_DONTPASS, "ranges", (int **)&rangep, &rangelen) !=
+	    DDI_SUCCESS || rangelen == 0) {
 		rangelen = 0;
 		rangep = NULL;
 	}
 
 	if (mp->map_type == DDI_MT_RNUMBER) {
-		int reglen;
+		uint_t reglen;
 		int rnumber = mp->map_obj.rnumber;
 		uint32_t *rp;
 
-		if (ddi_getlongprop(DDI_DEV_T_ANY, rdip, DDI_PROP_DONTPASS, "reg", (caddr_t)&rp, &reglen) != DDI_SUCCESS || reglen == 0) {
-			if (rangep) {
-				kmem_free(rangep, rangelen);
+		if (ddi_prop_lookup_int_array(DDI_DEV_T_ANY, rdip,
+		    DDI_PROP_DONTPASS, "reg", (int **)&rp, &reglen) !=
+		    DDI_SUCCESS || reglen == 0) {
+			if (rangep != NULL) {
+				ddi_prop_free(rangep);
 			}
 			return (DDI_ME_RNUMBER_RANGE);
 		}
 
-		int n = reglen / (sizeof(uint32_t) * (addr_cells + size_cells));
-		ASSERT(reglen % (sizeof(uint32_t) * (addr_cells + size_cells)) == 0);
+		int n = reglen / addr_cells + size_cells;
+		ASSERT(reglen % (addr_cells + size_cells) == 0);
 
 		if (rnumber < 0 || rnumber >= n) {
-			if (rangep) {
-				kmem_free(rangep, rangelen);
+			if (rangep != NULL) {
+				ddi_prop_free(rangep);
 			}
-			kmem_free(rp, reglen);
+			ddi_prop_free(rp);
 			return (DDI_ME_RNUMBER_RANGE);
 		}
 
@@ -293,7 +297,9 @@ smpl_bus_map(dev_info_t *dip, dev_info_t *rdip, ddi_map_req_t *mp, off_t offset,
 			size <<= 32;
 			size |= ntohl(rp[(addr_cells + size_cells) * rnumber + addr_cells + i]);
 		}
-		kmem_free(rp, reglen);
+
+		ddi_prop_free(rp);
+
 		ASSERT((addr & 0xffff000000000000ul) == 0);
 		ASSERT((size & 0xffff000000000000ul) == 0);
 		reg.regspec_bustype = ((addr >> 32) & 0xffff);
@@ -309,25 +315,26 @@ smpl_bus_map(dev_info_t *dip, dev_info_t *rdip, ddi_map_req_t *mp, off_t offset,
 		return (DDI_ME_INVAL);
 	}
 
-	if (rangep) {
+	if (rangep != NULL) {
 		int i;
 		int ranges_cells = (addr_cells + parent_addr_cells + size_cells);
 		int n = rangelen / ranges_cells;
+
 		for (i = 0; i < n; i++) {
 			uint64_t base = 0;
 			uint64_t target = 0;
 			uint64_t rsize = 0;
 			for (int j = 0; j < addr_cells; j++) {
 				base <<= 32;
-				base += htonl(rangep[ranges_cells * i + j]);
+				base += rangep[ranges_cells * i + j];
 			}
 			for (int j = 0; j < parent_addr_cells; j++) {
 				target <<= 32;
-				target += htonl(rangep[ranges_cells * i + addr_cells + j]);
+				target += rangep[ranges_cells * i + addr_cells + j];
 			}
 			for (int j = 0; j < size_cells; j++) {
 				rsize <<= 32;
-				rsize += htonl(rangep[ranges_cells * i + addr_cells + parent_addr_cells + j]);
+				rsize += rangep[ranges_cells * i + addr_cells + parent_addr_cells + j];
 			}
 
 			uint64_t rel_addr = (reg.regspec_bustype & 0xffff);
@@ -344,7 +351,9 @@ smpl_bus_map(dev_info_t *dip, dev_info_t *rdip, ddi_map_req_t *mp, off_t offset,
 				break;
 			}
 		}
-		kmem_free(rangep, rangelen);
+
+		ddi_prop_free(rangep);
+
 		if (i == n) {
 			return (DDI_FAILURE);
 		}
@@ -475,12 +484,15 @@ smpl_intr_ops(dev_info_t *pdip, dev_info_t *rdip, ddi_intr_op_t intr_op,
 			}
 
 			int *irupts_prop;
-			int irupts_len;
-			if (ddi_getlongprop(DDI_DEV_T_ANY, rdip, DDI_PROP_DONTPASS, "interrupts", (caddr_t)&irupts_prop, &irupts_len) != DDI_SUCCESS || irupts_len == 0) {
+			uint_t irupts_len;
+			if (ddi_prop_lookup_int_array(DDI_DEV_T_ANY, rdip,
+			    DDI_PROP_DONTPASS, "interrupts",
+			    (int **)&irupts_prop, &irupts_len) != DDI_SUCCESS ||
+			    irupts_len == 0) {
 				return (DDI_FAILURE);
 			}
-			if (interrupt_cells * hdlp->ih_inum >= irupts_len * sizeof(int)) {
-				kmem_free(irupts_prop, irupts_len);
+			if ((interrupt_cells * hdlp->ih_inum) >= irupts_len) {
+				ddi_prop_free(irupts_prop);
 				return (DDI_FAILURE);
 			}
 
@@ -499,10 +511,12 @@ smpl_intr_ops(dev_info_t *pdip, dev_info_t *rdip, ddi_intr_op_t intr_op,
 				cfg = ntohl((uint32_t)irupts_prop[interrupt_cells * hdlp->ih_inum + 2]);
 				break;
 			default:
-				kmem_free(irupts_prop, irupts_len);
+				ddi_prop_free(irupts_prop);
 				return (DDI_FAILURE);
 			}
-			kmem_free(irupts_prop, irupts_len);
+
+			ddi_prop_free(irupts_prop);
+
 			switch (grp) {
 			case 1:
 				hdlp->ih_vector = vec + 16;

--- a/usr/src/uts/armv8/meson-gxbb/io/simple-bus.c
+++ b/usr/src/uts/armv8/meson-gxbb/io/simple-bus.c
@@ -259,14 +259,18 @@ smpl_bus_map(dev_info_t *dip, dev_info_t *rdip, ddi_map_req_t *mp, off_t offset,
 	int rangelen;
 
 	bool parent_has_ranges = false;
-	if (ddi_getlongprop(DDI_DEV_T_ANY, ddi_get_parent(dip), DDI_PROP_DONTPASS, "ranges", (caddr_t)&rangep, &rangelen) == DDI_SUCCESS) {
+	if (ddi_prop_get_int_array(DDI_DEV_T_ANY, ddi_get_parent(dip),
+	    DDI_PROP_DONTPASS, "ranges", (caddr_t)&rangep, &rangelen) ==
+	    DDI_SUCCESS) {
 		parent_has_ranges = true;
 		if (rangelen) {
-			kmem_free(rangep, rangelen);
+			ddi_prop_free(rangep);
 		}
 	}
 
-	if (ddi_getlongprop(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS, "ranges", (caddr_t)&rangep, &rangelen) != DDI_SUCCESS || rangelen == 0) {
+	if (ddi_prop_get_int_array(DDI_DEV_T_ANY, dip,
+	    DDI_PROP_DONTPASS, "ranges", (caddr_t)&rangep, &rangelen) !=
+	    DDI_SUCCESS || rangelen == 0) {
 		rangelen = 0;
 		rangep = NULL;
 	}
@@ -276,21 +280,22 @@ smpl_bus_map(dev_info_t *dip, dev_info_t *rdip, ddi_map_req_t *mp, off_t offset,
 		int rnumber = mp->map_obj.rnumber;
 		uint32_t *rp;
 
-		if (ddi_getlongprop(DDI_DEV_T_ANY, rdip, DDI_PROP_DONTPASS, "reg", (caddr_t)&rp, &reglen) != DDI_SUCCESS || reglen == 0) {
-			if (rangep) {
-				kmem_free(rangep, rangelen);
+		if (ddi_prop_get_int_array(DDI_DEV_T_ANY, rdip,
+		    DDI_PROP_DONTPASS, "reg", (caddr_t)&rp, &reglen) !=
+		    DDI_SUCCESS || reglen == 0) {
+			if (rangep != NULL) {
+				ddi_prop_free(rangep);
 			}
 			return (DDI_ME_RNUMBER_RANGE);
 		}
 
-		int n = reglen / (sizeof(uint32_t) * (addr_cells + size_cells));
-		ASSERT(reglen % (sizeof(uint32_t) * (addr_cells + size_cells)) == 0);
+		ASSERT((reglen % (addr_cells + size_cells)) == 0);
 
 		if (rnumber < 0 || rnumber >= n) {
-			if (rangep) {
-				kmem_free(rangep, rangelen);
+			if (rangep != NULL) {
+				ddi_prop_free(rangep);
 			}
-			kmem_free(rp, reglen);
+			ddi_prop_free(rp);
 			return (DDI_ME_RNUMBER_RANGE);
 		}
 
@@ -313,7 +318,9 @@ smpl_bus_map(dev_info_t *dip, dev_info_t *rdip, ddi_map_req_t *mp, off_t offset,
 			size <<= 32;
 			size |= ntohl(rp[(addr_cells + size_cells) * rnumber + addr_cells + i]);
 		}
-		kmem_free(rp, reglen);
+
+		ddi_prop_free(rp);
+
 		ASSERT((addr & 0xffff000000000000ul) == 0);
 		ASSERT((size & 0xfffff00000000000ul) == 0);
 		reg.regspec_bustype = (addr >> 32) ;
@@ -363,7 +370,7 @@ smpl_bus_map(dev_info_t *dip, dev_info_t *rdip, ddi_map_req_t *mp, off_t offset,
 				break;
 			}
 		}
-		kmem_free(rangep, rangelen);
+		ddi_prop_free(rangep);
 		if (i == n) {
 			return (DDI_FAILURE);
 		}
@@ -495,11 +502,14 @@ smpl_intr_ops(dev_info_t *pdip, dev_info_t *rdip, ddi_intr_op_t intr_op,
 
 			int *irupts_prop;
 			int irupts_len;
-			if (ddi_getlongprop(DDI_DEV_T_ANY, rdip, DDI_PROP_DONTPASS, "interrupts", (caddr_t)&irupts_prop, &irupts_len) != DDI_SUCCESS || irupts_len == 0) {
+			if (ddi_prop_get_int_array(DDI_DEV_T_ANY, rdip,
+			    DDI_PROP_DONTPASS, "interrupts",
+			    (caddr_t)&irupts_prop, &irupts_len) !=
+			    DDI_SUCCESS || irupts_len == 0) {
 				return (DDI_FAILURE);
 			}
-			if (interrupt_cells * hdlp->ih_inum >= irupts_len * sizeof(int)) {
-				kmem_free(irupts_prop, irupts_len);
+			if (interrupt_cells * hdlp->ih_inum >= irupts_len) {
+				ddi_prop_free(irupts_prop);
 				return (DDI_FAILURE);
 			}
 
@@ -513,15 +523,20 @@ smpl_intr_ops(dev_info_t *pdip, dev_info_t *rdip, ddi_intr_op_t intr_op,
 				cfg = 4;
 				break;
 			case 3:
-				grp = ntohl((uint32_t)irupts_prop[interrupt_cells * hdlp->ih_inum + 0]);
-				vec = ntohl((uint32_t)irupts_prop[interrupt_cells * hdlp->ih_inum + 1]);
-				cfg = ntohl((uint32_t)irupts_prop[interrupt_cells * hdlp->ih_inum + 2]);
+				grp = irupts_prop[interrupt_cells *
+				    hdlp->ih_inum + 0];
+				vec = irupts_prop[interrupt_cells *
+				    hdlp->ih_inum + 1];
+				cfg = irupts_prop[interrupt_cells *
+				    hdlp->ih_inum + 2];
 				break;
 			default:
-				kmem_free(irupts_prop, irupts_len);
+				ddi_prop_free(irupts_prop);
 				return (DDI_FAILURE);
 			}
-			kmem_free(irupts_prop, irupts_len);
+
+			ddi_prop_free(irupts_prop);
+
 			switch (grp) {
 			case 1:
 				hdlp->ih_vector = vec + 16;

--- a/usr/src/uts/armv8/meson-gxbb/io/simple-bus.c
+++ b/usr/src/uts/armv8/meson-gxbb/io/simple-bus.c
@@ -303,20 +303,24 @@ smpl_bus_map(dev_info_t *dip, dev_info_t *rdip, ddi_map_req_t *mp, off_t offset,
 		uint64_t size = 0;
 
 		if (rangep) {
-			range_index = ntohl(rp[(addr_cells + size_cells) * rnumber + 0]);
+			range_index = rp[(addr_cells + size_cells) *
+			    rnumber + 0];
 			for (int i = 1; i < addr_cells; i++) {
 				addr <<= 32;
-				addr |= ntohl(rp[(addr_cells + size_cells) * rnumber + i - 1]);
+				addr |= rp[(addr_cells + size_cells) *
+				    rnumber + i - 1];
 			}
 		} else {
 			for (int i = 0; i < addr_cells; i++) {
 				addr <<= 32;
-				addr |= ntohl(rp[(addr_cells + size_cells) * rnumber + i]);
+				addr |= rp[(addr_cells + size_cells) *
+				    rnumber + i];
 			}
 		}
 		for (int i = 0; i < size_cells; i++) {
 			size <<= 32;
-			size |= ntohl(rp[(addr_cells + size_cells) * rnumber + addr_cells + i]);
+			size |= rp[(addr_cells + size_cells) *
+			    rnumber + addr_cells + i];
 		}
 
 		ddi_prop_free(rp);
@@ -344,22 +348,23 @@ smpl_bus_map(dev_info_t *dip, dev_info_t *rdip, ddi_map_req_t *mp, off_t offset,
 				regspec_addr |= (((uint64_t)(reg.regspec_bustype & 0xffff)) << 32);
 				for (int j = 1; j < addr_cells; j++) {
 					addr <<= 32;
-					addr |= ntohl(rangep[(addr_cells + parent_addr_cells + size_cells) * i + j]);
+					addr |= rangep[(addr_cells +
+					    parent_addr_cells + size_cells) * i + j];
 				}
 				regspec_addr += addr;
 
 				addr = 0;
 				if (parent_has_ranges) {
 					reg.regspec_bustype &= ~0xf0000000;
-					reg.regspec_bustype |= (ntohl(rangep[(addr_cells + parent_addr_cells + size_cells) * i + addr_cells]) << 28);
+					reg.regspec_bustype |= (rangep[(addr_cells + parent_addr_cells + size_cells) * i + addr_cells] << 28);
 					for (int j = 1; j < parent_addr_cells; j++) {
 						addr <<= 32;
-						addr |= ntohl(rangep[(addr_cells + parent_addr_cells + size_cells) * i + addr_cells + j - 1]);
+						addr |= rangep[(addr_cells + parent_addr_cells + size_cells) * i + addr_cells + j - 1];
 					}
 				} else {
 					for (int j = 0; j < parent_addr_cells; j++) {
 						addr <<= 32;
-						addr |= ntohl(rangep[(addr_cells + parent_addr_cells + size_cells) * i + addr_cells + j]);
+						addr |= rangep[(addr_cells + parent_addr_cells + size_cells) * i + addr_cells + j];
 					}
 				}
 				regspec_addr += addr;
@@ -519,7 +524,8 @@ smpl_intr_ops(dev_info_t *pdip, dev_info_t *rdip, ddi_intr_op_t intr_op,
 			switch (interrupt_cells) {
 			case 1:
 				grp = 0;
-				vec = ntohl((uint32_t)irupts_prop[interrupt_cells * hdlp->ih_inum + 0]);
+				vec = irupts_prop[interrupt_cells *
+				    hdlp->ih_inum + 0];
 				cfg = 4;
 				break;
 			case 3:

--- a/usr/src/uts/armv8/os/ddi_impl.c
+++ b/usr/src/uts/armv8/os/ddi_impl.c
@@ -1160,23 +1160,20 @@ i_ddi_free_intr_phdl(ddi_intr_handle_impl_t *hdlp)
 int
 i_ddi_get_intx_nintrs(dev_info_t *dip)
 {
-	int intrlen;
+	uint_t intrlen;
 	int intr_sz;
 	int *ip;
 	int ret = 0;
 
-	if (ddi_getlongprop(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS |
+	if (ddi_prop_lookup_int_array(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS |
 	    DDI_PROP_CANSLEEP,
-	    "interrupts", (caddr_t)&ip, &intrlen) == DDI_SUCCESS) {
-
-		intr_sz = ddi_getprop(DDI_DEV_T_ANY, dip,
+	    "interrupts", &ip, &intrlen) == DDI_SUCCESS) {
+		intr_sz = ddi_prop_get_int(DDI_DEV_T_ANY, dip,
 		    0, "#interrupt-cells", 1);
-		/* adjust for number of bytes */
-		intr_sz *= sizeof (int32_t);
 
 		ret = intrlen / intr_sz;
 
-		kmem_free(ip, intrlen);
+		ddi_prop_free(ip);
 	}
 
 	return (ret);


### PR DESCRIPTION
This changes things so typed access to the DDI gets integers byteswapped on its behalf at the DDI layer, as seems like the intended behaviour (though that's based on a comment on the intel side that turns out to have been wrong).

This is another part of the stack #91 came from, so I'd also appreciate opinions on whether it should be woven into that or land first, or land second.
