### PR TITLE
use DDI interfaces for interrupt stuff, not PROM ones

### DIFF
--- a/usr/src/uts/armv8/io/rootnex.c
+++ b/usr/src/uts/armv8/io/rootnex.c
@@ -695,7 +695,7 @@ rootnex_ctl_reportdev(dev_info_t *dev)
 		}
 		pri = INT_IPL(sparc_pd_getintr(dev, i)->intrspec_pri);
 		f_len += snprintf(buf + len, REPORTDEV_BUFSIZE - len,
-		    " sparc ipl %d", pri);
+		    " processor ipl %d", pri);
 		len = strlen(buf);
 	}
 #ifdef DEBUG

--- a/usr/src/uts/armv8/io/simple-bus.c
+++ b/usr/src/uts/armv8/io/simple-bus.c
@@ -372,7 +372,7 @@ smpl_ctlops(dev_info_t *dip, dev_info_t *rdip,
 	case DDI_CTLOPS_REPORTDEV:
 		if (rdip == (dev_info_t *)0)
 			return (DDI_FAILURE);
-		cmn_err(CE_CONT, "?%s%d at %s%d",
+		cmn_err(CE_CONT, "?%s%d at %s%d\n",
 		    ddi_driver_name(rdip), ddi_get_instance(rdip),
 		    ddi_driver_name(dip), ddi_get_instance(dip));
 		ret = DDI_SUCCESS;

--- a/usr/src/uts/armv8/meson-gxbb/io/simple-bus.c
+++ b/usr/src/uts/armv8/meson-gxbb/io/simple-bus.c
@@ -390,7 +390,7 @@ smpl_ctlops(dev_info_t *dip, dev_info_t *rdip,
 	case DDI_CTLOPS_REPORTDEV:
 		if (rdip == (dev_info_t *)0)
 			return (DDI_FAILURE);
-		cmn_err(CE_CONT, "?%s%d at %s%d",
+		cmn_err(CE_CONT, "?%s%d at %s%d\n",
 		    ddi_driver_name(rdip), ddi_get_instance(rdip),
 		    ddi_driver_name(dip), ddi_get_instance(dip));
 		ret = DDI_SUCCESS;

--- a/usr/src/uts/armv8/sys/ddi_subrdefs.h
+++ b/usr/src/uts/armv8/sys/ddi_subrdefs.h
@@ -46,6 +46,8 @@ extern int i_ddi_convert_dma_attr(ddi_dma_attr_t *, dev_info_t *,
     const ddi_dma_attr_t *);
 extern int i_ddi_update_dma_attr(dev_info_t *, ddi_dma_attr_t *);
 
+extern dev_info_t *i_ddi_interrupt_parent(dev_info_t *);
+
 #endif	/* _KERNEL */
 
 #ifdef	__cplusplus


### PR DESCRIPTION
This continues trying to tidy up and integrate DDI/nexus stuff.

I think the big thing is the actual use of ...`intx_nintrs` and folding the `NAVAIL`/`NINTRS` cases together.  Which seems to be what other platforms and busses do? I think?

@citrus-it @hadfl @rmustacc