### PR TITLE
use typed DDI interfaces where it might affect AArch64

### DIFF
--- a/usr/src/uts/armv8/io/ns16550a/ns16550a.c
+++ b/usr/src/uts/armv8/io/ns16550a/ns16550a.c
@@ -1367,15 +1367,19 @@ again:
 		 */
 		mutex_exit(&ns16550->ns16550_excl_hi);
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 		if (ddi_getlongprop(DDI_DEV_T_ANY, ddi_root_node(),
 		    0, "ttymodes",
 		    (caddr_t)&termiosp, &len) == DDI_PROP_SUCCESS &&
 		    len == sizeof (struct termios)) {
 			nsasync->nsasync_ttycommon.t_cflag = termiosp->c_cflag;
 			kmem_free(termiosp, len);
-		} else
+		} else {
 			cmn_err(CE_WARN,
 			    "ns16550: couldn't get ttymodes property!");
+		}
+#pragma GCC diagnostic pop
 		mutex_enter(&ns16550->ns16550_excl_hi);
 
 		/* eeprom mode support - respect properties */

--- a/usr/src/uts/common/cpr/cpr_driver.c
+++ b/usr/src/uts/common/cpr/cpr_driver.c
@@ -273,7 +273,7 @@ static int
 cpr_is_real_device(dev_info_t *dip)
 {
 	struct regspec *regbuf;
-	int length;
+	uint_t length;
 	int rc;
 
 	if (ddi_get_driver(dip) == NULL)
@@ -290,13 +290,13 @@ cpr_is_real_device(dev_info_t *dip)
 	/*
 	 * now the general case
 	 */
-	rc = ddi_getlongprop(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS, "reg",
-	    (caddr_t)&regbuf, &length);
+	rc = ddi_prop_lookup_int_array(DDI_DEV_T_ANY, dip,
+	    DDI_PROP_DONTPASS, "reg", (int **)&regbuf, &length);
 	ASSERT(rc != DDI_PROP_NO_MEMORY);
 	if (rc != DDI_PROP_SUCCESS) {
 		return (0);
 	} else {
-		kmem_free((caddr_t)regbuf, length);
+		ddi_prop_free(regbuf);
 		return (1);
 	}
 }

--- a/usr/src/uts/common/cpr/cpr_driver.c
+++ b/usr/src/uts/common/cpr/cpr_driver.c
@@ -41,7 +41,7 @@
 extern int devi_detach(dev_info_t *, int);
 extern int devi_attach(dev_info_t *, int);
 
-static char 	*devi_string(dev_info_t *, char *);
+static char	*devi_string(dev_info_t *, char *);
 static int	cpr_is_real_device(dev_info_t *);
 /*
  * Xen uses this code to suspend _all_ drivers quickly and easily.

--- a/usr/src/uts/common/crypto/io/dca.c
+++ b/usr/src/uts/common/crypto/io/dca.c
@@ -729,8 +729,8 @@ dca_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 	(void) mutex_init(&dca->dca_intrlock, NULL, MUTEX_DRIVER, ibc);
 
 	/* use RNGSHA1 by default */
