### PR TITLE
Widen regspec and rangespec

### DIFF
--- a/usr/src/cmd/prtconf/prt_xxx.c
+++ b/usr/src/cmd/prtconf/prt_xxx.c
@@ -150,18 +150,30 @@ static void
 obio_printregs(struct regspec *rp, int ilev)
 {
 	indent_to_level(ilev);
+#if defined(__aarch64__)
+	(void) printf("    Bus Type=0x%lx, Address=0x%lx, Size=0x%lx\n",
+	    rp->regspec_bustype, rp->regspec_addr, rp->regspec_size);
+#else
 	(void) printf("    Bus Type=0x%x, Address=0x%x, Size=0x%x\n",
 	    rp->regspec_bustype, rp->regspec_addr, rp->regspec_size);
+#endif
 }
 
 static void
 obio_printranges(struct rangespec *rp, int ilev)
 {
 	indent_to_level(ilev);
+#if defined(__aarch64__)
+	(void) printf("    Ch: %.2lx,%.16lx Pa: %.2lx,%.16lx, Sz: %lx\n",
+	    rp->rng_cbustype, rp->rng_coffset,
+	    rp->rng_bustype, rp->rng_offset,
+	    rp->rng_size);
+#else
 	(void) printf("    Ch: %.2x,%.8x Pa: %.2x,%.8x, Sz: %x\n",
 	    rp->rng_cbustype, rp->rng_coffset,
 	    rp->rng_bustype, rp->rng_offset,
 	    rp->rng_size);
+#endif
 }
 
 static void

--- a/usr/src/uts/aarch64/sys/ddi_isa.h
+++ b/usr/src/uts/aarch64/sys/ddi_isa.h
@@ -19,6 +19,7 @@
  * CDDL HEADER END
  */
 /*
+ * Copyright 2024 Michael van der Westhuizen
  * Copyright 2017 Hayashi Naoyuki
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.

--- a/usr/src/uts/armv8/io/simple-bus.c
+++ b/usr/src/uts/armv8/io/simple-bus.c
@@ -20,89 +20,69 @@
  */
 
 /*
- * Copyright 2017 Hayashi Naoyuki
  * Copyright (c) 1992, 2011, Oracle and/or its affiliates. All rights reserved.
  */
 
-#include <sys/types.h>
-#include <sys/cmn_err.h>
-#include <sys/conf.h>
-#include <sys/modctl.h>
-#include <sys/autoconf.h>
-#include <sys/errno.h>
-#include <sys/debug.h>
-#include <sys/kmem.h>
-#include <sys/ddidmareq.h>
-#include <sys/ddi_impldefs.h>
-#include <sys/ddi_subrdefs.h>
-#include <sys/dma_engine.h>
-#include <sys/ddi.h>
-#include <sys/sunddi.h>
-#include <sys/sunndi.h>
-#include <sys/mach_intr.h>
-#include <sys/note.h>
-#include <sys/promif.h>
-#include <sys/sysmacros.h>
-#include <sys/obpdefs.h>
+/*
+ * Copyright 2017 Hayashi Naoyuki
+ * Copyright 2024 Michael van der Westhuizen
+ */
 
-static int smpl_bus_map(dev_info_t *, dev_info_t *, ddi_map_req_t *, off_t,
-    off_t, caddr_t *);
+#include <sys/types.h>
+#include <sys/modctl.h>
+#include <sys/sunddi.h>
+#include <sys/cmn_err.h>
+
 static int smpl_ctlops(dev_info_t *, dev_info_t *, ddi_ctl_enum_t,
     void *, void *);
-static int smpl_intr_ops(dev_info_t *, dev_info_t *, ddi_intr_op_t,
-    ddi_intr_handle_impl_t *, void *);
-
-struct bus_ops smpl_bus_ops = {
-	BUSO_REV,
-	smpl_bus_map,
-	NULL,
-	NULL,
-	NULL,
-	i_ddi_map_fault,
-	NULL,
-	ddi_dma_allochdl,
-	ddi_dma_freehdl,
-	ddi_dma_bindhdl,
-	ddi_dma_unbindhdl,
-	ddi_dma_flush,
-	ddi_dma_win,
-	ddi_dma_mctl,
-	smpl_ctlops,
-	ddi_bus_prop_op,
-	NULL,		/* (*bus_get_eventcookie)();	*/
-	NULL,		/* (*bus_add_eventcall)();	*/
-	NULL,		/* (*bus_remove_eventcall)();	*/
-	NULL,		/* (*bus_post_event)();		*/
-	NULL,		/* (*bus_intr_ctl)(); */
-	NULL,		/* (*bus_config)(); */
-	NULL,		/* (*bus_unconfig)(); */
-	NULL,		/* (*bus_fm_init)(); */
-	NULL,		/* (*bus_fm_fini)(); */
-	NULL,		/* (*bus_fm_access_enter)(); */
-	NULL,		/* (*bus_fm_access_exit)(); */
-	NULL,		/* (*bus_power)(); */
-	smpl_intr_ops	/* (*bus_intr_op)(); */
-};
-
-
 static int smpl_attach(dev_info_t *devi, ddi_attach_cmd_t cmd);
 
