### PR TITLE
Simplify resource configuration, attach GIC properly

### DIFF
--- a/usr/src/pkg/manifests/system-kernel-platform.p5m
+++ b/usr/src/pkg/manifests/system-kernel-platform.p5m
@@ -51,11 +51,16 @@ $(aarch64_ONLY)file path=platform/armv8/kernel/dacf/aarch64/consconfig_dacf \
 $(aarch64_ONLY)dir path=platform/armv8/kernel/drv
 $(aarch64_ONLY)dir path=platform/armv8/kernel/drv/aarch64
 $(aarch64_ONLY)file path=platform/armv8/kernel/drv/aarch64/gicv2
+$(aarch64_ONLY)file path=platform/armv8/kernel/drv/aarch64/gicv2m
 $(aarch64_ONLY)file path=platform/armv8/kernel/drv/aarch64/gicv3
+$(aarch64_ONLY)file path=platform/armv8/kernel/drv/aarch64/gicv3its
 $(aarch64_ONLY)file path=platform/armv8/kernel/drv/aarch64/ns16550a
 $(aarch64_ONLY)file path=platform/armv8/kernel/drv/aarch64/rootnex
 $(aarch64_ONLY)file path=platform/armv8/kernel/drv/aarch64/simple-bus
 $(aarch64_ONLY)file path=platform/armv8/kernel/drv/ns16550a.conf
+$(aarch64_ONLY)dir path=platform/armv8/kernel/misc
+$(aarch64_ONLY)dir path=platform/armv8/kernel/misc/aarch64
+$(aarch64_ONLY)file path=platform/armv8/kernel/misc/aarch64/gic_autoconfig
 $(i386_ONLY)dir path=platform/i86pc group=sys
 $(i386_ONLY)dir path=platform/i86pc/$(ARCH64) group=sys
 $(i386_ONLY)dir path=platform/i86pc/kernel group=sys
@@ -195,6 +200,12 @@ $(i386_ONLY)driver name=balloon perms="* 0444 root sys"
 $(i386_ONLY)driver name=cpudrv alias=cpu
 $(i386_ONLY)driver name=domcaps perms="* 0444 root sys"
 $(i386_ONLY)driver name=evtchn perms="* 0666 root sys"
+$(aarch64_ONLY)driver name=gicv2 \
+    alias=arm,cortex-a15-gic \
+    alias=arm,gic-400
+$(aarch64_ONLY)driver name=gicv2m alias=arm,gic-v2m-frame
+$(aarch64_ONLY)driver name=gicv3 alias=arm,gic-v3
+$(aarch64_ONLY)driver name=gicv3its alias=arm,gic-v3-its
 $(i386_ONLY)driver name=isa class=sysbus alias=pciclass,060100
 $(i386_ONLY)driver name=npe alias=pciex_root_complex
 driver name=ns16550a perms="* 0666 root sys" perms="*,cu 0600 uucp uucp" \

--- a/usr/src/uts/aarch64/os/ddi_arch.c
+++ b/usr/src/uts/aarch64/os/ddi_arch.c
@@ -109,10 +109,10 @@ i_ddi_bus_map(dev_info_t *dip, dev_info_t *rdip, ddi_map_req_t *mp,
 
 #ifdef	DDI_MAP_DEBUG
 	cmn_err(CE_CONT,
-	    "i_ddi_bus_map: <%s,%s> <0x%x, 0x%x, 0x%x> "
+	    "i_ddi_bus_map: <%s,%s> <0x%x, 0x%lx, 0x%x> "
 	    "offset %ld len %ld handle 0x%p\n",
 	    ddi_get_name(dip), ddi_get_name(rdip),
-	    rp->regspec_bustype, rp->regspec_addr, rp->regspec_size,
+	    REGSPEC_BUSTYPE(rp), REGSPEC_ADDR(rp), REGSPEC_SIZE(rp),
 	    offset, len, mp->map_handlep);
 #endif	/* DDI_MAP_DEBUG */
 
@@ -124,35 +124,30 @@ i_ddi_bus_map(dev_info_t *dip, dev_info_t *rdip, ddi_map_req_t *mp,
 	 *	<bustype>1, addr=0, len=x>: x86-compatibility i/o
 	 */
 
-	if (rp->regspec_bustype > 1 && rp->regspec_addr != 0) {
+	if (REGSPEC_BUSTYPE(rp) > 1 && REGSPEC_ADDR(rp) != 0) {
 		cmn_err(CE_WARN, "<%s,%s>: invalid register spec"
-		    " <0x%x, 0x%x, 0x%x>\n", ddi_get_name(dip),
-		    ddi_get_name(rdip), rp->regspec_bustype,
-		    rp->regspec_addr, rp->regspec_size);
+		    " <0x%x, 0x%lx, 0x%x>\n", ddi_get_name(dip),
+		    ddi_get_name(rdip), REGSPEC_BUSTYPE(rp),
+		    REGSPEC_ADDR(rp), REGSPEC_SIZE(rp));
 		return (DDI_ME_INVAL);
 	}
 
-	if (rp->regspec_bustype > 1 && rp->regspec_addr == 0) {
-		/*
-		 * compatibility i/o mapping
-		 */
-		rp->regspec_bustype += (uint_t)offset;
-	} else {
-		/*
-		 * Normal memory or i/o mapping
-		 */
-		rp->regspec_addr += (uint_t)offset;
-	}
+	/* No compatibility i/o mapping on Arm */
+	VERIFY(!(REGSPEC_BUSTYPE(rp) > 1 && REGSPEC_ADDR(rp) == 0));
+	/*
+	 * Normal memory or i/o mapping
+	 */
+	REGSPEC_INCR_ADDR(rp, ((uint_t)offset));
 
 	if (len != 0)
-		rp->regspec_size = (uint_t)len;
+		REGSPEC_SET_SIZE(rp, len);
 
 #ifdef	DDI_MAP_DEBUG
 	cmn_err(CE_CONT,
-	    "               <%s,%s> <0x%x, 0x%x, %d> "
+	    "               <%s,%s> <0x%x, 0x%lx, %d> "
 	    "offset %ld len %ld\n",
 	    ddi_get_name(dip), ddi_get_name(rdip),
-	    rp->regspec_bustype, rp->regspec_addr, rp->regspec_size,
+	    REGSPEC_BUSTYPE(rp), REGSPEC_ADDR(rp), REGSPEC_SIZE(rp),
 	    offset, len);
 #endif	/* DDI_MAP_DEBUG */
 
@@ -205,17 +200,17 @@ i_ddi_rnumber_to_regspec(dev_info_t *dip, int rnumber)
 static int
 reg_is_enclosed_in_range(struct regspec *rp, struct rangespec *rangep)
 {
-	if (rp->regspec_bustype != rangep->rng_cbustype)
+	if (REGSPEC_BUSTYPE(rp) != RANGESPEC_CHILD_BUSTYPE(rangep))
 		return (0);
 
-	if (rp->regspec_addr < rangep->rng_coffset)
+	if (REGSPEC_ADDR(rp) < RANGESPEC_CHILD_OFFSET(rangep))
 		return (0);
 
-	if (rangep->rng_size == 0)
+	if (RANGESPEC_SIZE(rangep) == 0)
 		return (1);	/* size is really 2**(bits_per_word) */
 
-	if ((rp->regspec_addr + rp->regspec_size - 1) <=
-	    (rangep->rng_coffset + rangep->rng_size - 1))
+	if ((REGSPEC_ADDR(rp) + REGSPEC_SIZE(rp) - 1) <=
+	    (RANGESPEC_CHILD_OFFSET(rangep) + RANGESPEC_SIZE(rangep) - 1))
 		return (1);
 
 	return (0);
@@ -259,19 +254,21 @@ i_ddi_apply_range(dev_info_t *dp, dev_info_t *rdip, struct regspec *rp)
 	}
 
 #ifdef	DDI_MAP_DEBUG
-	ddi_map_debug("    Input:  %x.%x.%x\n", rp->regspec_bustype,
-	    rp->regspec_addr, rp->regspec_size);
-	ddi_map_debug("    Range:  %x.%x %x.%x %x\n",
-	    rangep->rng_cbustype, rangep->rng_coffset,
-	    rangep->rng_bustype, rangep->rng_offset, rangep->rng_size);
+	ddi_map_debug("    Input:  %x.%lx.%x\n", REGSPEC_BUSTYPE(rp),
+	    REGSPEC_ADDR(rp), REGSPEC_SIZE(rp));
+	ddi_map_debug("    Range:  %x.%lx %x.%lx %x\n",
+	    RANGESPEC_CHILD_BUSTYPE(rangep), RANGESPEC_CHILD_OFFSET(rangep),
+	    RANGESPEC_BUSTYPE(rangep), RANGESPEC_OFFSET(rangep),
+	    RANGESPEC_SIZE(rangep));
 #endif	/* DDI_MAP_DEBUG */
 
-	rp->regspec_bustype = rangep->rng_bustype;
-	rp->regspec_addr += rangep->rng_offset - rangep->rng_coffset;
+	REGSPEC_SET_BUSTYPE(rp, RANGESPEC_BUSTYPE(rangep));
+	REGSPEC_INCR_ADDR(rp,
+	    (RANGESPEC_OFFSET(rangep) - RANGESPEC_CHILD_OFFSET(rangep)));
 
 #ifdef	DDI_MAP_DEBUG
-	ddi_map_debug("    Return: %x.%x.%x\n", rp->regspec_bustype,
-	    rp->regspec_addr, rp->regspec_size);
+	ddi_map_debug("    Return: %x.%lx.%x\n", REGSPEC_BUSTYPE(rp),
+	    REGSPEC_ADDR(rp), REGSPEC_SIZE(rp));
 #endif	/* DDI_MAP_DEBUG */
 
 	return (0);

--- a/usr/src/uts/aarch64/sys/ddi_isa.h
+++ b/usr/src/uts/aarch64/sys/ddi_isa.h
@@ -50,6 +50,100 @@ extern "C" {
  */
 
 /*
+ * Helpers for regspec manipulation and conversion.
+ *
+ * In the aarch64 port we leave the top byte of the bustype for the bus type
+ * and steal the remaining bits for the top bytes of the address, which allows
+ * for 56-bit physical addressing, the maximum supported by aarch64. This is
+ * similar to how Arm themselves support top byte ignore (TBI) in the VMSA.
+ *
+ * When working with regspec and rangespec objects you should always use
+ * these macros. At the boundary between regspec and regspec64 your should
+ * use the `REGSPEC_TO_REGSPEC64' and `REGSPEC64_TO_REGSPEC' macros for
+ * conversion.
+ */
+#define	REGSPEC_BUSTYPE(__rs)	(((__rs)->regspec_bustype >> 24) & 0xff)
+#define	REGSPEC_ADDR(__rs)						\
+    ((((uint64_t)((__rs)->regspec_bustype & 0x00ffffff)) << 32) |	\
+    (__rs)->regspec_addr)
+#define	REGSPEC_SIZE(__rs)	((__rs)->regspec_size)
+
+#define	REGSPEC_SET_SIZE(__rs, __sz)	do {				\
+    (__rs)->regspec_size = (uint_t)(__sz);				\
+} while (0)
+
+#define	REGSPEC_SET_ADDR(__rs, __addr)	do {				\
+    (__rs)->regspec_bustype &= (0xff000000);				\
+    (__rs)->regspec_bustype |=						\
+    ((((uint64_t)(__addr)) >> 32) & 0x00ffffff);			\
+    (__rs)->regspec_addr = ((__addr) & 0xffffffff);			\
+} while (0)
+
+#define	REGSPEC_INCR_ADDR(__rs, __incr)	do {				\
+    REGSPEC_SET_ADDR((__rs), (REGSPEC_ADDR((__rs)) + (__incr)));	\
+} while (0)
+
+#define	REGSPEC_SET_BUSTYPE(__rs, __bt)	do {				\
+    (__rs)->regspec_bustype &= (0x00ffffff);				\
+    (__rs)->regspec_bustype |= (((uint_t)((__bt) & 0xff)) << 24);	\
+} while (0)
+
+#define	REGSPEC_TO_REGSPEC64(__rs, __rs64)	do {			\
+    (__rs64)->regspec_bustype = REGSPEC_BUSTYPE((__rs));		\
+    (__rs64)->regspec_addr = REGSPEC_ADDR((__rs));			\
+    (__rs64)->regspec_size = REGSPEC_SIZE((__rs));			\
+} while (0)
+
+#define	REGSPEC64_TO_REGSPEC(__rs64, __rs)	do {			\
+    REGSPEC_SET_BUSTYPE((__rs), (__rs64)->regspec_bustype);		\
+    VERIFY(((__rs64)->regspec_addr & 0x00fffffffffffffflu) ==		\
+    (__rs64)->regspec_addr);						\
+    REGSPEC_SET_ADDR((__rs), (__rs64)->regspec_addr);			\
+    VERIFY(((__rs64)->regspec_size & 0xffffffffu) ==			\
+    (__rs64)->regspec_size);						\
+    REGSPEC_SET_SIZE((__rs), (__rs64)->regspec_size);			\
+} while (0)
+
+/*
+ * Helpers for rangespec manipulation and use
+ */
+#define	RANGESPEC_CHILD_BUSTYPE(__rs)	(((__rs)->rng_cbustype >> 24) & 0xff)
+#define	RANGESPEC_SET_CHILD_BUSTYPE(__rs, __bt)	do {			\
+    (__rs)->rng_cbustype &= (0x00ffffff);				\
+    (__rs)->rng_cbustype |= (((uint_t)((__bt) & 0xff)) << 24);		\
+} while (0)
+
+#define	RANGESPEC_CHILD_OFFSET(__rs)					\
+    ((((uint64_t)((__rs)->rng_cbustype & 0x00ffffff)) << 32) |		\
+    (__rs)->rng_coffset)
+#define	RANGESPEC_SET_CHILD_OFFSET(__rs, __off)	do {			\
+    (__rs)->rng_cbustype &= (0xff000000);				\
+    (__rs)->rng_cbustype |= (((__off) >> 32) & 0x00ffffff);		\
+    (__rs)->rng_coffset = ((__off) & 0xffffffff);			\
+} while (0)
+
+#define	RANGESPEC_BUSTYPE(__rs)	(((__rs)->rng_bustype >> 24) & 0xff)
+#define	RANGESPEC_SET_BUSTYPE(__rs, __bt)	do {			\
+    (__rs)->rng_bustype &= (0x00ffffff);				\
+    (__rs)->rng_bustype |= (((uint_t)((__bt) & 0xff)) << 24);		\
+} while (0)
+
+#define	RANGESPEC_OFFSET(__rs)					\
+    ((((uint64_t)((__rs)->rng_bustype & 0x00ffffff)) << 32) |		\
+    (__rs)->rng_offset)
+#define	RANGESPEC_SET_OFFSET(__rs, __off)	do {			\
+    (__rs)->rng_bustype &= (0xff000000);				\
+    (__rs)->rng_bustype |= (((__off) >> 32) & 0x00ffffff);		\
+    (__rs)->rng_offset = ((__off) & 0xffffffff);			\
+} while (0)
+
+#define	RANGESPEC_SIZE(__rs)	((__rs)->rng_size)
+
+#define	RANGESPEC_SET_SIZE(__rs, __sz)	do {				\
+    (__rs)->rng_size = (uint_t)(__sz);					\
+} while (0)
+
+/*
  * DDI interfaces defined as functions
  */
 

