### PR TITLE
bcm2711_pcie: reset and enable PCIe controller

### DIFF
--- a/usr/src/uts/armv8/io/pciex/ecam/ecam.c
+++ b/usr/src/uts/armv8/io/pciex/ecam/ecam.c
@@ -50,7 +50,7 @@ ecam_cfgspace_acc(pci_cfgacc_req_t *req)
 
 	if (!pcie_cfgspace_access_check(bus, dev, func, reg, req->size)) {
 		if (!req->write)
-			VAL64(req) = -1;
+			VAL64(req) = PCI_EINVAL64;
 		return;
 	}
 


### PR DESCRIPTION
```
root@braich:~# /usr/lib/pci/pcieadm show-devs
BDF     TYPE           INSTANCE       DEVICE
0/0/0   PCI            --             BCM2711 PCIe Bridge
1/0/0   PCI            --             VL805/806 xHCI USB 3.0 Controller
```