### PR TITLE
prom: Implement `prom_nextnode` and `prom_childnode` more reasonably

### DIFF
--- a/usr/src/psm/stand/boot/port/prom_node.c
+++ b/usr/src/psm/stand/boot/port/prom_node.c
@@ -269,55 +269,52 @@ prom_nextprop(pnode_t nodeid, const char *name, char *next)
 	return next;
 }
 
+
 pnode_t
 prom_nextnode(pnode_t nodeid)
 {
 	if (nodeid == OBP_NONODE)
-		return prom_rootnode();
+		return (prom_rootnode());
 
 	int offset = fdt_node_offset_by_phandle(fdtp, (phandle_t)nodeid);
 	if (offset < 0)
-		return OBP_BADNODE;
+		return (OBP_BADNODE);
 
-	int depth = 1;
-	for (;;) {
-		offset = fdt_next_node(fdtp, offset, &depth);
-		if (offset < 0)
-			return OBP_NONODE;
-		if (depth == 1)
-			break;
+	int child = fdt_next_subnode(fdtp, offset);
+	if (child == -FDT_ERR_NOTFOUND) {
+		return (OBP_NONODE);
+	} else if (child < 0) {
+		return (OBP_BADNODE);
 	}
 
-	phandle_t phandle = get_phandle(offset);
+	phandle_t phandle = get_phandle(child);
 	if (phandle < 0)
-		return OBP_NONODE;
-	return (pnode_t)phandle;
+		return (OBP_NONODE);
+
+	return ((pnode_t)phandle);
 }
 
 pnode_t
 prom_childnode(pnode_t nodeid)
 {
 	if (nodeid == OBP_NONODE)
-		return prom_rootnode();
+		return (prom_rootnode());
 
 	int offset = fdt_node_offset_by_phandle(fdtp, (phandle_t)nodeid);
 	if (offset < 0)
-		return OBP_NONODE;
+		return (OBP_NONODE);
 
-	int depth = 0;
-	for (;;) {
-		offset = fdt_next_node(fdtp, offset, &depth);
-		if (offset < 0)
-			return OBP_NONODE;
-		if (depth == 0)
-			return OBP_NONODE;
-		if (depth == 1)
-			break;
+	int child = fdt_first_subnode(fdtp, offset);
+	if (child == -FDT_ERR_NOTFOUND) {
+		return (OBP_NONODE);
+	} else if (child < 0) {
+		return (OBP_BADNODE);
 	}
-	phandle_t phandle = get_phandle(offset);
+
+	phandle_t phandle = get_phandle(child);
 	if (phandle < 0)
-		return OBP_NONODE;
-	return (pnode_t)phandle;
+		return (OBP_NONODE);
+	return ((pnode_t)phandle);
 }
 
 pnode_t

--- a/usr/src/uts/aarch64/promif/prom_node.c
+++ b/usr/src/uts/aarch64/promif/prom_node.c
@@ -385,18 +385,17 @@ prom_nextnode(pnode_t nodeid)
 	if (offset < 0)
 		return (OBP_BADNODE);
 
-	int depth = 1;
-	for (;;) {
-		offset = fdt_next_node(fdtp, offset, &depth);
-		if (offset < 0)
-			return (OBP_NONODE);
-		if (depth == 1)
-			break;
+	int child = fdt_next_subnode(fdtp, offset);
+	if (child == -FDT_ERR_NOTFOUND) {
+		return (OBP_NONODE);
+	} else if (child < 0) {
+		return (OBP_BADNODE);
 	}
 
-	phandle_t phandle = get_phandle(offset);
+	phandle_t phandle = get_phandle(child);
 	if (phandle < 0)
 		return (OBP_NONODE);
+
 	return ((pnode_t)phandle);
 }
 
@@ -410,17 +409,14 @@ prom_childnode(pnode_t nodeid)
 	if (offset < 0)
 		return (OBP_NONODE);
 
-	int depth = 0;
-	for (;;) {
-		offset = fdt_next_node(fdtp, offset, &depth);
-		if (offset < 0)
-			return (OBP_NONODE);
-		if (depth == 0)
-			return (OBP_NONODE);
-		if (depth == 1)
-			break;
+	int child = fdt_first_subnode(fdtp, offset);
+	if (child == -FDT_ERR_NOTFOUND) {
+		return (OBP_NONODE);
+	} else if (child < 0) {
+		return (OBP_BADNODE);
 	}
-	phandle_t phandle = get_phandle(offset);
+
+	phandle_t phandle = get_phandle(child);
 	if (phandle < 0)
 		return (OBP_NONODE);
 	return ((pnode_t)phandle);


### PR DESCRIPTION
Rather than trying to homebrew it, with flaws, use the libfdt `_subnode()` API.

This should stop us making arbitrary splices in the tree, where we pulled nodes of equal depth together _across branches_.

@hadfl @r1mikey this should fix the weird devicetree stuff we've been seeing (though it doesn't actually fix the early pci-hacking on rpi4 crash)