### PR TITLE
Use constants for common property names

### DIFF
--- a/usr/src/uts/aarch64/sys/obpdefs.h
+++ b/usr/src/uts/aarch64/sys/obpdefs.h
@@ -78,6 +78,13 @@ typedef	phandle_t pnode_t;
 #define	OBP_CPU			"cpu"
 #define	OBP_ADDRESS		"address"
 
+#define	OBP_ADDRESS_CELLS		"#address-cells"
+#define	OBP_SIZE_CELLS			"#size-cells"
+
+#define	OBP_INTERRUPT_CONTROLLER	"interrupt-controller"
+#define	OBP_INTERRUPT_PARENT		"interrupt-parent"
+#define	OBP_INTERRUPT_CELLS		"#interrupt-cells"
+
 /*
  * OBP status values defines
  */

--- a/usr/src/uts/armv8/io/consplat.c
+++ b/usr/src/uts/armv8/io/consplat.c
@@ -43,6 +43,7 @@
 #include <sys/promif.h>
 #include <sys/modctl.h>
 #include <sys/termios.h>
+#include <sys/obpdefs.h>
 
 int
 plat_use_polled_debug()
@@ -96,12 +97,12 @@ plat_ttypath(void)
 	if (ttypath != NULL)
 		return (ttypath);
 
-	len = prom_getproplen(prom_chosennode(), "stdout-path");
+	len = prom_getproplen(prom_chosennode(), OBP_STDOUTPATH);
 	if (len <= 0)
 		return (NULL);
 
 
-	prom_getprop(prom_chosennode(), "stdout-path", buf);
+	prom_getprop(prom_chosennode(), OBP_STDOUTPATH, buf);
 	buf[len] = '\0';
 
 	char *p = strchr(buf, ':');

--- a/usr/src/uts/armv8/io/ns16550a/ns16550a.c
+++ b/usr/src/uts/armv8/io/ns16550a/ns16550a.c
@@ -57,6 +57,7 @@
 #include <sys/pci.h>
 #include <sys/policy.h>
 #include <sys/platmod.h>
+#include <sys/obpdefs.h>
 #include "ns16550a.h"
 
 #define UARTDR		0x00
@@ -945,13 +946,13 @@ ns16550probe(dev_info_t *dip)
 	if (node < 0)
 		return (DDI_PROBE_FAILURE);
 
-	int len = prom_getproplen(node, "status");
+	int len = prom_getproplen(node, OBP_STATUS);
 	if (len <= 0)
 		return (DDI_PROBE_SUCCESS);
 	if (len >= sizeof(buf))
 		return (DDI_PROBE_FAILURE);
 
-	prom_getprop(node, "status", (caddr_t)buf);
+	prom_getprop(node, OBP_STATUS, (caddr_t)buf);
 	if (strcmp(buf, "ok") != 0 && strcmp(buf, "okay") != 0)
 		return (DDI_PROBE_FAILURE);
 

--- a/usr/src/uts/armv8/io/pci/pci_autoconfig/pci_autoconfig.c
+++ b/usr/src/uts/armv8/io/pci/pci_autoconfig/pci_autoconfig.c
@@ -38,6 +38,7 @@
 #include <sys/promif.h>
 #include <sys/sunddi.h>
 #include <sys/sunndi.h>
+#include <sys/obpdefs.h>
 
 #include <sys/pci.h>
 #include <sys/pci_cfgspace.h>
@@ -62,9 +63,9 @@ create_pcie_root_bus(uchar_t bus, dev_info_t *dip)
 		return (B_FALSE);
 
 	(void) ndi_prop_update_string(DDI_DEV_T_NONE, dip,
-	    "device_type", "pciex");
+	    OBP_DEVICETYPE, "pciex");
 	(void) ndi_prop_update_string(DDI_DEV_T_NONE, dip,
-	    "compatible", "pciex_root_complex");
+	    OBP_COMPATIBLE, "pciex_root_complex");
 
 	pcie_rc_init_bus(dip);
 

--- a/usr/src/uts/armv8/io/pci/pci_common.c
+++ b/usr/src/uts/armv8/io/pci/pci_common.c
@@ -47,6 +47,7 @@
 #include <sys/pci_cfgspace.h>
 #include <sys/pci_impl.h>
 #include <sys/pci_cap.h>
