### PR TITLE
kmdb: don't restore all of the spsr after a single-step

### DIFF
--- a/usr/src/cmd/mdb/aarch64/kmdb/kaif.c
+++ b/usr/src/cmd/mdb/aarch64/kmdb/kaif.c
@@ -446,8 +446,13 @@ kaif_step(void)
 
 	kmdb_dpi_resume_master(); /* Run the next instruction and come back */
 
-	/* restore the single step setting and mask settings */
-	(void) kmdb_dpi_set_register("spsr", spsr);
+	/*
+	 * restore the single step setting and mask settings, leave the rest
+	 * of the status register alone.
+	 */
+	(void) kmdb_dpi_get_register("spsr", &spsr);
+	(void) kmdb_dpi_set_register("spsr",
+	    (spsr & ~(PSR_SS | PSR_I)) | PSR_D);
 	write_mdscr_el1(read_mdscr_el1() & ~MDSCR_SS);
 
 	return (0);


### PR DESCRIPTION
When single stepping, we need to flip some processor state to enable stepping, disable interrupts and debug traps.

Unfortunately, this was being done by saving and restoring the spsr across the step, which clobbers the condition codes of the stepped instruction.  If that's a `cmp` awful things will happen.

Many thanks to Andy Fiddaman for debugging this.

Instead, take the spsr from after the step, and clear the flags from _that_. We could try to be more cautious and restore the pre-step state of SS,I,D but I think that just makes things more complex.