### PR TITLE
fmd: prevent sign extension during P2ROUNDUP

### DIFF
--- a/usr/src/cmd/fm/fmd/common/fmd_ckpt.c
+++ b/usr/src/cmd/fm/fmd/common/fmd_ckpt.c
@@ -25,6 +25,7 @@
  */
 
 #include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/mkdev.h>
 #include <sys/stat.h>
 
@@ -46,9 +47,6 @@
 #include <fmd_ckpt.h>
 
 #include <fmd.h>
-
-#define	P2ROUNDUP(x, align)	(-(-(x) & -(align)))
-#define	IS_P2ALIGNED(v, a)	((((uintptr_t)(v)) & ((uintptr_t)(a) - 1)) == 0)
 
 /*
  * The fmd_ckpt_t structure is used to manage all of the state needed by the
@@ -372,7 +370,7 @@ fmd_ckpt_section(fmd_ckpt_t *ckp, const void *data, uint_t type, uint64_t size)
 	dp = &_fmd_ckpt_sections[type];
 
 	ckp->ckp_ptr = (uchar_t *)
-	    P2ROUNDUP((uintptr_t)ckp->ckp_ptr, dp->secd_align);
+	    P2ROUNDUP_TYPED(ckp->ckp_ptr, dp->secd_align, uintptr_t);
 
 	ckp->ckp_secp->fcfs_type = type;
 	ckp->ckp_secp->fcfs_align = dp->secd_align;
@@ -541,7 +539,7 @@ fmd_ckpt_save_nvlist(fmd_ckpt_t *ckp, nvlist_t *nvl)
 	ckp->ckp_ptr += sizeof (fcf_nvl_t) + nvsize;
 
 	ckp->ckp_ptr = (uchar_t *)
-	    P2ROUNDUP((uintptr_t)ckp->ckp_ptr, sizeof (uint64_t));
+	    P2ROUNDUP_TYPED(ckp->ckp_ptr, sizeof (uint64_t), uintptr_t);
 }
 
 static void


### PR DESCRIPTION
```
root@braich:/# mdb core.fmd.1741125751.100988
Loading modules: [ libumem.so.1 libc.so.1 libnvpair.so.1 libtopo.so.1 libuutil.so.1 libavl.so.1 libsysevent.so.1 ld.so.1 ]
> $C
0000ffffe7ffe040 libc.so.1`memcpy+0x114()
0000ffffe7ffe070 fmd_ckpt_section+0xa8(ffffe7ffe2d0, 20d9b00, 5, c0)
0000ffffe7ffe0c0 fmd_ckpt_save_buf+0x40(2118c30, ffffe7ffe2d0)
0000ffffe7ffe100 fmd_buf_hash_apply+0x4c(edf748, 422320, ffffe7ffe2d0)
0000ffffe7ffe170 fmd_ckpt_save_case+0x140(ffffe7ffe2d0, edf680)
0000ffffe7ffe1f0 fmd_ckpt_save_module+0x44(ffffe7ffe2d0, 51fa00)
0000ffffe7ffef40 fmd_ckpt_save+0x190(51fa00)
0000ffffe7ffef80 fmd_module_start+0x108(51fa00)
0000ffffe7ffefc0 fmd_thread_start+0x34(113a430)
0000ffffe7ffefe0 libc.so.1`_thrp_setup+0x70(ffffe9b07800)
0000000000000000 libc.so.1`_lwp_start()
> ::status
debugging core file of fmd (64-bit) from braich
file: /usr/lib/fm/fmd/fmd
initial argv: /usr/lib/fm/fmd/fmd -o fg=true
threading model: native threads
status: process terminated by SIGSEGV (Segmentation Fault), addr=ffffffff0219cbe0
> ffffffff0219cbe0::whatis
ffffffff0219cbe0 is unknown
```

However, rather suspiciously:

```
> 219cbe0::whatis
219cbe0 is 219cac0+120, allocated from umem_alloc_768:
            ADDR          BUFADDR        TIMESTAMP           THREAD
                            CACHE          LASTLOG         CONTENTS
         2177460          219cac0      fc6b6fc5c95               16
                           4c3028                0                0
                 libumem.so.1`umem_cache_alloc_debug+0x1e8
                 libumem.so.1`umem_cache_alloc+0x1d0
                 libumem.so.1`umem_alloc+0x60
                 fmd_alloc+0x24
                 fmd_zalloc+0x18
                 fmd_ckpt_alloc+0x68
                 fmd_ckpt_save+0x178
                 fmd_module_start+0x108
                 fmd_thread_start+0x34
                 libc.so.1`_thrp_setup+0x70
```

So it looks like something is being sign extended here. Let's step through:

```
root@braich:/# mdb /usr/lib/fm/fmd/fmd
> ::bp fmd_ckpt_section
> ::run -o fg=true
fmd_ckpt_section:       stp x29, x30, [sp, #-80]!
mdb: You've got symbols!
Loading modules: [ ld.so.1 libumem.so.1 libc.so.1 libnvpair.so.1 libtopo.so.1 libuutil.so.1 libavl.so.1 libsysevent.so.1 ]
> <x0>l
> <l::print fmd_ckpt_t
{
    ckp_src = [ "/var/fm/fmd/ckpt/zfs-diagnosis/zfs-diagnosis+" ]
    ckp_dst = [ "/var/fm/fmd/ckpt/zfs-diagnosis/zfs-diagnosis" ]
    ckp_buf = 0x2194ac0
    ckp_hdr = 0x2194ac0
    ckp_ptr = 0x2194be0
    ckp_size = 0x2b7
    ckp_secp = 0x2194b00
    ckp_modp = 0
    ckp_secs = 0
    ckp_strs = 0x2194cfc ""
    ckp_strp = 0x2194cfd ""
    ckp_strn = 0x7b
    ckp_fd = 0x39
    ckp_mp = 0x51fa00
    ckp_arg = 0
}
> ::step
mdb: target stopped at:
fmd_ckpt_section+4:     mov x29, sp
...
> <l::print fmd_ckpt_t ckp_ptr
ckp_ptr = 0x2194be0
> ::step
mdb: target stopped at:
fmd_ckpt_section+0x54:  str x4, [x19, #2064]
> ::step
mdb: target stopped at:
fmd_ckpt_section+0x58:  ldr x2, [x19, #2080]
<l::print -t fmd_ckpt_t ckp_ptr
main(void)kp_ptr = 0xffffffff02194be0
```

After staring at this bit for a bit, I realised that the alignment parameter being stored in `_fmd_ckpt_sections[type].secd_align` is a `uint32_t` and not a `size_t`, which explains
the type/sign extension.

Switching to `P2ROUNDUP_TYPED()` and using the definitions from `sys/sysmacros.h` gets this working without crashing again.
