### PR TITLE
support setting boot_time for systems that do not have a TOD

### DIFF
--- a/usr/src/uts/armv8/io/hardclk.c
+++ b/usr/src/uts/armv8/io/hardclk.c
@@ -21,6 +21,8 @@
 
 /*
  * Copyright 2017 Hayashi Naoyuki
+ * Copyright 2023 Oxide Computer Co.
+ * Copyright 2025 OmniOS Community Edition (OmniOSce) Association.
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
@@ -35,10 +37,16 @@
 #include <sys/archsystm.h>
 #include <sys/lockstat.h>
 
+#include <sys/brand.h>
 #include <sys/clock.h>
+#include <sys/door.h>
 #include <sys/debug.h>
 #include <sys/smp_impldefs.h>
 #include <sys/rtc.h>
+#include <sys/zone.h>
+
+#define	DOOR_PATH	"var/run/utmpd_door"
+#define	ONE_DAY		(24 * 3600)
 
 /*
  * This file contains all generic part of clock and timer handling.
@@ -50,6 +58,67 @@ char *tod_module_name;		/* Settable in /etc/system */
 
 extern void tod_set_prev(timestruc_t);
 
+static int
+process_zone_cb(zone_t *zone, void *arg)
+{
+	door_handle_t door;
+	int ret;
+	time_t boot_ts;
+	size_t dplen;
+	char *door_path;
+
+	/* ignore non-native zone brands */
+	if (ZONE_IS_BRANDED(zone))
+		return (0);
+
+	boot_ts = *(time_t *)arg;
+	dplen = zone->zone_rootpathlen + strlen(DOOR_PATH);
+
+	door_path = kmem_alloc(dplen, KM_NOSLEEP);
+	if (door_path == NULL)
+		return (0);
+
+	if (snprintf(door_path, dplen, "%s%s", zone->zone_rootpath,
+	    DOOR_PATH) >= dplen) {
+		goto out;
+	}
+
+	ret = door_ki_open(door_path, &door);
+	if (ret != 0) {
+		cmn_err(CE_WARN, "Time has stepped forwards; "
+		    "failed to open door to utmpd for zone %s, err %d",
+		    zone->zone_name, ret);
+
+		goto out;
+	}
+
+	door_arg_t darg = {
+		.data_ptr = (void *)&boot_ts,
+		.data_size = sizeof (boot_ts),
+	};
+
+	ret = door_ki_upcall_limited(door, &darg, NULL, 0, 0);
+	if (ret == 0) {
+		cmn_err(CE_CONT, "?Time has stepped forwards; "
+		    "successfully notified utmpd for zone %s.\n",
+		    zone->zone_name);
+	} else {
+		cmn_err(CE_WARN, "Time has stepped forwards; "
+		    "failed upcall to utmpd for zone %s, err %d",
+		    zone->zone_name, ret);
+	}
+
+	door_ki_rele(door);
+
+out:
+	kmem_free(door_path, dplen);
+	/*
+	 * Since we want to keep going if a zone is not running utmpd
+	 * for any reason, always return 0 here.
+	 */
+	return (0);
+}
+
 void
 tod_set(timestruc_t ts)
 {
@@ -59,6 +128,41 @@ tod_set(timestruc_t ts)
 		tod_set_prev(ts);		/* for tod_validate() */
 		TODOP_SET(tod_ops, ts);
 		tod_status_set(TOD_SET_DONE);	/* TOD was modified */
+	} else {
+		/*
+		 * There is no TOD unit, so there's nothing to do regarding
+		 * that.
+		 *
+		 * However we take this opportunity to spot when the clock is
+		 * stepped significantly forward, and use that as a cue that
+		 * the system clock has been set initially after time
+		 * synchronisation. When this happens we go through and update
+		 * the global `boot_time` variable, and the `zone_boot_time`
+		 * stored in each active zone (including the GZ) to correct the
+		 * kstats and so that userland software can use this to obtain
+		 * a more correct notion of the time that the system, and each
+		 * zone, booted.
+		 */
+		time_t adj = ts.tv_sec - gethrestime_sec();
+		extern time_t boot_time;
+
+		if (adj < ONE_DAY)
+			return;
+
+		if (boot_time < INT64_MAX - adj)
+			boot_time += adj;
+
+		zone_boottime_adjust(adj);
+
+		/*
+		 * Call up to each zone's utmpd process and ask it to rewrite
+		 * the utmpx and wtmpx database since the time has stepped
+		 * forward. We drop tod_lock as this can take a while.
+		 */
+		time_t boot_ts = boot_time;
+		mutex_exit(&tod_lock);
+		(void) zone_walk(process_zone_cb, &boot_ts);
+		mutex_enter(&tod_lock);
 	}
 }
 