-/*
- * Internal isa ctlops support routines
- */
-struct dev_ops smpl_ops = {
-	DEVO_REV,		/* devo_rev, */
-	0,			/* refcnt  */
-	ddi_no_info,		/* info */
-	nulldev,		/* identify */
-	nulldev,		/* probe */
-	smpl_attach,	/* attach */
-	nulldev,		/* detach */
-	nodev,			/* reset */
-	(struct cb_ops *)0,	/* driver operations */
-	&smpl_bus_ops,	/* bus operations */
-	NULL,			/* power */
-	ddi_quiesce_not_needed,	/* quiesce */
+static struct bus_ops smpl_bus_ops = {
+	.busops_rev		= BUSO_REV,
+	.bus_map		= i_ddi_bus_map,
+	.bus_get_intrspec	= NULL,	/* obsolete */
+	.bus_add_intrspec	= NULL,	/* obsolete */
+	.bus_remove_intrspec	= NULL,	/* obsolete */
+	.bus_map_fault		= i_ddi_map_fault,
+	.bus_dma_map		= NULL,
+	.bus_dma_allochdl	= ddi_dma_allochdl,
+	.bus_dma_freehdl	= ddi_dma_freehdl,
+	.bus_dma_bindhdl	= ddi_dma_bindhdl,
+	.bus_dma_unbindhdl	= ddi_dma_unbindhdl,
+	.bus_dma_flush		= ddi_dma_flush,
+	.bus_dma_win		= ddi_dma_win,
+	.bus_dma_ctl		= ddi_dma_mctl,
+	.bus_ctl		= smpl_ctlops,
+	.bus_prop_op		= ddi_bus_prop_op,
+	.bus_get_eventcookie	= NULL,
+	.bus_add_eventcall	= NULL,
+	.bus_remove_eventcall	= NULL,
+	.bus_post_event		= NULL,
+	.bus_intr_ctl		= NULL,	/* obsolete */
+	.bus_config		= NULL,
+	.bus_unconfig		= NULL,
+	.bus_fm_init		= NULL,
+	.bus_fm_fini		= NULL,
+	.bus_fm_access_enter	= NULL,
+	.bus_fm_access_exit	= NULL,
+	.bus_power		= NULL,
+	.bus_intr_op		= i_ddi_intr_ops,
+	.bus_hp_op		= NULL
+};
+
+static struct dev_ops smpl_ops = {
+	.devo_rev		= DEVO_REV,
+	.devo_refcnt		= 0,
+	.devo_getinfo		= ddi_no_info,
+	.devo_identify		= nulldev,
+	.devo_probe		= nulldev,
+	.devo_attach		= smpl_attach,
+	.devo_detach		= nulldev,
+	.devo_reset		= nodev,
+	.devo_cb_ops		= NULL,
+	.devo_bus_ops		= &smpl_bus_ops,
+	.devo_power		= NULL,
+	.devo_quiesce		= ddi_quiesce_not_needed,
 };
 
 /*
@@ -110,37 +90,26 @@ struct dev_ops smpl_ops = {
  */
 
 static struct modldrv modldrv = {
-	&mod_driverops, /* Type of module.  This is simple-bus bus driver */
-	"simple-bus nexus driver",
-	&smpl_ops,	/* driver ops */
+	.drv_modops		= &mod_driverops,
+	.drv_linkinfo		= "simple-bus nexus driver",
+	.drv_dev_ops		= &smpl_ops,
 };
 
 static struct modlinkage modlinkage = {
-	MODREV_1,
-	&modldrv,
-	NULL
+	.ml_rev			= MODREV_1,
+	.ml_linkage		= { &modldrv, NULL }
 };
 
 int
 _init(void)
 {
-	int	err;
-
-	if ((err = mod_install(&modlinkage)) != 0)
-		return (err);
-
-	return (0);
+	return (mod_install(&modlinkage));
 }
 
 int
 _fini(void)
 {
-	int	err;
-
-	if ((err = mod_remove(&modlinkage)) != 0)
-		return (err);
-
-	return (0);
+	return (mod_remove(&modlinkage));
 }
 
 int
@@ -149,11 +118,13 @@ _info(struct modinfo *modinfop)
 	return (mod_info(&modlinkage, modinfop));
 }
 