+#include <sys/obpdefs.h>
 
 /*
  * Function prototypes
@@ -91,7 +92,7 @@ pci_common_name_child(dev_info_t *child, char *name, int namelen)
 	}
 
 	if (ddi_prop_lookup_int_array(DDI_DEV_T_ANY, child, DDI_PROP_DONTPASS,
-	    "reg", (int **)&pci_rp, (uint_t *)&length) != DDI_PROP_SUCCESS) {
+	    OBP_REG, (int **)&pci_rp, (uint_t *)&length) != DDI_PROP_SUCCESS) {
 		cmn_err(CE_WARN, "cannot find reg property in %s",
 		    ddi_get_name(child));
 		return (DDI_FAILURE);

--- a/usr/src/uts/armv8/io/pci/pci_prd_armv8.c
+++ b/usr/src/uts/armv8/io/pci/pci_prd_armv8.c
@@ -28,6 +28,7 @@
 #include <sys/pci.h>
 #include <sys/pci_impl.h>
 #include <sys/plat/pci_prd.h>
+#include <sys/obpdefs.h>
 
 static pci_prd_upcalls_t *prd_upcalls;
 
@@ -73,7 +74,8 @@ pci_prd_find_resource(uint32_t bus, pci_prd_rsrc_t rsrc)
 		pnode_t node = prom_finddevice("/pcie");
 
 		pci_ranges_t *ranges;
-		int length = prom_getproplen(node, "ranges") / sizeof (*ranges);
+		int length =
+		    prom_getproplen(node, OBP_RANGES) / sizeof (*ranges);
 
 		ranges = kmem_zalloc(length * sizeof (*ranges), KM_SLEEP);
 

--- a/usr/src/uts/armv8/io/pcicfg/pcicfg.c
+++ b/usr/src/uts/armv8/io/pcicfg/pcicfg.c
@@ -44,6 +44,7 @@
 #include <sys/ndi_impldefs.h>
 #include <sys/pci_cfgacc.h>
 #include <sys/pci_props.h>
+#include <sys/obpdefs.h>
 
 /*
  * ************************************************************************
@@ -1908,7 +1909,7 @@ pcicfg_bridge_assign(dev_info_t *dip, void *hdl)
 	 * and program the base registers.
 	 */
 	if (ddi_prop_lookup_int_array(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
-	    "reg", (int **)&reg, &length) != DDI_PROP_SUCCESS) {
+	    OBP_REG, (int **)&reg, &length) != DDI_PROP_SUCCESS) {
 		DEBUG0("Failed to read reg property\n");
 		entry->error = PCICFG_FAILURE;
 		(void) pcicfg_config_teardown(&handle);
@@ -2035,8 +2036,8 @@ pcicfg_device_assign(dev_info_t *dip)
 	/*
 	 * XXX Failure here should be noted
 	 */
-	if (ddi_prop_lookup_int_array(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS, "reg",
-	    (int **)&reg, &length) != DDI_PROP_SUCCESS) {
+	if (ddi_prop_lookup_int_array(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
+	    OBP_REG, (int **)&reg, &length) != DDI_PROP_SUCCESS) {
 		DEBUG0("Failed to read reg property\n");
 		return (PCICFG_FAILURE);
 	}
@@ -2523,7 +2524,7 @@ pcicfg_sum_resources(dev_info_t *dip, void *hdl)
 		return (DDI_WALK_CONTINUE);
 	} else {
 		if (ddi_getlongprop(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
-		    "reg", (caddr_t)&pci_rp, &length) != DDI_PROP_SUCCESS) {
+		    OBP_REG, (caddr_t)&pci_rp, &length) != DDI_PROP_SUCCESS) {
 			/*
 			 * If one node in (the subtree of nodes)
 			 * doesn't have a "reg" property fail the
@@ -2625,7 +2626,7 @@ pcicfg_free_bridge_resources(dev_info_t *dip)
 
 
 	if ((i = ddi_prop_lookup_int_array(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
-	    "ranges", (int **)&ranges, &length)) != DDI_PROP_SUCCESS) {
+	    OBP_RANGES, (int **)&ranges, &length)) != DDI_PROP_SUCCESS) {
 		DEBUG0("Failed to read ranges property\n");
 		if (ddi_get_child(dip)) {
 			cmn_err(CE_WARN, "No ranges property found for %s",
@@ -2921,7 +2922,7 @@ pcicfg_match_dev(dev_info_t *dip, void *hdl)
 	int pci_func;
 
 	if (ddi_prop_lookup_int_array(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
-	    "reg", (int **)&pci_rp, (uint_t *)&length) != DDI_PROP_SUCCESS) {
+	    OBP_REG, (int **)&pci_rp, (uint_t *)&length) != DDI_PROP_SUCCESS) {
 		ctrl->dip = NULL;
 		return (DDI_WALK_TERMINATE);
 	}
@@ -3007,7 +3008,7 @@ pcicfg_update_ranges_prop(dev_info_t *dip, ppb_ranges_t *addition)
 	uint_t		status;
 
 	status = ddi_prop_lookup_int_array(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
-	    "ranges", (int **)&ranges, &rlen);
+	    OBP_RANGES, (int **)&ranges, &rlen);
 
 	rlen = CELLS_1275_TO_BYTES(rlen);
 
@@ -3020,7 +3021,7 @@ pcicfg_update_ranges_prop(dev_info_t *dip, ppb_ranges_t *addition)
 		default:
 			DEBUG0("no ranges property - creating one\n");
 			if (ndi_prop_update_int_array(DDI_DEV_T_NONE,
-			    dip, "ranges", (int *)addition,
+			    dip, OBP_RANGES, (int *)addition,
 			    sizeof (ppb_ranges_t)/sizeof (int))
 			    != DDI_SUCCESS) {
 				DEBUG0("Did'nt create ranges property\n");
@@ -3041,7 +3042,7 @@ pcicfg_update_ranges_prop(dev_info_t *dip, ppb_ranges_t *addition)
 	/*
 	 * Write out the new "ranges" property
 	 */
-	(void) ndi_prop_update_int_array(DDI_DEV_T_NONE, dip, "ranges",
+	(void) ndi_prop_update_int_array(DDI_DEV_T_NONE, dip, OBP_RANGES,
 	    (int *)newreg, (rlen + sizeof (ppb_ranges_t))/sizeof (int));
 
 	DEBUG1("Updating ranges property for %d entries",
@@ -3065,7 +3066,7 @@ pcicfg_update_reg_prop(dev_info_t *dip, uint32_t regvalue, uint_t reg_offset)
 	uint_t		status;
 
 	status = ddi_prop_lookup_int_array(DDI_DEV_T_ANY,
-	    dip, DDI_PROP_DONTPASS, "reg", (int **)&reg, &rlen);
+	    dip, DDI_PROP_DONTPASS, OBP_REG, (int **)&reg, &rlen);
 
 	rlen = CELLS_1275_TO_BYTES(rlen);
 
@@ -3127,7 +3128,7 @@ pcicfg_update_reg_prop(dev_info_t *dip, uint32_t regvalue, uint_t reg_offset)
 	/*
 	 * Write out the new "reg" property
 	 */
-	(void) ndi_prop_update_int_array(DDI_DEV_T_NONE, dip, "reg",
+	(void) ndi_prop_update_int_array(DDI_DEV_T_NONE, dip, OBP_REG,
 	    (int *)newreg, (rlen + sizeof (pci_regspec_t))/sizeof (int));
 
 	kmem_free(newreg, rlen + sizeof (pci_regspec_t));
@@ -3147,7 +3148,7 @@ pcicfg_update_assigned_prop_value(dev_info_t *dip, uint32_t size,
 	uint_t		status;
 
 	status = ddi_prop_lookup_int_array(DDI_DEV_T_ANY,
-	    dip, DDI_PROP_DONTPASS, "reg", (int **)&reg, &rlen);
+	    dip, DDI_PROP_DONTPASS, OBP_REG, (int **)&reg, &rlen);
 
 	rlen = CELLS_1275_TO_BYTES(rlen);
 
@@ -3247,14 +3248,14 @@ pcicfg_set_busnode_props(dev_info_t *dip, uint8_t pcie_device_type)
 		(void) strcpy(device_type, "pci");
 
 	if ((ret = ndi_prop_update_string(DDI_DEV_T_NONE, dip,
-	    "device_type", device_type)) != DDI_SUCCESS) {
+	    OBP_DEVICETYPE, device_type)) != DDI_SUCCESS) {
 		return (ret);
 	}
 	if ((ret = ndi_prop_update_int(DDI_DEV_T_NONE, dip,
-	    "#address-cells", 3)) != DDI_SUCCESS) {
+	    OBP_ADDRESS_CELLS, 3)) != DDI_SUCCESS) {
 		return (ret);
 	}