-	if (ddi_getprop(DDI_DEV_T_ANY, dip,
-	    DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS, "rngdirect", 0) == 0) {
+	if (ddi_prop_get_int(DDI_DEV_T_ANY, dip,
+	    DDI_PROP_DONTPASS, "rngdirect", 0) == 0) {
 		dca->dca_flags |= DCA_RNGSHA1;
 	}
 
@@ -1168,14 +1168,14 @@ dca_init(dca_t *dca)
 	wlp = WORKLIST(dca, MCR1);
 	(void) sprintf(wlp->dwl_name, "dca%d:mcr1",
 	    ddi_get_instance(dca->dca_dip));
-	wlp->dwl_lowater = ddi_getprop(DDI_DEV_T_ANY,
-	    dca->dca_dip, DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS,
+	wlp->dwl_lowater = ddi_prop_get_int(DDI_DEV_T_ANY,
+	    dca->dca_dip, DDI_PROP_DONTPASS,
 	    "mcr1_lowater", MCR1LOWATER);
-	wlp->dwl_hiwater = ddi_getprop(DDI_DEV_T_ANY,
-	    dca->dca_dip, DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS,
+	wlp->dwl_hiwater = ddi_prop_get_int(DDI_DEV_T_ANY,
+	    dca->dca_dip, DDI_PROP_DONTPASS,
 	    "mcr1_hiwater", MCR1HIWATER);
-	wlp->dwl_reqspermcr = min(ddi_getprop(DDI_DEV_T_ANY,
-	    dca->dca_dip, DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS,
+	wlp->dwl_reqspermcr = min(ddi_prop_get_int(DDI_DEV_T_ANY,
+	    dca->dca_dip, DDI_PROP_DONTPASS,
 	    "mcr1_maxreqs", MCR1MAXREQS), MAXREQSPERMCR);
 	wlp->dwl_dca = dca;
 	wlp->dwl_mcr = MCR1;
@@ -1189,14 +1189,14 @@ dca_init(dca_t *dca)
 	wlp = WORKLIST(dca, MCR2);
 	(void) sprintf(wlp->dwl_name, "dca%d:mcr2",
 	    ddi_get_instance(dca->dca_dip));
-	wlp->dwl_lowater = ddi_getprop(DDI_DEV_T_ANY,
-	    dca->dca_dip, DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS,
+	wlp->dwl_lowater = ddi_prop_get_int(DDI_DEV_T_ANY,
+	    dca->dca_dip, DDI_PROP_DONTPASS,
 	    "mcr2_lowater", MCR2LOWATER);
-	wlp->dwl_hiwater = ddi_getprop(DDI_DEV_T_ANY,
-	    dca->dca_dip, DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS,
+	wlp->dwl_hiwater = ddi_prop_get_int(DDI_DEV_T_ANY,
+	    dca->dca_dip, DDI_PROP_DONTPASS,
 	    "mcr2_hiwater", MCR2HIWATER);
-	wlp->dwl_reqspermcr = min(ddi_getprop(DDI_DEV_T_ANY,
-	    dca->dca_dip, DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS,
+	wlp->dwl_reqspermcr = min(ddi_prop_get_int(DDI_DEV_T_ANY,
+	    dca->dca_dip, DDI_PROP_DONTPASS,
 	    "mcr2_maxreqs", MCR2MAXREQS), MAXREQSPERMCR);
 	wlp->dwl_dca = dca;
 	wlp->dwl_mcr = MCR2;
@@ -4772,8 +4772,8 @@ dca_fma_init(dca_t *dca)
 	    DDI_FM_ERRCB_CAPABLE;
 
 	/* Read FMA capabilities from dca.conf file (if present) */
-	dca->fm_capabilities = ddi_getprop(DDI_DEV_T_ANY, dca->dca_dip,
-	    DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS, "fm-capable",
+	dca->fm_capabilities = ddi_prop_get_int(DDI_DEV_T_ANY, dca->dca_dip,
+	    DDI_PROP_DONTPASS, "fm-capable",
 	    fm_capabilities);
 
 	DBG(dca, DWARN, "dca->fm_capabilities = 0x%x", dca->fm_capabilities);

--- a/usr/src/uts/common/crypto/io/dca_kstat.c
+++ b/usr/src/uts/common/crypto/io/dca_kstat.c
@@ -48,8 +48,8 @@ dca_ksinit(dca_t *dca)
 	char	buf[64];
 	int	instance;
 
-	if (ddi_getprop(DDI_DEV_T_ANY, dca->dca_dip,
-	    DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS, "nostats", 0) != 0) {
+	if (ddi_prop_get_int(DDI_DEV_T_ANY, dca->dca_dip,
+	    DDI_PROP_DONTPASS, "nostats", 0) != 0) {
 		/*
 		 * sysadmin has explicity disabled stats to prevent
 		 * covert channel.

--- a/usr/src/uts/common/dtrace/fasttrap.c
+++ b/usr/src/uts/common/dtrace/fasttrap.c
@@ -2149,14 +2149,14 @@ fasttrap_attach(dev_info_t *devi, ddi_attach_cmd_t cmd)
 	dtrace_fasttrap_exit_ptr = &fasttrap_exec_exit;
 	dtrace_fasttrap_exec_ptr = &fasttrap_exec_exit;
 
-	fasttrap_max = ddi_getprop(DDI_DEV_T_ANY, devi, DDI_PROP_DONTPASS,
+	fasttrap_max = ddi_prop_get_int(DDI_DEV_T_ANY, devi, DDI_PROP_DONTPASS,
 	    "fasttrap-max-probes", FASTTRAP_MAX_DEFAULT);
 	fasttrap_total = 0;
 
 	/*
 	 * Conjure up the tracepoints hashtable...
 	 */
-	nent = ddi_getprop(DDI_DEV_T_ANY, devi, DDI_PROP_DONTPASS,
+	nent = ddi_prop_get_int(DDI_DEV_T_ANY, devi, DDI_PROP_DONTPASS,
 	    "fasttrap-hash-size", FASTTRAP_TPOINTS_DEFAULT_SIZE);
 
 	if (nent == 0 || nent > 0x1000000)

--- a/usr/src/uts/common/dtrace/profile.c
+++ b/usr/src/uts/common/dtrace/profile.c
@@ -474,7 +474,7 @@ profile_attach(dev_info_t *devi, ddi_attach_cmd_t cmd)
 		return (DDI_FAILURE);
 	}
 
-	profile_max = ddi_getprop(DDI_DEV_T_ANY, devi, DDI_PROP_DONTPASS,
+	profile_max = ddi_prop_get_int(DDI_DEV_T_ANY, devi, DDI_PROP_DONTPASS,
 	    "profile-max-probes", PROFILE_MAX_DEFAULT);
 
 	ddi_report_dev(devi);

--- a/usr/src/uts/common/io/1394/targets/scsa1394/hba.c
+++ b/usr/src/uts/common/io/1394/targets/scsa1394/hba.c
@@ -970,12 +970,12 @@ scsa1394_scsi_tgt_init(dev_info_t *dip, dev_info_t *cdip, scsi_hba_tran_t *tran,
 {
 	scsa1394_state_t *sp = (scsa1394_state_t *)tran->tran_hba_private;
 	int		lun;
-	int		plen = sizeof (int);
 	int		ret = DDI_FAILURE;
 
-	if (ddi_prop_op(DDI_DEV_T_ANY, cdip, PROP_LEN_AND_VAL_BUF,
-	    DDI_PROP_DONTPASS | DDI_PROP_CANSLEEP, SCSI_ADDR_PROP_LUN,
-	    (caddr_t)&lun, &plen) != DDI_PROP_SUCCESS) {
+	lun = ddi_prop_get_int(DDI_DEV_T_ANY, cdip,
+	    DDI_PROP_DONTPASS, SCSI_ADDR_PROP_LUN, -1);
+
+	if (lun == -1) {
 		return (DDI_FAILURE);
 	}
 
@@ -1013,15 +1013,15 @@ scsa1394_scsi_tgt_free(dev_info_t *dip, dev_info_t *cdip, scsi_hba_tran_t *tran,
 {
 	scsa1394_state_t *sp = (scsa1394_state_t *)tran->tran_hba_private;
 	int		lun;
-	int		plen = sizeof (int);
 
 	if (!scsa1394_is_my_child(cdip)) {
 		return;
 	}
 
-	if (ddi_prop_op(DDI_DEV_T_ANY, cdip, PROP_LEN_AND_VAL_BUF,
-	    DDI_PROP_DONTPASS | DDI_PROP_CANSLEEP, SCSI_ADDR_PROP_LUN,
-	    (caddr_t)&lun, &plen) != DDI_PROP_SUCCESS) {
+	lun = ddi_prop_get_int(DDI_DEV_T_ANY, cdip,
+	    DDI_PROP_DONTPASS, SCSI_ADDR_PROP_LUN, -1);
+
+	if (lun == -1) {
 		return;
 	}
 

--- a/usr/src/uts/common/io/aac/aac.c
+++ b/usr/src/uts/common/io/aac/aac.c
@@ -6956,8 +6956,8 @@ aac_fm_init(struct aac_softstate *softs)
 	 */
 	ddi_iblock_cookie_t fm_ibc;
 
-	softs->fm_capabilities = ddi_getprop(DDI_DEV_T_ANY, softs->devinfo_p,
-	    DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS, "fm-capable",
+	softs->fm_capabilities = ddi_prop_get_int(DDI_DEV_T_ANY,
+	    softs->devinfo_p, DDI_PROP_DONTPASS, "fm-capable",
 	    DDI_FM_EREPORT_CAPABLE | DDI_FM_ACCCHK_CAPABLE |
 	    DDI_FM_DMACHK_CAPABLE | DDI_FM_ERRCB_CAPABLE);
 

--- a/usr/src/uts/common/io/bge/bge_main2.c
+++ b/usr/src/uts/common/io/bge/bge_main2.c
@@ -3104,8 +3104,11 @@ bge_find_mac_address(bge_t *bgep, chip_id_t *cidp)
 	 */
 	nelts = sizeof (propbuf);
 	bzero(propbuf, nelts--);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	err = ddi_getlongprop_buf(DDI_DEV_T_ANY, bgep->devinfo,
 	    DDI_PROP_CANSLEEP, localmac_boolname, propbuf, (int *)&nelts);
+#pragma GCC diagnostic pop
 
 	/*
 	 * Now, if the address still isn't set from the hardware (SEEPROM)

--- a/usr/src/uts/common/io/cardbus/cardbus.c
+++ b/usr/src/uts/common/io/cardbus/cardbus.c
@@ -1279,8 +1279,8 @@ cardbus_initchild(dev_info_t *rdip, dev_info_t *dip, dev_info_t *child,
 		(ppd->ppd.par_intr)->intrspec_func = (uint_t (*)()) 0;
 #endif
 
-		if (ddi_prop_get_int(DDI_DEV_T_NONE, child, DDI_PROP_DONTPASS,
-		    "interrupts", -1) != -1)
+		if (ddi_prop_exists(DDI_DEV_T_NONE, child, DDI_PROP_DONTPASS,
+		    "interrupts"))
 			ppd->ppd.par_nintr = 1;
 
 		ppd->code = CB_PPD_CODE;

--- a/usr/src/uts/common/io/cardbus/cardbus.c
+++ b/usr/src/uts/common/io/cardbus/cardbus.c
@@ -1017,24 +1017,24 @@ cardbus_ctlops(dev_info_t *dip, dev_info_t *rdip,
 				    bus, device, function);
 				ptr = &ptr[strlen(ptr)];
 
-				val32 = ddi_getprop(DDI_DEV_T_ANY, rdip,
-				    DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS,
+				val32 = ddi_prop_get_int(DDI_DEV_T_ANY, rdip,
+				    DDI_PROP_DONTPASS,
 				    "vendor-id", -1);
 				if (val32 != -1) {
 					(void) sprintf(ptr, " Vendor 0x%04x",
 					    val32);
 					ptr = &ptr[strlen(ptr)];
 				}
-				val32 = ddi_getprop(DDI_DEV_T_ANY, rdip,
-				    DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS,
+				val32 = ddi_prop_get_int(DDI_DEV_T_ANY, rdip,
+				    DDI_PROP_DONTPASS,
 				    "device-id", -1);
 				if (val32 != -1) {
 					(void) sprintf(ptr, " Device 0x%04x",
 					    val32);
 					ptr = &ptr[strlen(ptr)];
 				}
-				val32 = ddi_getprop(DDI_DEV_T_ANY, rdip,
-				    DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS,
+				val32 = ddi_prop_get_int(DDI_DEV_T_ANY, rdip,
+				    DDI_PROP_DONTPASS,
 				    "class-code", -1);
 				if (val32 != -1) {
 					const char	*name;
@@ -1161,7 +1161,7 @@ cardbus_init_child_regs(dev_info_t *child)
 	/*
 	 * Initialize cache-line-size configuration register if needed.
 	 */
-	if (ddi_getprop(DDI_DEV_T_ANY, child, DDI_PROP_DONTPASS,
+	if (ddi_prop_get_int(DDI_DEV_T_ANY, child, DDI_PROP_DONTPASS,
 	    "cache-line-size", 0) == 0) {
 
 		pci_config_put8(config_handle, PCI_CONF_CACHE_LINESZ,
@@ -1175,7 +1175,7 @@ cardbus_init_child_regs(dev_info_t *child)
 	/*
 	 * Initialize latency timer registers if needed.
 	 */
-	if (ddi_getprop(DDI_DEV_T_ANY, child, DDI_PROP_DONTPASS,
+	if (ddi_prop_get_int(DDI_DEV_T_ANY, child, DDI_PROP_DONTPASS,
 	    "latency-timer", 0) == 0) {
 
 		if ((header_type & PCI_HEADER_TYPE_M) == PCI_HEADER_ONE) {
@@ -1279,7 +1279,7 @@ cardbus_initchild(dev_info_t *rdip, dev_info_t *dip, dev_info_t *child,
 		(ppd->ppd.par_intr)->intrspec_func = (uint_t (*)()) 0;
 #endif
 
-		if (ddi_getprop(DDI_DEV_T_NONE, child, DDI_PROP_DONTPASS,
+		if (ddi_prop_get_int(DDI_DEV_T_NONE, child, DDI_PROP_DONTPASS,
 		    "interrupts", -1) != -1)
 			ppd->ppd.par_nintr = 1;
 

--- a/usr/src/uts/common/io/cardbus/cardbus_cfg.c
+++ b/usr/src/uts/common/io/cardbus/cardbus_cfg.c
@@ -303,13 +303,12 @@ cardbus_validate_iline(dev_info_t *dip, ddi_acc_handle_t handle)
 	if (pci_config_get8(handle, PCI_CONF_IPIN)) {
 	intline = pci_config_get8(handle, PCI_CONF_ILINE);
 	if ((intline == 0) || (intline == 0xff)) {
-		intline = ddi_getprop(DDI_DEV_T_ANY, dip,
-		    DDI_PROP_CANSLEEP|DDI_PROP_DONTPASS,
+		intline = ddi_prop_get_int(DDI_DEV_T_ANY, dip,
+		    DDI_PROP_DONTPASS,
 		    "interrupt-line", 0xff);
 		if (intline == (uint8_t)0xff) {
-			intline = ddi_getprop(DDI_DEV_T_ANY,
-			    ddi_get_parent(dip),
-			    DDI_PROP_CANSLEEP /* |DDI_PROP_DONTPASS */,
+			intline = ddi_prop_get_int(DDI_DEV_T_ANY,
+			    ddi_get_parent(dip), 0,
 			    "interrupt-line", 0xb);
 		}
 

--- a/usr/src/uts/common/io/cardbus/cardbus_hp.c
+++ b/usr/src/uts/common/io/cardbus/cardbus_hp.c
@@ -1758,8 +1758,8 @@ cardbus_dump_pci_node(dev_info_t *dip)
 	for (next = ddi_get_child(dip); next;
 	    next = ddi_get_next_sibling(next)) {
 
-		VendorId = ddi_getprop(DDI_DEV_T_ANY, next,
-		    DDI_PROP_CANSLEEP|DDI_PROP_DONTPASS,
+		VendorId = ddi_prop_get_int(DDI_DEV_T_ANY, next,
+		    DDI_PROP_DONTPASS,
 		    "vendor-id", -1);
 		if (VendorId == -1) {
 			/* not a pci device */

--- a/usr/src/uts/common/io/chxge/ch.c
+++ b/usr/src/uts/common/io/chxge/ch.c
@@ -144,11 +144,11 @@ static	struct module_info ch_minfo = {
  */
 
 static struct qinit ch_rinit = {
-	(int (*)()) NULL, 	/* qi_putp */
+	(int (*)()) NULL,	/* qi_putp */
 	gld_rsrv,		/* qi_srvp */
 	gld_open,		/* qi_qopen */
 	gld_close,		/* qi_qclose */
-	(int (*)()) NULL, 	/* qi_qadmin */
+	(int (*)()) NULL,	/* qi_qadmin */
 	&ch_minfo,		/* qi_minfo */
 	NULL			/* qi_mstat */
 };
@@ -162,9 +162,9 @@ static struct qinit ch_rinit = {
 static struct qinit ch_winit = {
 	gld_wput,		/* qi_putp */
 	gld_wsrv,		/* qi_srvp */
-	(int (*)()) NULL, 	/* qi_qopen */
-	(int (*)()) NULL, 	/* qi_qclose */
-	(int (*)()) NULL, 	/* qi_qadmin */
+	(int (*)()) NULL,	/* qi_qopen */
+	(int (*)()) NULL,	/* qi_qclose */
+	(int (*)()) NULL,	/* qi_qadmin */
 	&ch_minfo,		/* qi_minfo */
 	NULL			/* qi_mstat */
 };
@@ -880,7 +880,7 @@ ch_detach(dev_info_t *dip, ddi_detach_cmd_t cmd)
 
 void *
 ch_alloc_dma_mem(ch_t *chp, int type, int flags, int size, uint64_t *paddr,
-	ulong_t *dh, ulong_t *ah)
+    ulong_t *dh, ulong_t *ah)
 {
 	ddi_dma_attr_t ch_dma_attr;
 	ddi_dma_cookie_t cookie;
@@ -1108,7 +1108,7 @@ ch_free_dma_handles(ch_t *chp)
 
 uint32_t
 ch_bind_dma_handle(ch_t *chp, int size, caddr_t vaddr, cmdQ_ce_t *cmp,
-	uint32_t cnt)
+    uint32_t cnt)
 {
 	ddi_dma_cookie_t cookie;
 	ddi_dma_handle_t ch_dh;
@@ -1296,7 +1296,7 @@ ch_free_dvma_handles(ch_t *chp)
 
 uint32_t
 ch_bind_dvma_handle(ch_t *chp, int size, caddr_t vaddr, cmdQ_ce_t *cmp,
-	uint32_t cnt)
+    uint32_t cnt)
 {
 	ddi_dma_cookie_t cookie;
 	ddi_dma_handle_t ch_dh;
@@ -1917,21 +1917,21 @@ ch_get_prop(ch_t *chp)
 	uint32_t *prop_val = NULL;
 	uint32_t prop_len = 0;
 
-	val = ddi_getprop(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
+	val = ddi_prop_get_int(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
 	    "enable_dvma", -1);
 	if (val == -1)
-		val = ddi_getprop(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
-		    "enable-dvma", -1);
+		val = ddi_prop_get_int(DDI_DEV_T_ANY, chp->ch_dip,
+		    DDI_PROP_DONTPASS, "enable-dvma", -1);
 	if (val != -1) {
 		if (val != 0)
 			chp->ch_config.enable_dvma = 1;
 	}
 
-	val = ddi_getprop(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
+	val = ddi_prop_get_int(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
 	    "amd_bug_workaround", -1);
 	if (val == -1)
-		val = ddi_getprop(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
-		    "amd-bug-workaround", -1);
+		val = ddi_prop_get_int(DDI_DEV_T_ANY, chp->ch_dip,
+		    DDI_PROP_DONTPASS, "amd-bug-workaround", -1);
 
 	if (val != -1) {
 		if (val == 0) {
@@ -2056,11 +2056,11 @@ fail_exit:
 	 * in chxge.conf
 	 */
 
-	val = ddi_getprop(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
+	val = ddi_prop_get_int(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
 	    "pci_burstsize", -1);
 	if (val == -1)
-		val = ddi_getprop(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
-		    "pci-burstsize", -1);
+		val = ddi_prop_get_int(DDI_DEV_T_ANY, chp->ch_dip,
+		    DDI_PROP_DONTPASS, "pci-burstsize", -1);
 
 	if (val != -1) {
 
@@ -2094,11 +2094,11 @@ fail_exit:
 	/*
 	 * set transaction count
 	 */
-	val = ddi_getprop(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
+	val = ddi_prop_get_int(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
 	    "pci_split_transaction_cnt", -1);
 	if (val == -1)
-		val = ddi_getprop(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
-		    "pci-split-transaction-cnt", -1);
+		val = ddi_prop_get_int(DDI_DEV_T_ANY, chp->ch_dip,
+		    DDI_PROP_DONTPASS, "pci-split-transaction-cnt", -1);
 
 	if (val != -1) {
 		switch (val) {
@@ -2156,11 +2156,11 @@ fail_exit:
 	/*
 	 * set relaxed ordering bit?
 	 */
-	val = ddi_getprop(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
+	val = ddi_prop_get_int(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
 	    "pci_relaxed_ordering_on", -1);
 	if (val == -1)
-		val = ddi_getprop(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
-		    "pci-relaxed-ordering-on", -1);
+		val = ddi_prop_get_int(DDI_DEV_T_ANY, chp->ch_dip,
+		    DDI_PROP_DONTPASS, "pci-relaxed-ordering-on", -1);
 
 	/*
 	 * default is to use system default value.
@@ -2172,11 +2172,11 @@ fail_exit:
 			chp->ch_config.relaxed_ordering = 1;
 	}
 
-	val = ddi_getprop(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
+	val = ddi_prop_get_int(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
 	    "enable_latency_timer", -1);
 	if (val == -1)
-		val = ddi_getprop(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
-		    "enable-latency-timer", -1);
+		val = ddi_prop_get_int(DDI_DEV_T_ANY, chp->ch_dip,
+		    DDI_PROP_DONTPASS, "enable-latency-timer", -1);
 	if (val != -1)
 		enable_latency_timer = (val == 0)? 0: 1;
 
@@ -2184,11 +2184,11 @@ fail_exit:
 	 * default maximum Jumbo Frame size.
 	 */
 	chp->ch_maximum_mtu = 9198;	/* tunable via chxge.conf */
-	val = ddi_getprop(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
+	val = ddi_prop_get_int(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
 	    "maximum_mtu", -1);
 	if (val == -1) {
-		val = ddi_getprop(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
-		    "maximum-mtu", -1);
+		val = ddi_prop_get_int(DDI_DEV_T_ANY, chp->ch_dip,
+		    DDI_PROP_DONTPASS, "maximum-mtu", -1);
 	}
 	if (val != -1) {
 		if (val > 9582) {
@@ -2212,11 +2212,11 @@ fail_exit:
 	 */
 	chp->ch_mtu = ETHERMTU;
 
-	val = ddi_getprop(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
+	val = ddi_prop_get_int(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
 	    "accept_jumbo", -1);
 	if (val == -1) {
-		val = ddi_getprop(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
-		    "accept-jumbo", -1);
+		val = ddi_prop_get_int(DDI_DEV_T_ANY, chp->ch_dip,
+		    DDI_PROP_DONTPASS, "accept-jumbo", -1);
 	}
 	if (val != -1) {
 		if (val)
@@ -2251,11 +2251,11 @@ fail_exit:
 #endif
 	chp->ch_config.cksum_enabled = 1;
 
-	val = ddi_getprop(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
+	val = ddi_prop_get_int(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
 	    "enable_checksum_offload", -1);
 	if (val == -1)
-		val = ddi_getprop(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
-		    "enable-checksum-offload", -1);
+		val = ddi_prop_get_int(DDI_DEV_T_ANY, chp->ch_dip,
+		    DDI_PROP_DONTPASS, "enable-checksum-offload", -1);
 	if (val != -1) {
 		if (val == 0)
 			chp->ch_config.cksum_enabled = 0;
@@ -2264,11 +2264,11 @@ fail_exit:
 	/*
 	 * Provides a tuning capability for the command queue 0 size.
 	 */
-	val = ddi_getprop(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
+	val = ddi_prop_get_int(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
 	    "sge_cmdq0_cnt", -1);
 	if (val == -1)
-		val = ddi_getprop(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
-		    "sge-cmdq0-cnt", -1);
+		val = ddi_prop_get_int(DDI_DEV_T_ANY, chp->ch_dip,
+		    DDI_PROP_DONTPASS, "sge-cmdq0-cnt", -1);
 	if (val != -1) {
 		if (val > 10)
 			sge_cmdq0_cnt = val;
@@ -2285,11 +2285,11 @@ fail_exit:
 	/*
 	 * Provides a tuning capability for the command queue 1 size.
 	 */
-	val = ddi_getprop(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
+	val = ddi_prop_get_int(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
 	    "sge_cmdq1_cnt", -1);
 	if (val == -1)
-		val = ddi_getprop(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
-		    "sge-cmdq1-cnt", -1);
+		val = ddi_prop_get_int(DDI_DEV_T_ANY, chp->ch_dip,
+		    DDI_PROP_DONTPASS, "sge-cmdq1-cnt", -1);
 	if (val != -1) {
 		if (val > 10)
 			sge_cmdq1_cnt = val;
@@ -2305,11 +2305,11 @@ fail_exit:
 	/*
 	 * Provides a tuning capability for the free list 0 size.
 	 */
-	val = ddi_getprop(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
+	val = ddi_prop_get_int(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
 	    "sge_flq0_cnt", -1);
 	if (val == -1)
-		val = ddi_getprop(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
-		    "sge-flq0-cnt", -1);
+		val = ddi_prop_get_int(DDI_DEV_T_ANY, chp->ch_dip,
+		    DDI_PROP_DONTPASS, "sge-flq0-cnt", -1);
 	if (val != -1) {
 		if (val > 512)
 			sge_flq0_cnt = val;
@@ -2327,11 +2327,11 @@ fail_exit:
 	/*
 	 * Provides a tuning capability for the free list 1 size.
 	 */
-	val = ddi_getprop(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
+	val = ddi_prop_get_int(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
 	    "sge_flq1_cnt", -1);
 	if (val == -1)
-		val = ddi_getprop(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
-		    "sge-flq1-cnt", -1);
+		val = ddi_prop_get_int(DDI_DEV_T_ANY, chp->ch_dip,
+		    DDI_PROP_DONTPASS, "sge-flq1-cnt", -1);
 	if (val != -1) {
 		if (val > 512)
 			sge_flq1_cnt = val;
@@ -2349,11 +2349,11 @@ fail_exit:
 	/*
 	 * Provides a tuning capability for the responce queue size.
 	 */
-	val = ddi_getprop(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
+	val = ddi_prop_get_int(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
 	    "sge_respq_cnt", -1);
 	if (val == -1)
-		val = ddi_getprop(DDI_DEV_T_ANY, chp->ch_dip, DDI_PROP_DONTPASS,
-		    "sge-respq-cnt", -1);
+		val = ddi_prop_get_int(DDI_DEV_T_ANY, chp->ch_dip,
+		    DDI_PROP_DONTPASS, "sge-respq-cnt", -1);
 	if (val != -1) {
 		if (val > 30)
 			sge_respq_cnt = val;

--- a/usr/src/uts/common/io/cmlb.c
+++ b/usr/src/uts/common/io/cmlb.c
@@ -2471,8 +2471,8 @@ cmlb_read_fdisk(struct cmlb_lun *cl, diskaddr_t capacity, void *tg_cookie)
 	if (lba != 0) {
 		dev_t dev = cmlb_make_device(cl);
 
-		if (ddi_prop_get_int(dev, CMLB_DEVINFO(cl), DDI_PROP_DONTPASS,
-		    "lba-access-ok", 0) == 0) {
+		if (!ddi_prop_exists(dev, CMLB_DEVINFO(cl), DDI_PROP_DONTPASS,
+		    "lba-access-ok")) {
 			/* not found; create it */
 			if (ddi_prop_create(dev, CMLB_DEVINFO(cl), 0,
 			    "lba-access-ok", (caddr_t)NULL, 0) !=

--- a/usr/src/uts/common/io/cmlb.c
+++ b/usr/src/uts/common/io/cmlb.c
@@ -2456,7 +2456,7 @@ cmlb_read_fdisk(struct cmlb_lun *cl, diskaddr_t capacity, void *tg_cookie)
 	 * First, check for lba-access-ok on root node (or prom root node)
 	 * if present there, don't need to search fdisk table.
 	 */
-	if (ddi_getprop(DDI_DEV_T_ANY, ddi_root_node(), 0,
+	if (ddi_prop_get_int(DDI_DEV_T_ANY, ddi_root_node(), 0,
 	    "lba-access-ok", 0) != 0) {
 		/* All drives do LBA; don't search fdisk table */
 		lba = 1;
@@ -2471,7 +2471,7 @@ cmlb_read_fdisk(struct cmlb_lun *cl, diskaddr_t capacity, void *tg_cookie)
 	if (lba != 0) {
 		dev_t dev = cmlb_make_device(cl);
 
-		if (ddi_getprop(dev, CMLB_DEVINFO(cl), DDI_PROP_DONTPASS,
+		if (ddi_prop_get_int(dev, CMLB_DEVINFO(cl), DDI_PROP_DONTPASS,
 		    "lba-access-ok", 0) == 0) {
 			/* not found; create it */
 			if (ddi_prop_create(dev, CMLB_DEVINFO(cl), 0,

--- a/usr/src/uts/common/io/comstar/port/qlt/qlt.c
+++ b/usr/src/uts/common/io/comstar/port/qlt/qlt.c
@@ -3808,7 +3808,7 @@ qlt_msix_resp_handler(caddr_t arg, caddr_t arg2)
 {
 	qlt_state_t	*qlt = (qlt_state_t *)arg;
 	uint32_t	risc_status;
-	uint16_t 	qi = 0;
+	uint16_t	qi = 0;
 
 	risc_status = REG_RD32(qlt, REG_RISC_STATUS);
 	if (qlt->qlt_mq_enabled) {
@@ -9505,8 +9505,8 @@ qlt_el_msg(qlt_state_t *qlt, const char *fn, int ce, ...)
 static int
 qlt_read_int_prop(qlt_state_t *qlt, char *prop, int defval)
 {
-	return (ddi_getprop(DDI_DEV_T_ANY, qlt->dip,
-	    DDI_PROP_DONTPASS | DDI_PROP_CANSLEEP, prop, defval));
+	return (ddi_prop_get_int(DDI_DEV_T_ANY, qlt->dip,
+	    DDI_PROP_DONTPASS, prop, defval));
 }
 
 static int

--- a/usr/src/uts/common/io/consconfig_dacf.c
+++ b/usr/src/uts/common/io/consconfig_dacf.c
@@ -1919,10 +1919,12 @@ consconfig_setmodes(dev_t dev, struct termios *termiosp)
 	(void) strcpy(name, "ttya-mode");	/* name of option we want */
 	name[3] = 'a' + i;			/* Adjust to correct line */
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	if (ddi_getlongprop_buf(DDI_DEV_T_ANY, ddi_root_node(), 0, name,
 	    buf, &len) != DDI_PROP_SUCCESS)
 		return (1);	/* if no such option, just return */
-
+#pragma GCC diagnostic pop
 	/*
 	 * The IEEE 1275 standard specifies that /aliases string property
 	 * values should be null-terminated.  Unfortunately the reality

--- a/usr/src/uts/common/io/cpqary3/cpqary3.c
+++ b/usr/src/uts/common/io/cpqary3/cpqary3.c
@@ -757,8 +757,8 @@ cpqary3_update_ctlrdetails(cpqary3_t *cpqary3p, uint32_t *cleanstatus)
 	uint8_t			mem_64_bar0_set = 0;
 	uint8_t			mem_bar1_set = 0;
 	uint8_t			mem_64_bar1_set = 0;
-	int32_t			reglen;
-	uint32_t		*regp;
+	uint_t			reglen;
+	int			*regp;
 	uint32_t		mem_bar0 = 0;
 	uint32_t		mem_64_bar0;
 	uint32_t		mem_bar1 = 0;
@@ -790,11 +790,13 @@ cpqary3_update_ctlrdetails(cpqary3_t *cpqary3p, uint32_t *cleanstatus)
 	 * Get the HW Configuration
 	 * Get Bus #, Dev # and Func # for this device
 	 * Free the memory that regp points towards after the
-	 * ddi_getlongprop() call
+	 * ddi_prop_lookup_int_array() call
 	 */
-	if (ddi_getlongprop(DDI_DEV_T_NONE, cpqary3p->dip, DDI_PROP_DONTPASS,
-	    "reg", (caddr_t)&regp, &reglen) != DDI_PROP_SUCCESS)
+	if (ddi_prop_lookup_int_array(DDI_DEV_T_NONE, cpqary3p->dip,
+	    DDI_PROP_DONTPASS, "reg", &regp, &reglen) != DDI_PROP_SUCCESS)
 		return (CPQARY3_FAILURE);
+
+	reglen = CELLS_1275_TO_BYTES(reglen);
 
 	cpqary3p->bus = PCI_REG_BUS_G(*regp);
 	cpqary3p->dev = PCI_REG_DEV_G(*regp);
@@ -830,7 +832,7 @@ cpqary3_update_ctlrdetails(cpqary3_t *cpqary3p, uint32_t *cleanstatus)
 	mem_bar0 = mem_64_bar0;
 	mem_bar1 = mem_64_bar1;
 
-	MEM_SFREE(regp, reglen);
+	ddi_prop_free(regp);
 
 	/*
 	 * Setup resources to access the Local PCI Bus

--- a/usr/src/uts/common/io/cpqary3/cpqary3_util.c
+++ b/usr/src/uts/common/io/cpqary3/cpqary3_util.c
@@ -45,7 +45,7 @@ cpqary3_read_conf_file(dev_info_t *dip, cpqary3_t *cpqary3p)
 	 *
 	 * eg. :
 	 *
-	 * retvalue = ddi_getprop(DDI_DEV_T_NONE, dip, DDI_PROP_DONTPASS,
+	 * retvalue = ddi_prop_get_int(DDI_DEV_T_NONE, dip, DDI_PROP_DONTPASS,
 	 *	"cpqary3_online_debug", -1);
 	 */
 

--- a/usr/src/uts/common/io/fdc.c
+++ b/usr/src/uts/common/io/fdc.c
@@ -214,7 +214,7 @@ struct bus_ops fdc_bus_ops = {
 	BUSO_REV,
 	nullbusmap,
 	0,	/* ddi_intrspec_t (*bus_get_intrspec)(); */
-	0,	/* int 	(*bus_add_intrspec)(); */
+	0,	/* int	(*bus_add_intrspec)(); */
 	0,	/* void (*bus_remove_intrspec)(); */
 	i_ddi_map_fault,
 	0,
@@ -354,7 +354,7 @@ static int
 fdc_bus_ctl(dev_info_t *dip, dev_info_t *rdip, ddi_ctl_enum_t ctlop,
     void *arg, void *result)
 {
-	struct 	fdcntlr *fcp;
+	struct	fdcntlr *fcp;
 	struct	fcu_obj *fjp;
 
 	_NOTE(ARGUNUSED(result));

--- a/usr/src/uts/common/io/fibre-channel/fca/qlc/ql_api.c
+++ b/usr/src/uts/common/io/fibre-channel/fca/qlc/ql_api.c
@@ -4361,9 +4361,12 @@ ql_port_manage(opaque_t fca_handle, fc_fca_pm_t *cmd)
 
 		i0 = 0;
 		/*LINTED [Solaris DDI_DEV_T_ANY Lint warning]*/
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 		rval2 = ddi_getlongprop(DDI_DEV_T_ANY, ha->dip,
 		    DDI_PROP_DONTPASS | DDI_PROP_CANSLEEP, "version",
 		    (caddr_t)&fcode_ver_buf, &i0);
+#pragma GCC diagnostic pop
 		length = (uint_t)i0;
 
 		if (rval2 != DDI_PROP_SUCCESS) {
@@ -18343,7 +18346,7 @@ cmd_text(cmd_table_t *entry, int cmd)
 
 /*
  * ql_els_24xx_iocb
- * 	els request indication.
+ *	els request indication.
  *
  * Input:
  *	ha:	adapter state pointer.

--- a/usr/src/uts/common/io/fibre-channel/fca/qlc/ql_hba_fru.c
+++ b/usr/src/uts/common/io/fibre-channel/fca/qlc/ql_hba_fru.c
@@ -298,14 +298,12 @@ ql_populate_hba_fru_details(ql_adapter_state_t *ha,
 
 	if (strlen(attrs->option_rom_version) == 0) {
 		int		rval = -1;
-		uint32_t	i = 0;
-		caddr_t		fcode_ver_buf = NULL;
+		char		*fcode_ver_buf = NULL;
 
 		if (CFG_IST(ha, CFG_CTRL_22XX)) {
 			/*LINTED [Solaris DDI_DEV_T_ANY Lint warning]*/
-			rval = ddi_getlongprop(DDI_DEV_T_ANY, ha->dip,
-			    DDI_PROP_DONTPASS | DDI_PROP_CANSLEEP, "version",
-			    (caddr_t)&fcode_ver_buf, (int32_t *)&i);
+			rval = ddi_prop_lookup_string(DDI_DEV_T_ANY, ha->dip,
+			    DDI_PROP_DONTPASS, "version", &fcode_ver_buf);
 		}
 
 		(void) snprintf(attrs->option_rom_version,
@@ -314,9 +312,8 @@ ql_populate_hba_fru_details(ql_adapter_state_t *ha,
 		    "No boot image detected"));
 
 		if (fcode_ver_buf != NULL) {
-			kmem_free(fcode_ver_buf, (size_t)i);
+			ddi_prop_free(fcode_ver_buf);
 		}
-
 	}
 
 	attrs->vendor_specific_id = ha->adapter_features;
@@ -622,7 +619,7 @@ ql_get_basedev_len(ql_adapter_state_t *ha, uint32_t *basedev_len,
  *	ha instance has same base device path as input's.
  *
  * Input:
- *	myha 		= current adapter state pointer.
+ *	myha		= current adapter state pointer.
  *	mybasedev_len	= Length of the base device in the
  *			  device path name.
  *

--- a/usr/src/uts/common/io/fibre-channel/fca/qlc/ql_init.c
+++ b/usr/src/uts/common/io/fibre-channel/fca/qlc/ql_init.c
@@ -523,6 +523,8 @@ ql_nvram_config(ql_adapter_state_t *ha)
 		idpromlen = 32;
 
 		/*LINTED [Solaris DDI_DEV_T_ANY Lint warning]*/
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored	"-Wdeprecated-declarations"
 		if (ddi_getlongprop_buf(DDI_DEV_T_ANY, ha->dip,
 		    DDI_PROP_CANSLEEP, "idprom", (caddr_t)idprombuf,
 		    &idpromlen) != DDI_PROP_SUCCESS) {
@@ -548,6 +550,7 @@ ql_nvram_config(ql_adapter_state_t *ha)
 			nv->port_name[0] = (uint8_t)
 			    (NAA_ID_IEEE_EXTENDED << 4 | ha->instance);
 		}
+#pragma GCC diagnostic pop
 
 		/* Don't print nvram message if it's an on-board 2200 */
 		if (!(CFG_IST(ha, CFG_CTRL_22XX)) &&
@@ -1007,6 +1010,8 @@ ql_nvram_24xx_config(ql_adapter_state_t *ha)
 		idpromlen = 32;
 
 		/*LINTED [Solaris DDI_DEV_T_ANY Lint warning]*/
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 		if (rval = ddi_getlongprop_buf(DDI_DEV_T_ANY, ha->dip,
 		    DDI_PROP_CANSLEEP, "idprom", (caddr_t)idprombuf,
 		    &idpromlen) != DDI_PROP_SUCCESS) {
@@ -1029,6 +1034,7 @@ ql_nvram_24xx_config(ql_adapter_state_t *ha)
 			nv->port_name[0] = (uint8_t)
 			    (NAA_ID_IEEE_EXTENDED << 4 | ha->instance);
 		}
+#pragma GCC diagnostic pop
 
 		cmn_err(CE_WARN, "%s(%d): Unreliable HBA NVRAM, using default "
 		    "HBA parameters and temporary "

--- a/usr/src/uts/common/io/fibre-channel/fca/qlc/ql_ioctl.c
+++ b/usr/src/uts/common/io/fibre-channel/fca/qlc/ql_ioctl.c
@@ -1782,8 +1782,11 @@ ql_adm_adapter_info(ql_adapter_state_t *ha, ql_adm_op_t *dop, int mode)
 	bzero(hba.fcode_ver, sizeof (hba.fcode_ver));
 
 	/*LINTED [Solaris DDI_DEV_T_ANY Lint warning]*/
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	rval = ddi_getlongprop(DDI_DEV_T_ANY, ha->dip,
 	    DDI_PROP_DONTPASS | DDI_PROP_CANSLEEP, "version", (caddr_t)&dp, &i);
+#pragma GCC diagnostic pop
 	length = i;
 	if (rval != DDI_PROP_SUCCESS) {
 		EL(ha, "failed, ddi_getlongprop=%xh\n", rval);

--- a/usr/src/uts/common/io/fibre-channel/fca/qlc/ql_xioctl.c
+++ b/usr/src/uts/common/io/fibre-channel/fca/qlc/ql_xioctl.c
@@ -898,6 +898,8 @@ ql_qry_hba_node(ql_adapter_state_t *ha, EXT_IOCTL *cmd, int mode)
 
 	/* FCode version. */
 	/*LINTED [Solaris DDI_DEV_T_ANY Lint error]*/
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	if (ddi_getlongprop(DDI_DEV_T_ANY, ha->dip, PROP_LEN_AND_VAL_ALLOC |
 	    DDI_PROP_DONTPASS | DDI_PROP_CANSLEEP, "version", (caddr_t)&bufp,
 	    (int *)&len) == DDI_PROP_SUCCESS) {
@@ -913,6 +915,7 @@ ql_qry_hba_node(ql_adapter_state_t *ha, EXT_IOCTL *cmd, int mode)
 	} else {
 		(void) sprintf((char *)tmp_node.OptRomVersion, "0");
 	}
+#pragma GCC diagnostic pop
 	tmp_node.PortCount = 1;
 	tmp_node.InterfaceType = EXT_DEF_FC_INTF_TYPE;
 
@@ -7142,7 +7145,7 @@ ql_check_pci(ql_adapter_state_t *ha, ql_fcache_t *fcache, uint32_t *nextpos)
 
 	if (CFG_IST(ha, CFG_SBUS_CARD)) {
 		caddr_t	bufp;
-		uint_t	len;
+
 
 		if (pciinfo[0] != SBUS_CODE_FCODE) {
 			EL(ha, "failed, unable to detect sbus fcode\n");
@@ -7151,14 +7154,12 @@ ql_check_pci(ql_adapter_state_t *ha, ql_fcache_t *fcache, uint32_t *nextpos)
 		fcache->type = FTYPE_FCODE;
 
 		/*LINTED [Solaris DDI_DEV_T_ANY Lint error]*/
-		if (ddi_getlongprop(DDI_DEV_T_ANY, ha->dip,
-		    PROP_LEN_AND_VAL_ALLOC | DDI_PROP_DONTPASS |
-		    DDI_PROP_CANSLEEP, "version", (caddr_t)&bufp,
-		    (int *)&len) == DDI_PROP_SUCCESS) {
-
+		if (ddi_prop_lookup_string(DDI_DEV_T_ANY, ha->dip,
+		    DDI_PROP_DONTPASS, "version",
+		    &bufp) == DDI_PROP_SUCCESS) {
 			(void) snprintf(fcache->verstr,
 			    FCHBA_OPTION_ROM_VERSION_LEN, "%s", bufp);
-			kmem_free(bufp, len);
+			ddi_prop_free(bufp);
 		}
 
 		*nextpos = 0xffffffff;

--- a/usr/src/uts/common/io/fibre-channel/impl/fctl.c
+++ b/usr/src/uts/common/io/fibre-channel/impl/fctl.c
@@ -2138,13 +2138,10 @@ fctl_initchild(dev_info_t *fca_dip, dev_info_t *port_dip)
 {
 	int		rval;
 	int		port_no;
-	int		port_len;
 	char		name[20];
 	fc_fca_tran_t	*tran;
 	dev_info_t	*dip;
 	int		portprop;
-
-	port_len = sizeof (port_no);
 
 	/* physical port do not has this property */
 	portprop = ddi_prop_get_int(DDI_DEV_T_ANY, port_dip,
@@ -2161,11 +2158,10 @@ fctl_initchild(dev_info_t *fca_dip, dev_info_t *port_dip)
 		return (DDI_FAILURE);
 	}
 
-	rval = ddi_prop_op(DDI_DEV_T_ANY, port_dip, PROP_LEN_AND_VAL_BUF,
-	    DDI_PROP_DONTPASS | DDI_PROP_CANSLEEP, "port",
-	    (caddr_t)&port_no, &port_len);
+	port_no = ddi_prop_get_int(DDI_DEV_T_ANY, port_dip,
+	    DDI_PROP_DONTPASS, "port", -1);
 
-	if (rval != DDI_SUCCESS) {
+	if (rval == -1) {
 		return (DDI_FAILURE);
 	}
 

--- a/usr/src/uts/common/io/fibre-channel/impl/fp.c
+++ b/usr/src/uts/common/io/fibre-channel/impl/fp.c
@@ -913,10 +913,8 @@ fp_init_symbolic_names(fc_local_port_t *port)
 static int
 fp_attach_handler(dev_info_t *dip)
 {
-	int			rval;
 	int			instance;
 	int			port_num;
-	int			port_len;
 	char			name[30];
 	char			i_pwwn[17];
 	fp_cmd_t		*pkt;
@@ -928,11 +926,11 @@ fp_attach_handler(dev_info_t *dip)
 	char pwwn[17], nwwn[17];
 
 	instance = ddi_get_instance(dip);
-	port_len = sizeof (port_num);
-	rval = ddi_prop_op(DDI_DEV_T_ANY, dip, PROP_LEN_AND_VAL_BUF,
-	    DDI_PROP_DONTPASS | DDI_PROP_CANSLEEP, "port",
-	    (caddr_t)&port_num, &port_len);
-	if (rval != DDI_SUCCESS) {
+
+	port_num = ddi_prop_get_int(DDI_DEV_T_ANY, dip,
+	    DDI_PROP_DONTPASS, "port", -1);
+
+	if (port_num == -1) {
 		cmn_err(CE_WARN, "fp(%d): No port property in devinfo",
 		    instance);
 		return (DDI_FAILURE);
@@ -7581,14 +7579,12 @@ fp_fciocmd(fc_local_port_t *port, intptr_t data, int mode, fcio_t *fcio)
 		} else {
 			fc_local_port_t *nextport = tmpport->fp_port_next;
 			fc_local_port_t *prevport = tmpport->fp_port_prev;
-			int portlen, portindex, ret;
+			int portindex;
 
-			portlen = sizeof (portindex);
-			ret = ddi_prop_op(DDI_DEV_T_ANY,
-			    tmpport->fp_port_dip, PROP_LEN_AND_VAL_BUF,
-			    DDI_PROP_DONTPASS | DDI_PROP_CANSLEEP, "port",
-			    (caddr_t)&portindex, &portlen);
-			if (ret != DDI_SUCCESS) {
+			portindex = ddi_prop_get_int(DDI_DEV_T_ANY,
+			    tmpport->fp_port_dip, DDI_PROP_DONTPASS, "port",
+			    -1);
+			if (portindex == -1) {
 				rval = EFAULT;
 				break;
 			}

--- a/usr/src/uts/common/io/gld.c
+++ b/usr/src/uts/common/io/gld.c
@@ -556,7 +556,7 @@ gld_register(dev_info_t *devinfo, char *devname, gld_mac_info_t *macinfo)
 	}
 
 	/* see gld_rsrv() */
-	if (ddi_getprop(DDI_DEV_T_NONE, devinfo, 0, "fast_recv", 0))
+	if (ddi_prop_get_int(DDI_DEV_T_NONE, devinfo, 0, "fast_recv", 0))
 		macinfo->gldm_options |= GLDOPT_FAST_RECV;
 
 	mutex_enter(&gld_device_list.gld_devlock);
@@ -583,7 +583,7 @@ gld_register(dev_info_t *devinfo, char *devname, gld_mac_info_t *macinfo)
 		mutex_init(&glddev->gld_devlock, NULL, MUTEX_DRIVER, NULL);
 
 		/* allow increase of number of supported multicast addrs */
-		glddev->gld_multisize = ddi_getprop(DDI_DEV_T_NONE,
+		glddev->gld_multisize = ddi_prop_get_int(DDI_DEV_T_NONE,
 		    devinfo, 0, "multisize", GLD_MAX_MULTICAST);
 
 		/*
@@ -592,8 +592,8 @@ gld_register(dev_info_t *devinfo, char *devname, gld_mac_info_t *macinfo)
 		 * -1 - don't create style 1 nodes
 		 * -2 - don't create style 2 nodes
 		 */
-		glddev->gld_styles = ddi_getprop(DDI_DEV_T_NONE, devinfo, 0,
-		    "gld-provider-styles", 0);
+		glddev->gld_styles = ddi_prop_get_int(DDI_DEV_T_NONE, devinfo,
+		    0, "gld-provider-styles", 0);
 
 		/* Stuff that's needed before any PPA gets attached */
 		glddev->gld_type = macinfo->gldm_type;

--- a/usr/src/uts/common/io/gldutil.c
+++ b/usr/src/uts/common/io/gldutil.c
@@ -1242,7 +1242,7 @@ gld_init_tr(gld_mac_info_t *macinfo)
 
 	/* Default is RDE enabled for this medium */
 	((gld_mac_pvt_t *)macinfo->gldm_mac_pvt)->rde_enabled =
-	    ddi_getprop(DDI_DEV_T_NONE, macinfo->gldm_devinfo, 0,
+	    ddi_prop_get_int(DDI_DEV_T_NONE, macinfo->gldm_devinfo, 0,
 	    "gld_rde_enable", 1);
 
 	/*
@@ -1255,13 +1255,13 @@ gld_init_tr(gld_mac_info_t *macinfo)
 	 * the RDE algorithms.
 	 */
 	((gld_mac_pvt_t *)macinfo->gldm_mac_pvt)->rde_str_indicator_ste =
-	    ddi_getprop(DDI_DEV_T_NONE, macinfo->gldm_devinfo, 0,
+	    ddi_prop_get_int(DDI_DEV_T_NONE, macinfo->gldm_devinfo, 0,
 	    "gld_rde_str_indicator_ste",
 	    ((gld_mac_pvt_t *)macinfo->gldm_mac_pvt)->rde_enabled);
 
 	/* Default 10 second route timeout on lack of activity */
 	{
-	int t = ddi_getprop(DDI_DEV_T_NONE, macinfo->gldm_devinfo, 0,
+	int t = ddi_prop_get_int(DDI_DEV_T_NONE, macinfo->gldm_devinfo, 0,
 	    "gld_rde_timeout", 10);
 	if (t < 1)
 		t = 1;		/* Let's be reasonable */

--- a/usr/src/uts/common/io/hme/hme.c
+++ b/usr/src/uts/common/io/hme/hme.c
@@ -202,7 +202,7 @@ static	uint_t hmeintr(caddr_t);
 static	void hmereclaim(struct hme *);
 static	int hmeinit(struct hme *);
 static	void hmeuninit(struct hme *hmep);
-static 	mblk_t *hmeread(struct hme *, hmebuf_t *, uint32_t);
+static	mblk_t *hmeread(struct hme *, hmebuf_t *, uint32_t);
 static	void hmesavecntrs(struct hme *);
 static	void hme_fatal_err(struct hme *, uint_t);
 static	void hme_nonfatal_err(struct hme *, uint_t);
@@ -402,7 +402,7 @@ static struct modlinkage modlinkage = {
 
 #define	BMAC_DEFAULT_JAMSIZE	(0x04)		/* jamsize equals 4 */
 #define	BMAC_LONG_JAMSIZE	(0x10)		/* jamsize equals 0x10 */
-static	int 	jamsize = BMAC_DEFAULT_JAMSIZE;
+static	int	jamsize = BMAC_DEFAULT_JAMSIZE;
 
 
 /*
@@ -937,7 +937,7 @@ hme_get_vpd_props(dev_info_t *dip)
  */
 
 typedef struct {
-	struct hme 		*hmep;
+	struct hme		*hmep;
 	dev_info_t		*parent;
 	uint8_t			bus, dev;
 	ddi_acc_handle_t	acch;
@@ -1163,9 +1163,8 @@ hmeattach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 {
 	struct hme *hmep;
 	mac_register_t *macp = NULL;
-	int 	regno;
+	int	regno;
 	int hm_rev = 0;
-	int prop_len = sizeof (int);
 	ddi_acc_handle_t cfg_handle;
 	struct {
 		uint16_t vendorid;
@@ -1206,7 +1205,7 @@ hmeattach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 	 * Might as well set up elements of data structure
 	 */
 	hmep->dip =		dip;
-	hmep->instance = 	ddi_get_instance(dip);
+	hmep->instance =	ddi_get_instance(dip);
 	hmep->pagesize =	ddi_ptob(dip, (ulong_t)1); /* IOMMU PSize */
 
 	/*
@@ -1384,9 +1383,8 @@ hmeattach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 
 	/* NEW routine to get the properties */
 
-	if (ddi_getlongprop_buf(DDI_DEV_T_ANY, hmep->dip, 0, "hm-rev",
-	    (caddr_t)&hm_rev, &prop_len) == DDI_PROP_SUCCESS) {
-
+	if ((hm_rev = ddi_prop_get_int(DDI_DEV_T_ANY, hmep->dip, 0, "hm-rev",
+	    -1)) != -1) {
 		hmep->asic_rev = hm_rev;
 		hmeget_hm_rev_property(hmep);
 	} else {
@@ -1676,7 +1674,6 @@ hmeinit_xfer_params(struct hme *hmep)
 {
 	int hme_ipg1_conf, hme_ipg2_conf;
 	int hme_ipg0_conf, hme_lance_mode_conf;
-	int prop_len = sizeof (int);
 	dev_info_t *dip;
 
 	dip = hmep->dip;
@@ -1693,23 +1690,23 @@ hmeinit_xfer_params(struct hme *hmep)
 	/*
 	 * Get the parameter values configured in .conf file.
 	 */
-	if (ddi_getlongprop_buf(DDI_DEV_T_ANY, dip, 0, "ipg1",
-	    (caddr_t)&hme_ipg1_conf, &prop_len) == DDI_PROP_SUCCESS) {
+	if ((hme_ipg1_conf = ddi_prop_get_int(DDI_DEV_T_ANY, dip,
+	    0, "ipg1", 0)) != 0) {
 		hmep->hme_ipg1 = hme_ipg1_conf & HME_MASK_8BIT;
 	}
 
-	if (ddi_getlongprop_buf(DDI_DEV_T_ANY, dip, 0, "ipg2",
-	    (caddr_t)&hme_ipg2_conf, &prop_len) == DDI_PROP_SUCCESS) {
+	if ((hme_ipg2_conf = ddi_prop_get_int(DDI_DEV_T_ANY, dip,
+	    0, "ipg2", 0)) != 0) {
 		hmep->hme_ipg2 = hme_ipg2_conf & HME_MASK_8BIT;
 	}
 
-	if (ddi_getlongprop_buf(DDI_DEV_T_ANY, dip, 0, "ipg0",
-	    (caddr_t)&hme_ipg0_conf, &prop_len) == DDI_PROP_SUCCESS) {
+	if ((hme_ipg0_conf = ddi_prop_get_int(DDI_DEV_T_ANY, dip,
+	    0, "ipg0", 0)) != 0) {
 		hmep->hme_ipg0 = hme_ipg0_conf & HME_MASK_5BIT;
 	}
 
-	if (ddi_getlongprop_buf(DDI_DEV_T_ANY, dip, 0, "lance_mode",
-	    (caddr_t)&hme_lance_mode_conf, &prop_len) == DDI_PROP_SUCCESS) {
+	if ((hme_lance_mode_conf = ddi_prop_get_int(DDI_DEV_T_ANY, dip,
+	    0, "lance_mode", 0)) != 0) {
 		hmep->hme_lance_mode = hme_lance_mode_conf & HME_MASK_1BIT;
 	}
 
@@ -3565,8 +3562,8 @@ hmesavecntrs(struct hme *hmep)
 static void
 hme_setup_mac_address(struct hme *hmep, dev_info_t *dip)
 {
-	char	*prop;
-	int	prop_len = sizeof (int);
+	uchar_t	*prop;
+	uint_t	prop_len;
 
 	hmep->hme_addrflags = 0;
 
@@ -3575,9 +3572,8 @@ hme_setup_mac_address(struct hme *hmep, dev_info_t *dip)
 	 * If it is present, save it as the "factory-address"
 	 * for this adapter.
 	 */
-	if (ddi_getlongprop(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
-	    "local-mac-address",
-	    (caddr_t)&prop, &prop_len) == DDI_PROP_SUCCESS) {
+	if (ddi_prop_lookup_byte_array(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
+	    "local-mac-address", &prop, &prop_len) == DDI_PROP_SUCCESS) {
 		if (prop_len == ETHERADDRL) {
 			hmep->hme_addrflags = HME_FACTADDR_PRESENT;
 			ether_bcopy(prop, &hmep->hme_factaddr);
@@ -3585,21 +3581,21 @@ hme_setup_mac_address(struct hme *hmep, dev_info_t *dip)
 			    "Local Ethernet address = %s",
 			    ether_sprintf(&hmep->hme_factaddr));
 		}
-		kmem_free(prop, prop_len);
+		ddi_prop_free(prop);
 	}
 
 	/*
 	 * Check if the adapter has published "mac-address" property.
 	 * If it is present, use it as the mac address for this device.
 	 */
-	if (ddi_getlongprop(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
-	    "mac-address", (caddr_t)&prop, &prop_len) == DDI_PROP_SUCCESS) {
+	if (ddi_prop_lookup_byte_array(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
+	    "mac-address", &prop, &prop_len) == DDI_PROP_SUCCESS) {
 		if (prop_len >= ETHERADDRL) {
 			ether_bcopy(prop, &hmep->hme_ouraddr);
-			kmem_free(prop, prop_len);
+			ddi_prop_free(prop);
 			return;
 		}
-		kmem_free(prop, prop_len);
+		ddi_prop_free(prop);
 	}
 
 #ifdef	__sparc

--- a/usr/src/uts/common/io/hotplug/pcihp/pcihp.c
+++ b/usr/src/uts/common/io/hotplug/pcihp/pcihp.c
@@ -3669,7 +3669,8 @@ pcihp_config_setup(dev_info_t **dip, ddi_acc_handle_t *handle,
     dev_info_t **new_child, int pci_dev, pcihp_t *pcihp_p)
 {
 	dev_info_t *pdip = pcihp_p->dip;
-	int bus, len, rc = DDI_SUCCESS;
+	int bus, rc = DDI_SUCCESS;
+	uint_t len;
 	struct pcihp_slotinfo *slotinfop;
 	hpc_slot_state_t rstate;
 	ddi_acc_hdl_t *hp;
@@ -3706,13 +3707,14 @@ pcihp_config_setup(dev_info_t **dip, ddi_acc_handle_t *handle,
 	 * If there is no dip then we need to see if an
 	 * adapter has just been hot plugged.
 	 */
-	len = sizeof (pci_bus_range_t);
-	if (ddi_getlongprop_buf(DDI_DEV_T_ANY, pdip,
-	    0, "bus-range",
-	    (caddr_t)&pci_bus_range, &len) != DDI_SUCCESS) {
-
+	int *arb;
+	if (ddi_prop_lookup_int_array(DDI_DEV_T_ANY, pdip,
+	    0, "bus-range", &arb, &len) != DDI_SUCCESS) {
 		return (PCIHP_FAILURE);
 	}
+
+	memcpy(&pci_bus_range, arb, sizeof (struct pci_bus_range));
+	ddi_prop_free(arb);
 
 	/* primary bus number of this bus node */
 	bus = pci_bus_range.lo;

--- a/usr/src/uts/common/io/hotplug/pcihp/pcihp.c
+++ b/usr/src/uts/common/io/hotplug/pcihp/pcihp.c
@@ -2913,8 +2913,8 @@ pcihp_event_handler(caddr_t slot_arg, uint_t event_mask)
 		else
 			hint = SE_OUTGOING_RES;
 
-		if (ddi_getprop(DDI_DEV_T_ANY, pcihp_p->dip, DDI_PROP_DONTPASS,
-		    "inkernel-autoconfig", 0) == 0) {
+		if (ddi_prop_get_int(DDI_DEV_T_ANY, pcihp_p->dip,
+		    DDI_PROP_DONTPASS, "inkernel-autoconfig", 0) == 0) {
 			pcihp_gen_sysevent(slotinfop->name, PCIHP_DR_REQ, hint,
 			    pcihp_p->dip, KM_SLEEP);
 			break;

--- a/usr/src/uts/common/io/ib/adapters/hermon/hermon_fm.c
+++ b/usr/src/uts/common/io/ib/adapters/hermon/hermon_fm.c
@@ -348,7 +348,7 @@ hermon_fm_init(hermon_state_t *state)
 	 * Check the "fm_disable" property. If it's defined,
 	 * use the Solaris FMA default action for Hermon.
 	 */
-	if (ddi_getprop(DDI_DEV_T_NONE, state->hs_dip, DDI_PROP_DONTPASS,
+	if (ddi_prop_get_int(DDI_DEV_T_NONE, state->hs_dip, DDI_PROP_DONTPASS,
 	    "fm_disable", 0) != 0) {
 		state->hs_fm_disable = 1;
 	}
@@ -775,8 +775,8 @@ error:
  */
 int
 hermon_regs_map_setup(hermon_state_t *state, uint_t rnumber, caddr_t *addrp,
-	offset_t offset, offset_t len, ddi_device_acc_attr_t *accattrp,
-	ddi_acc_handle_t *handle)
+    offset_t offset, offset_t len, ddi_device_acc_attr_t *accattrp,
+    ddi_acc_handle_t *handle)
 {
 	if (state->hs_fm_disable) {
 		return (ddi_regs_map_setup(state->hs_dip, rnumber, addrp,

--- a/usr/src/uts/common/io/ldterm.c
+++ b/usr/src/uts/common/io/ldterm.c
@@ -685,6 +685,8 @@ ldtermopen(queue_t *q, dev_t *devp, int oflag, int sflag, cred_t *crp)
 	 * Get termios defaults.  These are stored as
 	 * a property in the "options" node.
 	 */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	if (ddi_getlongprop(DDI_DEV_T_ANY, ddi_root_node(), DDI_PROP_NOTPROM,
 	    "ttymodes", (caddr_t)&termiosp, &len) == DDI_PROP_SUCCESS &&
 	    len == sizeof (struct termios)) {
@@ -697,6 +699,7 @@ ldtermopen(queue_t *q, dev_t *devp, int oflag, int sflag, cred_t *crp)
 		 */
 		cmn_err(CE_WARN, "ldterm: Couldn't get ttymodes property!");
 	}
+#pragma GCC diagnostic pop
 	bzero(&tp->t_dmodes, sizeof (struct termios));
 
 	tp->t_state = 0;

--- a/usr/src/uts/common/io/llc1.c
+++ b/usr/src/uts/common/io/llc1.c
@@ -276,7 +276,7 @@ llc1_attach(dev_info_t *devinfo, ddi_attach_cmd_t cmd)
 		ddi_remove_minor_node(devinfo, NULL);
 		return (DDI_FAILURE);
 	}
-	llc1_device_list.llc1_multisize = ddi_getprop(DDI_DEV_T_NONE,
+	llc1_device_list.llc1_multisize = ddi_prop_get_int(DDI_DEV_T_NONE,
 	    devinfo, 0, "multisize", 0);
 	if (llc1_device_list.llc1_multisize == 0)
 		llc1_device_list.llc1_multisize = LLC1_MAX_MULTICAST;

--- a/usr/src/uts/common/io/log.c
+++ b/usr/src/uts/common/io/log.c
@@ -80,8 +80,8 @@ log_attach(dev_info_t *devi, ddi_attach_cmd_t cmd)
 		return (DDI_FAILURE);
 	}
 	log_devi = devi;
-	log_msgid = ddi_getprop(DDI_DEV_T_ANY, log_devi,
-	    DDI_PROP_CANSLEEP, "msgid", 1);
+	log_msgid = ddi_prop_get_int(DDI_DEV_T_ANY, log_devi,
+	    0, "msgid", 1);
 	return (DDI_SUCCESS);
 }
 

--- a/usr/src/uts/common/io/mem.c
+++ b/usr/src/uts/common/io/mem.c
@@ -188,8 +188,8 @@ mm_attach(dev_info_t *devi, ddi_attach_cmd_t cmd)
 		kstat_install(ksp);
 	}
 
-	mm_kmem_io_access = ddi_getprop(DDI_DEV_T_ANY, devi, DDI_PROP_DONTPASS,
-	    "kmem_io_access", 0);
+	mm_kmem_io_access = ddi_prop_get_int(DDI_DEV_T_ANY, devi,
+	    DDI_PROP_DONTPASS, "kmem_io_access", 0);
 
 	return (DDI_SUCCESS);
 }

--- a/usr/src/uts/common/io/mlxcx/mlxcx.c
+++ b/usr/src/uts/common/io/mlxcx/mlxcx.c
@@ -519,14 +519,14 @@ mlxcx_load_model_props(mlxcx_t *mlxp)
 
 	mlxcx_load_prop_defaults(mlxp);
 
-	p->mldp_cq_size_shift = ddi_getprop(DDI_DEV_T_ANY, mlxp->mlx_dip,
-	    DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS, "cq_size_shift",
+	p->mldp_cq_size_shift = ddi_prop_get_int(DDI_DEV_T_ANY, mlxp->mlx_dip,
+	    DDI_PROP_DONTPASS, "cq_size_shift",
 	    p->mldp_cq_size_shift_default);
-	p->mldp_sq_size_shift = ddi_getprop(DDI_DEV_T_ANY, mlxp->mlx_dip,
-	    DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS, "sq_size_shift",
+	p->mldp_sq_size_shift = ddi_prop_get_int(DDI_DEV_T_ANY, mlxp->mlx_dip,
+	    DDI_PROP_DONTPASS, "sq_size_shift",
 	    p->mldp_sq_size_shift_default);
-	p->mldp_rq_size_shift = ddi_getprop(DDI_DEV_T_ANY, mlxp->mlx_dip,
-	    DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS, "rq_size_shift",
+	p->mldp_rq_size_shift = ddi_prop_get_int(DDI_DEV_T_ANY, mlxp->mlx_dip,
+	    DDI_PROP_DONTPASS, "rq_size_shift",
 	    p->mldp_rq_size_shift_default);
 }
 
@@ -535,63 +535,63 @@ mlxcx_load_props(mlxcx_t *mlxp)
 {
 	mlxcx_drv_props_t *p = &mlxp->mlx_props;
 
-	p->mldp_eq_size_shift = ddi_getprop(DDI_DEV_T_ANY, mlxp->mlx_dip,
-	    DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS, "eq_size_shift",
+	p->mldp_eq_size_shift = ddi_prop_get_int(DDI_DEV_T_ANY, mlxp->mlx_dip,
+	    DDI_PROP_DONTPASS, "eq_size_shift",
 	    MLXCX_EQ_SIZE_SHIFT_DFLT);
-	p->mldp_cqemod_period_usec = ddi_getprop(DDI_DEV_T_ANY, mlxp->mlx_dip,
-	    DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS, "cqemod_period_usec",
+	p->mldp_cqemod_period_usec = ddi_prop_get_int(DDI_DEV_T_ANY,
+	    mlxp->mlx_dip, DDI_PROP_DONTPASS, "cqemod_period_usec",
 	    MLXCX_CQEMOD_PERIOD_USEC_DFLT);
-	p->mldp_cqemod_count = ddi_getprop(DDI_DEV_T_ANY, mlxp->mlx_dip,
-	    DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS, "cqemod_count",
+	p->mldp_cqemod_count = ddi_prop_get_int(DDI_DEV_T_ANY, mlxp->mlx_dip,
+	    DDI_PROP_DONTPASS, "cqemod_count",
 	    MLXCX_CQEMOD_COUNT_DFLT);
-	p->mldp_intrmod_period_usec = ddi_getprop(DDI_DEV_T_ANY, mlxp->mlx_dip,
-	    DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS, "intrmod_period_usec",
+	p->mldp_intrmod_period_usec = ddi_prop_get_int(DDI_DEV_T_ANY,
+	    mlxp->mlx_dip, DDI_PROP_DONTPASS, "intrmod_period_usec",
 	    MLXCX_INTRMOD_PERIOD_USEC_DFLT);
 
-	p->mldp_tx_ngroups = ddi_getprop(DDI_DEV_T_ANY, mlxp->mlx_dip,
-	    DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS, "tx_ngroups",
+	p->mldp_tx_ngroups = ddi_prop_get_int(DDI_DEV_T_ANY, mlxp->mlx_dip,
+	    DDI_PROP_DONTPASS, "tx_ngroups",
 	    MLXCX_TX_NGROUPS_DFLT);
-	p->mldp_tx_nrings_per_group = ddi_getprop(DDI_DEV_T_ANY, mlxp->mlx_dip,
-	    DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS, "tx_nrings_per_group",
+	p->mldp_tx_nrings_per_group = ddi_prop_get_int(DDI_DEV_T_ANY,
+	    mlxp->mlx_dip, DDI_PROP_DONTPASS, "tx_nrings_per_group",
 	    MLXCX_TX_NRINGS_PER_GROUP_DFLT);
 
-	p->mldp_rx_ngroups_large = ddi_getprop(DDI_DEV_T_ANY, mlxp->mlx_dip,
-	    DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS, "rx_ngroups_large",
+	p->mldp_rx_ngroups_large = ddi_prop_get_int(DDI_DEV_T_ANY,
+	    mlxp->mlx_dip, DDI_PROP_DONTPASS, "rx_ngroups_large",
 	    MLXCX_RX_NGROUPS_LARGE_DFLT);
-	p->mldp_rx_ngroups_small = ddi_getprop(DDI_DEV_T_ANY, mlxp->mlx_dip,
-	    DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS, "rx_ngroups_small",
+	p->mldp_rx_ngroups_small = ddi_prop_get_int(DDI_DEV_T_ANY,
+	    mlxp->mlx_dip, DDI_PROP_DONTPASS, "rx_ngroups_small",
 	    MLXCX_RX_NGROUPS_SMALL_DFLT);
-	p->mldp_rx_nrings_per_large_group = ddi_getprop(DDI_DEV_T_ANY,
-	    mlxp->mlx_dip, DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS,
+	p->mldp_rx_nrings_per_large_group = ddi_prop_get_int(DDI_DEV_T_ANY,
+	    mlxp->mlx_dip, DDI_PROP_DONTPASS,
 	    "rx_nrings_per_large_group", MLXCX_RX_NRINGS_PER_LARGE_GROUP_DFLT);
-	p->mldp_rx_nrings_per_small_group = ddi_getprop(DDI_DEV_T_ANY,
-	    mlxp->mlx_dip, DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS,
+	p->mldp_rx_nrings_per_small_group = ddi_prop_get_int(DDI_DEV_T_ANY,
+	    mlxp->mlx_dip, DDI_PROP_DONTPASS,
 	    "rx_nrings_per_small_group", MLXCX_RX_NRINGS_PER_SMALL_GROUP_DFLT);
 
-	p->mldp_ftbl_root_size_shift = ddi_getprop(DDI_DEV_T_ANY, mlxp->mlx_dip,
-	    DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS, "ftbl_root_size_shift",
+	p->mldp_ftbl_root_size_shift = ddi_prop_get_int(DDI_DEV_T_ANY,
+	    mlxp->mlx_dip, DDI_PROP_DONTPASS, "ftbl_root_size_shift",
 	    MLXCX_FTBL_ROOT_SIZE_SHIFT_DFLT);
 
-	p->mldp_tx_bind_threshold = ddi_getprop(DDI_DEV_T_ANY, mlxp->mlx_dip,
-	    DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS, "tx_bind_threshold",
+	p->mldp_tx_bind_threshold = ddi_prop_get_int(DDI_DEV_T_ANY,
+	    mlxp->mlx_dip, DDI_PROP_DONTPASS, "tx_bind_threshold",
 	    MLXCX_TX_BIND_THRESHOLD_DFLT);
 
-	p->mldp_ftbl_vlan_size_shift = ddi_getprop(DDI_DEV_T_ANY, mlxp->mlx_dip,
-	    DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS, "ftbl_vlan_size_shift",
+	p->mldp_ftbl_vlan_size_shift = ddi_prop_get_int(DDI_DEV_T_ANY,
+	    mlxp->mlx_dip, DDI_PROP_DONTPASS, "ftbl_vlan_size_shift",
 	    MLXCX_FTBL_VLAN_SIZE_SHIFT_DFLT);
 
-	p->mldp_eq_check_interval_sec = ddi_getprop(DDI_DEV_T_ANY,
-	    mlxp->mlx_dip, DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS,
+	p->mldp_eq_check_interval_sec = ddi_prop_get_int(DDI_DEV_T_ANY,
+	    mlxp->mlx_dip, DDI_PROP_DONTPASS,
 	    "eq_check_interval_sec", MLXCX_EQ_CHECK_INTERVAL_SEC_DFLT);
-	p->mldp_cq_check_interval_sec = ddi_getprop(DDI_DEV_T_ANY,
-	    mlxp->mlx_dip, DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS,
+	p->mldp_cq_check_interval_sec = ddi_prop_get_int(DDI_DEV_T_ANY,
+	    mlxp->mlx_dip, DDI_PROP_DONTPASS,
 	    "cq_check_interval_sec", MLXCX_CQ_CHECK_INTERVAL_SEC_DFLT);
-	p->mldp_wq_check_interval_sec = ddi_getprop(DDI_DEV_T_ANY,
-	    mlxp->mlx_dip, DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS,
+	p->mldp_wq_check_interval_sec = ddi_prop_get_int(DDI_DEV_T_ANY,
+	    mlxp->mlx_dip, DDI_PROP_DONTPASS,
 	    "wq_check_interval_sec", MLXCX_WQ_CHECK_INTERVAL_SEC_DFLT);
 
-	p->mldp_rx_per_cq = ddi_getprop(DDI_DEV_T_ANY, mlxp->mlx_dip,
-	    DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS, "rx_limit_per_completion",
+	p->mldp_rx_per_cq = ddi_prop_get_int(DDI_DEV_T_ANY, mlxp->mlx_dip,
+	    DDI_PROP_DONTPASS, "rx_limit_per_completion",
 	    MLXCX_RX_PER_CQ_DEFAULT);
 
 	if (p->mldp_rx_per_cq < MLXCX_RX_PER_CQ_MIN ||
@@ -603,8 +603,8 @@ mlxcx_load_props(mlxcx_t *mlxp)
 		p->mldp_rx_per_cq = MLXCX_RX_PER_CQ_DEFAULT;
 	}
 
-	p->mldp_rx_p50_loan_min_size = ddi_getprop(DDI_DEV_T_ANY,
-	    mlxp->mlx_dip, DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS,
+	p->mldp_rx_p50_loan_min_size = ddi_prop_get_int(DDI_DEV_T_ANY,
+	    mlxp->mlx_dip, DDI_PROP_DONTPASS,
 	    "rx_p50_loan_min_size", MLXCX_P50_LOAN_MIN_SIZE_DFLT);
 }
 

--- a/usr/src/uts/common/io/nvme/nvme.c
+++ b/usr/src/uts/common/io/nvme/nvme.c
@@ -4918,8 +4918,8 @@ nvme_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 	/*
 	 * Set up FMA support.
 	 */
-	nvme->n_fm_cap = ddi_getprop(DDI_DEV_T_ANY, dip,
-	    DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS, "fm-capable",
+	nvme->n_fm_cap = ddi_prop_get_int(DDI_DEV_T_ANY, dip,
+	    DDI_PROP_DONTPASS, "fm-capable",
 	    DDI_FM_EREPORT_CAPABLE | DDI_FM_ACCCHK_CAPABLE |
 	    DDI_FM_DMACHK_CAPABLE | DDI_FM_ERRCB_CAPABLE);
 

--- a/usr/src/uts/common/io/pci_intr_lib.c
+++ b/usr/src/uts/common/io/pci_intr_lib.c
@@ -1231,7 +1231,7 @@ uint32_t
 pci_class_to_val(dev_info_t *rdip, char *property_name, pci_class_val_t *rec_p,
     int nrec, uint32_t default_val)
 {
-	int property_len;
+	uint_t property_len;
 	uint32_t class_code;
 	pci_class_val_t *conf;
 	uint32_t val = default_val;
@@ -1251,14 +1251,16 @@ pci_class_to_val(dev_info_t *rdip, char *property_name, pci_class_val_t *rec_p,
 
 
 	/* see if there is a more specific property specified value */
-	if (ddi_getlongprop(DDI_DEV_T_ANY, rdip, DDI_PROP_NOTPROM,
-	    property_name, (caddr_t)&conf, &property_len))
+	if (ddi_prop_lookup_int_array(DDI_DEV_T_ANY, rdip, DDI_PROP_NOTPROM,
+	    property_name, (int **)&conf, &property_len) != DDI_SUCCESS)
 			return (val);
+
+	property_len = CELLS_1275_TO_BYTES(property_len);
 
 	if ((property_len % sizeof (pci_class_val_t)) == 0)
 		val = pci_match_class_val(class_code, conf,
 		    property_len / sizeof (pci_class_val_t), val);
-	kmem_free(conf, property_len);
+	ddi_prop_free(conf);
 	return (val);
 }
 

--- a/usr/src/uts/common/io/pcic.c
+++ b/usr/src/uts/common/io/pcic.c
@@ -727,9 +727,9 @@ pcic_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 	pcic->pc_numpower = sizeof (pcic_power)/sizeof (pcic_power[0]);
 	pcic->pc_power = pcic_power;
 
-	pci_ctrn = ddi_getprop(DDI_DEV_T_ANY, dip, DDI_PROP_CANSLEEP,
+	pci_ctrn = ddi_prop_get_int(DDI_DEV_T_ANY, dip, 0,
 	    "pci-control-reg-number", pci_control_reg_num);
-	pci_cfrn = ddi_getprop(DDI_DEV_T_ANY, dip, DDI_PROP_CANSLEEP,
+	pci_cfrn = ddi_prop_get_int(DDI_DEV_T_ANY, dip, 0,
 	    "pci-config-reg-number", pci_config_reg_num);
 
 	ddi_set_driver_private(dip, pcic_nexus);
@@ -738,7 +738,7 @@ pcic_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 	 * pcic->pc_irq is really the IPL level we want to run at
 	 * set the default values here and override from intr spec
 	 */
-	pcic->pc_irq = ddi_getprop(DDI_DEV_T_ANY, dip, DDI_PROP_CANSLEEP,
+	pcic->pc_irq = ddi_prop_get_int(DDI_DEV_T_ANY, dip, 0,
 	    "interrupt-priorities", -1);
 
 	if (pcic->pc_irq == -1) {
@@ -795,9 +795,8 @@ pcic_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 		return (DDI_FAILURE);
 	}
 
-	if ((pcic->bus_speed = ddi_getprop(DDI_DEV_T_ANY, ddi_get_parent(dip),
-	    DDI_PROP_CANSLEEP,
-	    "clock-frequency", 0)) == 0) {
+	if ((pcic->bus_speed = ddi_prop_get_int(DDI_DEV_T_ANY,
+	    ddi_get_parent(dip), 0, "clock-frequency", 0)) == 0) {
 		if (pcic->pc_flags & PCF_PCIBUS)
 			pcic->bus_speed = PCIC_PCI_DEF_SYSCLK;
 		else
@@ -862,9 +861,8 @@ pcic_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 			return (DDI_FAILURE);
 		} /* ddi_regs_map_setup */
 
-		class_code = ddi_getprop(DDI_DEV_T_ANY, dip,
-		    DDI_PROP_CANSLEEP|DDI_PROP_DONTPASS,
-		    "class-code", -1);
+		class_code = ddi_prop_get_int(DDI_DEV_T_ANY, dip,
+		    DDI_PROP_DONTPASS, "class-code", -1);
 #ifdef  PCIC_DEBUG
 		if (pcic_debug) {
 			cmn_err(CE_CONT, "pcic_attach class_code=%x\n",
@@ -1096,9 +1094,8 @@ pcic_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 		case PCIC_CL_PD6730:
 		case PCIC_CL_PD6729:
 			pcic->pc_intr_mode = PCIC_INTR_MODE_PCI_1;
-			cfg = ddi_getprop(DDI_DEV_T_ANY, dip,
-			    DDI_PROP_CANSLEEP,
-			    "interrupts", 0);
+			cfg = ddi_prop_get_int(DDI_DEV_T_ANY, dip,
+			    0, "interrupts", 0);
 			/* if not interrupt pin then must use ISA style IRQs */
 			if (cfg == 0 || iline == 0xFF)
 				pcic->pc_intr_mode = PCIC_INTR_MODE_ISA;
@@ -1276,7 +1273,7 @@ pcic_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 
 		smi = 0xff;	/* no more override */
 
-		if (ddi_getprop(DDI_DEV_T_NONE, dip,
+		if (ddi_prop_get_int(DDI_DEV_T_NONE, dip,
 		    DDI_PROP_DONTPASS, "need-mult-irq",
 		    0xffff) != 0xffff)
 			pcic->pc_flags |= PCF_MULT_IRQ;
@@ -1339,11 +1336,11 @@ pcic_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 
 	cv_init(&pcic->pm_cv, NULL, CV_DRIVER, NULL);
 
-	if (!ddi_getprop(DDI_DEV_T_NONE, dip, DDI_PROP_DONTPASS,
+	if (!ddi_prop_get_int(DDI_DEV_T_NONE, dip, DDI_PROP_DONTPASS,
 	    "disable-audio", 0))
 		pcic->pc_flags |= PCF_AUDIO;
 
-	if (ddi_getprop(DDI_DEV_T_ANY, dip, DDI_PROP_CANSLEEP,
+	if (ddi_prop_get_int(DDI_DEV_T_ANY, dip, 0,
 	    "disable-cardbus", 0))
 		pcic->pc_flags &= ~PCF_CARDBUS;
 
@@ -5269,11 +5266,11 @@ pcic_find_pci_type(pcicdev_t *pcic)
 {
 	uint32_t vend, device;
 
-	vend = ddi_getprop(DDI_DEV_T_ANY, pcic->dip,
-	    DDI_PROP_CANSLEEP|DDI_PROP_DONTPASS,
+	vend = ddi_prop_get_int(DDI_DEV_T_ANY, pcic->dip,
+	    DDI_PROP_DONTPASS,
 	    "vendor-id", -1);
-	device = ddi_getprop(DDI_DEV_T_ANY, pcic->dip,
-	    DDI_PROP_CANSLEEP|DDI_PROP_DONTPASS,
+	device = ddi_prop_get_int(DDI_DEV_T_ANY, pcic->dip,
+	    DDI_PROP_DONTPASS,
 	    "device-id", -1);
 
 	device = PCI_ID(vend, device);

--- a/usr/src/uts/common/io/pciex/pcieb.c
+++ b/usr/src/uts/common/io/pciex/pcieb.c
@@ -2151,7 +2151,7 @@ pcieb_set_pci_perf_parameters(dev_info_t *dip, ddi_acc_handle_t cfg_hdl)
 	uint_t	n;
 
 	/* Initialize cache-line-size configuration register if needed */
-	if (ddi_getprop(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
+	if (ddi_prop_get_int(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
 	    "cache-line-size", 0) == 0) {
 		pci_config_put8(cfg_hdl, PCI_CONF_CACHE_LINESZ,
 		    PCIEB_CACHE_LINE_SIZE);
@@ -2163,7 +2163,7 @@ pcieb_set_pci_perf_parameters(dev_info_t *dip, ddi_acc_handle_t cfg_hdl)
 	}
 
 	/* Initialize latency timer configuration registers if needed */
-	if (ddi_getprop(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
+	if (ddi_prop_get_int(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
 	    "latency-timer", 0) == 0) {
 		uchar_t	min_gnt, latency_timer;
 		uchar_t header_type;

--- a/usr/src/uts/common/io/ptem.c
+++ b/usr/src/uts/common/io/ptem.c
@@ -214,6 +214,8 @@ ptemopen(
 	 * Get termios defaults.  These are stored as
 	 * a property in the "options" node.
 	 */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	if (ddi_getlongprop(DDI_DEV_T_ANY, ddi_root_node(), 0, "ttymodes",
 	    (caddr_t)&termiosp, &len) == DDI_PROP_SUCCESS &&
 	    len == sizeof (struct termios)) {
@@ -226,6 +228,7 @@ ptemopen(
 		 */
 		cmn_err(CE_WARN, "ptem: Couldn't get ttymodes property!");
 	}
+#pragma GCC diagnostic pop
 	ntp->wsz.ws_row = 0;
 	ntp->wsz.ws_col = 0;
 	ntp->wsz.ws_xpixel = 0;

--- a/usr/src/uts/common/io/sata/adapters/ahci/ahci.c
+++ b/usr/src/uts/common/io/sata/adapters/ahci/ahci.c
@@ -3451,9 +3451,9 @@ ahci_fm_init(ahci_ctl_t *ahci_ctlp)
 	 */
 	ddi_iblock_cookie_t fm_ibc;
 
-	ahci_ctlp->ahcictl_fm_cap = ddi_getprop(DDI_DEV_T_ANY,
+	ahci_ctlp->ahcictl_fm_cap = ddi_prop_get_int(DDI_DEV_T_ANY,
 	    ahci_ctlp->ahcictl_dip,
-	    DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS, "fm-capable",
+	    DDI_PROP_DONTPASS, "fm-capable",
 	    DDI_FM_EREPORT_CAPABLE | DDI_FM_ACCCHK_CAPABLE |
 	    DDI_FM_DMACHK_CAPABLE | DDI_FM_ERRCB_CAPABLE);
 

--- a/usr/src/uts/common/io/sata/adapters/nv_sata/nv_sata.c
+++ b/usr/src/uts/common/io/sata/adapters/nv_sata/nv_sata.c
@@ -574,10 +574,6 @@ nv_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 	nv_ctl_t *nvc;
 	uint8_t subclass;
 	uint32_t reg32;
-#ifdef SGPIO_SUPPORT
-	pci_regspec_t *regs;
-	int rlen;
-#endif
 
 	switch (cmd) {
 
@@ -744,13 +740,16 @@ nv_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 		}
 
 #ifdef SGPIO_SUPPORT
+		pci_regspec_t *regs;
+		uint_t rlen;
+
 		/*
 		 * save off the controller number
 		 */
-		(void) ddi_getlongprop(DDI_DEV_T_NONE, dip, DDI_PROP_DONTPASS,
-		    "reg", (caddr_t)&regs, &rlen);
+		(void) ddi_prop_lookup_int_array(DDI_DEV_T_NONE, dip,
+		    DDI_PROP_DONTPASS, "reg", (int **)&regs, &rlen);
 		nvc->nvc_ctlr_num = PCI_REG_FUNC_G(regs->pci_phys_hi);
-		kmem_free(regs, rlen);
+		ddi_prop_free(regs);
 
 		/*
 		 * initialize SGPIO

--- a/usr/src/uts/common/io/sata/adapters/nv_sata/nv_sata.c
+++ b/usr/src/uts/common/io/sata/adapters/nv_sata/nv_sata.c
@@ -6471,7 +6471,7 @@ nv_sgp_led_init(nv_ctl_t *nvc, ddi_acc_handle_t pci_conf_handle)
 	 * Only try to initialize SGPIO LED support if this property
 	 * indicates it should be.
 	 */
-	if (ddi_getprop(DDI_DEV_T_ANY, nvc->nvc_dip, DDI_PROP_DONTPASS,
+	if (ddi_prop_get_int(DDI_DEV_T_ANY, nvc->nvc_dip, DDI_PROP_DONTPASS,
 	    "enable-sgpio-leds", 0) != 1)
 		return;
 

--- a/usr/src/uts/common/io/sata/adapters/si3124/si3124.c
+++ b/usr/src/uts/common/io/sata/adapters/si3124/si3124.c
@@ -544,8 +544,8 @@ si_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 		attach_state |= ATTACH_PROGRESS_STATEP_ALLOC;
 
 		/* Initialize FMA */
-		si_ctlp->fm_capabilities = ddi_getprop(DDI_DEV_T_ANY, dip,
-		    DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS, "fm-capable",
+		si_ctlp->fm_capabilities = ddi_prop_get_int(DDI_DEV_T_ANY, dip,
+		    DDI_PROP_DONTPASS, "fm-capable",
 		    DDI_FM_EREPORT_CAPABLE | DDI_FM_ACCCHK_CAPABLE |
 		    DDI_FM_DMACHK_CAPABLE | DDI_FM_ERRCB_CAPABLE);
 

--- a/usr/src/uts/common/io/sata/impl/sata.c
+++ b/usr/src/uts/common/io/sata/impl/sata.c
@@ -2107,7 +2107,7 @@ sata_scsi_tgt_init(dev_info_t *hba_dip, dev_info_t *tgt_dip,
 	 * attach(9F) function.
 	 */
 	if ((sdinfo->satadrv_type == SATA_DTYPE_ATADISK) &&
-	    (ddi_getprop(DDI_DEV_T_ANY, hba_dip, DDI_PROP_DONTPASS,
+	    (ddi_prop_get_int(DDI_DEV_T_ANY, hba_dip, DDI_PROP_DONTPASS,
 	    "use-cmdk-devid-format", 0) == 1)) {
 		/* register a legacy devid for this target node */
 		sata_target_devid_register(tgt_dip, sdinfo);
@@ -2235,7 +2235,7 @@ sata_scsi_tgt_free(dev_info_t *hba_dip, dev_info_t *tgt_dip,
 	 * sd(4D) driver (i.e during detach(9F)) then do it here.
 	 */
 	if ((sdinfo->satadrv_type == SATA_DTYPE_ATADISK) &&
-	    (ddi_getprop(DDI_DEV_T_ANY, hba_dip, DDI_PROP_DONTPASS,
+	    (ddi_prop_get_int(DDI_DEV_T_ANY, hba_dip, DDI_PROP_DONTPASS,
 	    "use-cmdk-devid-format", 0) == 1) &&
 	    (ddi_devid_get(tgt_dip, &devid) == DDI_SUCCESS)) {
 		ddi_devid_unregister(tgt_dip);

--- a/usr/src/uts/common/io/scsi/adapters/mpt_sas/mptsas.c
+++ b/usr/src/uts/common/io/scsi/adapters/mpt_sas/mptsas.c
@@ -1248,8 +1248,8 @@ mptsas_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 	/*
 	 * Initialize FMA
 	 */
-	mpt->m_fm_capabilities = ddi_getprop(DDI_DEV_T_ANY, mpt->m_dip,
-	    DDI_PROP_CANSLEEP | DDI_PROP_DONTPASS, "fm-capable",
+	mpt->m_fm_capabilities = ddi_prop_get_int(DDI_DEV_T_ANY, mpt->m_dip,
+	    DDI_PROP_DONTPASS, "fm-capable",
 	    DDI_FM_EREPORT_CAPABLE | DDI_FM_ACCCHK_CAPABLE |
 	    DDI_FM_DMACHK_CAPABLE | DDI_FM_ERRCB_CAPABLE);
 

--- a/usr/src/uts/common/io/scsi/adapters/mpt_sas/mptsas.c
+++ b/usr/src/uts/common/io/scsi/adapters/mpt_sas/mptsas.c
@@ -2545,18 +2545,20 @@ mptsas_ioc_check_rev(mptsas_t *mpt)
 static void
 mptsas_find_mem_bar(mptsas_t *mpt)
 {
-	int		i, rcount;
 	pci_regspec_t	*reg_data;
-	int		reglen;
+	int		i;
+	uint_t		reglen, rcount;
 
 	mpt->m_mem_bar = MEM_SPACE; /* old default */
 	/*
 	 * Lookup the 'reg' property.
 	 */
-	if (ddi_getlongprop(DDI_DEV_T_ANY, mpt->m_dip,
-	    DDI_PROP_DONTPASS, "reg", (caddr_t)&reg_data, &reglen) ==
+	if (ddi_prop_lookup_int_array(DDI_DEV_T_ANY, mpt->m_dip,
+	    DDI_PROP_DONTPASS, "reg", (int **)&reg_data, &reglen) ==
 	    DDI_PROP_SUCCESS) {
+		reglen = CELLS_1275_TO_BYTES(reglen);
 		rcount = reglen / sizeof (pci_regspec_t);
+
 		for (i = 0; i < rcount; i++) {
 			if (PCI_REG_ADDR_G(reg_data[i].pci_phys_hi) ==
 			    PCI_REG_ADDR_G(PCI_ADDR_MEM64)) {
@@ -2565,6 +2567,7 @@ mptsas_find_mem_bar(mptsas_t *mpt)
 			}
 		}
 	}
+	ddi_prop_free(reg_data);
 }
 
 

--- a/usr/src/uts/common/io/scsi/adapters/pmcs/pmcs_attach.c
+++ b/usr/src/uts/common/io/scsi/adapters/pmcs/pmcs_attach.c
@@ -626,8 +626,8 @@ pmcs_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 	pwp->iqp_dma_attr = pwp->oqp_dma_attr =
 	    pwp->regdump_dma_attr = pwp->cip_dma_attr =
 	    pwp->fwlog_dma_attr = pmcs_dattr;
-	pwp->fm_capabilities = ddi_getprop(DDI_DEV_T_ANY, pwp->dip,
-	    DDI_PROP_NOTPROM | DDI_PROP_DONTPASS, "fm-capable",
+	pwp->fm_capabilities = ddi_prop_get_int(DDI_DEV_T_ANY, pwp->dip,
+	    DDI_PROP_NOTPROM, "fm-capable",
 	    DDI_FM_EREPORT_CAPABLE | DDI_FM_ACCCHK_CAPABLE |
 	    DDI_FM_DMACHK_CAPABLE | DDI_FM_ERRCB_CAPABLE);
 	pmcs_fm_init(pwp);

--- a/usr/src/uts/common/io/scsi/adapters/scsi_vhci/scsi_vhci.c
+++ b/usr/src/uts/common/io/scsi/adapters/scsi_vhci/scsi_vhci.c
@@ -4539,11 +4539,13 @@ vhci_parse_mpxio_lb_options(dev_info_t *dip, dev_info_t *cdip,
 	int			region_size = -1;
 	client_lb_t		load_balance;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	if (ddi_getlongprop(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS, datanameptr,
 	    (caddr_t)&config_list, &config_list_len) != DDI_PROP_SUCCESS) {
 		return;
 	}
-
+#pragma GCC diagnostic pop
 	list_len = config_list_len;
 	next_entry = config_list;
 	while (config_list_len > 0) {
@@ -4678,6 +4680,8 @@ vhci_get_device_type_mpxio_options(dev_info_t *dip, dev_info_t *cdip,
 	 * with those vids in the list if there is a match, lookup
 	 * the mpxio-options value
 	 */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	if (ddi_getlongprop(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
 	    MPXIO_OPTIONS_LIST,
 	    (caddr_t)&config_list, &config_list_len) == DDI_PROP_SUCCESS) {
@@ -4723,6 +4727,7 @@ vhci_get_device_type_mpxio_options(dev_info_t *dip, dev_info_t *cdip,
 			kmem_free(config_list, config_list_len);
 		}
 	}
+#pragma GCC diagnostic pop
 }
 
 static int

--- a/usr/src/uts/common/io/scsi/targets/sd.c
+++ b/usr/src/uts/common/io/scsi/targets/sd.c
@@ -6999,7 +6999,7 @@ sd_unit_attach(dev_info_t *devi)
 	if (un->un_f_is_fibre == TRUE) {
 		un->un_f_allow_bus_device_reset = TRUE;
 	} else {
-		if (ddi_getprop(DDI_DEV_T_ANY, devi, DDI_PROP_DONTPASS,
+		if (ddi_prop_get_int(DDI_DEV_T_ANY, devi, DDI_PROP_DONTPASS,
 		    "allow-bus-device-reset", 1) != 0) {
 			un->un_f_allow_bus_device_reset = TRUE;
 			SD_INFO(SD_LOG_ATTACH_DETACH, un,
@@ -7271,7 +7271,7 @@ sd_unit_attach(dev_info_t *devi)
 		 */
 		if (SD_IS_SERIAL(un)) {
 			un->un_max_xfer_size =
-			    ddi_getprop(DDI_DEV_T_ANY, devi, 0,
+			    ddi_prop_get_int(DDI_DEV_T_ANY, devi, 0,
 			    sd_max_xfer_size, SD_MAX_XFER_SIZE);
 			SD_INFO(SD_LOG_ATTACH_DETACH, un,
 			    "sd_unit_attach: un:0x%p max transfer "
@@ -7304,7 +7304,7 @@ sd_unit_attach(dev_info_t *devi)
 			 */
 			if (un->un_saved_throttle == sd_max_throttle) {
 				un->un_max_xfer_size =
-				    ddi_getprop(DDI_DEV_T_ANY, devi, 0,
+				    ddi_prop_get_int(DDI_DEV_T_ANY, devi, 0,
 				    sd_max_xfer_size, SD_MAX_XFER_SIZE);
 				SD_INFO(SD_LOG_ATTACH_DETACH, un,
 				    "sd_unit_attach: un:0x%p max transfer "
@@ -7320,7 +7320,7 @@ sd_unit_attach(dev_info_t *devi)
 		}
 	} else {
 		un->un_tagflags = FLAG_STAG;
-		un->un_max_xfer_size = ddi_getprop(DDI_DEV_T_ANY,
+		un->un_max_xfer_size = ddi_prop_get_int(DDI_DEV_T_ANY,
 		    devi, 0, sd_max_xfer_size, SD_MAX_XFER_SIZE);
 	}
 
@@ -7621,22 +7621,22 @@ sd_unit_attach(dev_info_t *devi)
 	 * per instance variable is preferable to match the capabilities of
 	 * different underlying hba's (4402600)
 	 */
-	sd_retry_on_reservation_conflict = ddi_getprop(DDI_DEV_T_ANY, devi,
+	sd_retry_on_reservation_conflict = ddi_prop_get_int(DDI_DEV_T_ANY, devi,
 	    DDI_PROP_DONTPASS, "retry-on-reservation-conflict",
 	    sd_retry_on_reservation_conflict);
 	if (sd_retry_on_reservation_conflict != 0) {
-		sd_retry_on_reservation_conflict = ddi_getprop(DDI_DEV_T_ANY,
-		    devi, DDI_PROP_DONTPASS, sd_resv_conflict_name,
-		    sd_retry_on_reservation_conflict);
+		sd_retry_on_reservation_conflict =
+		    ddi_prop_get_int(DDI_DEV_T_ANY, devi, DDI_PROP_DONTPASS,
+		    sd_resv_conflict_name, sd_retry_on_reservation_conflict);
 	}
 
 	/* Set up options for QFULL handling. */
-	if ((rval = ddi_getprop(DDI_DEV_T_ANY, devi, 0,
+	if ((rval = ddi_prop_get_int(DDI_DEV_T_ANY, devi, 0,
 	    "qfull-retries", -1)) != -1) {
 		(void) scsi_ifsetcap(SD_ADDRESS(un), "qfull-retries",
 		    rval, 1);
 	}
-	if ((rval = ddi_getprop(DDI_DEV_T_ANY, devi, 0,
+	if ((rval = ddi_prop_get_int(DDI_DEV_T_ANY, devi, 0,
 	    "qfull-retry-interval", -1)) != -1) {
 		(void) scsi_ifsetcap(SD_ADDRESS(un), "qfull-retry-interval",
 		    rval, 1);

--- a/usr/src/uts/common/io/scsi/targets/sgen.c
+++ b/usr/src/uts/common/io/scsi/targets/sgen.c
@@ -615,8 +615,8 @@ sgen_do_attach(dev_info_t *dip)
 	 * sgen_diag setting by setting sg_state's sgen_diag value.  If the
 	 * user gave a value out of range, default to '0'.
 	 */
-	sg_state->sgen_diag = ddi_getprop(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
-	    "sgen-diag", -1);
+	sg_state->sgen_diag = ddi_prop_get_int(DDI_DEV_T_ANY, dip,
+	    DDI_PROP_DONTPASS, "sgen-diag", -1);
 
 	if (sg_state->sgen_diag != -1) {
 		if (sg_state->sgen_diag < 0 || sg_state->sgen_diag > 3)

--- a/usr/src/uts/common/io/scsi/targets/st.c
+++ b/usr/src/uts/common/io/scsi/targets/st.c
@@ -2105,11 +2105,14 @@ st_get_conf_from_st_dot_conf(struct scsi_tape *un, char *vidpid,
 	 * checking the vendor ids of the earlier inquiry command and
 	 * comparing those with vids in tape-config-list defined in st.conf
 	 */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	if (ddi_getlongprop(DDI_DEV_T_ANY, ST_DEVINFO, DDI_PROP_DONTPASS,
 	    "tape-config-list", (caddr_t)&config_list, &config_list_len)
 	    != DDI_PROP_SUCCESS) {
 		return (found);
 	}
+#pragma GCC diagnostic pop
 
 	ST_DEBUG6(ST_DEVINFO, st_label, SCSI_DEBUG,
 	    "st_get_conf_from_st_dot_conf(): st.conf has tape-config-list\n");
@@ -2157,6 +2160,8 @@ st_get_conf_from_st_dot_conf(struct scsi_tape *un, char *vidpid,
 		/*
 		 * get the data list
 		 */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 		if (ddi_getlongprop(DDI_DEV_T_ANY, ST_DEVINFO, 0,
 		    datanameptr, (caddr_t)&data_list,
 		    &data_list_len) != DDI_PROP_SUCCESS) {
@@ -2169,6 +2174,7 @@ st_get_conf_from_st_dot_conf(struct scsi_tape *un, char *vidpid,
 			    datanameptr);
 			continue;
 		}
+#pragma GCC diagnostic pop
 
 		/*
 		 * now initialize the st_drivetype struct

--- a/usr/src/uts/common/io/scsi/targets/st.c
+++ b/usr/src/uts/common/io/scsi/targets/st.c
@@ -893,7 +893,8 @@ st_attach(dev_info_t *devi, ddi_attach_cmd_t cmd)
 
 	switch (cmd) {
 		case DDI_ATTACH:
-			if (ddi_getprop(DDI_DEV_T_ANY, devi, DDI_PROP_DONTPASS,
+			if (ddi_prop_get_int(DDI_DEV_T_ANY, devi,
+			    DDI_PROP_DONTPASS,
 			    "tape-command-recovery-disable", 0) != 0) {
 				st_recov_sz = sizeof (pkt_info);
 			}
@@ -1037,7 +1038,7 @@ st_attach(dev_info_t *devi, ddi_attach_cmd_t cmd)
 	 *	has gone away.
 	 */
 	if (un->un_arq_enabled && un->un_untagged_qing) {
-		if (ddi_getprop(DDI_DEV_T_ANY, devi, DDI_PROP_DONTPASS,
+		if (ddi_prop_get_int(DDI_DEV_T_ANY, devi, DDI_PROP_DONTPASS,
 		    "tape-driver-buffering", 0) != 0) {
 			scsi_log(ST_DEVINFO, st_label, CE_NOTE,
 			    "Write Data Buffering has been depricated. Your "

--- a/usr/src/uts/common/io/usb/scsa2usb/scsa2usb.c
+++ b/usr/src/uts/common/io/usb/scsa2usb/scsa2usb.c
@@ -2292,12 +2292,11 @@ scsa2usb_scsi_tgt_init(dev_info_t *dip, dev_info_t *cdip,
 	scsa2usb_state_t *scsa2usbp = (scsa2usb_state_t *)
 	    tran->tran_hba_private;
 	int lun;
-	int t_len = sizeof (lun);
 
-	if (ddi_prop_op(DDI_DEV_T_ANY, cdip, PROP_LEN_AND_VAL_BUF,
-	    DDI_PROP_DONTPASS|DDI_PROP_CANSLEEP, "lun", (caddr_t)&lun,
-	    &t_len) != DDI_PROP_SUCCESS) {
+	lun = ddi_prop_get_int(DDI_DEV_T_ANY, cdip,
+	    DDI_PROP_DONTPASS, "lun", -1);
 
+	if (lun == -1) {
 		return (DDI_FAILURE);
 	}
 
@@ -2361,18 +2360,16 @@ scsa2usb_scsi_tgt_free(dev_info_t *hba_dip, dev_info_t *cdip,
 	scsa2usb_state_t *scsa2usbp = (scsa2usb_state_t *)
 	    tran->tran_hba_private;
 	int lun;
-	int t_len = sizeof (lun);
 
 	/* is this our child? */
 	if (scsa2usb_is_usb(cdip) == 0) {
-
 		return;
 	}
 
-	if (ddi_prop_op(DDI_DEV_T_ANY, cdip, PROP_LEN_AND_VAL_BUF,
-	    DDI_PROP_DONTPASS|DDI_PROP_CANSLEEP, "lun", (caddr_t)&lun,
-	    &t_len) != DDI_PROP_SUCCESS) {
+	lun = ddi_prop_get_int(DDI_DEV_T_ANY, cdip,
+	    DDI_PROP_DONTPASS, "lun", -1);
 
+	if (lun == -1) {
 		return;
 	}
 

--- a/usr/src/uts/common/io/usb/usba/usba.c
+++ b/usr/src/uts/common/io/usb/usba/usba.c
@@ -291,7 +291,6 @@ usba_bus_ctl(
 		char			name[32];
 		int			*data;
 		int			rval;
-		int			len = sizeof (usb_addr);
 
 		usba_hcdi	= usba_hcdi_get_hcdi(dip);
 		usba_hcdi_ops	= usba_hcdi->hcdi_ops;
@@ -312,10 +311,9 @@ usba_bus_ctl(
 		}
 
 		/* the dip should have an address and reg property */
-		if (ddi_prop_op(DDI_DEV_T_NONE, child_dip, PROP_LEN_AND_VAL_BUF,
-		    DDI_PROP_DONTPASS |	DDI_PROP_CANSLEEP, "assigned-address",
-		    (caddr_t)&usb_addr,	&len) != DDI_SUCCESS) {
 
+		if ((usb_addr = ddi_prop_get_int(DDI_DEV_T_NONE, child_dip,
+		    DDI_PROP_DONTPASS, "assigned-address", -1)) == -1) {
 			USB_DPRINTF_L2(DPRINT_MASK_USBA, hubdi_log_handle,
 			    "usba_bus_ctl:\n\t"
 			    "%s%d %s%d op=%d rdip = 0x%p dip = 0x%p",

--- a/usr/src/uts/common/io/vcons.c
+++ b/usr/src/uts/common/io/vcons.c
@@ -174,6 +174,8 @@ vt_init_ttycommon(tty_common_t *pcommon)
 	 * These are stored as a property in the
 	 * "options" node.
 	 */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	if (ddi_getlongprop(DDI_DEV_T_ANY,
 	    ddi_root_node(), 0, "ttymodes",
 	    (caddr_t)&termiosp, &len) == DDI_PROP_SUCCESS) {
@@ -192,7 +194,7 @@ vt_init_ttycommon(tty_common_t *pcommon)
 		cmn_err(CE_WARN,
 		    "wc: Couldn't get ttymodes property!");
 	}
-
+#pragma GCC diagnostic pop
 	pcommon->t_iocpending = NULL;
 }
 

--- a/usr/src/uts/common/os/ddifm.c
+++ b/usr/src/uts/common/os/ddifm.c
@@ -751,7 +751,7 @@ ddi_fm_init(dev_info_t *dip, int *fmcap, ddi_iblock_cookie_t *ibcp)
 	 */
 	if (DDI_FM_EREPORT_CAP(*fmcap) && DDI_FM_EREPORT_CAP(pcap)) {
 		fmhdl->fh_errorq = ereport_errorq;
-		if (ddi_getprop(DDI_DEV_T_NONE, dip, DDI_PROP_DONTPASS,
+		if (ddi_prop_get_int(DDI_DEV_T_NONE, dip, DDI_PROP_DONTPASS,
 		    "fm-ereport-capable", 0) == 0)
 			(void) ddi_prop_create(DDI_DEV_T_NONE, dip,
 			    DDI_PROP_CANSLEEP, "fm-ereport-capable", NULL, 0);
@@ -764,7 +764,7 @@ ddi_fm_init(dev_info_t *dip, int *fmcap, ddi_iblock_cookie_t *ibcp)
 	 */
 
 	if (DDI_FM_ERRCB_CAP(*fmcap) && DDI_FM_ERRCB_CAP(pcap)) {
-		if (ddi_getprop(DDI_DEV_T_NONE, dip, DDI_PROP_DONTPASS,
+		if (ddi_prop_get_int(DDI_DEV_T_NONE, dip, DDI_PROP_DONTPASS,
 		    "fm-errcb-capable", 0) == 0)
 			(void) ddi_prop_create(DDI_DEV_T_NONE, dip,
 			    DDI_PROP_CANSLEEP, "fm-errcb-capable", NULL, 0);
@@ -780,7 +780,7 @@ ddi_fm_init(dev_info_t *dip, int *fmcap, ddi_iblock_cookie_t *ibcp)
 		i_ndi_fmc_create(&fmhdl->fh_dma_cache, 2, ibc);
 
 		/* Set-up dma chk capability prop */
-		if (ddi_getprop(DDI_DEV_T_NONE, dip, DDI_PROP_DONTPASS,
+		if (ddi_prop_get_int(DDI_DEV_T_NONE, dip, DDI_PROP_DONTPASS,
 		    "fm-dmachk-capable", 0) == 0)
 			(void) ddi_prop_create(DDI_DEV_T_NONE, dip,
 			    DDI_PROP_CANSLEEP, "fm-dmachk-capable", NULL, 0);
@@ -791,7 +791,7 @@ ddi_fm_init(dev_info_t *dip, int *fmcap, ddi_iblock_cookie_t *ibcp)
 	if (DDI_FM_ACC_ERR_CAP(*fmcap) && DDI_FM_ACC_ERR_CAP(pcap)) {
 		i_ndi_fmc_create(&fmhdl->fh_acc_cache, 2, ibc);
 		/* Set-up dma chk capability prop */
-		if (ddi_getprop(DDI_DEV_T_NONE, dip, DDI_PROP_DONTPASS,
+		if (ddi_prop_get_int(DDI_DEV_T_NONE, dip, DDI_PROP_DONTPASS,
 		    "fm-accchk-capable", 0) == 0)
 			(void) ddi_prop_create(DDI_DEV_T_NONE, dip,
 			    DDI_PROP_CANSLEEP, "fm-accchk-capable", NULL, 0);

--- a/usr/src/uts/common/os/sunddi.c
+++ b/usr/src/uts/common/os/sunddi.c
@@ -9465,9 +9465,8 @@ sid_node_create(dev_info_t *pdip, devi_branch_t *bp, dev_info_t **rdipp)
 		goto fail;
 	}
 
-	len = OBP_MAXDRVNAME;
-	if (ddi_getlongprop_buf(DDI_DEV_T_ANY, dip,
-	    DDI_PROP_DONTPASS | DDI_PROP_NOTPROM, "name", nbuf, &len)
+	if (ddi_prop_lookup_string(DDI_DEV_T_ANY, dip,
+	    DDI_PROP_DONTPASS | DDI_PROP_NOTPROM, "name", &nbuf)
 	    != DDI_PROP_SUCCESS) {
 		cmn_err(CE_WARN, "e_ddi_branch_create: devinfo node %p has"
 		    "no name property", (void *)dip);
@@ -9478,10 +9477,11 @@ sid_node_create(dev_info_t *pdip, devi_branch_t *bp, dev_info_t **rdipp)
 	if (ndi_devi_set_nodename(dip, nbuf, 0) != NDI_SUCCESS) {
 		cmn_err(CE_WARN, "e_ddi_branch_create: cannot set name (%s)"
 		    " for devinfo node %p", nbuf, (void *)dip);
+
 		goto fail;
 	}
 
-	kmem_free(nbuf, OBP_MAXDRVNAME);
+	ddi_prop_free(nbuf);
 
 	/*
 	 * Ignore bind failures just like boot does
@@ -9553,7 +9553,7 @@ sid_node_create(dev_info_t *pdip, devi_branch_t *bp, dev_info_t **rdipp)
 	return (rv);
 fail:
 	(void) ndi_devi_free(dip);
-	kmem_free(nbuf, OBP_MAXDRVNAME);
+	ddi_prop_free(nbuf);
 	return (DDI_WALK_ERROR);
 }
 

--- a/usr/src/uts/common/os/sunpm.c
+++ b/usr/src/uts/common/os/sunpm.c
@@ -4762,17 +4762,16 @@ void
 e_pm_props(dev_info_t *dip)
 {
 	char *pp;
-	int len;
 	int flags = 0;
-	int propflag = DDI_PROP_DONTPASS|DDI_PROP_CANSLEEP;
+	int propflag = DDI_PROP_DONTPASS;
 
 	/*
 	 * It doesn't matter if we do this more than once, we should always
 	 * get the same answers, and if not, then the last one in is the
 	 * best one.
 	 */
-	if (ddi_getlongprop(DDI_DEV_T_ANY, dip, propflag, "pm-hardware-state",
-	    (caddr_t)&pp, &len) == DDI_PROP_SUCCESS) {
+	if (ddi_prop_lookup_string(DDI_DEV_T_ANY, dip, propflag,
+	    "pm-hardware-state", &pp) == DDI_PROP_SUCCESS) {
 		if (strcmp(pp, "needs-suspend-resume") == 0) {
 			flags = PMC_NEEDS_SR;
 		} else if (strcmp(pp, "no-suspend-resume") == 0) {
@@ -4784,7 +4783,7 @@ e_pm_props(dev_info_t *dip)
 			    "%s property value '%s'", PM_NAME(dip),
 			    PM_ADDR(dip), "pm-hardware-state", pp);
 		}
-		kmem_free(pp, len);
+		ddi_prop_free(pp);
 	}
 	/*
 	 * This next segment (PMC_WANTS_NOTIFY) is in
@@ -4803,8 +4802,8 @@ e_pm_props(dev_info_t *dip)
 	/*
 	 * Is the device a CPU device?
 	 */
-	if (ddi_getlongprop(DDI_DEV_T_ANY, dip, propflag, "pm-class",
-	    (caddr_t)&pp, &len) == DDI_PROP_SUCCESS) {
+	if (ddi_prop_lookup_string(DDI_DEV_T_ANY, dip, propflag, "pm-class",
+	    &pp) == DDI_PROP_SUCCESS) {
 		if (strcmp(pp, "CPU") == 0) {
 			flags |= PMC_CPU_DEVICE;
 		} else {
@@ -4812,7 +4811,7 @@ e_pm_props(dev_info_t *dip)
 			    "%s property value '%s'", PM_NAME(dip),
 			    PM_ADDR(dip), "pm-class", pp);
 		}
-		kmem_free(pp, len);
+		ddi_prop_free(pp);
 	}
 	/* devfs single threads us */
 	DEVI(dip)->devi_pm_flags |= flags;

--- a/usr/src/uts/common/pcmcia/cs/cs.c
+++ b/usr/src/uts/common/pcmcia/cs/cs.c
@@ -315,7 +315,7 @@ cs_deinit()
 
 #if defined(CS_DEBUG)
 	if (cs_debug > 1)
-	    cmn_err(CE_CONT, "CS: cs_deinit\n");
+		cmn_err(CE_CONT, "CS: cs_deinit\n");
 #endif
 
 	/*
@@ -3611,9 +3611,8 @@ cs_card_for_client(client_t *client)
 	 *	that is currently in the socket.  This is a boolean
 	 *	property managed by Socket Services.
 	 */
-	if (ddi_getprop(DDI_DEV_T_ANY, client->dip,    (DDI_PROP_CANSLEEP |
-							DDI_PROP_NOTPROM),
-							PCM_DEV_ACTIVE, 0)) {
+	if (ddi_prop_get_int(DDI_DEV_T_ANY, client->dip, DDI_PROP_NOTPROM,
+	    PCM_DEV_ACTIVE, 0)) {
 #ifdef	CS_DEBUG
 	    if (cs_debug > 1) {
 		cmn_err(CE_CONT, "cs_card_for_client: client handle 0x%x "

--- a/usr/src/uts/common/pcmcia/nexus/pcmcia.c
+++ b/usr/src/uts/common/pcmcia/nexus/pcmcia.c
@@ -548,7 +548,7 @@ pcmcia_ctlops(dev_info_t *dip, dev_info_t *rdip,
 			    ddi_driver_name(dip),
 			    ddi_get_name_addr(dip),
 			    CS_GET_SOCKET_NUMBER(
-			    ddi_getprop(DDI_DEV_T_NONE, rdip,
+			    ddi_prop_get_int(DDI_DEV_T_NONE, rdip,
 			    DDI_PROP_DONTPASS,
 			    PCM_DEV_SOCKET, -1)));
 
@@ -1673,7 +1673,7 @@ pcm_find_devinfo(dev_info_t *pdip, struct pcm_device_info *info, int socket)
 		    "(instance=%d, socket=%d, name=%s)\n",
 		    (void *)dip, socket, info->pd_bind_name,
 		    ddi_get_instance(dip),
-		    ddi_getprop(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
+		    ddi_prop_get_int(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
 		    PCM_DEV_SOCKET, -1),
 		    ddi_get_name(dip));
 #endif
@@ -3173,7 +3173,7 @@ pcmcia_init_devinfo(dev_info_t *pdip, struct pcm_device_info *info)
 	unit = CS_MAKE_SOCKET_NUMBER(info->pd_socket, info->pd_function);
 
 	dip = pcm_find_devinfo(pdip, info, unit);
-	if ((dip != NULL) && (ddi_getprop(DDI_DEV_T_NONE, dip,
+	if ((dip != NULL) && (ddi_prop_get_int(DDI_DEV_T_NONE, dip,
 	    DDI_PROP_DONTPASS, PCM_DEV_SOCKET, -1) != -1)) {
 		/* it already exist but isn't a .conf file */
 
@@ -3953,13 +3953,13 @@ pcmcia_create_device(ss_make_device_node_t *init)
 		    PCM_EVENT_MORE : 0;
 		device.type = init->spec_type;
 		device.op = SS_CSINITDEV_CREATE_DEVICE;
-		device.socket = ddi_getprop(DDI_DEV_T_ANY, init->dip,
-		    DDI_PROP_CANSLEEP, PCM_DEV_SOCKET,
+		device.socket = ddi_prop_get_int(DDI_DEV_T_ANY, init->dip,
+		    0, PCM_DEV_SOCKET,
 		    -1);
 	} else if (init->flags & SS_CSINITDEV_REMOVE_DEVICE) {
 		device.op = SS_CSINITDEV_REMOVE_DEVICE;
-		device.socket = ddi_getprop(DDI_DEV_T_ANY, init->dip,
-		    DDI_PROP_CANSLEEP, PCM_DEV_SOCKET,
+		device.socket = ddi_prop_get_int(DDI_DEV_T_ANY, init->dip,
+		    0, PCM_DEV_SOCKET,
 		    -1);
 		if (init->name != NULL)
 			(void) strcpy(device.path, init->name);
@@ -4000,7 +4000,7 @@ pcmcia_get_minors(dev_info_t *dip, struct pcm_make_dev **minors)
 	major_t major;
 	struct dev_ops *ops;
 
-	socket = ddi_getprop(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
+	socket = ddi_prop_get_int(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
 	    PCM_DEV_SOCKET, -1);
 	ndi_devi_enter(dip);
 	if (DEVI(dip)->devi_minor != (struct ddi_minor_data *)NULL) {
@@ -4072,7 +4072,7 @@ pcmcia_dump_minors(dev_info_t *dip)
 	int unit, major;
 	dev_info_t *np;
 
-	unit = ddi_getprop(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
+	unit = ddi_prop_get_int(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
 	    PCM_DEV_SOCKET, -1);
 	cmn_err(CE_CONT,
 	    "pcmcia_dump_minors: dip=%p, socket=%d\n", (void *)dip, unit);
@@ -4520,8 +4520,7 @@ is_subtractv(dev_info_t *dip)
 
 	if (dip == NULL)
 		return (B_FALSE);
-	class = ddi_getprop(DDI_DEV_T_ANY, dip,
-	    DDI_PROP_CANSLEEP|DDI_PROP_DONTPASS,
+	class = ddi_prop_get_int(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
 	    "class-code", 0xff);
 	if (class == PPB_SUBTRACTIVE) {
 		return (B_TRUE);
@@ -5053,7 +5052,7 @@ pcmcia_intr_get_ispec(dev_info_t *rdip, int inum,
 	struct intrspec			*intrspec;
 	struct pcmcia_parent_private	*ppd;
 
-	if ((int)inum > 0 || (ddi_getprop(DDI_DEV_T_ANY, rdip,
+	if ((int)inum > 0 || (ddi_prop_get_int(DDI_DEV_T_ANY, rdip,
 	    DDI_PROP_DONTPASS, "interrupts", -1) < 0))
 		return (NULL);
 

--- a/usr/src/uts/common/pcmcia/sys/cs_priv.h
+++ b/usr/src/uts/common/pcmcia/sys/cs_priv.h
@@ -171,7 +171,7 @@ typedef struct cisregister_t {
  *
  * CS_MAX_CIS is one greater than CIS_MAX_FUNCTIONS since the CIS parser
  *	puts the global CIS chain on the CS_GLOBAL_CIS function index as
- * 	follows:
+ *	follows:
  *
  *	For single-function cards:
  *	    sp->cis[0] - CIS chain
@@ -249,9 +249,8 @@ typedef struct cisregister_t {
  *	the passed dip.  If the property can't be found, then the default
  *	value of cs_globals.max_socket_num is returned.
  */
-#define	DIP2SOCKET_NUM(dip)		ddi_getprop(DDI_DEV_T_NONE, dip,\
-						(DDI_PROP_CANSLEEP |	\
-							DDI_PROP_NOTPROM), \
+#define	DIP2SOCKET_NUM(dip)		ddi_prop_get_int(DDI_DEV_T_NONE, dip,\
+						DDI_PROP_NOTPROM, \
 						PCM_DEV_SOCKET,		\
 						cs_globals.max_socket_num)
 

--- a/usr/src/uts/common/sys/pcie_impl.h
+++ b/usr/src/uts/common/sys/pcie_impl.h
@@ -415,9 +415,9 @@ typedef struct pcie_bus {
 	uint16_t	bus_ecc_ver;		/* PCIX ecc version */
 	pci_bus_range_t	bus_bus_range;		/* pci bus-range property */
 	ppb_ranges_t	*bus_addr_ranges;	/* pci range property */
-	int		bus_addr_entries;	/* number of range prop */
+	uint_t		bus_addr_entries;	/* number of range prop */
 	pci_regspec_t	*bus_assigned_addr;	/* "assigned-address" prop */
-	int		bus_assigned_entries;	/* number of prop entries */
+	uint_t		bus_assigned_entries;	/* number of prop entries */
 
 	/* Cache of last fault data */
 	pf_data_t	*bus_pfd;

--- a/usr/src/uts/common/sys/sunddi.h
+++ b/usr/src/uts/common/sys/sunddi.h
@@ -871,9 +871,24 @@ ddi_prop_op_nblocks_blksize(dev_t dev, dev_info_t *dip, ddi_prop_op_t prop_op,
  *		DDI_PROP_NO_MEMORY:	Prop found, but unable to alloc mem.
  */
 
+/*
+ * XXXARM: Because the cpu and FDT properties have different endian-ness,
+ * un-typed access to integer properties sourced from the "PROM" will return
+ * bogus data.
+ *
+ * To try to get a handle on this with an audit, rather than attrition, we
+ * _temporarily_ mark the problematic DDI property accessors as deprecated so
+ * that builds fail if they are used.
+ */
+#if defined(__aarch64__)
+#define	__arm_deprecate	__attribute__((deprecated))
+#else
+#define	__arm_deprecate
+#endif	/* __aarch64___ */
+
 int
 ddi_getlongprop(dev_t dev, dev_info_t *dip, int flags,
-    char *name, caddr_t valuep, int *lengthp);
+    char *name, caddr_t valuep, int *lengthp) __arm_deprecate;
 
 /*
  *
@@ -901,7 +916,7 @@ ddi_getlongprop(dev_t dev, dev_info_t *dip, int flags,
 
 int
 ddi_getlongprop_buf(dev_t dev, dev_info_t *dip, int flags,
-    char *name, caddr_t valuep, int *lengthp);
+    char *name, caddr_t valuep, int *lengthp)  __arm_deprecate;
 
 /*
  * Integer/boolean sized props.
@@ -915,7 +930,8 @@ ddi_getlongprop_buf(dev_t dev, dev_info_t *dip, int flags,
  */
 
 int
-ddi_getprop(dev_t dev, dev_info_t *dip, int flags, char *name, int defvalue);
+ddi_getprop(dev_t dev, dev_info_t *dip, int flags,
+    char *name, int defvalue) __arm_deprecate;
 
 /*
  * Get prop length interface: flags are 0 or DDI_PROP_DONTPASS

--- a/usr/src/uts/common/xen/dtrace/xdt.c
+++ b/usr/src/uts/common/xen/dtrace/xdt.c
@@ -2050,7 +2050,7 @@ xdt_attach(dev_info_t *devi, ddi_attach_cmd_t cmd)
 		return (DDI_FAILURE);
 	}
 
-	val = ddi_getprop(DDI_DEV_T_ANY, devi, DDI_PROP_DONTPASS,
+	val = ddi_prop_get_int(DDI_DEV_T_ANY, devi, DDI_PROP_DONTPASS,
 	    "xdt_poll_nsec", XDT_POLL_DEFAULT);
 	xdt_poll_nsec = MAX(val, XDT_POLL_MIN);
 

--- a/usr/src/uts/i86pc/io/isa.c
+++ b/usr/src/uts/i86pc/io/isa.c
@@ -645,7 +645,7 @@ old_driver(dev_info_t *dip)
 	if (ndi_dev_is_persistent_node(dip)) {
 		if (ignore_hardware_nodes)
 			return (1);
-		if (ddi_getprop(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
+		if (ddi_prop_get_int(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
 		    "ignore-hardware-nodes", -1) != -1)
 			return (1);
 	}

--- a/usr/src/uts/i86pc/os/ddi_impl.c
+++ b/usr/src/uts/i86pc/os/ddi_impl.c
@@ -461,7 +461,7 @@ impl_xlate_intrs(dev_info_t *child, int *in,
 	 * "interrupts" property.
 	 */
 	inpri = NULL;
-	if ((ddi_getprop(DDI_DEV_T_ANY, child, DDI_PROP_DONTPASS,
+	if ((ddi_prop_get_int(DDI_DEV_T_ANY, child, DDI_PROP_DONTPASS,
 	    "ignore-hardware-nodes", -1) != -1) || ignore_hardware_nodes) {
 		/* the old style "interrupts" property... */
 
@@ -2130,7 +2130,7 @@ x86_old_bootpath_name_addr_match(dev_info_t *cdip, char *caddr, char *naddr)
 
 	if ((ddi_getlongprop(DDI_DEV_T_ANY, cdip, DDI_PROP_DONTPASS,
 	    "devconf-addr", (caddr_t)&daddr, &dlen) == DDI_PROP_SUCCESS) &&
-	    (ddi_getprop(DDI_DEV_T_ANY, cdip, DDI_PROP_DONTPASS,
+	    (ddi_prop_get_int(DDI_DEV_T_ANY, cdip, DDI_PROP_DONTPASS,
 	    "ignore-hardware-nodes", -1) != -1)) {
 		if (strcmp(daddr, caddr) == 0) {
 			return (DDI_SUCCESS);
@@ -2252,7 +2252,7 @@ x86_old_bootpath_name_addr_match(dev_info_t *cdip, char *caddr, char *naddr)
 	if (((lkupname = ddi_get_name(cdip)) != NULL) &&
 	    (strcmp(bootdev_module, lkupname) == 0 ||
 	    strcmp(bootdev_oldmod, lkupname) == 0) &&
-	    ((ddi_getprop(DDI_DEV_T_ANY, cdip, DDI_PROP_DONTPASS,
+	    ((ddi_prop_get_int(DDI_DEV_T_ANY, cdip, DDI_PROP_DONTPASS,
 	    "ignore-hardware-nodes", -1) != -1) ||
 	    ignore_hardware_nodes) &&
 	    strcmp(bootdev_newaddr, caddr) == 0 &&

--- a/usr/src/uts/intel/io/dktp/controller/ata/ata_common.c
+++ b/usr/src/uts/intel/io/dktp/controller/ata/ata_common.c
@@ -3333,7 +3333,7 @@ ata_check_revert_to_defaults(
 	prop_buf[j] = '\0';
 
 	/* look for a disk-specific "revert" property" */
-	propval = ddi_getprop(DDI_DEV_T_ANY, ata_ctlp->ac_dip,
+	propval = ddi_prop_get_int(DDI_DEV_T_ANY, ata_ctlp->ac_dip,
 	    DDI_PROP_DONTPASS, prop_buf, -1);
 	if (propval == 0)
 		return (FALSE);
@@ -3341,7 +3341,7 @@ ata_check_revert_to_defaults(
 		return (TRUE);
 
 	/* look for a global "revert" property" */
-	propval = ddi_getprop(DDI_DEV_T_ANY, ata_ctlp->ac_dip,
+	propval = ddi_prop_get_int(DDI_DEV_T_ANY, ata_ctlp->ac_dip,
 	    0, ATA_REVERT_PROP_GLOBAL, -1);
 	if (propval == 0)
 		return (FALSE);
@@ -3502,7 +3502,7 @@ static void
 ata_init_pm(dev_info_t *dip)
 {
 	int		instance;
-	ata_ctl_t 	*ata_ctlp;
+	ata_ctl_t	*ata_ctlp;
 #ifdef	ATA_USE_AUTOPM
 	char		pmc_name[16];
 	char		*pmc[] = {
@@ -3592,7 +3592,7 @@ static int
 ata_resume(dev_info_t *dip)
 {
 	int		instance;
-	ata_ctl_t 	*ata_ctlp;
+	ata_ctl_t	*ata_ctlp;
 	ddi_acc_handle_t io_hdl2;
 	caddr_t		ioaddr2;
 
@@ -3626,7 +3626,7 @@ static int
 ata_suspend(dev_info_t *dip)
 {
 	int		instance;
-	ata_ctl_t 	*ata_ctlp;
+	ata_ctl_t	*ata_ctlp;
 	ddi_acc_handle_t io_hdl2;
 
 	instance = ddi_get_instance(dip);
@@ -3656,7 +3656,7 @@ static int
 ata_power(dev_info_t *dip, int component, int level)
 {
 	int		instance;
-	ata_ctl_t 	*ata_ctlp;
+	ata_ctl_t	*ata_ctlp;
 	uint8_t		cmd;
 
 	ADBG_TRACE(("ata_power entered, component = %d, level = %d\n",

--- a/usr/src/uts/intel/io/dktp/hba/ghd/ghd_waitq.c
+++ b/usr/src/uts/intel/io/dktp/hba/ghd/ghd_waitq.c
@@ -35,12 +35,12 @@
 /*ARGSUSED*/
 gtgt_t *
 ghd_target_init(dev_info_t	*hba_dip,
-		dev_info_t	*tgt_dip,
-		ccc_t		*cccp,
-		size_t		 tgt_private_size,
-		void		*hba_private,
-		ushort_t	 target,
-		uchar_t		 lun)
+    dev_info_t	*tgt_dip,
+    ccc_t	*cccp,
+    size_t	 tgt_private_size,
+    void	*hba_private,
+    ushort_t	 target,
+    uchar_t	 lun)
 {
 	_NOTE(ARGUNUSED(hba_dip))
 	gtgt_t	*gtgtp;
@@ -65,7 +65,8 @@ ghd_target_init(dev_info_t	*hba_dip,
 	 * set the queue's maxactive to 1 if
 	 * property not specified on target or hba devinfo node
 	 */
-	maxactive = ddi_getprop(DDI_DEV_T_ANY, tgt_dip, 0, "ghd-maxactive", 1);
+	maxactive = ddi_prop_get_int(DDI_DEV_T_ANY, tgt_dip,
+	    0, "ghd-maxactive", 1);
 	gtgtp->gt_maxactive = maxactive;
 
 	/* initialize the linked list pointers */
@@ -134,9 +135,9 @@ foundit:
 /*ARGSUSED*/
 void
 ghd_target_free(dev_info_t	*hba_dip,
-		dev_info_t	*tgt_dip,
-		ccc_t		*cccp,
-		gtgt_t		*gtgtp)
+    dev_info_t	*tgt_dip,
+    ccc_t	*cccp,
+    gtgt_t	*gtgtp)
 {
 	_NOTE(ARGUNUSED(hba_dip,tgt_dip))
 

--- a/usr/src/uts/intel/io/dnet/dnet.c
+++ b/usr/src/uts/intel/io/dnet/dnet.c
@@ -608,7 +608,7 @@ dnet_attach(dev_info_t *devinfo, ddi_attach_cmd_t cmd)
 	 * Get the BNC/TP indicator from the conf file for 21040
 	 */
 	dnetp->bnc_indicator =
-	    ddi_getprop(DDI_DEV_T_ANY, devinfo, DDI_PROP_DONTPASS,
+	    ddi_prop_get_int(DDI_DEV_T_ANY, devinfo, DDI_PROP_DONTPASS,
 	    "bncaui", -1);
 
 	/*
@@ -617,10 +617,10 @@ dnet_attach(dev_info_t *devinfo, ddi_attach_cmd_t cmd)
 	 * with what's in the conf file
 	 */
 	dnetp->speed =
-	    ddi_getprop(DDI_DEV_T_ANY, devinfo, DDI_PROP_DONTPASS,
+	    ddi_prop_get_int(DDI_DEV_T_ANY, devinfo, DDI_PROP_DONTPASS,
 	    speed_propname, 0);
 	dnetp->full_duplex =
-	    ddi_getprop(DDI_DEV_T_ANY, devinfo, DDI_PROP_DONTPASS,
+	    ddi_prop_get_int(DDI_DEV_T_ANY, devinfo, DDI_PROP_DONTPASS,
 	    duplex_propname, -1);
 
 	if (dnetp->speed == 100) {
@@ -655,7 +655,7 @@ dnet_attach(dev_info_t *devinfo, ddi_attach_cmd_t cmd)
 
 	dnet_parse_srom(dnetp, &dnetp->sr, vendor_info);
 
-	if (ddi_getprop(DDI_DEV_T_ANY, devinfo, DDI_PROP_DONTPASS,
+	if (ddi_prop_get_int(DDI_DEV_T_ANY, devinfo, DDI_PROP_DONTPASS,
 	    printsrom_propname, 0))
 		dnet_print_srom(&dnetp->sr);
 
@@ -676,7 +676,7 @@ dnet_attach(dev_info_t *devinfo, ddi_attach_cmd_t cmd)
 	    (dnetp->board_type == DEVICE_ID_21143 && revid <= 0x30)) ? 1 : 0;
 
 	dnetp->overrun_workaround =
-	    ddi_getprop(DDI_DEV_T_ANY, devinfo, DDI_PROP_DONTPASS,
+	    ddi_prop_get_int(DDI_DEV_T_ANY, devinfo, DDI_PROP_DONTPASS,
 	    ofloprob_propname, dnetp->overrun_workaround);
 
 	/*
@@ -2097,7 +2097,7 @@ set_sia(struct dnetinstance *dnetp)
 			    block->un.sia.csr14,
 			    block->un.sia.csr15);
 #endif
-		sia_delay = ddi_getprop(DDI_DEV_T_ANY, dnetp->devinfo,
+		sia_delay = ddi_prop_get_int(DDI_DEV_T_ANY, dnetp->devinfo,
 		    DDI_PROP_DONTPASS, "sia-delay", 10000);
 
 		ddi_put32(dnetp->io_handle,
@@ -2808,7 +2808,7 @@ dnet_read_srom(dev_info_t *devinfo, int board_type, ddi_acc_handle_t io_handle,
 	 * If the dumpsrom property is present in the conf file, print
 	 * the contents of the SROM to the console
 	 */
-	if (ddi_getprop(DDI_DEV_T_ANY, devinfo, DDI_PROP_DONTPASS,
+	if (ddi_prop_get_int(DDI_DEV_T_ANY, devinfo, DDI_PROP_DONTPASS,
 	    "dumpsrom", 0))
 		dnet_dumpbin("SROM", vi, 1, maxlen);
 
@@ -2837,7 +2837,7 @@ dnet_read21040addr(dev_info_t *dip, ddi_acc_handle_t io_handle, caddr_t io_reg,
 	int		i;
 
 	/* No point reading more than the ethernet address */
-	*len = ddi_getprop(DDI_DEV_T_ANY, dip,
+	*len = ddi_prop_get_int(DDI_DEV_T_ANY, dip,
 	    DDI_PROP_DONTPASS, macoffset_propname, 0) + ETHERADDRL;
 
 	/* Reset ROM pointer */
@@ -2997,7 +2997,7 @@ get_alternative_srom_image(dev_info_t *devinfo, uchar_t *vi, int len)
 	int		devnum;
 	int		primary_devnum;
 
-	primary_devnum = ddi_getprop(DDI_DEV_T_ANY, devinfo, 0,
+	primary_devnum = ddi_prop_get_int(DDI_DEV_T_ANY, devinfo, 0,
 	    "DNET_DEVNUM", -1);
 	if (primary_devnum == -1)
 		return (1);	/* XXX NEEDSWORK -- We have no better idea */
@@ -3165,7 +3165,7 @@ find_active_media(struct dnetinstance *dnetp)
 		dnetp->selected_media_block = leaf->mii_block;
 		setup_block(dnetp);
 
-		if (ddi_getprop(DDI_DEV_T_ANY, dnetp->devinfo,
+		if (ddi_prop_get_int(DDI_DEV_T_ANY, dnetp->devinfo,
 		    DDI_PROP_DONTPASS, "portmon", 1)) {
 			/* XXX return value ignored */
 			(void) mii_start_portmon(dnetp->mii, dnet_mii_link_cb,
@@ -3357,10 +3357,10 @@ dnet_link_sense(struct dnetinstance *dnetp)
 		return (0);
 	}
 
-	delay_100 = ddi_getprop(DDI_DEV_T_ANY, dnetp->devinfo,
+	delay_100 = ddi_prop_get_int(DDI_DEV_T_ANY, dnetp->devinfo,
 	    DDI_PROP_DONTPASS, "autosense-delay-100", 2000);
 
-	delay_10 = ddi_getprop(DDI_DEV_T_ANY, dnetp->devinfo,
+	delay_10 = ddi_prop_get_int(DDI_DEV_T_ANY, dnetp->devinfo,
 	    DDI_PROP_DONTPASS, "autosense-delay-10", 400);
 
 	/*
@@ -3424,10 +3424,10 @@ send_test_packet(struct dnetinstance *dnetp)
 	 * required. This is done if the media type is TP
 	 */
 	if (media_code == MEDIA_TP || media_code == MEDIA_TP_FD) {
-		packet_delay = ddi_getprop(DDI_DEV_T_ANY, dnetp->devinfo,
+		packet_delay = ddi_prop_get_int(DDI_DEV_T_ANY, dnetp->devinfo,
 		    DDI_PROP_DONTPASS, "test_packet_delay_tp", 1300000);
 	} else {
-		packet_delay = ddi_getprop(DDI_DEV_T_ANY, dnetp->devinfo,
+		packet_delay = ddi_prop_get_int(DDI_DEV_T_ANY, dnetp->devinfo,
 		    DDI_PROP_DONTPASS, "test_packet_delay", 300000);
 	}
 	delay(drv_usectohz(packet_delay));
@@ -3538,7 +3538,7 @@ dnet_hack_interrupts(struct dnetinstance *dnetp, int secondary)
 	dev_info_t *devinfo = dnetp->devinfo;
 	uint32_t oui = 0;	/* Organizationally Unique ID */
 
-	if (ddi_getprop(DDI_DEV_T_ANY, devinfo, DDI_PROP_DONTPASS,
+	if (ddi_prop_get_int(DDI_DEV_T_ANY, devinfo, DDI_PROP_DONTPASS,
 	    "no_INTA_workaround", 0) != 0)
 		return (0);
 
@@ -3578,7 +3578,7 @@ dnet_hack_interrupts(struct dnetinstance *dnetp, int secondary)
 		 * a multiport card, but a second card on the same PCI bus.
 		 * BUGID: 4057747
 		 */
-		if (ddi_getprop(DDI_DEV_T_ANY, ddi_get_parent(devinfo),
+		if (ddi_prop_get_int(DDI_DEV_T_ANY, ddi_get_parent(devinfo),
 		    DDI_PROP_DONTPASS, hackintr_propname, 0) != 0)
 			return (0);
 				/* ... Primary not part of a multiport device */
@@ -3633,7 +3633,7 @@ dnet_hack_interrupts(struct dnetinstance *dnetp, int secondary)
 		/* Add the dnetp for this secondary device to the table */
 
 		hackintr_inf = (struct hackintr_inf *)(uintptr_t)
-		    ddi_getprop(DDI_DEV_T_ANY, ddi_get_parent(devinfo),
+		    ddi_prop_get_int(DDI_DEV_T_ANY, ddi_get_parent(devinfo),
 		    DDI_PROP_DONTPASS, hackintr_propname, 0);
 
 		if (hackintr_inf == NULL)
@@ -3705,7 +3705,7 @@ dnet_detach_hacked_interrupt(dev_info_t *devinfo)
 	    ddi_get_driver_private(devinfo);
 
 	hackintr_inf = (struct hackintr_inf *)(uintptr_t)
-	    ddi_getprop(DDI_DEV_T_ANY, ddi_get_parent(devinfo),
+	    ddi_prop_get_int(DDI_DEV_T_ANY, ddi_get_parent(devinfo),
 	    DDI_PROP_DONTPASS, hackintr_propname, 0);
 
 	/*
@@ -3992,7 +3992,7 @@ dnet_parse_srom(struct dnetinstance *dnetp, SROM_FORMAT *sr, uchar_t *vi)
 	int i;
 	uchar_t *p;
 
-	if (!ddi_getprop(DDI_DEV_T_ANY, dnetp->devinfo,
+	if (!ddi_prop_get_int(DDI_DEV_T_ANY, dnetp->devinfo,
 	    DDI_PROP_DONTPASS, "no_sromconfig", 0))
 		dnetp->sr.init_from_srom = check_srom_valid(vi);
 
@@ -4049,8 +4049,8 @@ dnet_parse_srom(struct dnetinstance *dnetp, SROM_FORMAT *sr, uchar_t *vi)
 		 * Assume vendor info contains ether address in first six bytes
 		 */
 
-		uchar_t *mac = vi + ddi_getprop(DDI_DEV_T_ANY, dnetp->devinfo,
-		    DDI_PROP_DONTPASS, macoffset_propname, 0);
+		uchar_t *mac = vi + ddi_prop_get_int(DDI_DEV_T_ANY,
+		    dnetp->devinfo, DDI_PROP_DONTPASS, macoffset_propname, 0);
 
 		for (i = 0; i < 6; i++)
 			sr->netaddr[i] = mac[i];

--- a/usr/src/uts/intel/io/dnet/dnet_mii.c
+++ b/usr/src/uts/intel/io/dnet/dnet_mii.c
@@ -80,10 +80,10 @@ static void postreset_NS83840(mii_handle_t mac, int phy);
  */
 
 int
-mii_create(dev_info_t *dip,		/* Passed to read/write functions */
-	    mii_writefunc_t writefunc, 	/* How to write to a MII register */
-	    mii_readfunc_t readfunc,	/* How to read from a MII regster */
-	    mii_handle_t *macp)
+mii_create(dev_info_t *dip,	/* Passed to read/write functions */
+    mii_writefunc_t writefunc,	/* How to write to a MII register */
+    mii_readfunc_t readfunc,	/* How to read from a MII regster */
+    mii_handle_t *macp)
 {
 	mii_handle_t mac;
 
@@ -172,11 +172,11 @@ mii_init_phy(mii_handle_t mac, int phy)
 
 	/* Override speed and duplex mode from conf-file if present */
 	phydata->fix_duplex =
-	    ddi_getprop(DDI_DEV_T_NONE,
+	    ddi_prop_get_int(DDI_DEV_T_NONE,
 	    mac->mii_dip, DDI_PROP_DONTPASS, "full-duplex", 0);
 
 	phydata->fix_speed =
-	    ddi_getprop(DDI_DEV_T_NONE,
+	    ddi_prop_get_int(DDI_DEV_T_NONE,
 	    mac->mii_dip, DDI_PROP_DONTPASS, "speed", 0);
 
 	status = mac->mii_read(dip, phy, MII_STATUS);
@@ -277,7 +277,7 @@ mii_init_phy(mii_handle_t mac, int phy)
 	/* Do all post-reset hacks and user settings */
 	(void) mii_sync(mac, phy);
 
-	if (ddi_getprop(DDI_DEV_T_NONE, mac->mii_dip, DDI_PROP_DONTPASS,
+	if (ddi_prop_get_int(DDI_DEV_T_NONE, mac->mii_dip, DDI_PROP_DONTPASS,
 	    "dump-phy", 0))
 		(void) mii_dump_phy(mac, phy);
 

--- a/usr/src/uts/intel/io/pci/pci_pci.c
+++ b/usr/src/uts/intel/io/pci/pci_pci.c
@@ -704,7 +704,7 @@ ppb_initchild(dev_info_t *child)
 	}
 
 	/* transfer select properties from PROM to kernel */
-	if (ddi_getprop(DDI_DEV_T_NONE, child, DDI_PROP_DONTPASS,
+	if (ddi_prop_get_int(DDI_DEV_T_NONE, child, DDI_PROP_DONTPASS,
 	    "interrupts", -1) != -1) {
 		pdptr = kmem_zalloc((sizeof (struct ddi_parent_private_data) +
 		    sizeof (struct intrspec)), KM_SLEEP);

--- a/usr/src/uts/intel/io/pciex/pcieb_x86.c
+++ b/usr/src/uts/intel/io/pciex/pcieb_x86.c
@@ -179,15 +179,16 @@ void
 pcieb_plat_initchild(dev_info_t *child)
 {
 	struct ddi_parent_private_data *pdptr;
-	if (ddi_prop_get_int(DDI_DEV_T_NONE, child, DDI_PROP_DONTPASS,
-	    "interrupts", -1) != -1) {
+	if (ddi_prop_exists(DDI_DEV_T_NONE, child, DDI_PROP_DONTPASS,
+	    "interrupts")) {
 		pdptr = kmem_zalloc((sizeof (struct ddi_parent_private_data) +
 		    sizeof (struct intrspec)), KM_SLEEP);
 		pdptr->par_intr = (struct intrspec *)(pdptr + 1);
 		pdptr->par_nintr = 1;
 		ddi_set_parent_data(child, pdptr);
-	} else
+	} else {
 		ddi_set_parent_data(child, NULL);
+	}
 }
 
 void

--- a/usr/src/uts/intel/io/pciex/pcieb_x86.c
+++ b/usr/src/uts/intel/io/pciex/pcieb_x86.c
@@ -179,8 +179,8 @@ void
 pcieb_plat_initchild(dev_info_t *child)
 {
 	struct ddi_parent_private_data *pdptr;
-	if (ddi_getprop(DDI_DEV_T_NONE, child, DDI_PROP_DONTPASS, "interrupts",
-	    -1) != -1) {
+	if (ddi_prop_get_int(DDI_DEV_T_NONE, child, DDI_PROP_DONTPASS,
+	    "interrupts", -1) != -1) {
 		pdptr = kmem_zalloc((sizeof (struct ddi_parent_private_data) +
 		    sizeof (struct intrspec)), KM_SLEEP);
 		pdptr->par_intr = (struct intrspec *)(pdptr + 1);


### PR DESCRIPTION
on fdt-based aarch64, "PROM" properties ultimately come from the FDT.  This data is defined (like ieee1275) to be big-endian 32bit integer cells, bytes, or strings.

Since we're using the CPU little-endian, this means when reading integer valued properties we need to byteswap each word.  We've had support to do this for a little while.

Unfortunately, only the typed interfaces can do this byteswapping (it would be poor form to byteswap a byte array), so any case we use the old un-typed interfaces to read something that might be an integer sourced from the device tree needs to use the new ones instead.

So:

- `ddi_getprop` -> `ddi_prop_get_int`
- `ddi_getlongprop` -> `ddi_prop_lookup_...`
- `ddi_getlongprop_buf` -> `ddi_prop_lookup_...`

There's several classes of bug I'm likely to have introduced here and won't get caught readily by testing, I'd appreciate paying attention to:

- the change from `ddi_getlongprop` (and `_buf`) to `ddi_prop_lookup_int_array` changes the granularity of the `length` out-arg to 32bit cells, not bytes, we have to use `CELLS_1275_TO_BYTES` to fix that up.
- the change from `ddi_getlongprop` requires using `ddi_prop_free` to free the result, not `kmem_free`
- the change from `ddi_getlongprop_buf` to `ddi_prop_lookup_...` means that this now allocates space for its result, which needs to be freed with `ddi_prop_free`
- the change from `ddi_getlongprop_buf` to `ddi_prop_lookup_...` means those calls now allocate, and can't happen in interrupt context.