### PR TITLE
kmdb: deferred breakpoint resolution can enter infinite loop

### DIFF
--- a/usr/src/cmd/mdb/aarch64/aarch64/kmdb/kmdb_asmutil.S
+++ b/usr/src/cmd/mdb/aarch64/aarch64/kmdb/kmdb_asmutil.S
@@ -32,6 +32,16 @@
 	ret
 	SET_SIZE(membar_producer)
 
+	ENTRY(flush_instr)
+	dc	cvau, x0
+	dsb	ish
+	ic	ivau, x0
+	dsb	ish
+	isb
+	nop
+	ret
+	SET_SIZE(flush_instr)
+
 	ENTRY(get_fp)
 	mov	x0, fp
 	ret

--- a/usr/src/cmd/mdb/aarch64/kmdb/kaif.c
+++ b/usr/src/cmd/mdb/aarch64/kmdb/kaif.c
@@ -39,6 +39,7 @@
 #include <kmdb/kmdb_io.h>
 #include <kmdb/kaif_start.h>
 #include <kmdb/kvm_isadep.h>
+#include <kmdb/kmdb_asmutil.h>
 
 #include <mdb/mdb_err.h>
 #include <mdb/mdb_debug.h>
@@ -237,6 +238,8 @@ kaif_brkpt_arm(uintptr_t addr, mdb_instr_t *instrp)
 	    sizeof (mdb_instr_t), addr) != sizeof (mdb_instr_t))
 		return (-1); /* errno is set for us */
 
+	flush_instr(addr);
+
 	return (0);
 }
 
@@ -246,6 +249,8 @@ kaif_brkpt_disarm(uintptr_t addr, mdb_instr_t instrp)
 	if (mdb_tgt_awrite(mdb.m_target, MDB_TGT_AS_VIRT_I, &instrp,
 	    sizeof (mdb_instr_t), addr) != sizeof (mdb_instr_t))
 		return (-1); /* errno is set for us */
+
+	flush_instr(addr);
 
 	return (0);
 }

--- a/usr/src/cmd/mdb/aarch64/kmdb/kmdb_asmutil.h
+++ b/usr/src/cmd/mdb/aarch64/kmdb/kmdb_asmutil.h
@@ -35,6 +35,7 @@ extern "C" {
 
 extern uintptr_t cas(uintptr_t *, uintptr_t, uintptr_t);
 extern void membar_producer(void);
+extern void flush_instr(uint64_t);
 
 extern uintptr_t get_fp(void);
 


### PR DESCRIPTION
When using deferred breakpoints on rpi4, kmdb never recovers after resolving the breakpoints following a module load. Despite replacing the `brk #0x0` instruction at the start of kmt_defbp_enter_debugger with the original before resuming, the system behaves as if the original brk instruction is still there.

The loop looks like:

    mdb DEBUG: brkpt disarmed at fffffffffe4d54d0 kmt_defbp_enter_debugger
    mdb DEBUG: Resume requested, pc is fffffffffe4d54d0
    mdb DEBUG: returning to driver - cmd 2 (work required)
    mdb DEBUG: Back from resume, pc: fffffffffe4d54d0, trapno: 60
    mdb DEBUG: returning from resume

Note that we continue to get trap 60 and the PC does not advance.

Flushing both the data and instruction caches for the address of the patched instruction, as well as data and instruction barriers, resolves the problem.

Per ARMv8-A-C.a-Dec2017 B2.2.5 Concurrent modification and execution of instructions

@hadfl