### PR TITLE
status_okay should return false if device is disabled in the device tree

### DIFF
--- a/usr/src/uts/armv8/io/ns16550a/ns16550a.c
+++ b/usr/src/uts/armv8/io/ns16550a/ns16550a.c
@@ -740,7 +740,6 @@ struct streamtab ns16550_str_info = {
 
 static int ns16550info(dev_info_t *dip, ddi_info_cmd_t infocmd, void *arg,
 		void **result);
-static int ns16550probe(dev_info_t *);
 static int ns16550attach(dev_info_t *, ddi_attach_cmd_t);
 static int ns16550detach(dev_info_t *, ddi_detach_cmd_t);
 static int ns16550quiesce(dev_info_t *);
@@ -768,7 +767,7 @@ struct dev_ops ns16550_ops = {
 	0,			/* devo_refcnt */
 	ns16550info,		/* devo_getinfo */
 	nulldev,		/* devo_identify */
-	ns16550probe,		/* devo_probe */
+	nulldev,		/* devo_probe */
 	ns16550attach,		/* devo_attach */
 	ns16550detach,		/* devo_detach */
 	nodev,			/* devo_reset */
@@ -928,26 +927,6 @@ ns16550detach(dev_info_t *devi, ddi_detach_cmd_t cmd)
 	}
 
 	return (DDI_SUCCESS);
-}
-
-/* Check the device is not disabled  */
-static int
-ns16550probe(dev_info_t *dip)
-{
-	char *buf;
-
-	if (ddi_prop_lookup_string(DDI_DEV_T_ANY, dip, 0,
-	    OBP_STATUS, &buf) != DDI_SUCCESS) {
-		return (DDI_PROBE_SUCCESS);
-	}
-
-	if (strcmp(buf, "ok") != 0 && strcmp(buf, "okay") != 0) {
-		ddi_prop_free(buf);
-		return (DDI_PROBE_FAILURE);
-	}
-
-	ddi_prop_free(buf);
-	return (DDI_PROBE_SUCCESS);
 }
 
 static int

--- a/usr/src/uts/armv8/rpi4/io/bcm2711_emmctwo/bcm2711_emmctwo.c
+++ b/usr/src/uts/armv8/rpi4/io/bcm2711_emmctwo/bcm2711_emmctwo.c
@@ -1659,26 +1659,6 @@ mmc_quiesce(dev_info_t *dip)
 	return (DDI_FAILURE);
 }
 
-/* Check the device is not disabled */
-static int
-mmc_probe(dev_info_t *dip)
-{
-	char *buf;
-
-	if (ddi_prop_lookup_string(DDI_DEV_T_ANY, dip, 0,
-	    OBP_STATUS, &buf) != DDI_SUCCESS) {
-		return (DDI_PROBE_SUCCESS);
-	}
-
-	if (strcmp(buf, "ok") != 0 && strcmp(buf, "okay") != 0) {
-		ddi_prop_free(buf);
-		return (DDI_PROBE_FAILURE);
-	}
-
-	ddi_prop_free(buf);
-	return (DDI_PROBE_SUCCESS);
-}
-
 static uint_t
 mmc_intr(caddr_t arg1, caddr_t arg2)
 {
@@ -1839,7 +1819,7 @@ static struct dev_ops mmc_dev_ops = {
 	0,				/* devo_refcnt */
 	ddi_no_info,			/* devo_getinfo */
 	nulldev,			/* devo_identify */
-	mmc_probe,			/* devo_probe */
+	nulldev,			/* devo_probe */
 	mmc_attach,			/* devo_attach */
 	mmc_detach,			/* devo_detach */
 	nodev,				/* devo_reset */

--- a/usr/src/uts/armv8/rpi4/io/bcm2711_genet/bcm2711_genet.c
+++ b/usr/src/uts/armv8/rpi4/io/bcm2711_genet/bcm2711_genet.c
@@ -716,25 +716,6 @@ genet_mii_read(void *arg, uint8_t phy, uint8_t reg)
 	return (data);
 }
 
-static int
-genet_probe(dev_info_t *dip)
-{
-	char *buf;
-
-	if (ddi_prop_lookup_string(DDI_DEV_T_ANY, dip, 0,
-	    OBP_STATUS, &buf) != DDI_SUCCESS) {
-		return (DDI_PROBE_SUCCESS);
-	}
-
-	if (strcmp(buf, "ok") != 0 && strcmp(buf, "okay") != 0) {
-		ddi_prop_free(buf);
-		return (DDI_PROBE_FAILURE);
-	}
-
-	ddi_prop_free(buf);
-	return (DDI_PROBE_SUCCESS);
-}
-
 static void
 genet_mii_notify(void *arg, link_state_t link)
 {
@@ -1247,7 +1228,7 @@ genet_m_ioctl(void *arg, queue_t *wq, mblk_t *mp)
 
 extern struct mod_ops mod_driverops;
 
-DDI_DEFINE_STREAM_OPS(genet_devops, nulldev, genet_probe, genet_attach,
+DDI_DEFINE_STREAM_OPS(genet_devops, nulldev, nulldev, genet_attach,
     genet_detach, nodev, NULL, D_MP, NULL, genet_quiesce);
 
 static struct modldrv genet_modldrv = {


### PR DESCRIPTION
Currently, `status_okay` will only return false if the device's status is `/^fail/`. This leads to trying to attach drivers which are disabled in the device three unless there is an individual probe in the driver itself.

I don't think there is a case on arm that a device with status `disabled` ever gets operational later. This commit makes `check_status` fail for disabled devices as well removing the need for individual probes in drivers.

Replaces https://github.com/richlowe/illumos-gate/pull/139

@r1mikey, @richlowe what do you think?