-	if ((ret = ndi_prop_update_int(DDI_DEV_T_NONE, dip, "#size-cells", 2))
+	if ((ret = ndi_prop_update_int(DDI_DEV_T_NONE, dip, OBP_SIZE_CELLS, 2))
 	    != DDI_SUCCESS) {
 		return (ret);
 	}
@@ -3830,7 +3831,7 @@ pcicfg_probe_bridge(dev_info_t *new_child, ddi_acc_handle_t h, uint_t bus,
 	 * for pci/pcie devices in pcie fabric.
 	 */
 	if (ndi_prop_update_string(DDI_DEV_T_NONE, new_child,
-	    "device_type", "pci") != DDI_SUCCESS) {
+	    OBP_DEVICETYPE, "pci") != DDI_SUCCESS) {
 		DEBUG0("Failed to set \"device_type\" props\n");
 		return (PCICFG_FAILURE);
 	}
@@ -4551,7 +4552,7 @@ next:
 	 * Remove the ranges property if it exists since we will create
 	 * a new one.
 	 */
-	(void) ndi_prop_remove(DDI_DEV_T_NONE, new_child, "ranges");
+	(void) ndi_prop_remove(DDI_DEV_T_NONE, new_child, OBP_RANGES);
 
 	DEBUG2("Creating Ranges property - Mem Address %lx Mem Size %x\n",
 	    mem_base, mem_size);
@@ -4762,8 +4763,8 @@ pcicfg_config_setup(dev_info_t *dip, ddi_acc_handle_t *handle)
 	/*
 	 * Get the pci register spec from the node
 	 */
-	status = ddi_prop_lookup_int_array(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS, "reg",
-	    (int **)&reg, &rlen);
+	status = ddi_prop_lookup_int_array(DDI_DEV_T_ANY, dip,
+	    DDI_PROP_DONTPASS, OBP_REG, (int **)&reg, &rlen);
 	rlen = CELLS_1275_TO_BYTES(rlen);
 
 	switch (status) {
@@ -4831,7 +4832,8 @@ pcicfg_add_config_reg(dev_info_t *dip,
 
 	reg[0] = PCICFG_MAKE_REG_HIGH(bus, device, func, 0);
 
-	return (ndi_prop_update_int_array(DDI_DEV_T_NONE, dip, "reg", reg, 5));
+	return (ndi_prop_update_int_array(DDI_DEV_T_NONE, dip,
+	    OBP_REG, reg, 5));
 }
 
 static int
@@ -4937,7 +4939,7 @@ is_pcie_fabric(dev_info_t *dip)
 	for (pdip = dip; pdip && (pdip != root) && !found;
 	    pdip = ddi_get_parent(pdip)) {
 		if (ddi_prop_lookup_string(DDI_DEV_T_ANY, pdip,
-		    DDI_PROP_DONTPASS, "device_type", &bus) !=
+		    DDI_PROP_DONTPASS, OBP_DEVICETYPE, &bus) !=
 		    DDI_PROP_SUCCESS)
 			break;
 

--- a/usr/src/uts/armv8/io/pciex/npe/npe.c
+++ b/usr/src/uts/armv8/io/pciex/npe/npe.c
@@ -74,6 +74,7 @@
 #include <io/pci/pci_tools_ext.h>
 #include <io/pci/pci_common.h>
 #include <io/pciex/pcie_nvidia.h>
+#include <sys/obpdefs.h>
 
 /*
  * Helper Macros
@@ -344,7 +345,7 @@ npe_attach(dev_info_t *devi, ddi_attach_cmd_t cmd)
 	npe_enable_htmsi_children(devi);
 #endif
 
-	if (ddi_prop_update_string(DDI_DEV_T_NONE, devi, "device_type",
+	if (ddi_prop_update_string(DDI_DEV_T_NONE, devi, OBP_DEVICETYPE,
 	    "pciex") != DDI_PROP_SUCCESS) {
 		cmn_err(CE_WARN, "npe:  'device_type' prop create failed");
 	}
@@ -1012,7 +1013,7 @@ npe_initchild(dev_info_t *child)
 			 * DDI_SUCCESS instead of DDI_FAILURE.
 			 */
 			if (ddi_prop_get_int(DDI_DEV_T_ANY, child,
-			    DDI_PROP_DONTPASS, "interrupts", -1) == -1)
+			    DDI_PROP_DONTPASS, OBP_INTERRUPTS, -1) == -1)
 				return (DDI_SUCCESS);
 			/*
 			 * Create the ddi_parent_private_data for a pseudo
@@ -1035,7 +1036,7 @@ npe_initchild(dev_info_t *child)
 	}
 
 	if (ddi_prop_get_int(DDI_DEV_T_ANY, child, DDI_PROP_DONTPASS,
-	    "interrupts", -1) != -1)
+	    OBP_INTERRUPTS, -1) != -1)
 		pci_common_set_parent_private_data(child);
 	else
 		ddi_set_parent_data(child, NULL);

--- a/usr/src/uts/armv8/io/pciex/npe/npe_misc.c
+++ b/usr/src/uts/armv8/io/pciex/npe/npe_misc.c
@@ -34,6 +34,7 @@
 #include <sys/pci_cap.h>
 #include <sys/pcie_impl.h>
 #include <sys/cpuvar.h>
+#include <sys/obpdefs.h>
 
 /*
  * Prototype declaration
@@ -83,7 +84,7 @@ npe_child_is_pci(dev_info_t *dip)
 	boolean_t parent_is_pci, child_is_pciex;
 
 	if (ddi_prop_lookup_string(DDI_DEV_T_ANY, ddi_get_parent(dip),
-	    DDI_PROP_DONTPASS, "device_type", &dev_type) ==
+	    DDI_PROP_DONTPASS, OBP_DEVICETYPE, &dev_type) ==
 	    DDI_PROP_SUCCESS) {
 		parent_is_pci = (strcmp(dev_type, "pci") == 0);
 		ddi_prop_free(dev_type);
@@ -92,7 +93,7 @@ npe_child_is_pci(dev_info_t *dip)
 	}
 
 	if (ddi_prop_lookup_string(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
-	    "device_type", &dev_type) == DDI_PROP_SUCCESS) {
+	    OBP_DEVICETYPE, &dev_type) == DDI_PROP_SUCCESS) {
 		child_is_pciex = (strcmp(dev_type, "pciex") == 0);
 		ddi_prop_free(dev_type);
 	} else {

--- a/usr/src/uts/armv8/io/pciex/pcieb_armv8.c
+++ b/usr/src/uts/armv8/io/pciex/pcieb_armv8.c
@@ -38,6 +38,7 @@
 #include <sys/pcie_impl.h>
 #include <sys/hotplug/hpctrl.h>
 #include <io/pciex/pcieb.h>
+#include <sys/obpdefs.h>
 
 void
 pcieb_peekpoke_cb(dev_info_t *dip, ddi_fm_error_t *derr)
@@ -153,7 +154,7 @@ pcieb_plat_initchild(dev_info_t *child)
 {
 	struct ddi_parent_private_data *pdptr;
 	if (ddi_prop_exists(DDI_DEV_T_NONE, child, DDI_PROP_DONTPASS,
-	    "interrupts")) {
+	    OBP_INTERRUPTS)) {
 		pdptr = kmem_zalloc((sizeof (struct ddi_parent_private_data) +
 		    sizeof (struct intrspec)), KM_SLEEP);
 		pdptr->par_intr = (struct intrspec *)(pdptr + 1);

--- a/usr/src/uts/armv8/io/simple-bus.c
+++ b/usr/src/uts/armv8/io/simple-bus.c
@@ -43,6 +43,7 @@
 #include <sys/note.h>
 #include <sys/promif.h>
 #include <sys/sysmacros.h>
+#include <sys/obpdefs.h>
 
 static int smpl_bus_map(dev_info_t *, dev_info_t *, ddi_map_req_t *, off_t,
     off_t, caddr_t *);
@@ -219,13 +220,13 @@ smpl_bus_apply_range(dev_info_t *dip, struct regspec64 *out)
 	ASSERT3P(parent, !=, NULL);
 
 	child_addr_cells = ddi_prop_get_int(DDI_DEV_T_ANY, dip,
-	    DDI_PROP_DONTPASS, "#address-cells", 0);
+	    DDI_PROP_DONTPASS, OBP_ADDRESS_CELLS, 0);
 	child_size_cells = ddi_prop_get_int(DDI_DEV_T_ANY, dip,
-	    DDI_PROP_DONTPASS, "#size-cells", 0);
+	    DDI_PROP_DONTPASS, OBP_SIZE_CELLS, 0);
 	parent_addr_cells = ddi_prop_get_int(DDI_DEV_T_ANY, parent,
-	    DDI_PROP_DONTPASS, "#address-cells", 0);
+	    DDI_PROP_DONTPASS, OBP_ADDRESS_CELLS, 0);
 	parent_size_cells = ddi_prop_get_int(DDI_DEV_T_ANY, parent,
-	    DDI_PROP_DONTPASS, "#size-cells", 0);
+	    DDI_PROP_DONTPASS, OBP_SIZE_CELLS, 0);
 
 	VERIFY3S(parent_addr_cells, !=, 0);
 	VERIFY3S(parent_size_cells, !=, 0);
@@ -233,7 +234,7 @@ smpl_bus_apply_range(dev_info_t *dip, struct regspec64 *out)
 	VERIFY3S(child_size_cells, !=, 0);
 
 	if (ddi_prop_lookup_int_array(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
-	    "ranges", (int **)&rangep, &rangelen) != DDI_SUCCESS) {
+	    OBP_RANGES, (int **)&rangep, &rangelen) != DDI_SUCCESS) {
 		dev_err(dip, CE_WARN, "error reading ranges property");
 		return (DDI_SUCCESS);
 	} else if (rangelen == 0) {
@@ -299,13 +300,13 @@ smpl_bus_map(dev_info_t *dip, dev_info_t *rdip, ddi_map_req_t *mp, off_t offset,
 	uint32_t *cregs = NULL;
 
 	if ((addr_cells = ddi_prop_get_int(DDI_DEV_T_ANY, dip,
-	    DDI_PROP_DONTPASS, "#address-cells", 0)) == 0) {
+	    DDI_PROP_DONTPASS, OBP_ADDRESS_CELLS, 0)) == 0) {
 		dev_err(rdip, CE_WARN, "couldn't read #address-cells");
 		return (DDI_ME_INVAL);
 	}
 
 	if ((size_cells = ddi_prop_get_int(DDI_DEV_T_ANY, dip,
-	    DDI_PROP_DONTPASS, "#size-cells", 0)) == 0) {
+	    DDI_PROP_DONTPASS, OBP_SIZE_CELLS, 0)) == 0) {
 		dev_err(rdip, CE_WARN, "couldn't read #size-cells");
 		return (DDI_ME_INVAL);
 	}
@@ -320,7 +321,7 @@ smpl_bus_map(dev_info_t *dip, dev_info_t *rdip, ddi_map_req_t *mp, off_t offset,
 		int rnumber = mp->map_obj.rnumber;
 
 		if ((ddi_prop_lookup_int_array(DDI_DEV_T_ANY, rdip,
-		    DDI_PROP_DONTPASS, "reg", (int **)&cregs, &n) !=
+		    DDI_PROP_DONTPASS, OBP_REG, (int **)&cregs, &n) !=
 		    DDI_SUCCESS) || (n == 0)) {
 			dev_err(rdip, CE_WARN,
 			    "couldn't read reg property\n");

--- a/usr/src/uts/armv8/os/cpuinfo_fdt.c
+++ b/usr/src/uts/armv8/os/cpuinfo_fdt.c
@@ -63,7 +63,7 @@ get_cpu_mpidr(pnode_t node)
 	if (ac != 1 && ac != 2)
 		return (affinity);
 
-	cv = prom_getprop(node, "reg", (caddr_t)parts);
+	cv = prom_getprop(node, OBP_REG, (caddr_t)parts);
 	if ((ac == 1 && cv != 4) || (ac == 2 && cv != 8))
 		return (affinity);
 
@@ -155,12 +155,12 @@ get_cpu_status(pnode_t node)
 	boolean_t	exists;
 	char		prop[OBP_STANDARD_MAXPROPNAME];
 
-	exists = prom_node_has_property(node, "status");
+	exists = prom_node_has_property(node, OBP_STATUS);
 	if (exists != B_TRUE)
 		return (CPUNODE_STATUS_UNKNOWN);
 
 	cv = prom_bounded_getprop(
-	    node, "status", prop, OBP_STANDARD_MAXPROPNAME - 1);
+	    node, OBP_STATUS, prop, OBP_STANDARD_MAXPROPNAME - 1);
 	if (cv < 0)
 		return (CPUNODE_STATUS_ERROR);
 
@@ -180,11 +180,11 @@ is_cpu_node(pnode_t node)
 	int ret;
 	char prop[OBP_STANDARD_MAXPROPNAME];
 
-	ret = prom_getprop(node, "device_type", prop);
+	ret = prom_getprop(node, OBP_DEVICETYPE, prop);
 	if (ret < 0)
 		return (B_FALSE);
 
-	return (strcmp(prop, "cpu") == 0 ? B_TRUE : B_FALSE);
+	return (strcmp(prop, OBP_CPU) == 0 ? B_TRUE : B_FALSE);
 }
 
 static pnode_t

--- a/usr/src/uts/armv8/os/ddi_impl.c
+++ b/usr/src/uts/armv8/os/ddi_impl.c
@@ -66,6 +66,7 @@
 #include <sys/mach_intr.h>
 #include <vm/hat_aarch64.h>
 #include <sys/gic.h>
+#include <sys/obpdefs.h>
 
 size_t dma_max_copybuf_size = 0x101000;		/* 1M + 4K */
 uint64_t ramdisk_start, ramdisk_end;
