### PR TITLE
boot: Document the UART location for Ampere Altra Max

### DIFF
--- a/usr/src/uts/armv8/boot/boot_early_uart.h
+++ b/usr/src/uts/armv8/boot/boot_early_uart.h
@@ -31,9 +31,10 @@
 
 #if defined(_EARLY_DBG_UART) && _EARLY_DBG_UART > 0
 /*
- *  qemu sbsa-ref is: 0x60000000ULL, 0x000eULL
- *      qemu virt is: 0x09000000ULL, 0x000eULL
- * Raspberry Pi 4 is: 0xfe201000ULL, 0x000eULL
+ *    qemu sbsa-ref is: 0x60000000ULL, 0x000eULL
+ *        qemu virt is: 0x09000000ULL, 0x000eULL
+ *   Raspberry Pi 4 is: 0xfe201000ULL, 0x000eULL
+ * Ampere Altra Max is: 0x100002620000ULL, 0x0003ULL
  */
 #define	EARLY_UART_PA	0x0ULL
 #define	EARLY_UART_TYPE	0x0ULL


### PR DESCRIPTION
Nothing exciting this time around, recording the early UART address for Ampere Altra Max systems.