### PR TITLE
Fix issues exposed by GCC 14.2.0

### DIFF
--- a/usr/src/cmd/halt/Makefile
+++ b/usr/src/cmd/halt/Makefile
@@ -49,8 +49,8 @@ CPPFLAGS += -I../../lib/libzpool/common
 CPPFLAGS += -I../../lib/libscf/inc
 CPPFLAGS += -I../../uts/common/fs/zfs
 
-LDLIBS += -lbsm -lscf -lzfs -lgen
-LDLIBS_i386 +=	-lbe
+LDLIBS += -lbsm -lscf
+LDLIBS_i386 +=	-lbe -lzfs -lgen
 LDLIBS +=	$(LDLIBS_$(MACH))
 
 CLOBBERFILES += $(ROOTLINKS) $(ROOTSYMLINKS)

--- a/usr/src/cmd/halt/halt.c
+++ b/usr/src/cmd/halt/halt.c
@@ -100,7 +100,9 @@
 #define	CUR_ELFDATA	ELFDATA2LSB
 #endif
 
+#ifndef __aarch64__		/* No fastreboot */
 static libzfs_handle_t *g_zfs;
+#endif
 
 extern int audit_halt_setup(int, char **);
 extern int audit_halt_success(void);
@@ -143,8 +145,10 @@ static char *fbarg_used;
 static int fbarg_entnum = BE_ENTRY_DEFAULT;
 #endif	/* __x86 */
 
+#ifndef __aarch64__		/* No fastreboot */
 static int validate_ufs_disk(char *, char *);
 static int validate_zfs_pool(char *, char *);
+#endif	/* __aarch64__ */
 
 static pid_t
 get_initpid()
@@ -593,7 +597,7 @@ check_zones_haltedness()
 	} while ((t < 30) && (t_prog < 5));
 }
 
-
+#ifndef __aarch64__		/* No fast boot */
 /*
  * Validate that this is a root disk or dataset
  * Returns 0 if it is a root disk or dataset;
@@ -917,6 +921,7 @@ err_out:
 	}
 	return (-1);
 }
+#endif
 
 static int
 halt_exec(const char *path, ...)
@@ -961,6 +966,7 @@ halt_exec(const char *path, ...)
 	return (st);
 }
 
+#ifndef __aarch64__ // No fastreboot
 /*
  * Mount the specified BE.
  *
@@ -1239,6 +1245,7 @@ parse_fastboot_args(char *bootargs_buf, size_t buf_size,
 
 	return (rc);
 }
+#endif	/* __aarch64__ */
 
 #define	MAXARGS		5
 
@@ -1438,8 +1445,7 @@ main(int argc, char *argv[])
 		    cmdname);
 		return (EINVAL);
 	}
-#endif
-
+#else
 	/*
 	 * If fast reboot, do some sanity check on the argument
 	 */
@@ -1475,6 +1481,7 @@ main(int argc, char *argv[])
 		if (strlen(bootargs_buf) != 0)
 			mdep = (uintptr_t)bootargs_buf;
 	}
+#endif	/* __aarch64__ */
 
 #if 0	/* For debugging */
 	if (mdep != NULL)

--- a/usr/src/stand/lib/fs/ufs/Makefile
+++ b/usr/src/stand/lib/fs/ufs/Makefile
@@ -23,12 +23,12 @@
 # Copyright 2004 Sun Microsystems, Inc.  All rights reserved.
 # Use is subject to license terms.
 #
-# ident	"%Z%%M%	%I%	%E% SMI"
-#
 
 LIBRARY = libufs.a
 OBJECTS = ufsops.o lufsboot.o
 
 include	../Makefile.com
+
+CERRWARN += -_gcc14=-Wno-dangling-pointer
 
 include ../../Makefile.targ

--- a/usr/src/uts/common/io/pciex/pcie_pwr.c
+++ b/usr/src/uts/common/io/pciex/pcie_pwr.c
@@ -271,9 +271,9 @@ pcie_bus_power(dev_info_t *dip, void *impl_arg, pm_bus_power_op_t op,
 	int *child_counters; /* per child dip counters */
 	pm_bp_child_pwrchg_t *bpc;
 	pm_bp_has_changed_t *bphc;
-	dev_info_t *cdip;
-	int new_level;
-	int old_level;
+	dev_info_t *cdip = NULL;
+	int new_level = 0;
+	int old_level = 0;
 	int rv = DDI_SUCCESS;
 	int level_allowed, comp;
 

--- a/usr/src/uts/common/io/sata/impl/sata.c
+++ b/usr/src/uts/common/io/sata/impl/sata.c
@@ -16969,7 +16969,7 @@ sata_check_modser(char *buf, int buf_len)
 	boolean_t ret;
 	char *s;
 	int i;
-	int tb;
+	int tb = 0;
 	char ch;
 
 	ret = B_FALSE;


### PR DESCRIPTION
- halt The removal of fastreboot support was not complete, and improved dead-code removal caused the link of libzfs and libgen to be noticed as unused.

- standalone ufs Gag warning about dangling pointer which seems legitimate, but of incredibly low value to fix

- PCIe power management Initialize variables to gag theoretically possible uninitialied use (I'm not sure if it is _actually_ possible)

- SATA Initialize to plug an uninitialized use that seems more practically possible

@hadfl, @tsoome