@@ -1127,14 +1128,14 @@ i_ddi_interrupt_domain(dev_info_t *pdip)
 
 		/* If we have "#interrupt-cells", we're what we want */
 		if (ddi_prop_exists(DDI_DEV_T_ANY, p, DDI_PROP_DONTPASS,
-		    "#interrupt-cells") != 0) {
+		    OBP_INTERRUPT_CELLS) != 0) {
 			ret = p;
 			break;
 		}
 
 		/* If not, if there's an interrupt-parent follow it */
 		if ((phandle = ddi_prop_get_int(DDI_DEV_T_ANY, p,
-		    DDI_PROP_DONTPASS, "interrupt-parent", -1)) != -1) {
+		    DDI_PROP_DONTPASS, OBP_INTERRUPT_PARENT, -1)) != -1) {
 			p = e_ddi_nodeid_to_dip(phandle);
 			VERIFY3P(p, !=, NULL);
 			continue;
@@ -1168,13 +1169,13 @@ i_ddi_get_interrupt(dev_info_t *dip, uint_t inumber, int **ret)
 	uint32_t		intr = 0;
 
 	if (ddi_prop_lookup_int_array(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
-	    "interrupts", &ip, &ip_sz) == DDI_SUCCESS) {
+	    OBP_INTERRUPTS, &ip, &ip_sz) == DDI_SUCCESS) {
 		dev_info_t *id = i_ddi_interrupt_domain(dip);
 
 		VERIFY3P(id, !=, NULL);
 
 		int intr_cells = ddi_prop_get_int(DDI_DEV_T_ANY, id,
-		    DDI_PROP_DONTPASS, "#interrupt-cells", 1);
+		    DDI_PROP_DONTPASS, OBP_INTERRUPT_CELLS, 1);
 
 		if (inumber >= ip_sz / intr_cells) {
 			return (0); /* failure */
@@ -1344,7 +1345,7 @@ i_ddi_unitaddr(dev_info_t *dip, uint_t *out, size_t out_cells)
 	uint_t reg_cells;
 
 	int addr_cells = ddi_prop_get_int(DDI_DEV_T_ANY, dip, 0,
-	    "#address-cells", 2);
+	    OBP_ADDRESS_CELLS, 2);
 
 	if (addr_cells == 0)
 		return (0);
