### PR TITLE
boot: Move boot_archive to an IPD 34 compliant location

### DIFF
--- a/usr/src/cmd/boot/scripts/boot-archive-update.ksh
+++ b/usr/src/cmd/boot/scripts/boot-archive-update.ksh
@@ -54,6 +54,15 @@ if [ `uname -p` = "i386" ]; then
 	[ -d $plat/archive_cache ] && rm -rf $plat/archive_cache
 fi
 
+if [ `uname -p` = "aarch64" ]; then
+	# Remove archives from pre IPD 34 location if present.
+	plat=/platform/`uname -m`
+	[ -f $plat/boot_archive ] && rm -f $plat/boot_archive
+	[ -f $plat/boot_archive.hash ] && rm -f $plat/boot_archive.hash
+	[ -f $plat/archive_cache ] && rm -f $plat/archive_cache
+	[ -d $plat/archive_cache ] && rm -rf $plat/archive_cache
+fi
+
 if [ -f $UPDATEFILE ] || [ -f /reconfigure ]; then
 	/usr/sbin/rtc -c > /dev/null 2>&1
 	/sbin/bootadm update-archive

--- a/usr/src/cmd/boot/scripts/create_ramdisk.ksh
+++ b/usr/src/cmd/boot/scripts/create_ramdisk.ksh
@@ -126,7 +126,7 @@ sun4u|sun4v)	ISA=sparc
 aarch64|armv8)  PLATFORM=armv8
 		ISA=aarch64
 		ARCH64=armv8
-		BOOT_ARCHIVE_SUFFIX=boot_archive
+		BOOT_ARCHIVE_SUFFIX=$ISA/boot_archive
 		;;
 *)		usage
 		;;

--- a/usr/src/psm/stand/boot/port/uname-i.c
+++ b/usr/src/psm/stand/boot/port/uname-i.c
@@ -137,10 +137,11 @@ newstate:
 }
 
 static void
-make_platform_path(char *fullpath, char *iarch, char *filename)
+make_platform_path(char *fullpath, char *iarch, char *isadir, char *filename)
 {
 	(void) strcpy(fullpath, "/platform/");
 	(void) strcat(fullpath, iarch);
+	(void) strcat(fullpath, isadir);
 	if (filename != NULL) {
 		(void) strcat(fullpath, "/");
 		(void) strcat(fullpath, filename);
@@ -168,7 +169,11 @@ open_platform_file(
 	 * Hunt the filesystem for one that works ..
 	 */
 	while ((ia = get_impl_arch_name(&state, 1)) != NULL) {
-		make_platform_path(fullpath, ia, filename);
+		make_platform_path(fullpath, ia, "/aarch64", filename);
+		if ((fd = (*openfn)(fullpath, arg)) != -1)
+			return (fd);
+
+		make_platform_path(fullpath, ia, "", filename);
 		if ((fd = (*openfn)(fullpath, arg)) != -1)
 			return (fd);
 	}


### PR DESCRIPTION
Out boot_archive location appears to reflect the strong SPARC influence in the original port, and as such does not include the ISA directory in the path.

So, to support treating the two modern illumos platforms as similarly as possible, move the boot archive into a location that can be constructed identically between the two platforms.

As a concrete example, on `i86pc` we have `/platform/i86pc/amd64/boot_archive`, while on `armv8` platforms we have `/platform/armv8/boot_archive`, where we should have `/platform/armv8/aarch64/boot_archive`.

This inconsistency causes us no pain today, given that we have our own highly custom `intetboot` bootloader. As we move closer to having `loader(7)` support for Arm systems this inconsistency can prevent sharing configuration files such as `loader.conf`, where `boot_archive_name` and `boot_archive.hash_name` cannot be easily shared across platforms (though these should really be using `module_path`, which would also not be easily shared without this change).

To produce images with this new location, the change in https://github.com/richlowe/arm64-gate/pull/54 is needed.

Tested in https://gist.github.com/r1mikey/72a71947d016b639ccc75a0b117d0649. This shows a freshly built image (https://gist.github.com/r1mikey/e07ea9142075d298ca1861396ebd1c22) booting, shows the built locations, reboots to automatically regerenarate the boot archive, then shows the regenerated contents.