--- a/usr/src/uts/aarch64/sys/gic.h
+++ b/usr/src/uts/aarch64/sys/gic.h
@@ -74,7 +74,6 @@ typedef int (*gic_is_spurious_t)(uint32_t intid);
 
 typedef struct gic_ops {
 	gic_send_ipi_t		go_send_ipi;
-	gic_init_t		go_init;
 	gic_cpu_init_t		go_cpu_init;
 	gic_config_irq_t	go_config_irq;
 	gic_addspl_t		go_addspl;

--- a/usr/src/uts/aarch64/sys/gic_reg.h
+++ b/usr/src/uts/aarch64/sys/gic_reg.h
@@ -851,7 +851,9 @@ extern "C" {
 #define	GITS_TYPER_PTA				0x0000000000080000
 #define	GITS_TYPER_SEIS				0x0000000000040000
 #define	GITS_TYPER_Devbits			0x000000000003E000
+#define	GITS_TYPER_Devbits_SHIFT		13
 #define	GITS_TYPER_ID_bits			0x0000000000001F00
+#define	GITS_TYPER_ID_bits_SHIFT		8
 #define	GITS_TYPER_ITT_entry_size		0x00000000000000F0
 #define	GITS_TYPER_CCT				0x0000000000000004
 #define	GITS_TYPER_Virtual			0x0000000000000002
@@ -914,6 +916,21 @@ extern "C" {
 
 #define	GITS_PIDR2				0xffe8
 #define	GITS_PIDR2_ArchRev			0x000000F0
+
+/*
+ * GICv2 MSI Frame
+ *
+ * Not public, derived from NetBSD.
+ */
+#define	GV2M_TYPER				0x0008
+#define	GV2M_SETSPI				0x0040
+#define	GV2M_PIDR				0x0fe8
+#define	GV2M_IIDR				0x0ffc
+
+#define	GV2M_TYPER_BASE_SHIFT			16
+#define	GV2M_TYPER_BASE_MASK			0x3ff
+#define	GV2M_TYPER_NUMBER_SHIFT			0
+#define	GV2M_TYPER_NUMBER_MASK			0x3ff
 
 #ifdef __cplusplus
 }

--- a/usr/src/uts/armv8/Makefile.armv8
+++ b/usr/src/uts/armv8/Makefile.armv8
@@ -200,6 +200,10 @@ DRV_KMODS += simple-bus
 DRV_KMODS += rootnex
 DRV_KMODS += ns16550a
 DRV_KMODS += gicv2
+DRV_KMODS += gicv2m
 DRV_KMODS += gicv3
+DRV_KMODS += gicv3its
+
+MISC_KMODS += gic_autoconfig
 
 DACF_KMODS += consconfig_dacf

--- a/usr/src/uts/armv8/Makefile.files
+++ b/usr/src/uts/armv8/Makefile.files
@@ -90,7 +90,11 @@ ROOTNEX_OBJS += rootnex.o
 NS16550A_OBJS += ns16550a.o
 
 GICV2_OBJS += gicv2.o
+GICV2M_OBJS += gicv2m.o
 GICV3_OBJS += gicv3.o
+GICV3ITS_OBJS += gicv3its.o
+
+GIC_AUTOCONFIG_OBJS += gic_autoconfig.o
 
 ASSYM_DEPS +=			\
 	aarch64_subr.o		\

--- a/usr/src/uts/armv8/Makefile.rules
+++ b/usr/src/uts/armv8/Makefile.rules
@@ -22,9 +22,14 @@
 #
 # Copyright (c) 1992, 2010, Oracle and/or its affiliates. All rights reserved.
 # Copyright 2017 Hayashi Naoyuki
+# Copyright 2024 Michael van der Westhuizen
 #
 
 $(OBJS_DIR)/%.o:		$(UTSBASE)/armv8/io/ns16550a/%.c
+	$(COMPILE.c) -o $@ $<
+	$(CTFCONVERT_O)
+
+$(OBJS_DIR)/%.o:		$(UTSBASE)/armv8/io/gic/%.c
 	$(COMPILE.c) -o $@ $<
 	$(CTFCONVERT_O)
 

--- a/usr/src/uts/armv8/gic_autoconfig/Makefile
+++ b/usr/src/uts/armv8/gic_autoconfig/Makefile
@@ -1,0 +1,57 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2024 Michael van der Westhuizen
+#
+
+#
+# Path to the base of the uts tree (nominally /usr/src/uts).
+#
+UTSBASE	= ../..
+
+#
+# Define the module and objects used to construct it.
+#
+MODULE		= gic_autoconfig
+OBJECTS		= $(GIC_AUTOCONFIG_OBJS:%=$(OBJS_DIR)/%)
+ROOTMODULE	= $(ROOT_PSM_MISC_DIR)/$(MODULE)
+
+#
+# Include common rules.
+#
+include $(UTSBASE)/armv8/Makefile.armv8
+
+#
+# Define targets
+#
+ALL_TARGET	= $(BINARY)
+INSTALL_TARGET	= $(BINARY) $(ROOTMODULE)
+
+#
+# Default build targets.
+#
+.KEEP_STATE:
+
+def:		$(DEF_DEPS)
+
+all:		$(ALL_DEPS)
+
+clean:		$(CLEAN_DEPS)
+
+clobber:	$(CLOBBER_DEPS)
+
+install:	$(INSTALL_DEPS)
+
+#
+# Include common targets.
+#
+include $(UTSBASE)/armv8/Makefile.targ

--- a/usr/src/uts/armv8/gicv2m/Makefile
+++ b/usr/src/uts/armv8/gicv2m/Makefile
@@ -1,0 +1,64 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2024 Michael van der Westhuizen
+#
+
+#
+#	Path to the base of the uts directory tree (usually /usr/src/uts).
+#
+UTSBASE	= ../..
+
+#
+#	Define the module and object file sets.
+#
+MODULE		= gicv2m
+OBJECTS		= $(GICV2M_OBJS:%=$(OBJS_DIR)/%)
+ROOTMODULE	= $(ROOT_PSM_DRV_DIR)/$(MODULE)
+
+#
+#	Include common rules.
+#
+include $(UTSBASE)/armv8/Makefile.armv8
+
+#
+#       Define targets
+#
+ALL_TARGET	= $(BINARY)
+INSTALL_TARGET	= $(BINARY) $(ROOTMODULE)
+
+#
+#	Overrides
+#
+ALL_BUILDS	= $(ALL_BUILDSONLY64)
+DEF_BUILDS	= $(DEF_BUILDSONLY64)
+
+#
+#	Default build targets.
+#
+.KEEP_STATE:
+
+all:		$(ALL_DEPS)
+
+def:		$(DEF_DEPS)
+
+clean:		$(CLEAN_DEPS)
+
+clobber:	$(CLOBBER_DEPS)
+
+install:	$(INSTALL_DEPS)
+
+
+#
+#	Include common targets.
+#
+include $(UTSBASE)/armv8/Makefile.targ

--- a/usr/src/uts/armv8/gicv3its/Makefile
+++ b/usr/src/uts/armv8/gicv3its/Makefile
@@ -1,0 +1,64 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2024 Michael van der Westhuizen
+#
+
+#
+#	Path to the base of the uts directory tree (usually /usr/src/uts).
+#
+UTSBASE	= ../..
+
+#
+#	Define the module and object file sets.
+#
+MODULE		= gicv3its
+OBJECTS		= $(GICV3ITS_OBJS:%=$(OBJS_DIR)/%)
+ROOTMODULE	= $(ROOT_PSM_DRV_DIR)/$(MODULE)
+
+#
+#	Include common rules.
+#
+include $(UTSBASE)/armv8/Makefile.armv8
+
+#
+#       Define targets
+#
+ALL_TARGET	= $(BINARY)
+INSTALL_TARGET	= $(BINARY) $(ROOTMODULE)
+
+#
+#	Overrides
+#
+ALL_BUILDS	= $(ALL_BUILDSONLY64)
+DEF_BUILDS	= $(DEF_BUILDSONLY64)
+
+#
+#	Default build targets.
+#
+.KEEP_STATE:
+
+all:		$(ALL_DEPS)
+
+def:		$(DEF_DEPS)
+
+clean:		$(CLEAN_DEPS)
+
+clobber:	$(CLOBBER_DEPS)
+
+install:	$(INSTALL_DEPS)
+
+
+#
+#	Include common targets.
+#
+include $(UTSBASE)/armv8/Makefile.targ

--- a/usr/src/uts/armv8/io/gic/gic_autoconfig.c
+++ b/usr/src/uts/armv8/io/gic/gic_autoconfig.c
@@ -1,0 +1,251 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2024 Michael van der Westhuizen
+ */
+
+/*
+ * Locate a GIC root interrupt controller, then attach that controller
+ * and any known child nodes.
+ *
+ * Supports orderly system startup by attaching the system interrupt
+ * controller as early as reasonably possible.
+ */
+
+#include <sys/types.h>
+#include <sys/sunddi.h>
+#include <sys/sunndi.h>
+#include <sys/ddi_subrdefs.h>
+#include <sys/ddi_impldefs.h>
+#include <sys/ndi_impldefs.h>
+#include <sys/ddi_implfuncs.h>
+#include <sys/ddi_arch_intr.h>
+#include <sys/modctl.h>
+#include <sys/obpdefs.h>
+
+typedef struct {
+	dev_info_t	*gsr_dip;
+	uint32_t	gsr_roots;
+} gic_search_result_t;
+
+static const char *compatible_gics[] = {
+	"arm,gic-v3",
+	"arm,gic-400",
+	"arm,cortex-a15-gic"
+};
+static const uint_t num_compatible_gics =
+    sizeof (compatible_gics) / sizeof (compatible_gics[0]);
+
+static const char *compatible_children[] = {
+	"arm,gic-v3-its",
+	"arm,gic-v2m-frame",
+};
+static const uint_t num_compatible_children =
+    sizeof (compatible_children) / sizeof (compatible_children[0]);
+
+static void gic_probe(int);
+
+static struct modlmisc modlmisc = {
+	.misc_modops	= &mod_miscops,
+	.misc_linkinfo	= "GIC Instantiation Helper"
+};
+
+static struct modlinkage modlinkage = {
+	.ml_rev		= MODREV_1,
+	.ml_linkage	= { &modlmisc, NULL }
+};
+
+int
+_init(void)
+{
+	int err;
+
+	if ((err = mod_install(&modlinkage)) != 0)
+		return (err);
+
+	impl_bus_add_probe(gic_probe);
+	return (err);
+}
+
+int
+_fini(void)
+{
+	int err;
+
+	impl_bus_delete_probe(gic_probe);
+	if ((err = mod_remove(&modlinkage)) != 0)
+		return (err);
+
+	return (err);
+}
+
+int
+_info(struct modinfo *modinfop)
+{
+	return (mod_info(&modlinkage, modinfop));
+}
+
+static boolean_t
+gic_test_compatible(dev_info_t *dip, const char **compats, uint_t ncompats)
+{
+	char	**data;
+	uint_t	nelements;
+	uint_t	n;
+	uint_t	i;
+
+	if (ddi_prop_lookup_string_array(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
+	    OBP_COMPATIBLE, &data, &nelements) != DDI_PROP_SUCCESS)
+		return (B_FALSE);
+
+	for (n = 0; n < nelements; ++n) {
+		for (i = 0; i < ncompats; ++i) {
+			if (strcmp(data[n], compats[i]) == 0) {
+				ddi_prop_free(data);
+				return (B_TRUE);
+			}
+		}
+	}
+
+	ddi_prop_free(data);
+	return (B_FALSE);
+}
+
+static int
+gic_online(dev_info_t *dip)
+{
+	dev_info_t	*pdip;
+	int		rv;
+
+	if (i_ddi_devi_attached(dip))
+		return (DDI_SUCCESS);
+
+	pdip = ddi_get_parent(dip);
+	if (pdip == ddi_root_node() && !i_ddi_devi_attached(pdip))
+		return (DDI_FAILURE);
+	ASSERT3P(pdip, !=, NULL);
+
+	if (gic_online(pdip) != DDI_SUCCESS)
+		return (DDI_FAILURE);
+
+	ndi_devi_enter(pdip);
+	rv = i_ndi_config_node(dip, DS_READY, 0);
+	ndi_devi_exit(pdip);
+	return (rv);
+}
+
+static int
+gic_searcher(dev_info_t *rdip, void *arg)
+{
+	gic_search_result_t	*gsr = arg;
+
+	ASSERT3P(rdip, !=, NULL);
+	ASSERT3P(gsr, !=, NULL);
+
+	/*
+	 * Filter out nodes that are not root interrupt controllers, which
+	 * is defined as an interrupt controller without an interrupt parent.
+	 */
+	if (ddi_prop_exists(DDI_DEV_T_ANY, rdip,
+	    DDI_PROP_DONTPASS, "interrupt-controller") == 0)
+		return (DDI_WALK_CONTINUE);
+
+	if (ddi_prop_exists(DDI_DEV_T_ANY, rdip,
+	    DDI_PROP_DONTPASS, "interrupt-parent") == 1)
+		return (DDI_WALK_CONTINUE);
+
+	/*
+	 * Track the number of discovered interrupt roots.
+	 */
+	gsr->gsr_roots++;
+
+	/*
+	 * We have what claims to be a root interrupt controller.
+	 *
+	 * If it's a compatible GIC and we have not yet recorded a compatible
+	 * GIC, then record it.
+	 */
+	if (gic_test_compatible(rdip, compatible_gics, num_compatible_gics))
+		if (gsr->gsr_dip == NULL)
+			gsr->gsr_dip = rdip;
+
+	return (DDI_WALK_CONTINUE);
+}
+
+static void
+gic_probe(int reprogram)
+{
+	dev_info_t		*cdip;
+	gic_search_result_t	search_results = {
+		.gsr_dip	= NULL,
+		.gsr_roots	= 0
+	};
+
+	if (reprogram == 0)
+		return;
+
+	/*
+	 * Find a compatible GIC which is the root interrupt controller.
+	 *
+	 * We prefer a root interrupt controller that is referenced from
+	 * the device tree root via an interrupt-parent property. Failing
+	 * that, we trawl around in the device tree for a compatible GIC.
+	 */
+	if ((cdip = i_ddi_interrupt_parent(ddi_root_node())) != NULL) {
+		if (gic_test_compatible(cdip,
+		    compatible_gics, num_compatible_gics) == B_TRUE) {
+			search_results.gsr_roots = 1;
+			search_results.gsr_dip = cdip;
+		}
+	} else {
+		ndi_devi_enter(ddi_root_node());
+		ddi_walk_devs(ddi_get_child(ddi_root_node()),
+		    gic_searcher, &search_results);
+		ndi_devi_exit(ddi_root_node());
+
+		ASSERT3U(search_results.gsr_roots, >=, 1);
+		if (search_results.gsr_roots == 0)
+			cmn_err(CE_PANIC, "gic_probe: failed to find any root "
+			    "interrupt controllers");
+	}
+
+	/*
+	 * Check that the discovered root controller is compatible.
+	 */
+	ASSERT3P(search_results.gsr_dip, !=, NULL);
+	if (search_results.gsr_dip == NULL)
+		cmn_err(CE_PANIC, "gic_probe: could not find a compatible "
+		    "root interrupt controller");
+
+	/*
+	 * OK, we have a compatible root controller, attach it so that the
+	 * rest of the tree can register interrupts.
+	 */
+	if (gic_online(search_results.gsr_dip) != DDI_SUCCESS)
+		cmn_err(CE_PANIC, "Unable to attach GIC %s",
+		    ddi_node_name(search_results.gsr_dip));
+
+	/*
+	 * Iterate through the root GIC child nodes and ensure that each
+	 * known child node has come online. This enables, for example,
+	 * MSI/MSI-X functionality.
+	 */
+	for (cdip = ddi_get_child(search_results.gsr_dip);
+	    cdip != NULL;
+	    cdip = ddi_get_next_sibling(cdip)) {
+		if (gic_test_compatible(cdip, compatible_children,
+		    num_compatible_children) == B_FALSE)
+			continue;
+		if (gic_online(cdip) != DDI_SUCCESS)
+			cmn_err(CE_PANIC, "Unable to online root interrupt "
+			    "controller child node %s", ddi_node_name(cdip));
+	}
+}

--- a/usr/src/uts/armv8/io/gic/gicv2.c
+++ b/usr/src/uts/armv8/io/gic/gicv2.c
@@ -66,54 +66,54 @@
 #include <sys/avintr.h>
 #include <sys/smp_impldefs.h>
 #include <sys/sunddi.h>
-#include <sys/promif.h>
 #include <sys/smp_impldefs.h>
 #include <sys/archsystm.h>
 
 extern void gic_remove_state(int);
 
-extern char *gic_module_name;
-
 typedef struct {
-	/* Base address of the CPU interface */
-	void		*gc_gicc;
-	/* Base address of the distributor */
-	void		*gc_gicd;
+	/* Base address and access handle for the CPU interface */
+	caddr_t			gc_gicc;
+	ddi_acc_handle_t	gc_gicc_regh;
+	/* Base address and access handle for the distributor */
+	caddr_t			gc_gicd;
+	ddi_acc_handle_t	gc_gicd_regh;
 	/*
 	 * Desired binary point value to support the priority scheme
 	 */
-	uint32_t	gc_bpr;
+	uint32_t		gc_bpr;
 	/*
 	 * PPI interrupt config for secondary CPUs.
 	 */
-	uint32_t	gc_icfgr1;
+	uint32_t		gc_icfgr1;
 	/*
 	 * Shadow copy of GICD_ISENABLER[0] used in initialization of
 	 * secondary CPUs (PPI-only);
 	 */
-	uint32_t	gc_enabled_local;
+	uint32_t		gc_enabled_local;
 	/*
 	 * Shadow copy of  GICD_IPRIORITYR<0-7> used in initialization of
 	 * secondary CPUs.
 	 */
-	uint32_t	gc_priority[8];
+	uint32_t		gc_priority[8];
 	/*
 	 * Protect access to global GIC state.
 	 * In the current implementation, the distributor.
 	 */
-	lock_t		gc_lock;
+	lock_t			gc_lock;
 	/*
 	 * Mapping from cpuid to GIC target identifier
 	 */
-	uint8_t		gc_target[8];
+	uint8_t			gc_target[8];
 	/*
 	 * CPUs for which we have initialized the GIC.  Used to limit IPIs to
 	 * only those CPUs we can target.
 	 */
-	cpuset_t	gc_cpuset;
+	cpuset_t		gc_cpuset;
 } gicv2_conf_t;
 
-static gicv2_conf_t	conf;
+static gicv2_conf_t	*conf;
+static void		*gicv2_soft_state;
 
 static uint32_t standard_priorities[] = {
 	[0]	= 248,
@@ -191,45 +191,45 @@ static uint32_t gicv2_prio_pmr_mask;
 #define	GIC_IPL_TO_PRIO(v)		(gicv2_prio_map[((v) & 0xF)])
 
 #define	GICV2_GICD_LOCK_INIT_HELD()	uint64_t __s = disable_interrupts(); \
-					LOCK_INIT_HELD(&conf.gc_lock)
+					LOCK_INIT_HELD(&conf->gc_lock)
 #define	GICV2_GICD_LOCK()		uint64_t __s = disable_interrupts(); \
-					lock_set(&conf.gc_lock)
-#define	GICV2_GICD_UNLOCK()		lock_clear(&conf.gc_lock); \
+					lock_set(&conf->gc_lock)
+#define	GICV2_GICD_UNLOCK()		lock_clear(&conf->gc_lock); \
 					restore_interrupts(__s)
-#define	GICV2_ASSERT_GICD_LOCK_HELD()	ASSERT(LOCK_HELD(&conf.gc_lock))
+#define	GICV2_ASSERT_GICD_LOCK_HELD()	ASSERT(LOCK_HELD(&conf->gc_lock))
 
 static inline uint32_t
-gicc_read(gicv2_conf_t *gic, uint32_t reg)
+gicc_read(gicv2_conf_t *sc, uint32_t reg)
 {
-	return (i_ddi_get32(NULL, (uint32_t *)(gic->gc_gicc + reg)));
+	return (ddi_get32(sc->gc_gicc_regh, (uint32_t *)(sc->gc_gicc + reg)));
 }
 
 static inline void
-gicc_write(gicv2_conf_t *gic, uint32_t reg, uint32_t val)
+gicc_write(gicv2_conf_t *sc, uint32_t reg, uint32_t val)
 {
-	i_ddi_put32(NULL, (uint32_t *)(gic->gc_gicc + reg), val);
+	ddi_put32(sc->gc_gicc_regh, (uint32_t *)(sc->gc_gicc + reg), val);
 }
 
 static inline uint32_t
-gicd_read(gicv2_conf_t *gic, uint32_t reg)
+gicd_read(gicv2_conf_t *sc, uint32_t reg)
 {
-	return (i_ddi_get32(NULL, (uint32_t *)(gic->gc_gicd + reg)));
+	return (ddi_get32(sc->gc_gicd_regh, (uint32_t *)(sc->gc_gicd + reg)));
 }
 
 static inline void
-gicd_write(gicv2_conf_t *gic, uint32_t reg, uint32_t val)
+gicd_write(gicv2_conf_t *sc, uint32_t reg, uint32_t val)
 {
-	i_ddi_put32(NULL, (uint32_t *)(gic->gc_gicd + reg), val);
+	ddi_put32(sc->gc_gicd_regh, (uint32_t *)(sc->gc_gicd + reg), val);
 }
 
 static inline uint32_t
-gicd_rmw(gicv2_conf_t *gic, uint32_t reg, uint32_t clrbits, uint32_t setbits)
+gicd_rmw(gicv2_conf_t *sc, uint32_t reg, uint32_t clrbits, uint32_t setbits)
 {
 	uint32_t val;
-	uint32_t *regaddr = (uint32_t *)(gic->gc_gicd + reg);
+	uint32_t *regaddr = (uint32_t *)(sc->gc_gicd + reg);
 
-	val = (i_ddi_get32(NULL, regaddr) & (~clrbits)) | setbits;
-	i_ddi_put32(NULL, regaddr, val);
+	val = (ddi_get32(sc->gc_gicd_regh, regaddr) & (~clrbits)) | setbits;
+	ddi_put32(sc->gc_gicd_regh, regaddr, val);
 	return (val);
 }
 
@@ -244,11 +244,11 @@ gicd_rmw(gicv2_conf_t *gic, uint32_t reg, uint32_t clrbits, uint32_t setbits)
  * We never try to configure SGIs.
  */
 static void
-gicv2_enable_irq(int irq)
+gicv2_enable_irq(gicv2_conf_t *sc, int irq)
 {
 	if (GIC_INTID_IS_SPI(irq) || GIC_INTID_IS_PPI(irq)) {
 		GICV2_ASSERT_GICD_LOCK_HELD();
-		gicd_write(&conf, GICD_ISENABLERn(GICD_IENABLER_REGNUM(irq)),
+		gicd_write(sc, GICD_ISENABLERn(GICD_IENABLER_REGNUM(irq)),
 		    GICD_IENABLER_REGBIT(irq));
 	}
 }
@@ -265,11 +265,11 @@ gicv2_enable_irq(int irq)
  * We never try to configure SGIs.
  */
 static void
-gicv2_disable_irq(int irq)
+gicv2_disable_irq(gicv2_conf_t *sc, int irq)
 {
 	if (GIC_INTID_IS_SPI(irq) || GIC_INTID_IS_PPI(irq)) {
 		GICV2_ASSERT_GICD_LOCK_HELD();
-		gicd_write(&conf, GICD_ICENABLERn(GICD_IENABLER_REGNUM(irq)),
+		gicd_write(sc, GICD_ICENABLERn(GICD_IENABLER_REGNUM(irq)),
 		    GICD_IENABLER_REGBIT(irq));
 	}
 }
@@ -296,7 +296,7 @@ gicv2_config_irq(uint32_t irq, bool is_edge)
 	 * corresponding programmable Int_config field is changed. GIC
 	 * behavior is otherwise UNPREDICTABLE.
 	 */
-	ASSERT(((gicd_read(&conf, GICD_ISENABLERn(GICD_IENABLER_REGNUM(irq))) &
+	ASSERT(((gicd_read(conf, GICD_ISENABLERn(GICD_IENABLER_REGNUM(irq))) &
 	    GICD_IENABLER_REGBIT(irq)) == 0));
 
 	/*
@@ -304,7 +304,7 @@ gicv2_config_irq(uint32_t irq, bool is_edge)
 	 * bit is reserved, the odd bit is 1 for edge-triggered 0 for
 	 * level.
 	 */
-	(void) gicd_rmw(&conf,
+	(void) gicd_rmw(conf,
 	    GICD_ICFGRn(GICD_ICFGR_REGNUM(irq)),
 	    GICD_ICFGR_REGVAL(irq, GICD_ICFGR_INT_CONFIG_MASK),
 	    GICD_ICFGR_REGVAL(irq, v));
@@ -324,7 +324,7 @@ gicv2_setlvl(int irq)
 	new_ipl = autovect[irq].avh_hi_pri;
 
 	if (new_ipl != 0) {
-		gicc_write(&conf, GICC_PMR,
+		gicc_write(conf, GICC_PMR,
 		    GIC_IPL_TO_PRIO(new_ipl) & gicv2_prio_pmr_mask);
 	}
 
@@ -337,7 +337,7 @@ gicv2_setlvl(int irq)
 static void
 gicv2_setlvlx(int ipl)
 {
-	gicc_write(&conf, GICC_PMR, GIC_IPL_TO_PRIO(ipl) & gicv2_prio_pmr_mask);
+	gicc_write(conf, GICC_PMR, GIC_IPL_TO_PRIO(ipl) & gicv2_prio_pmr_mask);
 }
 
 /*
@@ -345,20 +345,20 @@ gicv2_setlvlx(int ipl)
  * If IRQ is an SGI or PPI, shadow that priority into `ipriorityr_private`
  */
 static void
-gicv2_set_ipl(uint32_t irq, uint32_t ipl)
+gicv2_set_ipl(gicv2_conf_t *sc, uint32_t irq, uint32_t ipl)
 {
 	uint32_t ipriorityr;
 	uint32_t n;
 
 	GICV2_ASSERT_GICD_LOCK_HELD();
 	n = GICD_IPRIORITY_REGNUM(irq);
-	ipriorityr = gicd_rmw(&conf,
+	ipriorityr = gicd_rmw(sc,
 	    GICD_IPRIORITYRn(n),
 	    GICD_IPRIORITY_REGVAL(irq, GICD_IPRIORITY_REGMASK),
 	    GICD_IPRIORITY_REGVAL(irq, GIC_IPL_TO_PRIO(ipl)));
 
 	if (GIC_INTID_IS_PERCPU(irq)) {
-		conf.gc_priority[n] = ipriorityr;
+		sc->gc_priority[n] = ipriorityr;
 	}
 }
 
@@ -368,7 +368,7 @@ gicv2_set_ipl(uint32_t irq, uint32_t ipl)
  * XXXARM: We need interrupt redistribution.
  */
 static void
-gicv2_add_target(uint32_t irq)
+gicv2_add_target(gicv2_conf_t *sc, uint32_t irq)
 {
 	uint32_t coreMask = GICD_ITARGETSR_REGMASK; /* all 8 cpus */
 
@@ -381,7 +381,7 @@ gicv2_add_target(uint32_t irq)
 	 */
 	if (!GIC_INTID_IS_PERCPU(irq)) {
 		GICV2_ASSERT_GICD_LOCK_HELD();
-		(void) gicd_rmw(&conf,
+		(void) gicd_rmw(sc,
 		    GICD_ITARGETSRn(GICD_ITARGETSR_REGNUM(irq)),
 		    GICD_ITARGETSR_REGVAL(irq, GICD_ITARGETSR_REGMASK),
 		    GICD_ITARGETSR_REGVAL(irq, coreMask));
@@ -410,11 +410,11 @@ static int
 gicv2_addspl(int irq, int ipl, int min_ipl, int max_ipl)
 {
 	GICV2_GICD_LOCK();
-	gicv2_set_ipl((uint32_t)irq, (uint32_t)ipl);
-	gicv2_add_target((uint32_t)irq);
-	gicv2_enable_irq((uint32_t)irq);
+	gicv2_set_ipl(conf, (uint32_t)irq, (uint32_t)ipl);
+	gicv2_add_target(conf, (uint32_t)irq);
+	gicv2_enable_irq(conf, (uint32_t)irq);
 	if (GIC_INTID_IS_PPI(irq) && CPU->cpu_id == 0) {
-		conf.gc_enabled_local |= (1U << irq);
+		conf->gc_enabled_local |= (1U << irq);
 	}
 	GICV2_GICD_UNLOCK();
 	return (0);
@@ -430,10 +430,10 @@ static int
 gicv2_delspl(int irq, int ipl, int min_ipl, int max_ipl)
 {
 	GICV2_GICD_LOCK();
-	gicv2_disable_irq((uint32_t)irq);
-	gicv2_set_ipl((uint32_t)irq, 0);
+	gicv2_disable_irq(conf, (uint32_t)irq);
+	gicv2_set_ipl(conf, (uint32_t)irq, 0);
 	if (GIC_INTID_IS_PPI(irq) && CPU->cpu_id == 0) {
-		conf.gc_enabled_local &= ~(1U << irq);
+		conf->gc_enabled_local &= ~(1U << irq);
 	}
 	GICV2_GICD_UNLOCK();
 
@@ -451,24 +451,24 @@ gicv2_send_ipi(cpuset_t cpuset, int irq)
 	uint32_t target = 0;
 
 	GICV2_GICD_LOCK();
-	CPUSET_AND(cpuset, conf.gc_cpuset);
+	CPUSET_AND(cpuset, conf->gc_cpuset);
 	while (!CPUSET_ISNULL(cpuset)) {
 		uint_t cpu;
 		CPUSET_FIND(cpuset, cpu);
-		target |= conf.gc_target[cpu];
+		target |= conf->gc_target[cpu];
 		CPUSET_DEL(cpuset, cpu);
 	}
 	dsb(ish);
 
 	/* The third argument (NSATTR) is ignored from the non-secure world */
-	gicd_write(&conf, GICD_SGIR, GICD_MAKE_SGIR_REGVAL(0, target, 0, irq));
+	gicd_write(conf, GICD_SGIR, GICD_MAKE_SGIR_REGVAL(0, target, 0, irq));
 	GICV2_GICD_UNLOCK();
 }
 
 static uint64_t
 gicv2_acknowledge(void)
 {
-	return ((uint64_t)gicc_read(&conf, GICC_IAR));
+	return ((uint64_t)gicc_read(conf, GICC_IAR));
 }
 
 static uint32_t
@@ -480,13 +480,13 @@ gicv2_ack_to_vector(uint64_t ack)
 static void
 gicv2_eoi(uint64_t ack)
 {
-	gicc_write(&conf, GICC_EOIR, (uint32_t)(ack & 0xFFFFFFFF));
+	gicc_write(conf, GICC_EOIR, (uint32_t)(ack & 0xFFFFFFFF));
 }
 
 static void
 gicv2_deactivate(uint64_t ack)
 {
-	gicc_write(&conf, GICC_DIR, (uint32_t)(ack & 0xFFFFFFFF));
+	gicc_write(conf, GICC_DIR, (uint32_t)(ack & 0xFFFFFFFF));
 }
 
 /*
@@ -496,86 +496,11 @@ gicv2_deactivate(uint64_t ack)
  * This sets the Nth bit for target N
  */
 static uint_t
-gicv2_get_target(void)
+gicv2_get_target(gicv2_conf_t *gc)
 {
 	GICV2_ASSERT_GICD_LOCK_HELD();
 	return (1U << __builtin_ctz(
-	    gicd_read(&conf, GICD_ITARGETSRn(0)) & 0xFF));
-}
-
-/*
- * Return the GICv2 PROM node, or OBP_NONODE if none was found.
- */
-static pnode_t
-find_gic(pnode_t nodeid, int depth)
-{
-	pnode_t	node;
-	pnode_t	child;
-
-	GICV2_ASSERT_GICD_LOCK_HELD();
-
-	if (prom_is_compatible(nodeid, "arm,cortex-a15-gic") ||
-	    prom_is_compatible(nodeid, "arm,gic-400")) {
-		return (nodeid);
-	}
-
-	child = prom_childnode(nodeid);
-	while (child > 0) {
-		node = find_gic(child, depth + 1);
-		if (node > 0)
-			return (node);
-		child = prom_nextnode(child);
-	}
-
-	return (OBP_NONODE);
-}
-
-/*
- * Map the GICv2 distributor and CPU interface MMIO regions into the device
- * arena.
- */
-static int
-gicv2_map(void)
-{
-	pnode_t		node;
-	uint64_t	gicd_base;
-	uint64_t	gicd_size;
-	uint64_t	gicc_base;
-	uint64_t	gicc_size;
-	caddr_t		addr;
-
-	GICV2_ASSERT_GICD_LOCK_HELD();
-
-	node = find_gic(prom_rootnode(), 0);
-	if (node <= 0)
-		return (-1);
-
-	if (prom_get_reg_address(node, 0, &gicd_base) != 0)
-		return (-1);
-
-	if (prom_get_reg_size(node, 0, &gicd_size) != 0)
-		return (-1);
-
-	if (prom_get_reg_address(node, 1, &gicc_base) != 0)
-		return (-1);
-
-	if (prom_get_reg_size(node, 1, &gicc_size) != 0)
-		return (-1);
-
-	addr = psm_map_phys(gicd_base, gicd_size, PROT_READ|PROT_WRITE);
-	if (addr == NULL)
-		return (-1);
-	conf.gc_gicd = (void *)addr;
-
-	addr = psm_map_phys(gicc_base, gicc_size, PROT_READ|PROT_WRITE);
-	if (addr == NULL) {
-		psm_unmap_phys((caddr_t)conf.gc_gicd, gicd_size);
-		conf.gc_gicd = NULL;
-		return (-1);
-	}
-	conf.gc_gicc = (void *)addr;
-
-	return (0);
+	    gicd_read(gc, GICD_ITARGETSRn(0)) & 0xFF));
 }
 
 /*
@@ -588,14 +513,14 @@ gicv2_map(void)
  * distributor lock.
  */
 static void
-gicv2_cpu_init_raw(cpu_t *cp)
+gicv2_cpu_init_raw(gicv2_conf_t *sc, cpu_t *cp)
 {
 	GICV2_ASSERT_GICD_LOCK_HELD();
 
 	/*
 	 * Disable the current CPU interface.
 	 */
-	gicc_write(&conf, GICC_CTLR, 0);
+	gicc_write(sc, GICC_CTLR, 0);
 
 	/*
 	 * Clear enabled/pending/active status of the CPU-specific interrupts.
@@ -605,9 +530,9 @@ gicv2_cpu_init_raw(cpu_t *cp)
 	 * Note that we do not attempt to disable SGIs, as that's an
 	 * implementation-defined operation.
 	 */
-	gicd_write(&conf, GICD_ICENABLERn(0), 0xffff0000);
-	gicd_write(&conf, GICD_ICPENDRn(0), 0xffffffff);
-	gicd_write(&conf, GICD_ICACTIVERn(0), 0xffffffff);
+	gicd_write(sc, GICD_ICENABLERn(0), 0xffff0000);
+	gicd_write(sc, GICD_ICPENDRn(0), 0xffffffff);
+	gicd_write(sc, GICD_ICACTIVERn(0), 0xffffffff);
 
 	/*
 	 * When initialising the boot CPU we do a bit more.
@@ -620,21 +545,21 @@ gicv2_cpu_init_raw(cpu_t *cp)
 		 * this variable. We later use this information when booting
 		 * secondary CPUs.
 		 */
-		conf.gc_enabled_local = 0x0;
+		sc->gc_enabled_local = 0x0;
 
 		/*
 		 * Figure out how to map IPLs to GIC priorities.
 		 */
-		gicc_write(&conf, GICC_PMR, 0xFF);
+		gicc_write(sc, GICC_PMR, 0xFF);
 
-		if ((gicc_read(&conf, GICC_PMR) & 0xf) == 0) {
+		if ((gicc_read(sc, GICC_PMR) & 0xf) == 0) {
 			gicv2_prio_map = bodged_priorities;
 			gicv2_prio_pmr_mask = BODGED_PRIORITY_PMR_MASK;
-			conf.gc_bpr = BODGED_BPR;
+			sc->gc_bpr = BODGED_BPR;
 		} else {
 			gicv2_prio_map = standard_priorities;
 			gicv2_prio_pmr_mask = STANDARD_PRIORITY_PMR_MASK;
-			conf.gc_bpr = STANDARD_BPR;
+			sc->gc_bpr = STANDARD_BPR;
 		}
 
 		/*
@@ -644,9 +569,9 @@ gicv2_cpu_init_raw(cpu_t *cp)
 		 * other processors.
 		 */
 		for (int i = 0; i < 8; ++i) {
-			gicd_write(&conf, GICD_IPRIORITYRn(i), 0xffffffff);
-			conf.gc_priority[i] =
-			    gicd_read(&conf, GICD_IPRIORITYRn(i));
+			gicd_write(sc, GICD_IPRIORITYRn(i), 0xffffffff);
+			sc->gc_priority[i] =
+			    gicd_read(sc, GICD_IPRIORITYRn(i));
 		}
 	} else {
 		/*
@@ -655,15 +580,15 @@ gicv2_cpu_init_raw(cpu_t *cp)
 		 * Configuring PPIs is implementation-defined, so this might
 		 * have no effect.
 		 */
-		gicd_write(&conf, GICD_ICFGRn(1), conf.gc_icfgr1);
+		gicd_write(sc, GICD_ICFGRn(1), sc->gc_icfgr1);
 
 		/*
 		 * Initialize interrupt priorities for per-CPU interrupts from
 		 * the shadow copy of the priority registers.
 		 */
 		for (int i = 0; i < 8; ++i) {
-			gicd_write(&conf, GICD_IPRIORITYRn(i),
-			    conf.gc_priority[i]);
+			gicd_write(sc, GICD_IPRIORITYRn(i),
+			    sc->gc_priority[i]);
 		}
 
 		/*
@@ -673,25 +598,25 @@ gicv2_cpu_init_raw(cpu_t *cp)
 		 * time the secondary CPU comes up. No further attempt at
 		 * synchronization is made.
 		 */
-		gicd_write(&conf, GICD_ISENABLERn(0), conf.gc_enabled_local);
+		gicd_write(sc, GICD_ISENABLERn(0), sc->gc_enabled_local);
 	}
 
 	/*
 	 * Apply our subpriority configuration.
 	 */
-	gicc_write(&conf, GICC_BPR, conf.gc_bpr);
+	gicc_write(sc, GICC_BPR, sc->gc_bpr);
 
 	/*
 	 * Confugure the priority mask register to leave us at LOCK_LEVEL once
 	 * initialized.
 	 */
-	gicc_write(&conf, GICC_PMR,
+	gicc_write(sc, GICC_PMR,
 	    GIC_IPL_TO_PRIO(LOCK_LEVEL) & gicv2_prio_pmr_mask);
 
 	/*
 	 * Record our target for interrupt routing.
 	 */
-	conf.gc_target[cp->cpu_id] = gicv2_get_target();
+	sc->gc_target[cp->cpu_id] = gicv2_get_target(sc);
 
 	/*
 	 * Enable the CPU interface.
@@ -699,13 +624,13 @@ gicv2_cpu_init_raw(cpu_t *cp)
 	 * Note that we enable split priority drop and deactivation so that we
 	 * can properly support threaded intrerrupts.
 	 */
-	gicc_write(&conf, GICC_CTLR,
+	gicc_write(sc, GICC_CTLR,
 	    GICC_CTLR_EnableGrp1 | GICC_CTLR_EOImodeNS);
 
 	/*
 	 * Finally, tell the world we're ready.
 	 */
-	CPUSET_ADD(conf.gc_cpuset, cp->cpu_id);
+	CPUSET_ADD(sc->gc_cpuset, cp->cpu_id);
 }
 
 /*
@@ -716,8 +641,10 @@ gicv2_cpu_init_raw(cpu_t *cp)
 static void
 gicv2_cpu_init(cpu_t *cp)
 {
+	gicv2_conf_t *sc = ddi_get_soft_state(gicv2_soft_state, 0);
+	ASSERT3P(sc, !=, NULL);
 	GICV2_GICD_LOCK();
-	gicv2_cpu_init_raw(cp);
+	gicv2_cpu_init_raw(sc, cp);
 	GICV2_GICD_UNLOCK();
 }
 
@@ -728,35 +655,28 @@ gicv2_cpu_init(cpu_t *cp)
  * Returns non-zero on error.
  */
 static int
-gicv2_init(void)
+gicv2_init(gicv2_conf_t *sc)
 {
-	GICV2_GICD_LOCK_INIT_HELD();
-
-	if (gicv2_map() != 0) {
-		GICV2_GICD_UNLOCK();
-		return (-1);
-	}
-
 	/*
 	 * Mask all interrupts on the current CPU interface, then disable it.
 	 *
 	 * This is the last time we should touch the GIC CPU interface in this
 	 * function.
 	 */
-	gicc_write(&conf, GICC_CTLR, 0);
+	gicc_write(sc, GICC_CTLR, 0);
 
 	/*
 	 * Disable the distributor.
 	 */
-	gicd_write(&conf, GICD_CTLR, 0);
+	gicd_write(sc, GICD_CTLR, 0);
 
 	/*
 	 * Clear enabled/pending/active status of global interrupts.
 	 */
 	for (int i = 1; i < 32; ++i) {
-		gicd_write(&conf, GICD_ICENABLERn(i), 0xffffffff);
-		gicd_write(&conf, GICD_ICPENDRn(i), 0xffffffff);
-		gicd_write(&conf, GICD_ICACTIVERn(i), 0xffffffff);
+		gicd_write(sc, GICD_ICENABLERn(i), 0xffffffff);
+		gicd_write(sc, GICD_ICPENDRn(i), 0xffffffff);
+		gicd_write(sc, GICD_ICACTIVERn(i), 0xffffffff);
 	}
 
 	/*
@@ -766,14 +686,14 @@ gicv2_init(void)
 	 * GICD_ICFGRn(1) is PPI, configuring these is implementation-defined.
 	 */
 	for (int i = 1; i < 64; i++) {
-		gicd_write(&conf, GICD_ICFGRn(i), 0x0);
+		gicd_write(sc, GICD_ICFGRn(i), 0x0);
 	}
 
 	/*
 	 * Save PPI interrupt configuration so we can apply it to secondary
 	 * CPUs. Configuring PPIs is implementation-defined, but we try anyway.
 	 */
-	conf.gc_icfgr1 = gicd_read(&conf, GICD_ICFGRn(1));
+	sc->gc_icfgr1 = gicd_read(sc, GICD_ICFGRn(1));
 
 	/*
 	 * Initialize interrupt priorities for global interrupts, setting them
@@ -781,67 +701,231 @@ gicv2_init(void)
 	 * CPUs. XXXARM: we need to implement interrupt redistribution.
 	 */
 	for (int i = 8; i < 256; ++i) {
-		gicd_write(&conf, GICD_IPRIORITYRn(i), 0xffffffff);
-		gicd_write(&conf, GICD_ITARGETSRn(i), 0xffffffff);
+		gicd_write(sc, GICD_IPRIORITYRn(i), 0xffffffff);
+		gicd_write(sc, GICD_ITARGETSRn(i), 0xffffffff);
 	}
 
 	/*
 	 * No CPUs have been configured yet.
 	 */
-	CPUSET_ZERO(conf.gc_cpuset);
+	CPUSET_ZERO(sc->gc_cpuset);
 
 	/*
 	 * Enable the distributor.
 	 */
-	gicd_write(&conf, GICD_CTLR, GICD_CTLR_EnableGrp1);
+	gicd_write(sc, GICD_CTLR, GICD_CTLR_EnableGrp1);
 
 	/*
 	 * While we still hold the lock we initialize the boot processor.
 	 */
-	gicv2_cpu_init_raw(CPU);
-
-	GICV2_GICD_UNLOCK();
-	return (0);
+	gicv2_cpu_init_raw(sc, CPU);
+	return (DDI_SUCCESS);
 }
 
-static struct modlmisc modlmisc = {
-	&mod_miscops,
-	"Generic Interrupt Controller v2"
+static int
+gicv2_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
+{
+	int ret;
+	int nregs;
+	int instance;
+	gicv2_conf_t *xconf;
+
+	ddi_device_acc_attr_t gicv2_reg_acc_attr = {
+		.devacc_attr_version		= DDI_DEVICE_ATTR_V0,
+		.devacc_attr_endian_flags	= DDI_STRUCTURE_LE_ACC,
+		.devacc_attr_dataorder		= DDI_STRICTORDER_ACC
+	};
+
+	switch (cmd) {
+	case DDI_ATTACH:
+		break;
+	case DDI_RESUME:	/* fallthrough */
+	case DDI_PM_RESUME:
+		return (DDI_SUCCESS);
+	default:
+		dev_err(dip, CE_NOTE, "Unhandled attach command: %d", (int)cmd);
+		return (DDI_FAILURE);
+	}
+	ASSERT3U(cmd, ==, DDI_ATTACH);
+
+	instance = ddi_get_instance(dip);
+
+	if ((ret = ddi_dev_nregs(dip, &nregs)) != DDI_SUCCESS)
+		return (ret);
+
+	if (nregs < 2)
+		return (DDI_FAILURE);
+
+	if ((ret = ddi_soft_state_zalloc(gicv2_soft_state,
+	    instance)) != DDI_SUCCESS)
+		return (ret);
+	xconf = ddi_get_soft_state(gicv2_soft_state, instance);
+	VERIFY3P(xconf, !=, NULL);
+
+	if ((ret = ddi_regs_map_setup(dip, 0, &xconf->gc_gicd, 0, 0,
+	    &gicv2_reg_acc_attr, &xconf->gc_gicd_regh)) != DDI_SUCCESS) {
+		ddi_soft_state_free(gicv2_soft_state, instance);
+		return (ret);
+	}
+
+	if ((ret = ddi_regs_map_setup(dip, 1, &xconf->gc_gicc, 0, 0,
+	    &gicv2_reg_acc_attr, &xconf->gc_gicc_regh)) != DDI_SUCCESS) {
+		ddi_regs_map_free(&xconf->gc_gicd_regh);
+		ddi_soft_state_free(gicv2_soft_state, instance);
+		return (ret);
+	}
+
+	conf = xconf;
+	GICV2_GICD_LOCK_INIT_HELD();
+
+	if ((ret = gicv2_init(xconf)) != DDI_SUCCESS) {
+		GICV2_GICD_UNLOCK();
+		ddi_regs_map_free(&xconf->gc_gicc_regh);
+		ddi_regs_map_free(&xconf->gc_gicd_regh);
+		conf = NULL;
+		ddi_soft_state_free(gicv2_soft_state, instance);
+		return (ret);
+	}
+
+	GICV2_GICD_UNLOCK();
+
+	gic_ops.go_send_ipi = gicv2_send_ipi;
+	gic_ops.go_cpu_init = gicv2_cpu_init;
+	gic_ops.go_config_irq = gicv2_config_irq;
+	gic_ops.go_addspl = gicv2_addspl;
+	gic_ops.go_delspl = gicv2_delspl;
+	gic_ops.go_setlvl = gicv2_setlvl;
+	gic_ops.go_setlvlx = gicv2_setlvlx;
+	gic_ops.go_acknowledge = gicv2_acknowledge;
+	gic_ops.go_ack_to_vector = gicv2_ack_to_vector;
+	gic_ops.go_eoi = gicv2_eoi;
+	gic_ops.go_deactivate = gicv2_deactivate;
+	/*
+	 * Explicitly use the default "is special" handler.
+	 */
+	gic_ops.go_is_spurious = (gic_is_spurious_t)NULL;
+
+	ddi_report_dev(dip);
+	return (DDI_SUCCESS);
+}
+
+static int
+gicv2_bus_ctl(dev_info_t *dip, dev_info_t *rdip, ddi_ctl_enum_t ctlop,
+    void *arg, void *result)
+{
+	int ret;
+
+	switch (ctlop) {
+	case DDI_CTLOPS_INITCHILD:
+		ret = impl_ddi_sunbus_initchild(arg);
+		break;
+	case DDI_CTLOPS_UNINITCHILD:
+		impl_ddi_sunbus_removechild(arg);
+		ret = DDI_SUCCESS;
+		break;
+	case DDI_CTLOPS_REPORTDEV:
+		if (rdip == NULL)
+			return (DDI_FAILURE);
+		cmn_err(CE_CONT, "?%s%d at %s%d\n",
+		    ddi_driver_name(rdip), ddi_get_instance(rdip),
+		    ddi_driver_name(dip), ddi_get_instance(dip));
+		/* XXXARM: intercept the child here and add the v2m frame */
+		ret = DDI_SUCCESS;
+		break;
+	default:
+		ret = ddi_ctlops(dip, rdip, ctlop, arg, result);
+		break;
+	}
+
+	return (ret);
+}
+
+static struct bus_ops gicv2_bus_ops = {
+	.busops_rev		= BUSO_REV,
+	.bus_map		= i_ddi_bus_map,
+	.bus_get_intrspec	= NULL,	/* obsolete */
+	.bus_add_intrspec	= NULL,	/* obsolete */
+	.bus_remove_intrspec	= NULL,	/* obsolete */
+	.bus_map_fault		= i_ddi_map_fault,
+	.bus_dma_map		= NULL,
+	.bus_dma_allochdl	= ddi_dma_allochdl,
+	.bus_dma_freehdl	= ddi_dma_freehdl,
+	.bus_dma_bindhdl	= ddi_dma_bindhdl,
+	.bus_dma_unbindhdl	= ddi_dma_unbindhdl,
+	.bus_dma_flush		= ddi_dma_flush,
+	.bus_dma_win		= ddi_dma_win,
+	.bus_dma_ctl		= ddi_dma_mctl,
+	.bus_ctl		= gicv2_bus_ctl,
+	.bus_prop_op		= ddi_bus_prop_op,
+	.bus_get_eventcookie	= NULL,
+	.bus_add_eventcall	= NULL,
+	.bus_remove_eventcall	= NULL,
+	.bus_post_event		= NULL,
+	.bus_intr_ctl		= NULL,
+	.bus_config		= NULL,
+	.bus_unconfig		= NULL,
+	.bus_fm_init		= NULL,
+	.bus_fm_fini		= NULL,
+	.bus_fm_access_enter	= NULL,
+	.bus_fm_access_exit	= NULL,
+	.bus_power		= NULL,
+	.bus_intr_op		= i_ddi_intr_ops,
+	.bus_hp_op		= NULL
+};
+
+static struct dev_ops gicv2_ops = {
+	.devo_rev		= DEVO_REV,
+	.devo_refcnt		= 0,
+	.devo_getinfo		= ddi_no_info,
+	.devo_identify		= nulldev,
+	.devo_probe		= nulldev,
+	.devo_attach		= gicv2_attach,
+	.devo_detach		= nulldev,
+	.devo_reset		= nodev,
+	.devo_cb_ops		= NULL,
+	.devo_bus_ops		= &gicv2_bus_ops,
+	.devo_power		= NULL,
+	.devo_quiesce		= ddi_quiesce_not_needed,
+};
+
+static struct modldrv gicv2_modldrv = {
+	.drv_modops		= &mod_driverops,
+	.drv_linkinfo		= "Generic Interrupt Controller v2",
+	.drv_dev_ops		= &gicv2_ops
 };
 
 static struct modlinkage modlinkage = {
-	MODREV_1, (void *)&modlmisc, NULL
+	.ml_rev			= MODREV_1,
+	.ml_linkage		= { &gicv2_modldrv, NULL }
 };
 
 int
 _init(void)
 {
-	if (strcmp(gic_module_name, "gicv2") == 0) {
-		gic_ops.go_send_ipi = gicv2_send_ipi;
-		gic_ops.go_init = gicv2_init;
-		gic_ops.go_cpu_init = gicv2_cpu_init;
-		gic_ops.go_config_irq = gicv2_config_irq;
-		gic_ops.go_addspl = gicv2_addspl;
-		gic_ops.go_delspl = gicv2_delspl;
-		gic_ops.go_setlvl = gicv2_setlvl;
-		gic_ops.go_setlvlx = gicv2_setlvlx;
-		gic_ops.go_acknowledge = gicv2_acknowledge;
-		gic_ops.go_ack_to_vector = gicv2_ack_to_vector;
-		gic_ops.go_eoi = gicv2_eoi;
-		gic_ops.go_deactivate = gicv2_deactivate;
-		/*
-		 * Explicitly use the default "is special" handler.
-		 */
-		gic_ops.go_is_spurious = (gic_is_spurious_t)NULL;
+	int err;
+
+	if ((err = ddi_soft_state_init(&gicv2_soft_state,
+	    sizeof (gicv2_conf_t), 1)) != 0)
+		return (err);
+
+	if ((err = mod_install(&modlinkage)) != 0) {
+		ddi_soft_state_fini(&gicv2_soft_state);
+		return (err);
 	}
 
-	return (mod_install(&modlinkage));
+	return (err);
 }
 
 int
 _fini(void)
 {
-	return (EBUSY);
+	int err;
+
+	if ((err = mod_remove(&modlinkage)))
+		return (err);
+
+	ddi_soft_state_fini(&gicv2_soft_state);
+	return (err);
 }
 
 int

--- a/usr/src/uts/armv8/io/gic/gicv2m.c
+++ b/usr/src/uts/armv8/io/gic/gicv2m.c
@@ -1,0 +1,126 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2024 Michael van der Westhuizen
+ */
+
+#include <sys/types.h>
+#include <sys/gic.h>
+#include <sys/gic_reg.h>
+#include <sys/avintr.h>
+#include <sys/smp_impldefs.h>
+#include <sys/sunddi.h>
+#include <sys/promif.h>
+#include <sys/cpuinfo.h>
+#include <sys/sysmacros.h>
+#include <sys/archsystm.h>
+
+typedef struct {
+	dev_info_t		*gc_dip;
+	caddr_t			gc_gv2m;
+	ddi_acc_handle_t	gc_regh;
+	uint32_t		gc_base_spi;
+	uint32_t		gc_num_spis;
+} gicv2m_sc_t;
+
+#define	GV2M_REG32(sc, offset)	((uint32_t *)((sc)->gc_gv2m + (offset)))
+
+static void *gicv2m_soft_state;
+
+static int
+gicv2m_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
+{
+	switch (cmd) {
+	case DDI_ATTACH:
+		break;
+	case DDI_RESUME:	/* fallthrough */
+	case DDI_PM_RESUME:
+		return (DDI_SUCCESS);
+	default:
+		dev_err(dip, CE_NOTE, "Unhandled attach command: %d", (int)cmd);
+		return (DDI_FAILURE);
+	}
+	ASSERT3U(cmd, ==, DDI_ATTACH);
+
+	ddi_report_dev(dip);
+	return (DDI_SUCCESS);
+}
+
+static int
+gicv2m_detach(dev_info_t *dip, ddi_detach_cmd_t cmd)
+{
+	return (DDI_FAILURE);
+}
+
+static struct dev_ops gicv2m_ops = {
+	.devo_rev		= DEVO_REV,
+	.devo_refcnt		= 0,
+	.devo_getinfo		= ddi_no_info,
+	.devo_identify		= nulldev,
+	.devo_probe		= nulldev,
+	.devo_attach		= gicv2m_attach,
+	.devo_detach		= gicv2m_detach,
+	.devo_reset		= nodev,
+	.devo_cb_ops		= NULL,
+	.devo_bus_ops		= NULL,
+	.devo_power		= NULL,
+	.devo_quiesce		= ddi_quiesce_not_needed,
+};
+
+static char modlinkinfo[] =
+	"Generic Interrupt Controller v2 MSI Frame";
+
+static struct modldrv gicv2m_modldrv = {
+	.drv_modops		= &mod_driverops,
+	.drv_linkinfo		= modlinkinfo,
+	.drv_dev_ops		= &gicv2m_ops
+};
+
+static struct modlinkage modlinkage = {
+	.ml_rev			= MODREV_1,
+	.ml_linkage		= { &gicv2m_modldrv, NULL }
+};
+
+int
+_init(void)
+{
+	int err;
+
+	if ((err = ddi_soft_state_init(&gicv2m_soft_state,
+	    sizeof (gicv2m_sc_t), 16)) != 0)
+		return (err);
+
+	if ((err = mod_install(&modlinkage)) != 0) {
+		ddi_soft_state_fini(&gicv2m_soft_state);
+		return (err);
+	}
+
+	return (err);
+}
+
+int
+_fini(void)
+{
+	int err;
+
+	if ((err = mod_remove(&modlinkage)))
+		return (err);
+
+	ddi_soft_state_fini(&gicv2m_soft_state);
+	return (err);
+}
+
+int
+_info(struct modinfo *modinfop)
+{
+	return (mod_info(&modlinkage, modinfop));
+}

--- a/usr/src/uts/armv8/io/gic/gicv3.c
+++ b/usr/src/uts/armv8/io/gic/gicv3.c
@@ -69,14 +69,11 @@
 #include <sys/avintr.h>
 #include <sys/smp_impldefs.h>
 #include <sys/sunddi.h>
-#include <sys/promif.h>
 #include <sys/cpuinfo.h>
 #include <sys/sysmacros.h>
 #include <sys/archsystm.h>
 
 extern void gic_remove_state(int);
-
-extern char *gic_module_name;
 
 /*
  * A redistributor region is a block of redistributor MMIO space. One finds
@@ -89,8 +86,8 @@ extern char *gic_module_name;
  * regions.
  */
 typedef struct {
-	void		*base;
-	uint64_t	size;
+	caddr_t			base;
+	ddi_acc_handle_t	hdl;
 } gicv3_redist_region_t;
 
 /*
@@ -114,12 +111,9 @@ typedef struct {
 } gicv3_redistributor_t;
 
 typedef struct {
-	/* Base address of the CPU interface */
-	void			*gc_gicc;
-	/* Base address of the distributor */
-	void			*gc_gicd;
-	/* Size of the distributor mapping */
-	uint64_t		gc_gicd_size;
+	/* Base address of, and handle to, the distributor */
+	caddr_t			gc_gicd;
+	ddi_acc_handle_t	gc_gicd_regh;
 	/* Shadow copy of the distributor type register */
 	uint32_t		gc_gicd_typer;
 	/* Number of interrupt sources in the traditional interrupt space */
@@ -145,26 +139,27 @@ typedef struct {
 	/* A flag indicating that we have 32 (or more) priority levels */
 	uint32_t		gc_pri32;
 	/* Protect access the distributor */
-	lock_t		gc_dist_lock;
+	lock_t			gc_dist_lock;
 	/*
 	 * CPUs for which we have initialized the GIC.  Used to limit IPIs to
 	 * only those CPUs we can target.
 	 */
-	cpuset_t	gc_cpuset;
+	cpuset_t		gc_cpuset;
 } gicv3_conf_t;
 
-static gicv3_conf_t	conf;
+static gicv3_conf_t	*conf;
+static void		*gicv3_soft_state;
 
 #define	GICR_FRAME_SIZE		(64 * 1024)
 
-#define	GIC_IPL_TO_PRI(ipl)	(conf.gc_pri32 ? (GIC_IPL_TO_PRIO((ipl))) : \
+#define	GIC_IPL_TO_PRI(ipl)	(conf->gc_pri32 ? (GIC_IPL_TO_PRIO((ipl))) : \
 				(GIC_IPL_TO_PRIO16((ipl))))
 
 #define	GICD_LOCK_INIT_HELD()	uint64_t __s = disable_interrupts(); \
-				LOCK_INIT_HELD(&conf.gc_dist_lock)
+				LOCK_INIT_HELD(&conf->gc_dist_lock)
 #define	GICD_LOCK()		uint64_t __s = disable_interrupts(); \
-				lock_set(&conf.gc_dist_lock)
-#define	GICD_UNLOCK()		lock_clear(&conf.gc_dist_lock); \
+				lock_set(&conf->gc_dist_lock)
+#define	GICD_UNLOCK()		lock_clear(&conf->gc_dist_lock); \
 				restore_interrupts(__s)
 
 static inline uint32_t
@@ -394,10 +389,10 @@ gicv3_config_irq(uint32_t irq, bool is_edge)
 	if (GIC_INTID_IS_SGI(irq)) {
 		/* SGIs are not configurable */
 	} else if (GIC_INTID_IS_PPI(irq)) {
-		gicv3_for_each_gicr(&conf,
+		gicv3_for_each_gicr(conf,
 		    gicv3_config_irq_percpu, irq, v);
 	} else if (GIC_INTID_IS_SPI(irq)) {
-		gicv3_config_irq_spi(&conf, irq, v);
+		gicv3_config_irq_spi(conf, irq, v);
 	}
 }
 
@@ -467,7 +462,7 @@ gicv3_addspl_spi(gicv3_conf_t *gc, uint32_t irq, uint32_t ipl)
 	/*
 	 * Set the target CPU.
 	 */
-	if ((conf.gc_gicd_typer & GICD_TYPER_No1N) == 0)
+	if ((conf->gc_gicd_typer & GICD_TYPER_No1N) == 0)
 		gicd_write8(gc, GICD_IROUTERn(irq),
 		    GICD_IROUTER_Interrupt_Routing_Mode);
 	else
@@ -505,10 +500,10 @@ static int
 gicv3_addspl(int irq, int ipl, int min_ipl __unused, int max_ipl __unused)
 {
 	if (GIC_INTID_IS_PERCPU(irq)) {
-		gicv3_for_each_gicr(&conf,
+		gicv3_for_each_gicr(conf,
 		    gicv3_addspl_percpu, (uint32_t)irq, (uint32_t)ipl);
 	} else if (GIC_INTID_IS_SPI(irq)) {
-		gicv3_addspl_spi(&conf, (uint32_t)irq, (uint32_t)ipl);
+		gicv3_addspl_spi(conf, (uint32_t)irq, (uint32_t)ipl);
 	}
 
 	return (0);
@@ -582,10 +577,10 @@ gicv3_delspl(int irq, int ipl __unused,
     int min_ipl __unused, int max_ipl __unused)
 {
 	if (GIC_INTID_IS_PERCPU(irq)) {
-		gicv3_for_each_gicr(&conf,
+		gicv3_for_each_gicr(conf,
 		    gicv3_delspl_percpu, (uint32_t)irq, 0);
 	} else if (GIC_INTID_IS_SPI(irq)) {
-		gicv3_delspl_spi(&conf, (uint32_t)irq);
+		gicv3_delspl_spi(conf, (uint32_t)irq);
 	}
 
 	return (0);
@@ -616,12 +611,12 @@ gicv3_send_ipi(cpuset_t cpuset, int irq)
 	 *
 	 * However, this is obviously correct, which will do for now.
 	 */
-	CPUSET_AND(cpuset, conf.gc_cpuset);
+	CPUSET_AND(cpuset, conf->gc_cpuset);
 	CPUSET_DEL(cpuset, CPU->cpu_id);
 	while (!CPUSET_ISNULL(cpuset)) {
 		uint_t cpun;
 		CPUSET_FIND(cpuset, cpun);
-		sgir = conf.gc_redist[cpun].gr_sgir;
+		sgir = conf->gc_redist[cpun].gr_sgir;
 		if (!has_rss && ICC_SGInR_EL1_HAS_RS(sgir)) {
 			panic("cpu%d: Need range selector support to target "
 			    "cpu%d with an SGI", CPU->cpu_id, cpun);
@@ -670,130 +665,6 @@ static void
 gicv3_deactivate(uint64_t ack)
 {
 	write_icc_dir_el1(ack);
-}
-
-/*
- * Private helper function to deallocate and unmap any allocated GIC
- * configuration.
- *
- * This function is only used for cleanup in error paths.
- */
-static void
-gicv3_clear_conf(gicv3_conf_t *gc)
-{
-	uint32_t i;
-
-	if (gc->gc_num_redist && gc->gc_redist) {
-		kmem_free(gc->gc_redist,
-		    sizeof (gicv3_redistributor_t) * gc->gc_num_redist);
-	}
-
-	gc->gc_redist = NULL;
-	gc->gc_num_redist = 0;
-
-	if (gc->gc_num_redist_regions && gc->gc_redist_regions) {
-		for (i = 0; i < gc->gc_num_redist_regions; ++i) {
-			if (gc->gc_redist_regions[i].size) {
-				psm_unmap_phys(
-				    (caddr_t)gc->gc_redist_regions[i].base,
-				    gc->gc_redist_regions[i].size);
-			}
-			gc->gc_redist_regions[i].base = NULL;
-			gc->gc_redist_regions[i].size = 0;
-		}
-
-		kmem_free(gc->gc_redist_regions,
-		    sizeof (gicv3_redist_region_t) * gc->gc_num_redist_regions);
-	}
-
-	gc->gc_redist_regions = NULL;
-	gc->gc_num_redist_regions = 0;
-
-	if (gc->gc_gicd && gc->gc_gicd_size)
-		psm_unmap_phys((caddr_t)gc->gc_gicd, gc->gc_gicd_size);
-
-	gc->gc_gicd = NULL;
-	gc->gc_gicd_size = 0;
-}
-
-/*
- * Return the GICv3 PROM node, or OBP_NONODE if none was found.
- */
-static pnode_t
-find_gic(pnode_t nodeid, int depth)
-{
-	pnode_t	node;
-	pnode_t	child;
-
-	if (prom_is_compatible(nodeid, "arm,gic-v3"))
-		return (nodeid);
-
-	child = prom_childnode(nodeid);
-	while (child > 0) {
-		node = find_gic(child, depth + 1);
-		if (node > 0)
-			return (node);
-		child = prom_nextnode(child);
-	}
-
-	return (OBP_NONODE);
-}
-
-/*
- * Map the GICv3 distributor and redistributor MMIO regions into the device
- * arena.
- */
-static int
-gicv3_map(gicv3_conf_t *gc)
-{
-	pnode_t			node;
-	uint32_t		i;
-	uint64_t		gicd_base;
-	uint64_t		gicd_size;
-	uint64_t		gicrr_base;
-	uint64_t		gicrr_size;
-	uint32_t		num_redist_regions;
-	caddr_t			addr;
-
-	node = find_gic(prom_rootnode(), 0);
-	if (node <= 0)
-		return (-1);
-
-	if (prom_get_reg_address(node, 0, &gicd_base) != 0)
-		return (-1);
-
-	if (prom_get_reg_size(node, 0, &gicd_size) != 0)
-		return (-1);
-
-	addr = psm_map_phys(gicd_base, gicd_size, PROT_READ|PROT_WRITE);
-	if (addr == NULL)
-		return (-1);
-	gc->gc_gicd = (void *)addr;
-	gc->gc_gicd_size = gicd_size;
-
-	gc->gc_redist_stride =
-	    prom_get_prop_u64(node, "redistributor-stride", 0);
-	num_redist_regions =
-	    prom_get_prop_u32(node, "#redistributor-regions", 1);
-	gc->gc_redist_regions = kmem_zalloc(
-	    sizeof (gicv3_redist_region_t) * num_redist_regions, KM_SLEEP);
-	gc->gc_num_redist_regions = num_redist_regions;
-
-	for (i = 0; i < gc->gc_num_redist_regions; ++i) {
-		if (prom_get_reg_address(node, 1 + i, &gicrr_base) != 0 ||
-		    prom_get_reg_size(node, 1 + i, &gicrr_size) != 0)
-			return (-1);
-
-		addr = psm_map_phys(gicrr_base, gicrr_size,
-		    PROT_READ|PROT_WRITE);
-		if (addr == NULL)
-			return (-1);
-
-		gc->gc_redist_regions[i].base = (void *)addr;
-		gc->gc_redist_regions[i].size = gicrr_size;
-	}
-
-	return (0);
 }
 
 /*
@@ -970,7 +841,7 @@ gicv3_cpu_init(cpu_t *cp)
 	 * Tell the hardware that this CPU is awake and wait for the wakeup to
 	 * complete.
 	 */
-	gicv3_awaken_cpu(&conf, cp);
+	gicv3_awaken_cpu(conf, cp);
 
 	/*
 	 * CPU Interface Configuration
@@ -1008,7 +879,7 @@ gicv3_cpu_init(cpu_t *cp)
 	/*
 	 * Finally, tell the world we're ready.
 	 */
-	CPUSET_ADD(conf.gc_cpuset, cp->cpu_id);
+	CPUSET_ADD(conf->gc_cpuset, cp->cpu_id);
 }
 
 /*
@@ -1019,40 +890,22 @@ gicv3_cpu_init(cpu_t *cp)
  * Returns non-zero on error.
  */
 static int
-gicv3_init(void)
+gicv3_init(gicv3_conf_t *gc)
 {
 	uint32_t	n;
 
-	if (gicv3_enable_system_register_access() != 0)
-		prom_panic("cpu0: Failed to enable the GIC system register "
-		    "interface.");
-
-	/*
-	 * Global initialization involves the distributor, so lock it.
-	 */
 	GICD_LOCK_INIT_HELD();
-	gicv3_clear_conf(&conf);
-
-	/*
-	 * Map redistributor regions.
-	 */
-	if (gicv3_map(&conf) != 0) {
-		gicv3_clear_conf(&conf);
-		GICD_UNLOCK();
-		return (-1);
-	}
 
 	/*
 	 * Allocate redistributors and assign pointers to them.
 	 */
-	if (gicv3_assign_redistributors(&conf) != 0) {
-		gicv3_clear_conf(&conf);
+	if (gicv3_assign_redistributors(conf) != 0) {
 		GICD_UNLOCK();
-		return (-1);
+		return (DDI_FAILURE);
 	}
 
-	conf.gc_gicd_typer = gicd_read4(&conf, GICD_TYPER);
-	conf.gc_maxsources = GICD_TYPER_LINES(conf.gc_gicd_typer);
+	conf->gc_gicd_typer = gicd_read4(conf, GICD_TYPER);
+	conf->gc_maxsources = GICD_TYPER_LINES(conf->gc_gicd_typer);
 
 	/*
 	 * Disable the distributor and drain writes. This is done is pieces
@@ -1065,13 +918,13 @@ gicv3_init(void)
 	 * In an implementation that only supports one security state, ARE
 	 * is the same bit as ARE_NS, so this logic holds.
 	 */
-	(void) gicd_rmw4(&conf, GICD_CTLR,
+	(void) gicd_rmw4(conf, GICD_CTLR,
 	    GICD_CTLR_RWP|GICD_CTLR_EnableGrp1A|GICD_CTLR_EnableGrp1, 0x0);
-	gicd_drain_writes(&conf);
-	(void) gicd_rmw4(&conf, GICD_CTLR,
+	gicd_drain_writes(conf);
+	(void) gicd_rmw4(conf, GICD_CTLR,
 	    GICD_CTLR_RWP|GICD_CTLR_ARE_NS, GICD_CTLR_ARE_NS);
-	gicd_drain_writes(&conf);
-	VERIFY((gicd_read4(&conf, GICD_CTLR) & GICD_CTLR_ARE_NS) ==
+	gicd_drain_writes(conf);
+	VERIFY((gicd_read4(conf, GICD_CTLR) & GICD_CTLR_ARE_NS) ==
 	    GICD_CTLR_ARE_NS);
 
 	/*
@@ -1091,40 +944,40 @@ gicv3_init(void)
 	 * single security state is 4. If two states are implemented the
 	 * minimum is 5.
 	 */
-	conf.gc_pri32 =
+	conf->gc_pri32 =
 	    ((ICC_CTLR_NUM_PRI_BITS(read_icc_ctlr_el1()) >= 5) ? 1 : 0);
 
 	/*
 	 * Disable all SPIs.
 	 */
-	for (n = 32; n < conf.gc_maxsources; n += 32)
-		gicd_write4(&conf, GICD_ICENABLERn(n >> 5), 0xFFFFFFFF);
-	gicd_drain_writes(&conf);
+	for (n = 32; n < conf->gc_maxsources; n += 32)
+		gicd_write4(conf, GICD_ICENABLERn(n >> 5), 0xFFFFFFFF);
+	gicd_drain_writes(conf);
 
 	/*
 	 * Move all SPIs to non-secure group 1.
 	 */
-	for (n = 32; n < conf.gc_maxsources; n += 32) {
-		gicd_write4(&conf, GICD_IGROUPRn(n >> 5), 0xFFFFFFFF);
-		gicd_write4(&conf, GICD_IGRPMODRn(n >> 5), 0x0);
+	for (n = 32; n < conf->gc_maxsources; n += 32) {
+		gicd_write4(conf, GICD_IGROUPRn(n >> 5), 0xFFFFFFFF);
+		gicd_write4(conf, GICD_IGRPMODRn(n >> 5), 0x0);
 	}
 
 	/*
 	 * Drop all SPIs to the lowest priority.
 	 */
-	for (n = 32; n < conf.gc_maxsources; n += 4)
-		gicd_write4(&conf, GICD_IPRIORITYRn(n >> 2), 0xFFFFFFFF);
+	for (n = 32; n < conf->gc_maxsources; n += 4)
+		gicd_write4(conf, GICD_IPRIORITYRn(n >> 2), 0xFFFFFFFF);
 
 	/*
 	 * Make all SPIs level-sensitive.
 	 */
-	for (n = 32; n < conf.gc_maxsources; n += 16)
-		gicd_write4(&conf, GICD_ICFGRn(n >> 4), 0x0);
+	for (n = 32; n < conf->gc_maxsources; n += 16)
+		gicd_write4(conf, GICD_ICFGRn(n >> 4), 0x0);
 
 	/*
 	 * Enable the distributor.
 	 */
-	(void) gicd_rmw4(&conf, GICD_CTLR, GICD_CTLR_RWP,
+	(void) gicd_rmw4(conf, GICD_CTLR, GICD_CTLR_RWP,
 	    GICD_CTLR_EnableGrp1A);
 
 	/*
@@ -1135,58 +988,259 @@ gicv3_init(void)
 	/*
 	 * Reset all of the redistributors.
 	 */
-	gicv3_for_each_gicr(&conf, gicv3_init_gicr, 0, 0);
+	gicv3_for_each_gicr(conf, gicv3_init_gicr, 0, 0);
 
 	/*
 	 * No CPUs have been configured yet.
 	 */
-	CPUSET_ZERO(conf.gc_cpuset);
+	CPUSET_ZERO(conf->gc_cpuset);
 
 	/*
 	 * Initialize the boot processor.
 	 */
 	gicv3_cpu_init(CPU);
-	return (0);
+	return (DDI_SUCCESS);
 }
 
-static struct modlmisc modlmisc = {
-	&mod_miscops,
-	"Generic Interrupt Controller v3"
+static int
+gicv3_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
+{
+	int ret;
+	int nregs;
+	int instance;
+	int i;
+	int j;
+	off_t regsize;
+	uint32_t num_redist_regions;
+	gicv3_conf_t *gc;
+
+	ddi_device_acc_attr_t gicv3_reg_acc_attr = {
+		.devacc_attr_version		= DDI_DEVICE_ATTR_V0,
+		.devacc_attr_endian_flags	= DDI_STRUCTURE_LE_ACC,
+		.devacc_attr_dataorder		= DDI_STRICTORDER_ACC
+	};
+
+	switch (cmd) {
+	case DDI_ATTACH:
+		break;
+	case DDI_RESUME:	/* fallthrough */
+	case DDI_PM_RESUME:
+		return (DDI_SUCCESS);
+	default:
+		dev_err(dip, CE_NOTE, "Unhandled attach command: %d", (int)cmd);
+		return (DDI_FAILURE);
+	}
+	ASSERT3U(cmd, ==, DDI_ATTACH);
+
+	if (gicv3_enable_system_register_access() != 0) {
+		dev_err(dip, CE_PANIC, "Failed to enable the GIC system "
+		    "register interface for the boot processor.");
+	}
+
+	instance = ddi_get_instance(dip);
+
+	if ((ret = ddi_dev_nregs(dip, &nregs)) != DDI_SUCCESS)
+		return (ret);
+
+	if (nregs < 1)
+		return (DDI_FAILURE);
+
+	if ((ret = ddi_dev_regsize(dip, 0, &regsize)) != DDI_SUCCESS)
+		return (ret);
+
+	if ((ret = ddi_soft_state_zalloc(
+	    gicv3_soft_state, instance)) != DDI_SUCCESS)
+		return (ret);
+	gc = ddi_get_soft_state(gicv3_soft_state, instance);
+	VERIFY3P(gc, !=, NULL);
+
+	if ((ret = ddi_regs_map_setup(dip, 0, &gc->gc_gicd, 0, regsize,
+	    &gicv3_reg_acc_attr, &gc->gc_gicd_regh)) != DDI_SUCCESS) {
+		ddi_soft_state_free(gicv3_soft_state, instance);
+		return (ret);
+	}
+
+	gc->gc_redist_stride =
+	    ddi_prop_get_int(DDI_DEV_T_ANY, dip, 0, "redistributor-stride", 0);
+
+	num_redist_regions = ddi_prop_get_int(
+	    DDI_DEV_T_ANY, dip, 0, "#redistributor-regions", 1);
+
+	gc->gc_redist_regions = kmem_zalloc(
+	    sizeof (gicv3_redist_region_t) * num_redist_regions, KM_SLEEP);
+	gc->gc_num_redist_regions = num_redist_regions;
+
+	for (i = 0; i < gc->gc_num_redist_regions; ++i) {
+		if ((ret = ddi_dev_regsize(dip, 1 + i, &regsize))
+		    != DDI_SUCCESS || (ret = ddi_regs_map_setup(
+		    dip, 1 + i, &gc->gc_redist_regions[i].base, 0, regsize,
+		    &gicv3_reg_acc_attr, &gc->gc_redist_regions[i].hdl))
+		    != DDI_SUCCESS) {
+			for (j = 0; j < i; ++j)
+				ddi_regs_map_free(
+				    &gc->gc_redist_regions[j].hdl);
+			kmem_free(gc->gc_redist_regions,
+			    sizeof (gicv3_redist_region_t) *
+			    gc->gc_num_redist_regions);
+			ddi_regs_map_free(&gc->gc_gicd_regh);
+			ddi_soft_state_free(gicv3_soft_state, instance);
+			return (ret);
+		}
+	}
+
+	conf = gc;
+
+	if ((ret = gicv3_init(gc)) != DDI_SUCCESS) {
+		if (gc->gc_num_redist && gc->gc_redist)
+			kmem_free(gc->gc_redist,
+			    sizeof (gicv3_redistributor_t) * gc->gc_num_redist);
+		for (i = 0; i < gc->gc_num_redist_regions; ++i)
+			ddi_regs_map_free(&gc->gc_redist_regions[i].hdl);
+		kmem_free(gc->gc_redist_regions,
+		    sizeof (gicv3_redist_region_t) *
+		    gc->gc_num_redist_regions);
+		ddi_regs_map_free(&gc->gc_gicd_regh);
+		ddi_soft_state_free(gicv3_soft_state, instance);
+		return (ret);
+	}
+
+	gic_ops.go_send_ipi = gicv3_send_ipi;
+	gic_ops.go_cpu_init = gicv3_cpu_init;
+	gic_ops.go_config_irq = gicv3_config_irq;
+	gic_ops.go_addspl = gicv3_addspl;
+	gic_ops.go_delspl = gicv3_delspl;
+	gic_ops.go_setlvl = gicv3_setlvl;
+	gic_ops.go_setlvlx = gicv3_setlvlx;
+	gic_ops.go_acknowledge = gicv3_acknowledge;
+	gic_ops.go_ack_to_vector = gicv3_ack_to_vector;
+	gic_ops.go_eoi = gicv3_eoi;
+	gic_ops.go_deactivate = gicv3_deactivate;
+	/*
+	 * Explicitly use the default "is special" handler.
+	 */
+	gic_ops.go_is_spurious = (gic_is_spurious_t)NULL;
+
+	ddi_report_dev(dip);
+	return (DDI_SUCCESS);
+}
+
+static int
+gicv3_bus_ctl(dev_info_t *dip, dev_info_t *rdip, ddi_ctl_enum_t ctlop,
+    void *arg, void *result)
+{
+	int ret;
+
+	switch (ctlop) {
+	case DDI_CTLOPS_INITCHILD:
+		ret = impl_ddi_sunbus_initchild(arg);
+		break;
+	case DDI_CTLOPS_UNINITCHILD:
+		impl_ddi_sunbus_removechild(arg);
+		ret = DDI_SUCCESS;
+		break;
+	case DDI_CTLOPS_REPORTDEV:
+		if (rdip == NULL)
+			return (DDI_FAILURE);
+		cmn_err(CE_CONT, "?%s%d at %s%d\n",
+		    ddi_driver_name(rdip), ddi_get_instance(rdip),
+		    ddi_driver_name(dip), ddi_get_instance(dip));
+		/* XXXARM: intercept the child here and add the ITS frame */
+		ret = DDI_SUCCESS;
+		break;
+	default:
+		ret = ddi_ctlops(dip, rdip, ctlop, arg, result);
+		break;
+	}
+
+	return (ret);
+}
+
+static struct bus_ops gicv3_bus_ops = {
+	.busops_rev		= BUSO_REV,
+	.bus_map		= i_ddi_bus_map,
+	.bus_get_intrspec	= NULL,	/* obsolete */
+	.bus_add_intrspec	= NULL,	/* obsolete */
+	.bus_remove_intrspec	= NULL,	/* obsolete */
+	.bus_map_fault		= i_ddi_map_fault,
+	.bus_dma_map		= NULL,
+	.bus_dma_allochdl	= ddi_dma_allochdl,
+	.bus_dma_freehdl	= ddi_dma_freehdl,
+	.bus_dma_bindhdl	= ddi_dma_bindhdl,
+	.bus_dma_unbindhdl	= ddi_dma_unbindhdl,
+	.bus_dma_flush		= ddi_dma_flush,
+	.bus_dma_win		= ddi_dma_win,
+	.bus_dma_ctl		= ddi_dma_mctl,
+	.bus_ctl		= gicv3_bus_ctl,
+	.bus_prop_op		= ddi_bus_prop_op,
+	.bus_get_eventcookie	= NULL,
+	.bus_add_eventcall	= NULL,
+	.bus_remove_eventcall	= NULL,
+	.bus_post_event		= NULL,
+	.bus_intr_ctl		= NULL,
+	.bus_config		= NULL,
+	.bus_unconfig		= NULL,
+	.bus_fm_init		= NULL,
+	.bus_fm_fini		= NULL,
+	.bus_fm_access_enter	= NULL,
+	.bus_fm_access_exit	= NULL,
+	.bus_power		= NULL,
+	.bus_intr_op		= i_ddi_intr_ops,
+	.bus_hp_op		= NULL
+};
+
+static struct dev_ops gicv3_ops = {
+	.devo_rev		= DEVO_REV,
+	.devo_refcnt		= 0,
+	.devo_getinfo		= ddi_no_info,
+	.devo_identify		= nulldev,
+	.devo_probe		= nulldev,
+	.devo_attach		= gicv3_attach,
+	.devo_detach		= nulldev,
+	.devo_reset		= nodev,
+	.devo_cb_ops		= NULL,
+	.devo_bus_ops		= &gicv3_bus_ops,
+	.devo_power		= NULL,
+	.devo_quiesce		= ddi_quiesce_not_needed,
+};
+
+static struct modldrv gicv3_modldrv = {
+	.drv_modops		= &mod_driverops,
+	.drv_linkinfo		= "Generic Interrupt Controller v3",
+	.drv_dev_ops		= &gicv3_ops
 };
 
 static struct modlinkage modlinkage = {
-	MODREV_1, (void *)&modlmisc, NULL
+	.ml_rev			= MODREV_1,
+	.ml_linkage		= { &gicv3_modldrv, NULL }
 };
 
 int
 _init(void)
 {
-	if (strcmp(gic_module_name, "gicv3") == 0) {
-		gic_ops.go_send_ipi = gicv3_send_ipi;
-		gic_ops.go_init = gicv3_init;
-		gic_ops.go_cpu_init = gicv3_cpu_init;
-		gic_ops.go_config_irq = gicv3_config_irq;
-		gic_ops.go_addspl = gicv3_addspl;
-		gic_ops.go_delspl = gicv3_delspl;
-		gic_ops.go_setlvl = gicv3_setlvl;
-		gic_ops.go_setlvlx = gicv3_setlvlx;
-		gic_ops.go_acknowledge = gicv3_acknowledge;
-		gic_ops.go_ack_to_vector = gicv3_ack_to_vector;
-		gic_ops.go_eoi = gicv3_eoi;
-		gic_ops.go_deactivate = gicv3_deactivate;
-		/*
-		 * Explicitly use the default "is special" handler.
-		 */
-		gic_ops.go_is_spurious = (gic_is_spurious_t)NULL;
+	int err;
+
+	if ((err = ddi_soft_state_init(&gicv3_soft_state,
+	    sizeof (gicv3_conf_t), 1)) != 0)
+		return (err);
+
+	if ((err = mod_install(&modlinkage)) != 0) {
+		ddi_soft_state_fini(&gicv3_soft_state);
+		return (err);
 	}
 
-	return (mod_install(&modlinkage));
+	return (err);
 }
 
 int
 _fini(void)
 {
-	return (EBUSY);
+	int err;
+
+	if ((err = mod_remove(&modlinkage)))
+		return (err);
+
+	ddi_soft_state_fini(&gicv3_soft_state);
+	return (err);
 }
 
 int

--- a/usr/src/uts/armv8/io/gic/gicv3its.c
+++ b/usr/src/uts/armv8/io/gic/gicv3its.c
@@ -1,0 +1,185 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2024 Michael van der Westhuizen
+ */
+
+#include <sys/types.h>
+#include <sys/gic.h>
+#include <sys/gic_reg.h>
+#include <sys/avintr.h>
+#include <sys/smp_impldefs.h>
+#include <sys/sunddi.h>
+#include <sys/promif.h>
+#include <sys/cpuinfo.h>
+#include <sys/sysmacros.h>
+#include <sys/archsystm.h>
+
+typedef struct {
+	dev_info_t		*sc_dip;
+	caddr_t			sc_gits;
+	ddi_acc_handle_t	sc_regh;
+} gicv3its_sc_t;
+
+#define	GITS_MAX		256
+#define	GITS_REG64(sc, offset)	((uint64_t *)((sc)->sc_gits + (offset)))
+
+static void *gicv3its_soft_state;
+
+static int
+gicv3its_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
+{
+	int ret;
+	int nregs;
+	int instance;
+	off_t regsize;
+	gicv3its_sc_t *sc;
+
+	ddi_device_acc_attr_t gicv3its_reg_acc_attr = {
+		.devacc_attr_version		= DDI_DEVICE_ATTR_V0,
+		.devacc_attr_endian_flags	= DDI_STRUCTURE_LE_ACC,
+		.devacc_attr_dataorder		= DDI_STRICTORDER_ACC
+	};
+
+
+	switch (cmd) {
+	case DDI_ATTACH:
+		break;
+	case DDI_RESUME:	/* fallthrough */
+	case DDI_PM_RESUME:
+		return (DDI_SUCCESS);
+	default:
+		dev_err(dip, CE_NOTE, "Unhandled attach command: %d", (int)cmd);
+		return (DDI_FAILURE);
+	}
+	ASSERT3U(cmd, ==, DDI_ATTACH);
+
+	instance = ddi_get_instance(dip);
+
+	if ((ret = ddi_dev_nregs(dip, &nregs)) != DDI_SUCCESS)
+		return (ret);
+
+	if (nregs < 1)
+		return (DDI_FAILURE);
+
+	if ((ret = ddi_dev_regsize(dip, 0, &regsize)) != DDI_SUCCESS)
+		return (DDI_FAILURE);
+
+	if ((ret = ddi_soft_state_zalloc(
+	    gicv3its_soft_state, instance)) != DDI_SUCCESS)
+		return (ret);
+	sc = ddi_get_soft_state(gicv3its_soft_state, instance);
+	VERIFY3P(sc, !=, NULL);
+	sc->sc_dip = dip;
+
+	if ((ret = ddi_regs_map_setup(dip, 0, &sc->sc_gits, 0, regsize,
+	    &gicv3its_reg_acc_attr, &sc->sc_regh)) != DDI_SUCCESS) {
+		ddi_soft_state_free(gicv3its_soft_state, instance);
+		return (ret);
+	}
+
+	ddi_report_dev(dip);
+	return (DDI_SUCCESS);
+}
+
+static int
+gicv3its_detach(dev_info_t *dip, ddi_detach_cmd_t cmd)
+{
+	int instance;
+	gicv3its_sc_t *sc;
+
+	switch (cmd) {
+	case DDI_DETACH:
+		break;
+	case DDI_SUSPEND:	/* fallthrough */
+	case DDI_PM_SUSPEND:	/* fallthrough */
+	case DDI_HOTPLUG_DETACH:
+		return (DDI_FAILURE);
+	default:
+		dev_err(dip, CE_NOTE, "Unhandled detach command: %d", (int)cmd);
+		return (DDI_FAILURE);
+	}
+	ASSERT3U(cmd, ==, DDI_DETACH);
+
+	instance = ddi_get_instance(dip);
+	sc = ddi_get_soft_state(gicv3its_soft_state, instance);
+	VERIFY3P(sc, !=, NULL);
+	VERIFY3P(sc->sc_dip, ==, dip);
+
+	ddi_regs_map_free(&sc->sc_regh);
+	ddi_soft_state_free(gicv3its_soft_state, instance);
+	return (DDI_SUCCESS);
+}
+
+static struct dev_ops gicv3its_ops = {
+	.devo_rev		= DEVO_REV,
+	.devo_refcnt		= 0,
+	.devo_getinfo		= ddi_no_info,
+	.devo_identify		= nulldev,
+	.devo_probe		= nulldev,
+	.devo_attach		= gicv3its_attach,
+	.devo_detach		= gicv3its_detach,
+	.devo_reset		= nodev,
+	.devo_cb_ops		= NULL,
+	.devo_bus_ops		= NULL,
+	.devo_power		= NULL,
+	.devo_quiesce		= ddi_quiesce_not_needed,
+};
+
+static char modlinkinfo[] =
+	"Generic Interrupt Controller v3 Interrupt Translation Service";
+
+static struct modldrv gicv3its_modldrv = {
+	.drv_modops		= &mod_driverops,
+	.drv_linkinfo		= modlinkinfo,
+	.drv_dev_ops		= &gicv3its_ops
+};
+
+static struct modlinkage modlinkage = {
+	.ml_rev			= MODREV_1,
+	.ml_linkage		= { &gicv3its_modldrv, NULL }
+};
+
+int
+_init(void)
+{
+	int err;
+
+	if ((err = ddi_soft_state_init(&gicv3its_soft_state,
+	    sizeof (gicv3its_sc_t), GITS_MAX)) != 0)
+		return (err);
+
+	if ((err = mod_install(&modlinkage)) != 0) {
+		ddi_soft_state_fini(&gicv3its_soft_state);
+		return (err);
+	}
+
+	return (err);
+}
+
+int
+_fini(void)
+{
+	int err;
+
+	if ((err = mod_remove(&modlinkage)))
+		return (err);
+
+	ddi_soft_state_fini(&gicv3its_soft_state);
+	return (err);
+}
+
+int
+_info(struct modinfo *modinfop)
+{
+	return (mod_info(&modlinkage, modinfop));
+}

--- a/usr/src/uts/armv8/io/simple-bus.c
+++ b/usr/src/uts/armv8/io/simple-bus.c
@@ -20,126 +20,93 @@
  */
 
 /*
- * Copyright 2017 Hayashi Naoyuki
  * Copyright (c) 1992, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2017 Hayashi Naoyuki
+ * Copyright 2024 Michael van der Westhuizen
  */
 
 #include <sys/types.h>
-#include <sys/cmn_err.h>
-#include <sys/conf.h>
-#include <sys/modctl.h>
-#include <sys/autoconf.h>
-#include <sys/errno.h>
-#include <sys/debug.h>
-#include <sys/kmem.h>
-#include <sys/ddidmareq.h>
-#include <sys/ddi_impldefs.h>
-#include <sys/dma_engine.h>
-#include <sys/ddi.h>
+#include <sys/dditypes.h>
+#include <sys/nexusdefs.h>
+#include <sys/devops.h>
+#include <sys/ddi_implfuncs.h>
 #include <sys/sunddi.h>
-#include <sys/sunndi.h>
-#include <sys/mach_intr.h>
-#include <sys/note.h>
-#include <sys/avintr.h>
-#include <sys/gic.h>
-#include <sys/promif.h>
+#include <sys/cmn_err.h>
+#include <sys/modctl.h>
 
-static int smpl_bus_map(dev_info_t *, dev_info_t *, ddi_map_req_t *, off_t,
-    off_t, caddr_t *);
-static int smpl_ctlops(dev_info_t *, dev_info_t *, ddi_ctl_enum_t,
-    void *, void *);
-static int smpl_intr_ops(dev_info_t *, dev_info_t *, ddi_intr_op_t,
-    ddi_intr_handle_impl_t *, void *);
+static int smpl_ctlops(dev_info_t *dip, dev_info_t *rdip,
+    ddi_ctl_enum_t ctlop, void *arg, void *result);
+static int smpl_attach(dev_info_t *dip, ddi_attach_cmd_t cmd);
 
-struct bus_ops smpl_bus_ops = {
-	BUSO_REV,
-	smpl_bus_map,
-	NULL,
-	NULL,
-	NULL,
-	i_ddi_map_fault,
-	NULL,
-	ddi_dma_allochdl,
-	ddi_dma_freehdl,
-	ddi_dma_bindhdl,
-	ddi_dma_unbindhdl,
-	ddi_dma_flush,
-	ddi_dma_win,
-	ddi_dma_mctl,
-	smpl_ctlops,
-	ddi_bus_prop_op,
-	NULL,		/* (*bus_get_eventcookie)();	*/
-	NULL,		/* (*bus_add_eventcall)();	*/
-	NULL,		/* (*bus_remove_eventcall)();	*/
-	NULL,		/* (*bus_post_event)();		*/
-	NULL,		/* (*bus_intr_ctl)(); */
-	NULL,		/* (*bus_config)(); */
-	NULL,		/* (*bus_unconfig)(); */
-	NULL,		/* (*bus_fm_init)(); */
-	NULL,		/* (*bus_fm_fini)(); */
-	NULL,		/* (*bus_fm_access_enter)(); */
-	NULL,		/* (*bus_fm_access_exit)(); */
-	NULL,		/* (*bus_power)(); */
-	smpl_intr_ops	/* (*bus_intr_op)(); */
+static struct bus_ops smpl_bus_ops = {
+	.busops_rev		= BUSO_REV,
+	.bus_map		= i_ddi_bus_map,
+	.bus_get_intrspec	= NULL,	/* obsolete */
+	.bus_add_intrspec	= NULL,	/* obsolete */
+	.bus_remove_intrspec	= NULL,	/* obsolete */
+	.bus_map_fault		= i_ddi_map_fault,
+	.bus_dma_map		= NULL,
+	.bus_dma_allochdl	= ddi_dma_allochdl,
+	.bus_dma_freehdl	= ddi_dma_freehdl,
+	.bus_dma_bindhdl	= ddi_dma_bindhdl,
+	.bus_dma_unbindhdl	= ddi_dma_unbindhdl,
+	.bus_dma_flush		= ddi_dma_flush,
+	.bus_dma_win		= ddi_dma_win,
+	.bus_dma_ctl		= ddi_dma_mctl,
+	.bus_ctl		= smpl_ctlops,
+	.bus_prop_op		= ddi_bus_prop_op,
+	.bus_get_eventcookie	= NULL,
+	.bus_add_eventcall	= NULL,
+	.bus_remove_eventcall	= NULL,
+	.bus_post_event		= NULL,
+	.bus_intr_ctl		= NULL,
+	.bus_config		= NULL,
+	.bus_unconfig		= NULL,
+	.bus_fm_init		= NULL,
+	.bus_fm_fini		= NULL,
+	.bus_fm_access_enter	= NULL,
+	.bus_fm_access_exit	= NULL,
+	.bus_power		= NULL,
+	.bus_intr_op		= i_ddi_intr_ops,
+	.bus_hp_op		= NULL
 };
 
-
-static int smpl_attach(dev_info_t *devi, ddi_attach_cmd_t cmd);
-
-/*
- * Internal isa ctlops support routines
- */
-struct dev_ops smpl_ops = {
-	DEVO_REV,		/* devo_rev, */
-	0,			/* refcnt  */
-	ddi_no_info,		/* info */
-	nulldev,		/* identify */
-	nulldev,		/* probe */
-	smpl_attach,	/* attach */
-	nulldev,		/* detach */
-	nodev,			/* reset */
-	(struct cb_ops *)0,	/* driver operations */
-	&smpl_bus_ops,	/* bus operations */
-	NULL,			/* power */
-	ddi_quiesce_not_needed,	/* quiesce */
+static struct dev_ops smpl_ops = {
+	.devo_rev		= DEVO_REV,
+	.devo_refcnt		= 0,
+	.devo_getinfo		= ddi_no_info,
+	.devo_identify		= nulldev,
+	.devo_probe		= nulldev,
+	.devo_attach		= smpl_attach,
+	.devo_detach		= nulldev,
+	.devo_reset		= nodev,
+	.devo_cb_ops		= NULL,
+	.devo_bus_ops		= &smpl_bus_ops,
+	.devo_power		= NULL,
+	.devo_quiesce		= ddi_quiesce_not_needed,
 };
-
-/*
- * Module linkage information for the kernel.
- */
 
 static struct modldrv modldrv = {
-	&mod_driverops, /* Type of module.  This is simple-bus bus driver */
-	"simple-bus nexus driver",
-	&smpl_ops,	/* driver ops */
+	.drv_modops		= &mod_driverops,
+	.drv_linkinfo		= "simple-bus nexus driver",
+	.drv_dev_ops		= &smpl_ops,
 };
 
 static struct modlinkage modlinkage = {
-	MODREV_1,
-	&modldrv,
-	NULL
+	.ml_rev			= MODREV_1,
+	.ml_linkage		= { &modldrv, NULL }
 };
 
 int
 _init(void)
 {
-	int	err;
-
-	if ((err = mod_install(&modlinkage)) != 0)
-		return (err);
-
-	return (0);
+	return (mod_install(&modlinkage));
 }
 
 int
 _fini(void)
 {
-	int	err;
-
-	if ((err = mod_remove(&modlinkage)) != 0)
-		return (err);
-
-	return (0);
+	return (mod_remove(&modlinkage));
 }
 
 int
@@ -148,238 +115,27 @@ _info(struct modinfo *modinfop)
 	return (mod_info(&modlinkage, modinfop));
 }
 
-/*ARGSUSED*/
 static int
-smpl_attach(dev_info_t *devi, ddi_attach_cmd_t cmd)
+smpl_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 {
-	int rval;
 	switch (cmd) {
 	case DDI_ATTACH:
 		break;
-	case DDI_RESUME:
+	case DDI_RESUME:	/* fallthrough */
+	case DDI_PM_RESUME:
 		return (DDI_SUCCESS);
 	default:
 		return (DDI_FAILURE);
 	}
 
-	ddi_report_dev(devi);
-
+	ddi_report_dev(dip);
 	return (DDI_SUCCESS);
-}
-
-static int
-get_address_cells(pnode_t node)
-{
-	int address_cells = 0;
-
-	while (node > 0) {
-		int len = prom_getproplen(node, "#address-cells");
-		if (len > 0) {
-			ASSERT(len == sizeof (int));
-			int prop;
-			prom_getprop(node, "#address-cells", (caddr_t)&prop);
-			address_cells = ntohl(prop);
-			break;
-		}
-		node = prom_parentnode(node);
-	}
-	return (address_cells);
-}
-
-static int
-get_size_cells(pnode_t node)
-{
-	int size_cells = 0;
-
-	while (node > 0) {
-		int len = prom_getproplen(node, "#size-cells");
-		if (len > 0) {
-			ASSERT(len == sizeof (int));
-			int prop;
-			prom_getprop(node, "#size-cells", (caddr_t)&prop);
-			size_cells = ntohl(prop);
-			break;
-		}
-		node = prom_parentnode(node);
-	}
-	return (size_cells);
-}
-
-static int
-get_interrupt_cells(pnode_t node)
-{
-	int interrupt_cells = 0;
-
-	while (node > 0) {
-		int len = prom_getproplen(node, "#interrupt-cells");
-		if (len > 0) {
-			ASSERT(len == sizeof (int));
-			int prop;
-			prom_getprop(node, "#interrupt-cells", (caddr_t)&prop);
-			interrupt_cells = ntohl(prop);
-			break;
-		}
-		len = prom_getproplen(node, "interrupt-parent");
-		if (len > 0) {
-			ASSERT(len == sizeof (int));
-			int prop;
-			prom_getprop(node, "interrupt-parent", (caddr_t)&prop);
-			node = prom_findnode_by_phandle(ntohl(prop));
-			continue;
-		}
-		node = prom_parentnode(node);
-	}
-	return (interrupt_cells);
-}
-
-static int
-smpl_bus_map(dev_info_t *dip, dev_info_t *rdip, ddi_map_req_t *mp, off_t offset,
-    off_t len, caddr_t *vaddrp)
-{
-	ddi_map_req_t mr;
-	dev_info_t *pdip = ddi_get_parent(dip);
-	int error;
-
-	int addr_cells = get_address_cells(ddi_get_nodeid(dip));
-	int size_cells = get_size_cells(ddi_get_nodeid(dip));
-
-	int parent_addr_cells = get_address_cells(ddi_get_nodeid(pdip));
-	int parent_size_cells = get_size_cells(ddi_get_nodeid(pdip));
-
-	ASSERT(addr_cells == 1 || addr_cells == 2);
-	ASSERT(size_cells == 1 || size_cells == 2);
-
-	ASSERT(parent_addr_cells == 1 || parent_addr_cells == 2);
-	ASSERT(parent_size_cells == 1 || parent_size_cells == 2);
-
-	int *regs;
-	struct regspec reg = {0};
-	struct rangespec range = {0};
-
-	uint32_t *rangep;
-	uint_t rangelen;
-
-	if (ddi_prop_lookup_int_array(DDI_DEV_T_ANY, dip,
-	    DDI_PROP_DONTPASS, "ranges", (int **)&rangep, &rangelen) !=
-	    DDI_SUCCESS || rangelen == 0) {
-		rangelen = 0;
-		rangep = NULL;
-	}
-
-	if (mp->map_type == DDI_MT_RNUMBER) {
-		uint_t reglen;
-		int rnumber = mp->map_obj.rnumber;
-		uint32_t *rp;
-
-		if (ddi_prop_lookup_int_array(DDI_DEV_T_ANY, rdip,
-		    DDI_PROP_DONTPASS, "reg", (int **)&rp, &reglen) !=
-		    DDI_SUCCESS || reglen == 0) {
-			if (rangep != NULL) {
-				ddi_prop_free(rangep);
-			}
-			return (DDI_ME_RNUMBER_RANGE);
-		}
-
-		int n = reglen / addr_cells + size_cells;
-		ASSERT(reglen % (addr_cells + size_cells) == 0);
-
-		if (rnumber < 0 || rnumber >= n) {
-			if (rangep != NULL) {
-				ddi_prop_free(rangep);
-			}
-			ddi_prop_free(rp);
-			return (DDI_ME_RNUMBER_RANGE);
-		}
-
-		uint64_t addr = 0;
-		uint64_t size = 0;
-
-		for (int i = 0; i < addr_cells; i++) {
-			addr <<= 32;
-			addr |= rp[(addr_cells + size_cells) * rnumber + i];
-		}
-		for (int i = 0; i < size_cells; i++) {
-			size <<= 32;
-			size |= rp[(addr_cells + size_cells) *
-			    rnumber + addr_cells + i];
-		}
-
-		ddi_prop_free(rp);
-
-		ASSERT((addr & 0xffff000000000000ul) == 0);
-		ASSERT((size & 0xffff000000000000ul) == 0);
-		reg.regspec_bustype = ((addr >> 32) & 0xffff);
-		reg.regspec_bustype |= (((size >> 32)) << 16);
-		reg.regspec_addr    = (addr & 0xffffffff);
-		reg.regspec_size    = (size & 0xffffffff);
-	} else if (mp->map_type == DDI_MT_REGSPEC) {
-		reg = *mp->map_obj.rp;
-		uint64_t rel_addr = (reg.regspec_bustype & 0xffff);
-		rel_addr <<= 32;
-		rel_addr |= (reg.regspec_addr & 0xffffffff);
-	} else {
-		return (DDI_ME_INVAL);
-	}
-
-	if (rangep != NULL) {
-		int i;
-		int ranges_cells = (addr_cells + parent_addr_cells + size_cells);
-		int n = rangelen / ranges_cells;
-
-		for (i = 0; i < n; i++) {
-			uint64_t base = 0;
-			uint64_t target = 0;
-			uint64_t rsize = 0;
-			for (int j = 0; j < addr_cells; j++) {
-				base <<= 32;
-				base += rangep[ranges_cells * i + j];
-			}
-			for (int j = 0; j < parent_addr_cells; j++) {
-				target <<= 32;
-				target += rangep[ranges_cells * i + addr_cells + j];
-			}
-			for (int j = 0; j < size_cells; j++) {
-				rsize <<= 32;
-				rsize += rangep[ranges_cells * i + addr_cells + parent_addr_cells + j];
-			}
-
-			uint64_t rel_addr = (reg.regspec_bustype & 0xffff);
-			rel_addr <<= 32;
-			rel_addr |= (reg.regspec_addr & 0xffffffff);
-
-			if (base <= rel_addr && rel_addr <= base + rsize - 1) {
-				rel_addr = (rel_addr - base) + target;
-
-				reg.regspec_bustype &= ~0xffff;
-				reg.regspec_bustype |= ((rel_addr >> 32) &
-				    0xffff);
-				reg.regspec_addr    = (rel_addr & 0xffffffff);
-
-				break;
-			}
-		}
-
-		ddi_prop_free(rangep);
-
-		if (i == n) {
-			return (DDI_FAILURE);
-		}
-	}
-
-	mr = *mp;
-	mr.map_type = DDI_MT_REGSPEC;
-	mr.map_obj.rp = &reg;
-	mp = &mr;
-	return (ddi_map(dip, mp, offset, 0, vaddrp));
 }
 
 static int
 smpl_ctlops(dev_info_t *dip, dev_info_t *rdip,
     ddi_ctl_enum_t ctlop, void *arg, void *result)
 {
-	struct regspec *child_rp;
-	uint_t reglen;
-	int nreg;
 	int ret;
 
 	switch (ctlop) {
@@ -393,9 +149,9 @@ smpl_ctlops(dev_info_t *dip, dev_info_t *rdip,
 		break;
 
 	case DDI_CTLOPS_REPORTDEV:
-		if (rdip == (dev_info_t *)0)
+		if (rdip == NULL)
 			return (DDI_FAILURE);
-		cmn_err(CE_CONT, "?%s%d at %s%d",
+		cmn_err(CE_CONT, "?%s%d at %s%d\n",
 		    ddi_driver_name(rdip), ddi_get_instance(rdip),
 		    ddi_driver_name(dip), ddi_get_instance(dip));
 		ret = DDI_SUCCESS;
@@ -405,197 +161,6 @@ smpl_ctlops(dev_info_t *dip, dev_info_t *rdip,
 		ret = ddi_ctlops(dip, rdip, ctlop, arg, result);
 		break;
 	}
+
 	return (ret);
-}
-
-static int
-get_pil(dev_info_t *rdip)
-{
-	static struct {
-		const char *name;
-		int pil;
-	} name_to_pil[] = {
-		{"serial",			12},
-		{"Ethernet controller",		6},
-		{ NULL}
-	};
-	const char *type_name[] = {
-		"device_type",
-		"model",
-		NULL
-	};
-
-	pnode_t node = ddi_get_nodeid(rdip);
-	for (int i = 0; type_name[i]; i++) {
-		int len = prom_getproplen(node, type_name[i]);
-		if (len <= 0) {
-			continue;
-		}
-		char *name = __builtin_alloca(len);
-		prom_getprop(node, type_name[i], name);
-
-		for (int j = 0; name_to_pil[j].name; j++) {
-			if (strcmp(name_to_pil[j].name, name) == 0) {
-				return (name_to_pil[j].pil);
-			}
-		}
-	}
-	return (5);
-}
-
-static int
-smpl_intr_ops(dev_info_t *pdip, dev_info_t *rdip, ddi_intr_op_t intr_op,
-    ddi_intr_handle_impl_t *hdlp, void *result)
-{
-	switch (intr_op) {
-	case DDI_INTROP_GETCAP:
-		*(int *)result = DDI_INTR_FLAG_LEVEL;
-		break;
-
-	case DDI_INTROP_ALLOC:
-		*(int *)result = hdlp->ih_scratch1;
-		break;
-
-	case DDI_INTROP_FREE:
-		break;
-
-	case DDI_INTROP_GETPRI:
-		if (hdlp->ih_pri == 0) {
-			hdlp->ih_pri = get_pil(rdip);
-		}
-
-		*(int *)result = hdlp->ih_pri;
-		break;
-	case DDI_INTROP_SETPRI:
-		if (*(int *)result > LOCK_LEVEL)
-			return (DDI_FAILURE);
-		hdlp->ih_pri = *(int *)result;
-		break;
-
-	case DDI_INTROP_ADDISR:
-		break;
-	case DDI_INTROP_REMISR:
-		if (hdlp->ih_type != DDI_INTR_TYPE_FIXED)
-			return (DDI_FAILURE);
-		break;
-	case DDI_INTROP_ENABLE:
-		{
-			pnode_t node = ddi_get_nodeid(rdip);
-			int interrupt_cells = get_interrupt_cells(node);
-			switch (interrupt_cells) {
-			case 1:
-			case 3:
-				break;
-			default:
-				return (DDI_FAILURE);
-			}
-
-			int *irupts_prop;
-			uint_t irupts_len;
-			if (ddi_prop_lookup_int_array(DDI_DEV_T_ANY, rdip,
-			    DDI_PROP_DONTPASS, "interrupts",
-			    (int **)&irupts_prop, &irupts_len) != DDI_SUCCESS ||
-			    irupts_len == 0) {
-				return (DDI_FAILURE);
-			}
-			if ((interrupt_cells * hdlp->ih_inum) >= irupts_len) {
-				ddi_prop_free(irupts_prop);
-				return (DDI_FAILURE);
-			}
-
-			int vec;
-			int grp;
-			int cfg;
-			off_t off = interrupt_cells * hdlp->ih_inum;
-			switch (interrupt_cells) {
-			case 1:
-				grp = 0;
-				vec = irupts_prop[interrupt_cells *
-				    hdlp->ih_inum + 0];
-				cfg = 4;
-				break;
-			case 3:
-				grp = irupts_prop[(interrupt_cells *
-				    hdlp->ih_inum) + 0];
-				vec = irupts_prop[(interrupt_cells *
-				    hdlp->ih_inum) + 1];
-				cfg = irupts_prop[(interrupt_cells * hdlp->ih_inum)
-				    + 2];
-				break;
-			default:
-				ddi_prop_free(irupts_prop);
-				return (DDI_FAILURE);
-			}
-
-			ddi_prop_free(irupts_prop);
-
-			hdlp->ih_vector = GIC_VEC_TO_IRQ(grp, vec);
-
-			cfg &= 0xFF;
-			switch (cfg) {
-			case 1:
-				gic_config_irq(hdlp->ih_vector, B_TRUE);
-				break;
-			default:
-				gic_config_irq(hdlp->ih_vector, B_FALSE);
-				break;
-			}
-
-			if (!add_avintr((void *)hdlp, hdlp->ih_pri,
-			    hdlp->ih_cb_func, DEVI(rdip)->devi_name,
-			    hdlp->ih_vector, hdlp->ih_cb_arg1, hdlp->ih_cb_arg2,
-			    NULL, rdip)) {
-				return (DDI_FAILURE);
-			}
-		}
-		break;
-
-	case DDI_INTROP_DISABLE:
-		rem_avintr((void *)hdlp, hdlp->ih_pri, hdlp->ih_cb_func,
-		    hdlp->ih_vector);
-		break;
-	case DDI_INTROP_SETMASK:
-	case DDI_INTROP_CLRMASK:
-	case DDI_INTROP_GETPENDING:
-		return (DDI_FAILURE);
-	case DDI_INTROP_NAVAIL:
-		{
-			pnode_t node = ddi_get_nodeid(rdip);
-			int interrupt_cells = get_interrupt_cells(node);
-			int irupts_len;
-			if (interrupt_cells != 0 &&
-			    ddi_getproplen(DDI_DEV_T_ANY, rdip,
-			    DDI_PROP_DONTPASS, "interrupts",
-			    &irupts_len) == DDI_SUCCESS) {
-				*(int *)result = irupts_len /
-				    CELLS_1275_TO_BYTES(interrupt_cells);
-			} else {
-				return (DDI_FAILURE);
-			}
-		}
-		break;
-	case DDI_INTROP_NINTRS:
-		{
-			pnode_t node = ddi_get_nodeid(rdip);
-			int interrupt_cells = get_interrupt_cells(node);
-			int irupts_len;
-			if (interrupt_cells != 0 &&
-			    ddi_getproplen(DDI_DEV_T_ANY, rdip,
-			    DDI_PROP_DONTPASS, "interrupts",
-			    &irupts_len) == DDI_SUCCESS) {
-				*(int *)result = irupts_len /
-				    CELLS_1275_TO_BYTES(interrupt_cells);
-			} else {
-				return (DDI_FAILURE);
-			}
-		}
-		break;
-	case DDI_INTROP_SUPPORTED_TYPES:
-		*(int *)result = DDI_INTR_TYPE_FIXED;	/* Always ... */
-		break;
-	default:
-		return (DDI_FAILURE);
-	}
-
-	return (DDI_SUCCESS);
 }

--- a/usr/src/uts/armv8/os/ddi_impl.c
+++ b/usr/src/uts/armv8/os/ddi_impl.c
@@ -3324,7 +3324,10 @@ impl_bus_initialprobe(void)
 {
 	struct bus_probe *probe;
 
-	modload("misc", "pci_autoconfig");
+	if (modload("misc", "gic_autoconfig") < 0)
+		panic("failed to load misc/gic_autoconfig");
+
+	(void) modload("misc", "pci_autoconfig");
 
 	probe = bus_probes;
 	while (probe) {

--- a/usr/src/uts/armv8/os/ddi_impl.c
+++ b/usr/src/uts/armv8/os/ddi_impl.c
@@ -74,6 +74,7 @@ size_t dma_max_copybuf_size = 0x101000;		/* 1M + 4K */
 uint64_t ramdisk_start, ramdisk_end;
 
 static void impl_bus_initialprobe(void);
+static void impl_bus_reprobe(void);
 
 /*
  * Platform drivers on this platform
@@ -3276,6 +3277,10 @@ configure(void)
 	extern void i_ddi_init_root();
 
 	i_ddi_init_root();
+
+	/* reprogram devices not set up by firmware */
+	impl_bus_reprobe();
+
 	i_ddi_attach_hw_nodes("dld");
 }
 
@@ -3329,6 +3334,23 @@ impl_bus_initialprobe(void)
 	}
 
 //	ddi_walk_devs(ddi_root_node(), print_dip, (void *)0);
+}
+
+/*
+ * impl_bus_reprobe
+ *	Reprogram devices not set up by firmware.
+ */
+static void
+impl_bus_reprobe(void)
+{
+	struct bus_probe *probe;
+
+	probe = bus_probes;
+	while (probe) {
+		/* run the probe function */
+		(*probe->probe)(1);
+		probe = probe->next;
+	}
 }
 
 void

--- a/usr/src/uts/armv8/os/gic.c
+++ b/usr/src/uts/armv8/os/gic.c
@@ -19,7 +19,6 @@
 #include <sys/gic.h>
 #include <sys/gic_reg.h>
 #include <sys/modctl.h>
-#include <sys/promif.h>
 #include <sys/smp_impldefs.h>
 #include <sys/sysmacros.h>
 #include <sys/types.h>
@@ -41,15 +40,8 @@ static void stub_setlvlx(int ipl);
 kmutex_t gic_intrs_lock;
 avl_tree_t gic_intrs;
 
-/*
- * Used by implementations to ensure that they only fill in gic_ops when
- * appropriate.
- */
-char *gic_module_name = NULL;
-
 gic_ops_t gic_ops = {
 	.go_send_ipi		= (gic_send_ipi_t)stub_not_config,
-	.go_init		= (gic_init_t)stub_not_config,
 	.go_cpu_init		= (gic_cpu_init_t)stub_not_config,
 	.go_config_irq		= (gic_config_irq_t)stub_not_config,
 	.go_addspl		= (gic_addspl_t)stub_not_config,
@@ -66,7 +58,7 @@ gic_ops_t gic_ops = {
 static void
 stub_not_config(void)
 {
-	prom_panic("GIC not configured\n");
+	panic("GIC not configured\n");
 }
 
 static void
@@ -256,39 +248,9 @@ gic_is_spurious(uint32_t intid)
 	return (0);
 }
 
-/*
- * GIC Initialisation
- */
-static void
-set_gic_module_name(void)
-{
-	if (prom_has_compatible("arm,gic-400") ||
-	    prom_has_compatible("arm,cortex-a15-gic")) {
-		gic_module_name = "gicv2";
-		return;
-	}
-
-	if (prom_has_compatible("arm,gic-v3")) {
-		gic_module_name = "gicv3";
-		return;
-	}
-
-	gic_module_name = NULL;
-}
-
 int
 gic_init(void)
 {
-	set_gic_module_name();
-	if (gic_module_name == NULL)
-		return (ENOTSUP);
-
-	if (modload("drv", gic_module_name) == -1)
-		return (ENOENT);
-
-	if (gic_ops.go_init() != 0)
-		return (-1);
-
 	mutex_init(&gic_intrs_lock, NULL, MUTEX_DEFAULT, NULL);
 	avl_create(&gic_intrs, gic_intr_state_cmp, sizeof (gic_intr_state_t),
 	    offsetof(gic_intr_state_t, gi_node));

--- a/usr/src/uts/armv8/sys/ddi_arch_intr.h
+++ b/usr/src/uts/armv8/sys/ddi_arch_intr.h
@@ -1,0 +1,48 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2024 Michael van der Westhuizen
+ */
+
+#ifndef _DDI_ARCH_INTR_H
+#define	_DDI_ARCH_INTR_H
+
+/*
+ * DDI interrupt extensions for Arm BSA hardware
+ *
+ * Specifically, handle data needed for the Arm Generic Interrupt Controller.
+ */
+
+#include <sys/types.h>
+#include <sys/ddi_impldefs.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct ddi_arch_parent_private_data {
+	/*
+	 * `ppd' must come first, and must not be a pointer.
+	 *
+	 * This allows us to cast to/from ddi_parent_private_data.
+	 */
+	struct ddi_parent_private_data	ppd;
+	int				*par_icfg;
+};
+
+extern dev_info_t * i_ddi_interrupt_parent(dev_info_t *);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _DDI_ARCH_INTR_H */


### PR DESCRIPTION
There's a lot of special handling of the GIC which is no longer absolutely necessary, but there's some heavy-lifting needed to isolate GIC specialness.

This PR does the base work needed to simplify and standardise resource management, then fixes up boot-time probe/reprobe hooks before using those hooks to identify and attach the system GIC early enough to appease the autoconfig process.

So, three big pieces:
1. Reintroduce parent private data, extend it to store interrupt configuration and use it throughout the tree. This has the desirable side-effect of isolating raw PROM access (so, FDT-awareness) in the DDI implementation layer and removing open-coding of FDT-specifics. There is a nod to the ACPI port in this change, where we identify the codepaths that need to be modified to handle ACPI for interrupts.
2. Resurrect bus probes, specifically reprobes. These disappeared along the way, probably because they were unused.
3. Move GIC drivers to `armv8/io/gic`, add placeholder drivers for GIC children and add an autoconfig module for the GIC.

These changes were picked back out of my ACPI tree. There's still a more exploratory work to do around how the GIC changes, which I need to do in both trees, but the end-state I envision at the moment is:
* The root nexus always has an `interrupt-parent` property. Any interrupt operation that reaches the root nexus directly (these still will reach `rootnex` as we don't want to change common DDI logic) will be redispatched to the rdip `interrupt-parent` for handling. This means that calls to GIC functions will happen directly in the GIC module (reducing our reliance on `armv8/os/gic.c`. It also means that devices connected to subordinate interrupt controllers will be transparently routed to the right `interrupt-parent`.
* Reintroduce PSM function pointers and stub implementations for IRQ entry and exit. Since entry and exit are largely common, include the majority of the implementation in a default implementation in the machine-default implementations and also set up function pointers for the GIC-specific parts - have each GIC module set those as appropriate.
* Reintroduce a PSM IRQ ops function, with a "returns errors" default implementation. Have each GIC module update this as appropriate at attach time.
* Identify remaining PSM IRQ interactions and have each GIC provide implementations (xcalls etc.)
* With the above in place we should be able to isolate all GIC logic in the GIC drivers and expose interfaces that are compatible with those used in `i86pc`, allowing us to reuse more advanced code, such as the PCIe stack, with minimal changes.

And, with all of that done we'll be in a good place to iterate on implementing MSI/MSI-X, exposing it through PSM-compatible interfaces, filled in by the GIC drivers.

If we do end up introducing a proper PSM in the future (for CPU control etc.) we can have it leave interrupt management the GIC drivers.

This will all settle down once GICv5 is published and available (at least in qemu), which will put any abstractions we've built to the test (from what I've seen it's quite different).

Testing:
* Tested on `qemu-virt` with a GICv2: https://gist.github.com/r1mikey/74a9a7a65f7ce8c9621e62ade630dbb8
* Tested on `qemu-virt` with a GICv3: https://gist.github.com/r1mikey/57b83c57f3b09f9a919d5303b8eb5b90
* Tested on `rpi4` (GICv2): https://gist.github.com/r1mikey/adc8498cc5a4715fd9315b1c8e50716b