### PR TITLE
Use loaders to abstract the arch_timer frequency

### DIFF
--- a/usr/src/psm/stand/boot/aarch64/rpi4/machdep.c
+++ b/usr/src/psm/stand/boot/aarch64/rpi4/machdep.c
@@ -171,6 +171,7 @@ exitto(int (*entrypoint)())
 
 	char *str;
 
+	xboot_info.bi_arch_timer_freq = arch_timer_freq();
 	xboot_info.bi_phys_avail = (uint64_t)pfreelistp;
 	xboot_info.bi_phys_installed = (uint64_t)pinstalledp;
 	xboot_info.bi_boot_scratch = (uint64_t)pscratchlistp;

--- a/usr/src/psm/stand/boot/aarch64/virt/machdep.c
+++ b/usr/src/psm/stand/boot/aarch64/virt/machdep.c
@@ -255,6 +255,7 @@ exitto(int (*entrypoint)())
 
 	char *str;
 
+	xboot_info.bi_arch_timer_freq = arch_timer_freq();
 	xboot_info.bi_phys_avail = (uint64_t)pfreelistp;
 	xboot_info.bi_phys_installed = (uint64_t)pinstalledp;
 	xboot_info.bi_boot_scratch = (uint64_t)pscratchlistp;

--- a/usr/src/uts/aarch64/sys/arch_timer.h
+++ b/usr/src/uts/aarch64/sys/arch_timer.h
@@ -11,6 +11,7 @@
 
 /*
  * Copyright 2023 Brian McKenzie
+ * Copyright 2024 Michael van der Westhuizen
  */
 
 /*
@@ -40,6 +41,7 @@ extern void arch_timer_disable(void);
 extern void arch_timer_set_cval(uint64_t cval);
 extern uint64_t arch_timer_freq(void);
 extern uint64_t arch_timer_count(void);
+extern void arch_timer_set_fw_freq(uint64_t freq);
 extern void arch_timer_select(arch_timer_t type);
 extern void arch_timer_udelay(uint32_t us);
 

--- a/usr/src/uts/aarch64/sys/bootinfo.h
+++ b/usr/src/uts/aarch64/sys/bootinfo.h
@@ -95,6 +95,7 @@ struct xboot_info {
 	uint64_t		bi_phys_installed;
 	uint64_t		bi_boot_scratch;
 	uint64_t		bi_bsvc_uart_mmio_base;
+	uint64_t		bi_arch_timer_freq;
 	xbi_bsvc_uart_type_t	bi_bsvc_uart_type;
 	uint32_t		bi_module_cnt;
 	uint32_t		bi_psci_version;

--- a/usr/src/uts/armv8/ml/locore.S
+++ b/usr/src/uts/armv8/ml/locore.S
@@ -21,6 +21,7 @@
  */
 /*
  * Copyright 2017 Hayashi Naoyuki
+ * Copyright 2024 Michael van der Westhuizen
  */
 
 #include <sys/asm_linkage.h>
@@ -50,7 +51,9 @@ t0:
 	mov	x29, x1
 	mov	sp, x1
 
+	stp	x0, xzr, [sp, #-0x10]!
 	bl	kobj_start
+	ldp	x1, xzr, [sp], #0x10
 	mov	x0, sp
 	bl	mlsetup
 	bl	main

--- a/usr/src/uts/armv8/os/mlsetup.c
+++ b/usr/src/uts/armv8/os/mlsetup.c
@@ -101,7 +101,7 @@ kobj_start(struct xboot_info *xbp)
  * before main() allows us to call it in a machine-independent fashion.
  */
 void
-mlsetup(struct regs *rp)
+mlsetup(struct regs *rp, struct xboot_info *xbp)
 {
 	extern char t0stack[];
 	extern struct classfuncs sys_classfuncs;
@@ -177,6 +177,7 @@ mlsetup(struct regs *rp)
 	/*
 	 * Select the system timer. Use the phys timer only if EL2.
 	 */
+	arch_timer_set_fw_freq(xbp->bi_arch_timer_freq);
 	arch_timer_select((CPU->cpu_m.mcpu_boot_el == 2) ? TMR_PHYS : TMR_VIRT);
 
 	/*


### PR DESCRIPTION
We have a very early FDT dependency in unix for the arch_timer frequency. This dependency exists to deal with the case where the firmware has not programmed the `CNTFRQ_EL0` register, requiring a fallback to firmware tables.

The loaders can't simply ensure that this value is properly programmed, as it can only be written from the highest implemented EL, which is going to be EL3 on most proper hardware (i.e. where ATF runs).

Since we already have this information in the loaders, pass the corrected value through to `unix` using `xboot_info`. To ensure that we're setting this as early as reasonable (without repurposing `kobj_start` any more than we already have), pass `xboot_info` as a second argument to `mlsetup` to allow setting the frequency after the initial module linkage and immediately before the timer functions are selected.

Tested on qemu virt: https://gist.github.com/r1mikey/c1c35cc68724c3a54b48079b13d80774
Also tested on rpi4:  https://gist.github.com/r1mikey/ce2b4d306f5c18c0604b5d8e7077a3c0