@@ -1353,7 +1354,7 @@ i_ddi_unitaddr(dev_info_t *dip, uint_t *out, size_t out_cells)
 		return (-1);
 
 	if (ddi_prop_lookup_int_array(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
-	    "reg", &reg, &reg_cells) != DDI_SUCCESS) {
+	    OBP_REG, &reg, &reg_cells) != DDI_SUCCESS) {
 		/*
 		 * XXXGIC: If we have address cells, but no registers to fill
 		 * them from.  Fill with 0.  This feels like the wrong thing
@@ -1401,7 +1402,7 @@ i_ddi_unitintr(dev_info_t *dip, uint_t inum)
 {
 	unit_intr_t *ui;
 	int addr_cells = ddi_prop_get_int(DDI_DEV_T_ANY, dip, 0,
-	    "#address-cells", 2);
+	    OBP_ADDRESS_CELLS, 2);
 
 	int *intrs = NULL;
 	int intr_cells = i_ddi_get_interrupt(dip, inum, &intrs);
@@ -1438,9 +1439,9 @@ map_interrupt(dev_info_t *dip, ddi_intr_handle_impl_t *hdlp)
 		priv->ip_unitintr = i_ddi_unitintr(dip, hdlp->ih_inum);
 
 	if (ddi_prop_exists(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
-	    "interrupt-controller") != 0) {
+	    OBP_INTERRUPT_CONTROLLER) != 0) {
 		phandle_t ip = ddi_prop_get_int(DDI_DEV_T_ANY, dip,
-		    DDI_PROP_DONTPASS, "interrupt-parent", -1);
+		    DDI_PROP_DONTPASS, OBP_INTERRUPT_PARENT, -1);
 
 		/*
 		 * In the algorithm presented in the spec we would
@@ -1487,7 +1488,7 @@ map_interrupt(dev_info_t *dip, ddi_intr_handle_impl_t *hdlp)
 			ASSERT3P(i_ddi_interrupt_domain(dip), ==, dip);
 
 			int intr_cells = ddi_prop_get_int(DDI_DEV_T_ANY, dip,
-			    DDI_PROP_DONTPASS, "#interrupt-cells", 1);
+			    DDI_PROP_DONTPASS, OBP_INTERRUPT_CELLS, 1);
 
 			VERIFY((intr_mask_sz == ui->ui_nelems) ||
 			    (intr_mask_sz == 0));
@@ -1522,9 +1523,9 @@ map_interrupt(dev_info_t *dip, ddi_intr_handle_impl_t *hdlp)
 				VERIFY3P(i_ddi_interrupt_domain(parent), ==, parent);
 
 				int par_addr_cells = ddi_prop_get_int(DDI_DEV_T_ANY,
-				    parent, 0, "#address-cells", 2);
+				    parent, 0, OBP_ADDRESS_CELLS, 2);
 				int par_intr_cells = ddi_prop_get_int(DDI_DEV_T_ANY,
-				    parent, DDI_PROP_DONTPASS, "#interrupt-cells",
+				    parent, DDI_PROP_DONTPASS, OBP_INTERRUPT_CELLS,
 				    1);
 
 				if (memcmp(ui->ui_v, scan,
@@ -1570,7 +1571,7 @@ map_interrupt(dev_info_t *dip, ddi_intr_handle_impl_t *hdlp)
 		 * that need to process interrupt operations.
 		 */
 		int ip = ddi_prop_get_int(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
-		    "interrupt-parent", -1);
+		    OBP_INTERRUPT_PARENT, -1);
 
 		if (ip != -1) {
 			ipar = e_ddi_nodeid_to_dip(ip);
@@ -1594,10 +1595,10 @@ map_interrupt(dev_info_t *dip, ddi_intr_handle_impl_t *hdlp)
 		dev_info_t *idom = i_ddi_interrupt_domain(ipar);
 
 		int intr_cells = ddi_prop_get_int(DDI_DEV_T_ANY, idom,
-		    DDI_PROP_DONTPASS, "#interrupt-cells", 1);
+		    DDI_PROP_DONTPASS, OBP_INTERRUPT_CELLS, 1);
 
 		int addr_cells = ddi_prop_get_int(DDI_DEV_T_ANY, ipar, 0,
-		    "#address-cells", 2);
+		    OBP_ADDRESS_CELLS, 2);
 
 		if ((intr_cells + addr_cells) == ui->ui_nelems) {
 			/* Same size, just overwrite the unit address */
@@ -1744,13 +1745,13 @@ i_ddi_get_intx_nintrs(dev_info_t *dip)
 	int ret = 0;
 
 	if (ddi_prop_lookup_int_array(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
-	    "interrupts", &ip, &intrlen) == DDI_SUCCESS) {
+	    OBP_INTERRUPTS, &ip, &intrlen) == DDI_SUCCESS) {
 		dev_info_t *intrd = i_ddi_interrupt_domain(dip);
 
 		VERIFY3P(intrd, !=, NULL);
 
 		intr_sz = ddi_prop_get_int(DDI_DEV_T_ANY, intrd,
-		    DDI_PROP_DONTPASS, "#interrupt-cells", -1);
+		    DDI_PROP_DONTPASS, OBP_INTERRUPT_CELLS, -1);
 
 		VERIFY3S(intr_sz, !=, -1);
 
