### PR TITLE
loader(7): 01 of 16 - preparation

### DIFF
--- a/usr/src/common/util/bzero.c
+++ b/usr/src/common/util/bzero.c
@@ -37,9 +37,14 @@
 #include "lint.h"
 #endif /* !_KMDB && !_BOOT */
 
+#if defined(_BOOT)
+#include <sys/types.h>
+#include <sys/systm.h>
+#else
 #include <sys/types.h>
 #include <string.h>
 #include <strings.h>
+#endif
 
 /*
  * Set an array of n chars starting at sp to zero.

--- a/usr/src/common/util/memchr.c
+++ b/usr/src/common/util/memchr.c
@@ -29,7 +29,7 @@
 
 
 #include <sys/types.h>
-#if defined(_KERNEL)
+#if defined(_KERNEL) || defined(_BOOT)
 #include <sys/systm.h>
 #else
 #include <string.h>

--- a/usr/src/common/util/memcmp.c
+++ b/usr/src/common/util/memcmp.c
@@ -35,7 +35,7 @@
 #endif /* !_KMDB && !_BOOT && !_KERNEL */
 
 #include <sys/types.h>
-#if defined(_KERNEL)
+#if defined(_KERNEL) || defined(_BOOT)
 #include <sys/systm.h>
 #else
 #include <string.h>

--- a/usr/src/common/util/memmove.c
+++ b/usr/src/common/util/memmove.c
@@ -26,7 +26,7 @@
 /*	Copyright (c) 1988 AT&T	*/
 /*	  All Rights Reserved  	*/
 
-#if !defined(_KMDB) && !defined(_KERNEL)
+#if !defined(_KMDB) && !defined(_KERNEL) && !defined(_BOOT)
 
 #include "lint.h"
 
@@ -40,7 +40,7 @@
 
 #include <sys/types.h>
 
-#if defined(_KERNEL)
+#if defined(_KERNEL) || defined(_BOOT)
 #include <sys/systm.h>
 #else
 #include <string.h>

--- a/usr/src/common/util/strtoul.c
+++ b/usr/src/common/util/strtoul.c
@@ -42,10 +42,17 @@
 #include <stand.h>
 #include <limits.h>
 #else
+#if	defined(_BOOT)
+#include <sys/ctype.h>
+#include <sys/null.h>
+#include <sys/errno.h>
+extern int errno;
+#else
 #include <errno.h>
 #include <ctype.h>
 #include <limits.h>
 #include <stdlib.h>
+#endif
 #endif	/* _STANDALONE */
 #endif	/* _KERNEL && !_BOOT */
 #include "strtolctype.h"

--- a/usr/src/contrib/libfdt/libfdt_env.h
+++ b/usr/src/contrib/libfdt/libfdt_env.h
@@ -7,17 +7,30 @@
  * Copyright 2012 Kim Phillips, Freescale Semiconductor.
  */
 
+#if defined(_STANDALONE)
+#include <stand.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <limits.h>
+#else
 #include <sys/inttypes.h>
 #include <sys/null.h>
 #include <sys/types.h>
 #include <sys/stdbool.h>
+#endif
 
 #if defined(_KERNEL) && !defined(_BOOT)
 #include <sys/ddi.h>
 #include <sys/sunddi.h>
-#else
+#elif (!defined(_STANDALONE) && !defined(_BOOT))
 #include <stdlib.h>
 #include <string.h>
+#elif defined(_BOOT)
+#include <sys/systm.h>
+extern size_t strlen(const char *) __PURE;
+extern size_t strnlen(const char *, size_t) __PURE;
+extern void *memchr(const void *, int, size_t);
+extern unsigned long strtoul(const char *, char **, int);
 #endif
 
 #ifdef __CHECKER__

--- a/usr/src/uts/common/sys/types.h
+++ b/usr/src/uts/common/sys/types.h
@@ -593,7 +593,8 @@ typedef	unsigned int	uint;
 typedef	unsigned long	ulong;
 /* END CSTYLED */
 
-#if defined(_KERNEL) || defined(_FAKE_KERNEL)
+#if defined(_KERNEL) || defined(_FAKE_KERNEL) || \
+	(defined(__aarch64__) && defined(_BOOT))
 
 #define	CHAR_BIT	8		/* max # of bits in a "char" */
 #define	SCHAR_MIN	(-128)		/* min value of a "signed char" */


### PR DESCRIPTION
This preparation PR includes changes to headers and common code needed to build `loader(7)` and `dboot` for aarch64.

The only mildly controversial change is in `usr/src/uts/common/sys/types.h`, where we enable integer type limits visibility for `dboot`, but only for `aarch64`. This is done to reduce impact on other platforms.