-/*ARGSUSED*/
+/*
+ * Nexus implementation.
+ */
+
 static int
 smpl_attach(dev_info_t *devi, ddi_attach_cmd_t cmd)
 {
-	int rval;
 	switch (cmd) {
 	case DDI_ATTACH:
 		break;
@@ -164,232 +135,13 @@ smpl_attach(dev_info_t *devi, ddi_attach_cmd_t cmd)
 	}
 
 	ddi_report_dev(devi);
-
 	return (DDI_SUCCESS);
-}
-
-void
-smpl_bus_cook_regs(uint32_t *regs, struct regspec64 *out, int addr_cells,
-    int size_cells)
-{
-	uint64_t addr = 0;
-	uint64_t size = 0;
-
-	ASSERT(addr_cells == 1 || addr_cells == 2);
-	ASSERT(size_cells == 1 || size_cells == 2);
-
-	for (int i = 0; i < addr_cells; i++) {
-		addr = (addr << 32) | regs[i];
-	}
-
-	for (int i = 0; i < size_cells; i++) {
-		size = (size << 32) | regs[addr_cells + i];
-	}
-
-	out->regspec_addr = addr;
-	out->regspec_size = size;
-}
-
-static inline int
-smpl_bus_regno_to_offset(int regno, int addr_cells, int size_cells)
-{
-	return (regno * (addr_cells + size_cells));
-}
-
-/*
- * Apply our ranges property to the child's reg property and return addresses
- * in the parent bus's space
- *
- * We can't use `i_ddi_apply_range` since there are no ranges in
- * the parent data because we can't guarantee the address and size formats.
- *
- * XXXROOTNEX: We could arrange for that to be possible, instead, however.
- */
-static int
-smpl_bus_apply_range(dev_info_t *dip, struct regspec64 *out)
-{
-	dev_info_t *parent;
-	uint32_t *rangep;
-	uint_t rangelen;
-	int parent_addr_cells, parent_size_cells;
-	int child_addr_cells, child_size_cells;
-
-	ASSERT3P(dip, !=, NULL);
-
-	parent = ddi_get_parent(dip);
-	ASSERT3P(parent, !=, NULL);
-
-	child_addr_cells = ddi_prop_get_int(DDI_DEV_T_ANY, dip,
-	    DDI_PROP_DONTPASS, OBP_ADDRESS_CELLS, 0);
-	child_size_cells = ddi_prop_get_int(DDI_DEV_T_ANY, dip,
-	    DDI_PROP_DONTPASS, OBP_SIZE_CELLS, 0);
-	parent_addr_cells = ddi_prop_get_int(DDI_DEV_T_ANY, parent,
-	    DDI_PROP_DONTPASS, OBP_ADDRESS_CELLS, 0);
-	parent_size_cells = ddi_prop_get_int(DDI_DEV_T_ANY, parent,
-	    DDI_PROP_DONTPASS, OBP_SIZE_CELLS, 0);
-
-	VERIFY3S(parent_addr_cells, !=, 0);
-	VERIFY3S(parent_size_cells, !=, 0);
-	VERIFY3S(child_addr_cells, !=, 0);
-	VERIFY3S(child_size_cells, !=, 0);
-
-	if (ddi_prop_lookup_int_array(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
-	    OBP_RANGES, (int **)&rangep, &rangelen) != DDI_SUCCESS) {
-		dev_err(dip, CE_WARN, "error reading ranges property");
-		return (DDI_SUCCESS);
-	} else if (rangelen == 0) {
-		ddi_prop_free(rangep);
-		dev_err(dip, CE_WARN, "0-length ranges property");
-		return (DDI_SUCCESS);
-	}
-
-	int i;
-	int ranges_cells = (child_addr_cells + parent_addr_cells +
-	    child_size_cells);
-	int n = rangelen / ranges_cells;
-
-	for (i = 0; i < n; i++) {
-		uint64_t base = 0;
-		uint64_t target = 0;
-		uint64_t rsize = 0;
-		for (int j = 0; j < child_addr_cells; j++) {
-			base <<= 32;
-			base += rangep[ranges_cells * i + j];
-		}
-		for (int j = 0; j < parent_addr_cells; j++) {
-			target <<= 32;
-			target += rangep[ranges_cells * i +
-			    child_addr_cells + j];
-		}
-		for (int j = 0; j < child_size_cells; j++) {
-			rsize <<= 32;
-			rsize += rangep[ranges_cells * i + child_addr_cells +
-			    parent_addr_cells + j];
-		}
-
-		uint64_t rel_addr = out->regspec_addr;
-		uint64_t rel_offset = out->regspec_addr - base;
-
-		if (base <= rel_addr && rel_addr <= base + rsize - 1) {
-			out->regspec_addr = rel_offset + target;
-			out->regspec_size = MIN(out->regspec_size, (rsize -
-			    rel_offset));
-			break;
-		}
-
-		ddi_prop_free(rangep);
-
-		/* Not found */
-		if (i == n) {
-			dev_err(dip, CE_WARN, "specified register bounds "
-			    "are outside range");
-			return (DDI_FAILURE);
-		}
-	}
-
-	return (DDI_SUCCESS);
-}
-
-static int
-smpl_bus_map(dev_info_t *dip, dev_info_t *rdip, ddi_map_req_t *mp, off_t offset,
-    off_t len, caddr_t *vaddrp)
-{
-	ddi_map_req_t mr;
-	struct regspec64 reg = {0};
-	int error, addr_cells, size_cells;
-	uint32_t *cregs = NULL;
-
-	if ((addr_cells = ddi_prop_get_int(DDI_DEV_T_ANY, dip,
-	    DDI_PROP_DONTPASS, OBP_ADDRESS_CELLS, 0)) == 0) {
-		dev_err(rdip, CE_WARN, "couldn't read #address-cells");
-		return (DDI_ME_INVAL);
-	}
-
-	if ((size_cells = ddi_prop_get_int(DDI_DEV_T_ANY, dip,
-	    DDI_PROP_DONTPASS, OBP_SIZE_CELLS, 0)) == 0) {
-		dev_err(rdip, CE_WARN, "couldn't read #size-cells");
-		return (DDI_ME_INVAL);
-	}
-
-	switch (mp->map_type) {
-	case DDI_MT_REGSPEC:
-		smpl_bus_cook_regs((uint32_t *)mp->map_obj.rp, &reg,
-		    addr_cells, size_cells);
-		break;
-	case DDI_MT_RNUMBER: {
-		uint_t n;
-		int rnumber = mp->map_obj.rnumber;
-
-		if ((ddi_prop_lookup_int_array(DDI_DEV_T_ANY, rdip,
-		    DDI_PROP_DONTPASS, OBP_REG, (int **)&cregs, &n) !=
-		    DDI_SUCCESS) || (n == 0)) {
-			dev_err(rdip, CE_WARN,
-			    "couldn't read reg property\n");
-			return (DDI_ME_RNUMBER_RANGE);
-		}
-
-		ASSERT(n % (addr_cells + size_cells) == 0);
-
-		if (rnumber < 0 || rnumber >= n) {
-			ddi_prop_free(cregs);
-			return (DDI_ME_RNUMBER_RANGE);
-		}
-
-		int off = smpl_bus_regno_to_offset(rnumber, addr_cells,
-		    size_cells);
-		smpl_bus_cook_regs(&cregs[off], &reg,
-		    addr_cells, size_cells);
-
-		break;
-	}
-	default:
-		return (DDI_ME_INVAL);
-	}
-
-	if (cregs != NULL)
-		ddi_prop_free(cregs);
-
-	/* Adjust our reg property with offset and length */
-	if (reg.regspec_addr + offset < MAX(reg.regspec_addr, offset))
-		return (DDI_FAILURE);
-
-	reg.regspec_addr += offset;
-	if (len)
-		reg.regspec_size = len;
-
-
-#ifdef	DDI_MAP_DEBUG
-	dev_err(dip, CE_CONT, "<%s,%s> <0x%lx, 0x%lx, %ld> "
-	    "offset %ld len %ld handle 0x%p\n", ddi_get_name(dip),
-	    ddi_get_name(rdip), reg.regspec_bustype, reg.regspec_addr,
-	    reg.regspec_size, offset, len, mp->map_handlep);
-#endif	/* DDI_MAP_DEBUG */
-
-	if ((error = smpl_bus_apply_range(dip, &reg)) != DDI_SUCCESS)
-		return (DDI_SUCCESS);
-
-	mr = *mp;
-	mr.map_type = DDI_MT_REGSPEC;
-	mr.map_obj.rp = (struct regspec *)&reg;
-	mr.map_flags |= DDI_MF_EXT_REGSPEC;
-	mp = &mr;
-#ifdef	DDI_MAP_DEBUG
-	cmn_err(CE_CONT, "             <%s,%s> <0x%" PRIx64 ", 0x%" PRIx64
-	    ", %" PRId64 "> offset %ld len %ld handle 0x%p\n",
-	    ddi_get_name(dip), ddi_get_name(rdip), reg.regspec_bustype,
-	    reg.regspec_addr, reg.regspec_size, offset, len, mp->map_handlep);
-#endif	/* DDI_MAP_DEBUG */
-
-	/* `offset` is already added in, above */
-	return (ddi_map(dip, mp, 0, 0, vaddrp));
 }
 
 static int
 smpl_ctlops(dev_info_t *dip, dev_info_t *rdip,
     ddi_ctl_enum_t ctlop, void *arg, void *result)
 {
-	uint_t reglen;
-	int nreg;
 	int ret;
 
 	switch (ctlop) {
@@ -403,7 +155,7 @@ smpl_ctlops(dev_info_t *dip, dev_info_t *rdip,
 		break;
 
 	case DDI_CTLOPS_REPORTDEV:
-		if (rdip == (dev_info_t *)0)
+		if (rdip == NULL)
 			return (DDI_FAILURE);
 		cmn_err(CE_CONT, "?%s%d at %s%d\n",
 		    ddi_driver_name(rdip), ddi_get_instance(rdip),
@@ -415,12 +167,6 @@ smpl_ctlops(dev_info_t *dip, dev_info_t *rdip,
 		ret = ddi_ctlops(dip, rdip, ctlop, arg, result);
 		break;
 	}
-	return (ret);
-}
 
-static int
-smpl_intr_ops(dev_info_t *pdip, dev_info_t *rdip, ddi_intr_op_t intr_op,
-    ddi_intr_handle_impl_t *hdlp, void *result)
-{
-	return (i_ddi_intr_ops(pdip, rdip, intr_op, hdlp, result));
+	return (ret);
 }

--- a/usr/src/uts/armv8/os/ddi_impl.c
+++ b/usr/src/uts/armv8/os/ddi_impl.c
@@ -1838,7 +1838,14 @@ get_size_cells(pnode_t node)
 }
 
 /*
- * We're prepared for either 2 or 1 address cells and 2 or 1 size cells
+ * We're prepared for either 2 or 1 address cells and 2 or 1 size cells.
+ *
+ * The derived address is expected to fit into 56 bits (the LPA2 maximum), as
+ * is the derived size.
+ *
+ * We warn separately for >56-bit values (exceeding architectural maximums
+ * for physical address-space) and >48-bit sizes (exceeding current
+ * illumos limitations for physical address-space).
  */
 static int
 impl_xlate_regs(dev_info_t *child, uint32_t *in, size_t in_len,
@@ -1859,23 +1866,24 @@ impl_xlate_regs(dev_info_t *child, uint32_t *in, size_t in_len,
 	    0, OBP_SIZE_CELLS, 0);
 
 	if (parent_size_cells < 1 || parent_size_cells > 2) {
-		dev_err(child, CE_WARN, "unsupported size cells %d",
+		dev_err(child, CE_WARN, "regspec: unsupported size cells %d",
 		    parent_size_cells);
 		return (1);
 	}
 
 	if (parent_addr_cells < 1 || parent_addr_cells > 2) {
-		dev_err(child, CE_WARN, "unsupported addr cells %d",
+		dev_err(child, CE_WARN, "regspec: unsupported addr cells %d",
 		    parent_addr_cells);
 		return (1);
 	}
 
 	int reg_size = parent_addr_cells + parent_size_cells;
+	ASSERT(in_len % reg_size == 0);
 	int nregs = in_len / reg_size;
 
 	if (nregs > 0) {
-		rp = pdptr->par_reg = kmem_zalloc(nregs * sizeof (struct regspec),
-		    KM_SLEEP);
+		rp = pdptr->par_reg =
+		    kmem_zalloc(nregs * sizeof (struct regspec), KM_SLEEP);
 		pdptr->par_nreg = nregs;
 
 		for (int i = 0; i < nregs; i++, rp++) {
@@ -1891,13 +1899,20 @@ impl_xlate_regs(dev_info_t *child, uint32_t *in, size_t in_len,
 				    (parent_addr_cells + j)];
 			}
 
-			if (addr > UINT32_MAX) {
-				dev_err(child, CE_WARN, "regspec %d needs 64bit "
-				    "addressing", i);
+			if ((addr & 0x00fffffffffffffful) != addr) {
+				dev_err(child, CE_WARN, "regspec %d needs "
+				    ">56bit addressing", i);
+			} else if ((addr & 0x0000fffffffffffful) != addr) {
+				dev_err(child, CE_WARN, "regspec %d needs "
+				    ">48bit addressing", i);
 			}
-			if (size > UINT32_MAX) {
-				dev_err(child, CE_WARN, "regspec %d needs 64bit "
-				    "sizing", i);
+
+			if ((size & 0x00fffffffffffffful) != size) {
+				dev_err(child, CE_WARN, "regspec %d needs "
+				    ">56bit sizing", i);
+			} else if ((size & 0x0000fffffffffffful) != size) {
+				dev_err(child, CE_WARN, "regspec %d needs "
+				    ">48bit sizing", i);
 			}
 
 			rp->regspec_addr = addr;
@@ -1905,6 +1920,162 @@ impl_xlate_regs(dev_info_t *child, uint32_t *in, size_t in_len,
 		}
 	}
 
+	return (0);
+}
+
+/*
+ * We're prepared for 3, 2 or 1 address cells and 2 or 1 size cells.
+ *
+ * We only support 3 address cells when the child format is known to contain
+ * the 64-bit address in the last two address cells.
+ *
+ * The derived addresses are expected to fit into 56 bits (the LPA2 maximum),
+ * while the derived sizes are expected to fit into 32 bits.
+ *
+ * We warn separately for >56-bit addressing (exceeding architectural maximums
+ * for physical address-space) and >48-bit addressing (exceeding current
+ * illumos limitations for physical address-space).
+ */
+static int
+impl_xlate_ranges(dev_info_t *child, uint32_t *in, size_t in_len,
+    struct ddi_parent_private_data *pdptr)
+{
+	dev_info_t		*pdip;
+	struct rangespec	*data;	/* normalised data */
+	int			dlen;	/* length of normalised data */
+	int			cac;	/* child #address-cells */
+	int			pac;	/* parent #address-cells */
+	int			csc;	/* child #size-cells */
+	int			n;
+	int			i;
+	uint64_t		caddr;
+	uint64_t		paddr;
+	uint64_t		size;
+	char			**compats;
+	int			ncompats;
+	int			max_cac = 2;
+	static const char	*known_3cell[] = {
+		"pciex_root_complex",
+	};
+	static const int	num_known_3cell =
+	    (int)(sizeof (known_3cell) / sizeof (known_3cell[0]));
+
+	/* zero-length input means identity mapping */
+	if (in_len == 0) {
+		pdptr->par_rng = kmem_zalloc(
+		    sizeof (struct rangespec) * 1, KM_SLEEP);
+		pdptr->par_nrng = 1;
+		return (0);
+	}
+
+	VERIFY3P(child, !=, NULL);
+	if (child == ddi_root_node())
+		return (1);	/* ranges on the root node make no sense */
+	pdip = ddi_get_parent(child);
+	VERIFY3P(pdip, !=, NULL);
+
+	/*
+	 * Explicitly allow children with a known 3 address-cell format, such
+	 * as PCIe root complexes. Our code will just shift the extra data off
+	 * the end of the child address.
+	 */
+	if (ddi_prop_lookup_string_array(DDI_DEV_T_ANY, child,
+	    DDI_PROP_DONTPASS, OBP_COMPATIBLE,
+	    &compats, (uint_t *)&ncompats) == DDI_PROP_SUCCESS) {
+		for (n = 0; n < ncompats; ++n) {
+			for (i = 0; i < num_known_3cell; ++i) {
+				if (strcmp(compats[n], known_3cell[i]) == 0) {
+					max_cac = 3;
+					break;
+				}
+
+				if (max_cac == 3)
+					break;
+			}
+		}
+
+		ddi_prop_free(compats);
+	}
+
+	pac = ddi_prop_get_int(DDI_DEV_T_ANY, pdip, 0, OBP_ADDRESS_CELLS, 0);
+	cac = ddi_prop_get_int(DDI_DEV_T_ANY, child, 0, OBP_ADDRESS_CELLS, 0);
+	csc = ddi_prop_get_int(DDI_DEV_T_ANY, child, 0, OBP_SIZE_CELLS, 0);
+
+	if (csc < 1 || csc > 2) {
+		dev_err(child, CE_WARN,
+		    "rangespec: unsupported child size cells %d", csc);
+		return (1);
+	}
+
+	if (cac < 1 || cac > max_cac) {
+		dev_err(child, CE_WARN,
+		    "rangespec: unsupported child addr cells %d", cac);
+		return (1);
+	}
+
+	if (pac < 1 || pac > 2) {
+		dev_err(pdip, CE_WARN,
+		    "rangespec: unsupported parent addr cells %d", pac);
+		return (1);
+	}
+
+	if (in_len % (cac + pac + csc) != 0) {
+		dev_err(child, CE_WARN, "invalid ranges data");
+		return (1);
+	}
+
+	dlen = in_len / (cac + pac + csc);
+	data = kmem_zalloc(sizeof (struct rangespec) * dlen, KM_SLEEP);
+
+	for (n = 0; n < dlen; ++n) {
+		caddr = paddr = size = 0;
+
+		for (i = 0; i < cac; ++i) {
+			caddr <<= 32;
+			caddr |= in[((cac + pac + csc) * n) + i];
+		}
+
+		for (i = 0; i < pac; ++i) {
+			paddr <<= 32;
+			paddr |= in[((cac + pac + csc) * n) + cac + i];
+		}
+
+		for (i = 0; i < csc; ++i) {
+			size <<= 32;
+			size |= in[((cac + pac + csc) * n) + cac + pac + i];
+		}
+
+		if ((caddr & 0x00fffffffffffffful) != caddr) {
+			dev_err(child, CE_WARN, "rangespec %d needs >56bit "
+			    "child addressing", n);
+		} else if ((caddr & 0x0000fffffffffffful) != caddr) {
+			dev_err(child, CE_WARN, "rangespec %d needs >48bit "
+			    "child addressing", n);
+		}
+
+		if ((paddr & 0x00fffffffffffffful) != paddr) {
+			dev_err(child, CE_WARN, "rangespec %d needs >56bit "
+			    "parent addressing", n);
+		} else if ((paddr & 0x0000fffffffffffful) != paddr) {
+			dev_err(child, CE_WARN, "rangespec %d needs >48bit "
+			    "parent addressing", n);
+		}
+
+		if ((size & 0x00fffffffffffffful) != size) {
+			dev_err(child, CE_WARN, "rangespec %d needs >56bit "
+			    "sizing", n);
+		} else if ((size & 0x0000fffffffffffful) != size) {
+			dev_err(child, CE_WARN, "rangespec %d needs >48bit "
+			    "sizing", n);
+		}
+
+		data[n].rng_coffset = caddr;
+		data[n].rng_offset = paddr;
+		data[n].rng_size = size;
+	}
+
+	pdptr->par_rng = data;
+	pdptr->par_nrng = dlen;
 	return (0);
 }
 
@@ -1919,9 +2090,8 @@ impl_xlate_regs(dev_info_t *child, uint32_t *in, size_t in_len,
  * The "reg" property is in a firmware-defined shape and converted into
  * `struct regspec`.
  *
- * XXXROOTNEX: "ranges" is currently left alone, unless it is of a
- * pre-determined shape.  This matches behaviour on SPARC (for eg), but we
- * easily could genericize it if we had a 64bit range structure to use.
+ * The "ranges" property is in a firmware-defined shape and converted into
+ * `struct rangespec`.
  */
 void
 make_ddi_ppd(dev_info_t *child, struct ddi_parent_private_data **ppd)
@@ -1943,9 +2113,9 @@ make_ddi_ppd(dev_info_t *child, struct ddi_parent_private_data **ppd)
 	/*
 	 * Handle the 'reg' property.
 	 */
-	if ((ddi_prop_lookup_int_array(DDI_DEV_T_ANY, child, DDI_PROP_DONTPASS,
-	    OBP_REG, &reg_prop, &reg_len) == DDI_PROP_SUCCESS) &&
-	    (reg_len != 0)) {
+	if (((n = ddi_prop_lookup_int_array(DDI_DEV_T_ANY, child,
+	    DDI_PROP_DONTPASS, OBP_REG, &reg_prop, &reg_len))
+	    == DDI_PROP_SUCCESS) && (reg_len != 0)) {
 		if (impl_xlate_regs(child, (uint32_t *)reg_prop, reg_len,
 		    pdptr) != 0) {
 			dev_err(child, CE_WARN, "couldn't initialize regs in "
@@ -1953,51 +2123,38 @@ make_ddi_ppd(dev_info_t *child, struct ddi_parent_private_data **ppd)
 		}
 
 		ddi_prop_free(reg_prop);
+	} else {
+		if (n != DDI_PROP_NOT_FOUND && n != DDI_PROP_UNDEFINED) {
+			dev_err(child, CE_WARN,
+			    "unable to read %s property: %d", OBP_REG, n);
+		}
 	}
-
-	child_addr_cells = ddi_prop_get_int(DDI_DEV_T_ANY, child,
-	    0, OBP_ADDRESS_CELLS, 0);
-	child_size_cells = ddi_prop_get_int(DDI_DEV_T_ANY, child,
-	    0, OBP_SIZE_CELLS, 0);
-	parent_addr_cells = ddi_prop_get_int(DDI_DEV_T_ANY, parent,
-	    0, OBP_ADDRESS_CELLS, 0);
-	parent_size_cells = ddi_prop_get_int(DDI_DEV_T_ANY, parent,
-	    0, OBP_SIZE_CELLS, 0);
-
-	ASSERT3U(child_addr_cells, !=, 0);
-	ASSERT3U(child_size_cells, !=, 0);
-	ASSERT3U(parent_addr_cells, !=, 0);
-	ASSERT3U(parent_size_cells, !=, 0);
 
 	/*
 	 * Ranges, of of which we only handle certain shapes.
-	 *
-	 * XXXROOTNEX: Genericize, like we do regs?
-	 *
-	 * This is only used in relation to `i_ddi_apply_range` so we easily
-	 * _could_, though we'd then run into the same 32bit assumptions as
-	 * with "regs"
 	 */
-	if (ddi_prop_lookup_int_array(DDI_DEV_T_ANY, child,
-	    DDI_PROP_DONTPASS, OBP_RANGES, &rng_prop, &rng_len)
+	if ((n = ddi_prop_lookup_int_array(DDI_DEV_T_ANY, child,
+	    DDI_PROP_DONTPASS, OBP_RANGES, &rng_prop, &rng_len))
 	    == DDI_PROP_SUCCESS) {
-		if (child_addr_cells != 2 || parent_addr_cells != 2 ||
-		    child_size_cells != 1 || parent_size_cells != 1) {
-			NDI_CONFIG_DEBUG((CE_NOTE,
-			    "!ranges not made in parent data; "
-			    "#address-cells or #size-cells have "
-			    "non-default values\n"
-			    "\tparent: #address-cells = %d, #size-cells = %d\n"
-			    "\tchild: #address-cells = %d, #size-cells = %d",
-			    parent_addr_cells, parent_size_cells,
-			    child_addr_cells, child_size_cells));
-			ddi_prop_free(rng_prop);
-			return;
+		if (impl_xlate_ranges(child, (uint32_t *)rng_prop, rng_len,
+		    pdptr) != 0) {
+			dev_err(child, CE_WARN, "couldn't initialize ranges in "
+			    "parent data");
 		}
 
-		pdptr->par_nrng = CELLS_1275_TO_BYTES(rng_len) /
-		    (sizeof (struct rangespec));
-		pdptr->par_rng = (struct rangespec *)rng_prop;
+		if (rng_prop)
+			ddi_prop_free(rng_prop);
+	} else {
+		if (n == DDI_PROP_END_OF_DATA) {
+			/* empty ranges property means identity mapping */
+			if (impl_xlate_ranges(child, NULL, 0, pdptr) != 0) {
+				dev_err(child, CE_WARN, "couldn't initialize "
+				    "ranges in parent data");
+			}
+		} else if (n != DDI_PROP_NOT_FOUND && n != DDI_PROP_UNDEFINED) {
+			dev_err(child, CE_WARN,
+			    "unable to read %s property: %d", OBP_RANGES, n);
+		}
 	}
 }
 
@@ -2018,8 +2175,8 @@ impl_sunbus_name_child(dev_info_t *child, char *name, int namelen)
 		 * Note that unlike other platforms, we don't include the
 		 * bustype, to match practice in devicetree.
 		 */
-		(void) snprintf(name, namelen, "%x",
-		    (uint_t)sparc_pd_getreg(child, 0)->regspec_addr);
+		(void) snprintf(name, namelen, "%lx",
+		    sparc_pd_getreg(child, 0)->regspec_addr);
 	}
 
 	return (DDI_SUCCESS);
@@ -2053,7 +2210,7 @@ impl_free_ddi_ppd(dev_info_t *dip)
 		return;
 
 	if ((n = (size_t)pdptr->par_nrng) != 0)
-		ddi_prop_free((void *)pdptr->par_rng);
+		kmem_free(pdptr->par_rng, n * sizeof (struct rangespec));
 
 	if ((n = pdptr->par_nreg) != 0) {
 		kmem_free(pdptr->par_reg, n * sizeof (struct regspec));

--- a/usr/src/uts/common/io/viommionex/viommionex.c
+++ b/usr/src/uts/common/io/viommionex/viommionex.c
@@ -36,10 +36,6 @@
 #include "virtio.h"
 #include "virtio_impl.h"
 
-static int viommionex_ddi_map(dev_info_t *pdip, dev_info_t *dp,
-    ddi_map_req_t *mp, off_t offset, off_t len, caddr_t *addrp);
-static int viommionex_intr_op(dev_info_t *pdip, dev_info_t *rdip,
-    ddi_intr_op_t intr_op, ddi_intr_handle_impl_t *hdlp, void *result);
 static int viommionex_ctlops(dev_info_t *dip, dev_info_t *rdip,
     ddi_ctl_enum_t ctlop, void *arg, void *result);
 static int viommionex_attach(dev_info_t *dip, ddi_attach_cmd_t cmd);
@@ -50,7 +46,7 @@ static int viommionex_bus_unconfig(dev_info_t *parent, uint_t flags,
 
 static struct bus_ops viommionex_bus_ops = {
 	.busops_rev		= BUSO_REV,
-	.bus_map		= viommionex_ddi_map,
+	.bus_map		= i_ddi_bus_map,
 	.bus_get_intrspec	= NULL, /* obsolete */
 	.bus_add_intrspec	= NULL, /* obsolete */
 	.bus_remove_intrspec	= NULL, /* obsolete */
@@ -77,7 +73,7 @@ static struct bus_ops viommionex_bus_ops = {
 	.bus_fm_access_enter	= NULL,
 	.bus_fm_access_exit	= NULL,
 	.bus_power		= NULL,
-	.bus_intr_op		= viommionex_intr_op,
+	.bus_intr_op		= i_ddi_intr_ops,
 	.bus_hp_op		= NULL
 };
 
@@ -138,20 +134,6 @@ _info(struct modinfo *modinfop)
 /*
  * Nexus implementation
  */
-
-static int
-viommionex_ddi_map(dev_info_t *pdip, dev_info_t *dp __unused,
-    ddi_map_req_t *mp, off_t offset, off_t len, caddr_t *addrp)
-{
-	return (ddi_map(pdip, mp, offset, len, addrp));
-}
-
-static int
-viommionex_intr_op(dev_info_t *pdip, dev_info_t *rdip __unused,
-    ddi_intr_op_t intr_op, ddi_intr_handle_impl_t *hdlp, void *result)
-{
-	return (i_ddi_intr_ops(pdip, rdip, intr_op, hdlp, result));
-}
 
 static int
 viommionex_ctlops(dev_info_t *dip, dev_info_t *rdip, ddi_ctl_enum_t ctlop,

--- a/usr/src/uts/common/sys/ddi_impldefs.h
+++ b/usr/src/uts/common/sys/ddi_impldefs.h
@@ -639,9 +639,15 @@ int	i_ddi_set_devi_class(dev_info_t *, const char *, int);
  * device. It is used in an array for devices with multiple address windows.
  */
 struct regspec {
+#if defined(__aarch64__)
+	uint64_t regspec_bustype;	/* cookie for bus type it's on */
+	uint64_t regspec_addr;		/* address of reg relative to bus */
+	uint64_t regspec_size;		/* size of this register set */
+#else
 	uint_t regspec_bustype;		/* cookie for bus type it's on */
 	uint_t regspec_addr;		/* address of reg relative to bus */
 	uint_t regspec_size;		/* size of this register set */
+#endif
 };
 
 /*
@@ -661,11 +667,19 @@ struct regspec64 {
  * to define the childs offsets in the parents bus space.
  */
 struct rangespec {
+#if defined(__aarch64__)
+	uint64_t rng_cbustype;		/* Child's address, hi order */
+	uint64_t rng_coffset;		/* Child's address, lo order */
+	uint64_t rng_bustype;		/* Parent's address, hi order */
+	uint64_t rng_offset;		/* Parent's address, lo order */
+	uint64_t rng_size;		/* size of space for this entry */
+#else
 	uint_t rng_cbustype;		/* Child's address, hi order */
 	uint_t rng_coffset;		/* Child's address, lo order */
 	uint_t rng_bustype;		/* Parent's address, hi order */
 	uint_t rng_offset;		/* Parent's address, lo order */
 	uint_t rng_size;		/* size of space for this entry */
+#endif
 };
 
 #ifdef _KERNEL


### PR DESCRIPTION
**Targets the pic-hacking branch**

Widen the fields in both regspec and rangespec to be 64-bit on aarch64.

This change allows us to use 64-bit addresses in the same way as regspec64 (regspec is now identical to regspec64) and allows us to use both 64-bit addresses and 64-bit sizes in ranges, gracefully handling PCIe range sizes >4GiB.

This also allows us to simplify simple-bus and viommionex, having them use the implementation DDI for bus mapping and interrupt operations.

Tested on qemu-virt: https://gist.github.com/r1mikey/934a0ee5eb72d90c6de0f7daf4621cc0

An alternative approach can be found in https://github.com/r1mikey/illumos-gate/commit/f4bd9ecdbf467a341a7cc3bb9194d277fa684e1c, which could be extended to handle register addresses up to 48 bits and sizes up to 40 bits (instead of register sizes up to 56 bits). This would reuse bits from the bustype field though, and might be a bit uglier than what I have here.

I'm not particularly attached to either way, so let me know what you think would be best.