### PR TITLE
avintr: Treat autovec like a hashtable

### DIFF
--- a/usr/src/uts/armv8/io/gicthree.c
+++ b/usr/src/uts/armv8/io/gicthree.c
@@ -395,13 +395,9 @@ gicv3_config_irq(uint32_t irq, bool is_edge)
 static int
 gicv3_intr_enter(int irq)
 {
-	int new_ipl;
+	int new_ipl = 0;
 
-	ASSERT3S(irq, <, MAX_VECT);
-
-	new_ipl = autovect[irq].avh_hi_pri;
-
-	if (new_ipl != 0) {
+	if (av_get_vec_lvl(irq, &new_ipl) && new_ipl != 0) {
 		write_icc_pmr_el1(GIC_IPL_TO_PRI(new_ipl));
 	}
 

--- a/usr/src/uts/armv8/io/gictwo.c
+++ b/usr/src/uts/armv8/io/gictwo.c
@@ -324,13 +324,9 @@ gicv2_config_irq(uint32_t irq, bool is_edge)
 static int
 gicv2_intr_enter(int irq)
 {
-	int new_ipl;
+	int new_ipl = 0;
 
-	ASSERT3S(irq, <, MAX_VECT);
-
-	new_ipl = autovect[irq].avh_hi_pri;
-
-	if (new_ipl != 0) {
+	if (av_get_vec_lvl(irq, &new_ipl) && new_ipl != 0) {
 		gicc_write(conf, GICC_PMR,
 		    GIC_IPL_TO_PRIO(new_ipl) & gicv2_prio_pmr_mask);
 	}

--- a/usr/src/uts/armv8/os/gic.c
+++ b/usr/src/uts/armv8/os/gic.c
@@ -184,9 +184,9 @@ gic_addspl(int irq, int ipl, int min_ipl, int max_ipl)
 static int
 gic_delspl(int irq, int ipl, int min_ipl, int max_ipl)
 {
-	ASSERT3S(irq, <, MAX_VECT);
+	int pri = -1;
 
-	if (autovect[irq].avh_hi_pri == 0) {
+	if (av_get_vec_lvl(irq, &pri) == 0 || pri == 0) {
 		int ret = 0;
 		mutex_enter(&gic_intrs_lock);
 		gic_remove_state(irq);

--- a/usr/src/uts/armv8/sys/smp_impldefs.h
+++ b/usr/src/uts/armv8/sys/smp_impldefs.h
@@ -85,7 +85,6 @@ extern void psm_unmap_phys(caddr_t, size_t);
 /*
  *	External Reference Data
  */
-extern struct av_head autovect[]; /* array of auto intr vectors		*/
 extern uint32_t rm_platter_pa;	/* phy addr realmode startup storage	*/
 extern caddr_t rm_platter_va;	/* virt addr realmode startup storage	*/
 extern cpuset_t mp_cpus;	/* bit map of possible cpus found	*/

--- a/usr/src/uts/common/sys/avintr.h
+++ b/usr/src/uts/common/sys/avintr.h
@@ -58,6 +58,7 @@ struct autovec {
 	 */
 
 	struct autovec *av_link;	/* pointer to next on in chain */
+	uint_t av_vecnum;
 	uint_t	(*av_vector)();
 	caddr_t	av_intarg1;
 	caddr_t	av_intarg2;
@@ -108,6 +109,7 @@ extern void update_avsoftintr_args(void *intr_id, int lvl, caddr_t arg2);
 extern void rem_avintr(void *intr_id, int lvl, avfunc xxintr, int vect);
 extern void wait_till_seen(int ipl);
 extern uint_t softlevel1(caddr_t, caddr_t);
+extern int av_get_vec_lvl(uint_t vect, int *lvl);
 
 #endif	/* _KERNEL */
 


### PR DESCRIPTION
**This PR is against the PCI hacking branch**

The `avintr` functionality looks like it does what we need for aarch64, but it has some fairly surprising behaviour:
* Vectors are inserted modulo the `autovect` array size, but dispatched using the raw interrupt number. At best this hits an assertion in a debug kernel when the modulus would be needed, at worst this indexes off the end of the array. It is also possible to unnecessarily invoke handlers for unrelated interrupts.
* As per the last statement, interrupts can be surprisingly shared if modulus was used to find an `av_head`, but they can't be executed by normal means in this case!
* The `autovect` array is interacted with in an open-coded manner (at least from GIC code), meaning external code has intimate knowledge of the rules governing `avintr`.
* The design seems at least somewhat guided by the limitations of cascaded PICs on old Intel systems, where interrupts are glommed into levels and extensively shared. All handlers at a level are tried, not just the vector that fired.

To make this behave a little more like we need on Arm systems we make the following changes (and these only apply on Arm systems):
* Always select the `av_head` via a modulus operation.
* Add the original vector number to the `autovec` structure, alongside the handler function pointer.
* When traversing the vector chain in an `av_head`, always match on the supplied vector, so that false-sharing is avoided.
* Introduce a helper function to look up the priority of an interrupt, as used by the GIC drivers. This simply matches the first matching vector. The GIC drivers are responsible for avoiding adding conflicting priorities for shared interrupts (we could push this down to `avintr` if we want).

These changes mean that we can insert an arbitrary number of vectors, including those with high vector numbers, and avoid falsely sharing those vectors. This should help make it possible to:
* Add LPIs
* Deal with large, sparse interrupt-space
* Register fake interrupt numbers for subordinate controllers if we choose to do that at a later date (redispatch would be from the subordinate controller's interrupt handler).

Testing:
* qemu-virt, gicv2: https://gist.github.com/r1mikey/29f8777ab28fe04af204f22c97ea4a08
* qemu-virt, gicv3: https://gist.github.com/r1mikey/76ddaad2e85ff01fabb8a59e8199c986