@@ -1805,11 +1806,11 @@ get_address_cells(pnode_t node)
 	int address_cells = 0;
 
 	while (node > 0) {
-		int len = prom_getproplen(node, "#address-cells");
+		int len = prom_getproplen(node, OBP_ADDRESS_CELLS);
 		if (len > 0) {
 			ASSERT(len == sizeof (int));
 			int prop;
-			prom_getprop(node, "#address-cells", (caddr_t)&prop);
+			prom_getprop(node, OBP_ADDRESS_CELLS, (caddr_t)&prop);
 			address_cells = ntohl(prop);
 			break;
 		}
@@ -1824,11 +1825,11 @@ get_size_cells(pnode_t node)
 	int size_cells = 0;
 
 	while (node > 0) {
-		int len = prom_getproplen(node, "#size-cells");
+		int len = prom_getproplen(node, OBP_SIZE_CELLS);
 		if (len > 0) {
 			ASSERT(len == sizeof (int));
 			int prop;
-			prom_getprop(node, "#size-cells", (caddr_t)&prop);
+			prom_getprop(node, OBP_SIZE_CELLS, (caddr_t)&prop);
 			size_cells = ntohl(prop);
 			break;
 		}
@@ -1854,9 +1855,9 @@ impl_xlate_regs(dev_info_t *child, uint32_t *in, size_t in_len,
 	}
 
 	int parent_addr_cells = ddi_prop_get_int(DDI_DEV_T_ANY, parent,
-	    0, "#address-cells", 0);
+	    0, OBP_ADDRESS_CELLS, 0);
 	int parent_size_cells = ddi_prop_get_int(DDI_DEV_T_ANY, parent,
-	    0, "#size-cells", 0);
+	    0, OBP_SIZE_CELLS, 0);
 
 	if (parent_size_cells < 1 || parent_size_cells > 2) {
 		dev_err(child, CE_WARN, "unsupported size cells %d",
@@ -1944,7 +1945,7 @@ make_ddi_ppd(dev_info_t *child, struct ddi_parent_private_data **ppd)
 	 * Handle the 'reg' property.
 	 */
 	if ((ddi_prop_lookup_int_array(DDI_DEV_T_ANY, child, DDI_PROP_DONTPASS,
-	    "reg", &reg_prop, &reg_len) == DDI_PROP_SUCCESS) &&
+	    OBP_REG, &reg_prop, &reg_len) == DDI_PROP_SUCCESS) &&
 	    (reg_len != 0)) {
 		if (impl_xlate_regs(child, (uint32_t *)reg_prop, reg_len,
 		    pdptr) != 0) {
@@ -1956,13 +1957,13 @@ make_ddi_ppd(dev_info_t *child, struct ddi_parent_private_data **ppd)
 	}
 
 	child_addr_cells = ddi_prop_get_int(DDI_DEV_T_ANY, child,
-	    0, "#address-cells", 0);
+	    0, OBP_ADDRESS_CELLS, 0);
 	child_size_cells = ddi_prop_get_int(DDI_DEV_T_ANY, child,
-	    0, "#size-cells", 0);
+	    0, OBP_SIZE_CELLS, 0);
 	parent_addr_cells = ddi_prop_get_int(DDI_DEV_T_ANY, parent,
-	    0, "#address-cells", 0);
+	    0, OBP_ADDRESS_CELLS, 0);
 	parent_size_cells = ddi_prop_get_int(DDI_DEV_T_ANY, parent,
-	    0, "#size-cells", 0);
+	    0, OBP_SIZE_CELLS, 0);
 
 	ASSERT3U(child_addr_cells, !=, 0);
 	ASSERT3U(child_size_cells, !=, 0);