--- a/usr/src/uts/armv8/rpi4/io/bcm2711_sensors/bcm2711_sensors.c
+++ b/usr/src/uts/armv8/rpi4/io/bcm2711_sensors/bcm2711_sensors.c
@@ -27,6 +27,7 @@
 #include <sys/cmn_err.h>
 #include <sys/sensors.h>
 #include <sys/stdbool.h>
+#include <sys/sysmacros.h>
 #include <sys/platmod.h>
 #include <sys/bcm2835_mbox.h>
 #include <sys/bcm2835_vcprop.h>
@@ -87,8 +88,7 @@ static const bcm2711_sensors_t bcm2711_sensors[] = {
 	}
 };
 
-static const int nsensors =
-    sizeof (bcm2711_sensors) / sizeof (bcm2711_sensors[0]);
+static const int nsensors = ARRAY_SIZE(bcm2711_sensors);
 
 typedef struct bcm2711_sensor {
 	struct bcmsensors	*bs_bcmsensors;

--- a/usr/src/uts/common/sys/zone.h
+++ b/usr/src/uts/common/sys/zone.h
@@ -24,6 +24,7 @@
  * Copyright 2014 Igor Kozhukhov <ikozhukhov@gmail.com>.
  * Copyright 2019 Nexenta Systems, Inc. All rights reserved.
  * Copyright 2020 Joyent, Inc.
+ * Copyright 2023 Oxide Computer Company
  */
 
 #ifndef _SYS_ZONE_H
@@ -671,7 +672,8 @@ extern zoneid_t getzoneid(void);
 extern zone_t *zone_find_by_id_nolock(zoneid_t);
 extern int zone_datalink_walk(zoneid_t, int (*)(datalink_id_t, void *), void *);
 extern int zone_check_datalink(zoneid_t *, datalink_id_t);
-extern void zone_loadavg_update();
+extern void zone_loadavg_update(void);
+extern void zone_boottime_adjust(time_t);
 
 /*
  * Zone-specific data (ZSD) APIs


### PR DESCRIPTION
This is derived from oxide.

Currently, if one boots on a device w/o a TOD (like the RPI 4) one ends up with something like this after setting the time:
```
root@braich:~# uptime
23:06:37    up 3391 day(s),  8:06,  2 users,  load average: 0.00, 0.04, 0.08
```

This adds a mechanism for systems w/o a TOD to re-set the boot time once the hardware clock jumped more than one day. The kernel will then notify `utmpd` which will update the `wtmpx` and `utmpx` databases since (and including) the last `system boot` entry:
```
root@braich:~# date
Tue Nov 10 15:03:27 UTC 2015
root@braich:~# uptime
15:03:29    up 3 min(s),  2 users,  load average: 0.46, 0.39, 0.17
root@braich:~# /usr/bin/kstat -p :::boot_time
unix:0:system_misc:boot_time    1447167641
zones:0:global:boot_time        1447167641
root@braich:~# /usr/sbin/chronyd -q
2015-11-10T15:03:50Z chronyd version 4.6.1 starting (+CMDMON +NTP +REFCLOCK -RTC +PRIVDROP -SCFILTER +SIGND +ASYNCDNS -NTS +SECHASH +IPV6 -DEBUG)
2015-11-10T15:03:54Z System clock wrong by 293162705.775413 seconds (step)
Nov 10 15:03:54 braich unix: NOTICE: Time has stepped forwards; successfully notified utmpd.
2025-02-23T17:09:01Z chronyd exiting
root@braich:~# Feb 23 17:09:02 braich genunix: WARNING: Time of Day clock error: reason [Changed in Clock Rate]. --  Stopped tracking Time Of Day clock.

root@braich:~# date
Sun Feb 23 17:09:09 UTC 2025
root@braich:~# uptime
17:09:11    up 3 min(s),  2 users,  load average: 0.26, 0.35, 0.16
root@braich:~# /usr/bin/kstat -p :::boot_time
unix:0:system_misc:boot_time    1740330348
zones:0:global:boot_time        1740330348
```

utmpd log:
```
Poll timeout set to 300
WTMPX update frequency set to 60
Max fds set to 4064
Door server running on /var/run/utmpd_door
utmp warning timer set to 3600 seconds
Load tables
  add_pid: pid = 0 fd = 0 index = 0 pidcnt = 1
Scan utmps
  add_pid: pid = 101018 fd = 32 index = 1 pidcnt = 2
  add_pid: pid = 101036 fd = 33 index = 2 pidcnt = 3
Door request received, size 8.
Boot timestamp: 1740330348
Processing database //var/adm/wtmpx
< @system boot - 2015-11-10 15:00:53.000000
> @system boot - 2025-02-23 17:05:48.000000
< @run-level S - 2015-11-10 15:01:50.000000
> @run-level S - 2025-02-23 17:06:45.000000
< @run-level S - 2015-11-10 15:01:50.000000
> @run-level S - 2025-02-23 17:06:45.000000
< @run-level S - 2015-11-10 15:01:50.000000
> @run-level S - 2025-02-23 17:06:45.000000
< @run-level 3 - 2015-11-10 15:01:52.000000
> @run-level 3 - 2025-02-23 17:06:47.000000
< .startd@ - 2015-11-10 15:01:52.000000
> .startd@ - 2025-02-23 17:06:47.000000
< .startd@ - 2015-11-10 15:01:52.000000
> .startd@ - 2025-02-23 17:06:47.000000
< zsmon@ - 2015-11-10 15:01:52.000000
> zsmon@ - 2025-02-23 17:06:47.000000
< LOGIN@console - 2015-11-10 15:01:52.000000
> LOGIN@console - 2025-02-23 17:06:47.000000
< root@console - 2015-11-10 15:02:00.000000
> root@console - 2025-02-23 17:06:55.000000
< root@ttyp0 - 2015-11-10 15:02:45.579737
drain_pipe: Recd command 1, pid 101018
> root@ttyp0 - 2025-02-23 17:07:40.579737
Processing database //var/adm/utmpx
< @system boot - 2015-11-10 15:00:53.000000
> @system boot - 2025-02-23 17:05:48.000000
< @run-level 3 - 2015-11-10 15:01:52.000000
> @run-level 3 - 2025-02-23 17:06:47.000000
< root@console - 2015-11-10 15:02:00.000000
> root@console - 2025-02-23 17:06:55.000000
< zsmon@ - 2015-11-10 15:01:52.000000
> zsmon@ - 2025-02-23 17:06:47.000000
< root@ttyp0 - 2015-11-10 15:02:45.579737
> root@ttyp0 - 2025-02-23 17:07:40.579737
Door return.
utmp warning timer expired
Scan utmps
drain_pipe: Recd command 1, pid 101036
drain_pipe: Recd command 1, pid 101018
drain_pipe: Recd command 1, pid 101036
```

I also verified on follow up boots, that utmpd does not alter earlier entries but just from the latest boot.

