### PR TITLE
aarch64: hat: Don't clean dcache for non-memory pages

### DIFF
--- a/usr/src/uts/armv8/vm/hat_aarch64.c
+++ b/usr/src/uts/armv8/vm/hat_aarch64.c
@@ -821,8 +821,9 @@ hati_load_common(
 	else
 		PTE_SET(pte, PTE_UXN);
 
-	if ((attr & PROT_EXEC) ||
-	    (attr & HAT_ORDER_MASK) != HAT_STORECACHING_OK) {
+	if (((attr & PROT_EXEC) ||
+	    (attr & HAT_ORDER_MASK) != HAT_STORECACHING_OK) &&
+	    pf_is_memory(pfn)) {
 		clean_dcache(hat_kpm_pfn2va(pfn), LEVEL_SIZE(level));
 	}
 


### PR DESCRIPTION
The dcache cleaning implementation assumes that the referenced PFN can be found mapped in segkpm, but we're actively removing device mappings from that region. Attempting to clean an unmapped range in the KVA traps, causing boot to fail when the boot UART (or framebuffer) is remapped, which triggers this cache-cleaning for a non-existent mapping.

As with all fun-to-debug bugs this only showed up on real hardware, which was rpi4 in my case.

Tested in my loader-aarch64 branch (https://github.com/r1mikey/illumos-gate/tree/r1mikey/loader-aarch64) - this branch does no device mapping in segkpm at all.