@@ -1979,7 +1980,7 @@ make_ddi_ppd(dev_info_t *child, struct ddi_parent_private_data **ppd)
 	 * with "regs"
 	 */
 	if (ddi_prop_lookup_int_array(DDI_DEV_T_ANY, child,
-	    DDI_PROP_DONTPASS, "ranges", &rng_prop, &rng_len)
+	    DDI_PROP_DONTPASS, OBP_RANGES, &rng_prop, &rng_len)
 	    == DDI_PROP_SUCCESS) {
 		if (child_addr_cells != 2 || parent_addr_cells != 2 ||
 		    child_size_cells != 1 || parent_size_cells != 1) {
@@ -3289,7 +3290,7 @@ getlongprop_buf(int id, char *name, char *buf, int maxlen)
 	if (-1 == prom_getprop((pnode_t)id, name, buf))
 		return (-1);
 
-	if (strcmp("name", name) == 0) {
+	if (strcmp(OBP_NAME, name) == 0) {
 		if (buf[size - 1] != '\0') {
 			buf[size] = '\0';
 			size += 1;
@@ -3333,7 +3334,7 @@ status_okay(int id, char *buf, int buflen)
 	char *bufp = buf;
 	int len = buflen;
 	int proplen;
-	static const char *status = "status";
+	static const char *status = OBP_STATUS;
 	static const char *fail = "fail";
 	int fail_len = (int)strlen(fail);
 

--- a/usr/src/uts/armv8/rpi4/io/bcm2711-emmc2/bcm2711-emmc2.c
+++ b/usr/src/uts/armv8/rpi4/io/bcm2711-emmc2/bcm2711-emmc2.c
@@ -37,6 +37,7 @@
 #include <sys/sdcard/sda.h>
 #include <sys/callo.h>
 #include <sys/ddi_subrdefs.h>
+#include <sys/obpdefs.h>
 
 #include "bcm2711-emmc2.h"
 
@@ -1557,11 +1558,11 @@ mmc_probe(dev_info_t *dip)
 	if (node < 0)
 		return (DDI_PROBE_FAILURE);
 
-	len = prom_getproplen(node, "status");
+	len = prom_getproplen(node, OBP_STATUS);
 	if (len <= 0 || len >= sizeof (buf))
 		return (DDI_PROBE_FAILURE);
 
-	prom_getprop(node, "status", (caddr_t)buf);
+	prom_getprop(node, OBP_STATUS, (caddr_t)buf);
 	if (strcmp(buf, "ok") != 0 && (strcmp(buf, "okay") != 0))
 		return (DDI_PROBE_FAILURE);
 

--- a/usr/src/uts/armv8/rpi4/io/genet/genet.c
+++ b/usr/src/uts/armv8/rpi4/io/genet/genet.c
@@ -41,6 +41,7 @@
 #include <sys/sysmacros.h>
 #include <sys/platmod.h>
 #include <sys/controlregs.h>
+#include <sys/obpdefs.h>
 #include "genet.h"
 
 #define	GENET_DMA_BUFFER_SIZE	1536
@@ -656,11 +657,11 @@ genet_probe(dev_info_t *dip)
 	if (node < 0)
 		return (DDI_PROBE_FAILURE);
 
-	len = prom_getproplen(node, "status");
+	len = prom_getproplen(node, OBP_STATUS);
 	if (len <= 0 || len >= sizeof (buf))
 		return (DDI_PROBE_FAILURE);
 
-	prom_getprop(node, "status", (caddr_t)buf);
+	prom_getprop(node, OBP_STATUS, (caddr_t)buf);
 	if (strcmp(buf, "ok") != 0 && (strcmp(buf, "okay") != 0))
 		return (DDI_PROBE_FAILURE);
 


### PR DESCRIPTION
**Targets the arm64/pci-hacking branch**

Use the constants defined in `sys/obpdefs.h` for property access.

Extend these properties to include those used throughout the aarch64 port, specifically:
* `interrupt-controller`
* `interrupt-parent`
* `#interrupt-cells`
* `#address-cells`
* `#size-cells`

Tested on qemu-virt: https://gist.github.com/r1mikey/fac239596214bddaac00e843cd7a5c7a