### PR TITLE
loader(7): 03 of 16 - loader portability

### DIFF
--- a/usr/src/boot/common/module.c
+++ b/usr/src/boot/common/module.c
@@ -80,7 +80,11 @@ static vm_offset_t loadaddr = 0;
 #if defined(LOADER_FDT_SUPPORT)
 static const char *default_searchpath = "/boot/kernel;/boot/modules;/boot/dtb";
 #else
+#if defined(__aarch64__)
+static const char *default_searchpath = "/platform/armv8";
+#else
 static const char *default_searchpath = "/platform/i86pc";
+#endif
 #endif
 
 static STAILQ_HEAD(, moduledir) moduledir_list =

--- a/usr/src/boot/efi/loader/loader_efi.h
+++ b/usr/src/boot/efi/loader/loader_efi.h
@@ -64,6 +64,8 @@ void * efi_translate(vm_offset_t);
 vm_offset_t efi_physaddr(multiboot_tag_module_t *, vm_offset_t,
     EFI_MEMORY_DESCRIPTOR *, size_t, UINTN, vm_offset_t, size_t);
 void bi_isadir(void);
+void bi_basearch(void);
+void bi_implarch(void);
 
 multiboot2_info_header_t *efi_copy_finish(struct relocator *);
 void multiboot_tramp(uint32_t, struct relocator *, uint64_t);

--- a/usr/src/boot/efi/loader/main.c
+++ b/usr/src/boot/efi/loader/main.c
@@ -941,6 +941,8 @@ main(int argc, CHAR16 *argv[])
 	autoload_font(false);		/* Set up the font list for console. */
 	efi_init_environment();
 	bi_isadir();			/* set ISADIR */
+	bi_basearch();			/* set BASEARCH */
+	bi_implarch();			/* set IMPLARCH */
 	acpi_detect();
 
 	if ((ptr = efi_get_table(&gEfiSmbios3TableGuid)) == NULL)

--- a/usr/src/boot/forth/loader.conf
+++ b/usr/src/boot/forth/loader.conf
@@ -13,7 +13,7 @@
 
 exec=".( Loading /boot/defaults/loader.conf ) cr"
 
-kernel="i86pc/kernel/${ISADIR}"	# /platform sub-directory containing kernel
+kernel="${BASEARCH}/kernel/${ISADIR}"	# /platform sub-directory containing kernel
 bootfile="unix"		# Kernel name (possibly absolute path)
 # boot-args=""		# Flags to be passed to the kernel
 
@@ -60,7 +60,7 @@ loader_logo="illumos"		# Desired logo: orbbw, orb, fbsdbw, beastiebw, beastie, n
 #loader_brand="illumos"		# brand name
 console="text,ttya,ttyb,ttyc,ttyd"	# A comma separated list of console(s)
 #currdev="disk1s1a"		# Set the current device
-module_path="/platform/i86pc/${ISADIR}/"	# Set the module search path
+module_path="/platform/${BASEARCH}/${ISADIR}/"	# Set the module search path
 #prompt="\\${interpret}"	# Set the command prompt
 #root_disk_unit="0"		# Force the root disk unit number
 #rootdev="disk1s1a"		# Set the root filesystem
@@ -77,11 +77,11 @@ module_path="/platform/i86pc/${ISADIR}/"	# Set the module search path
 ##############################################################
 boot_archive_load="YES"		# illumos will not boot without rootfs
 boot_archive_type="rootfs"
-boot_archive_name="/platform/i86pc/${ISADIR}/boot_archive"
+boot_archive_name="/platform/${BASEARCH}/${ISADIR}/boot_archive"
 
 boot_archive.hash_load="YES"	# use hash file as it will use ISADIR
 boot_archive.hash_type="hash"
-boot_archive.hash_name="/platform/i86pc/${ISADIR}/boot_archive.hash"
+boot_archive.hash_name="/platform/${BASEARCH}/${ISADIR}/boot_archive.hash"
 
 ##############################################################
 ###  Module loading syntax example  ##########################

--- a/usr/src/boot/i386/libi386/cpuid.c
+++ b/usr/src/boot/i386/libi386/cpuid.c
@@ -142,3 +142,26 @@ bi_isadir(void)
 		    "variable: %d\n", rc);
 	}
 }
+
+void
+bi_basearch(void)
+{
+	int rc;
+	if ((rc = setenv("BASEARCH", "i86pc", 1)) != 0) {
+		printf("Warning: failed to set BASEARCH environment "
+		    "variable: %d\n", rc);
+	}
+}
+
+/*
+ * IMPLARCH is the same as BASEARCH for i86pc.
+ */
+void
+bi_implarch(void)
+{
+	int rc;
+	if ((rc = setenv("IMPLARCH", "i86pc", 1)) != 0) {
+		printf("Warning: failed to set IMPLARCH environment "
+		    "variable: %d\n", rc);
+	}
+}

--- a/usr/src/boot/i386/libi386/libi386.h
+++ b/usr/src/boot/i386/libi386/libi386.h
@@ -144,6 +144,8 @@ int	bi_load64(char *args, vm_offset_t addr, vm_offset_t *modulep,
 	    vm_offset_t *kernend, int add_smap);
 int	bi_checkcpu(void);
 void	bi_isadir(void);
+void	bi_basearch(void);
+void	bi_implarch(void);
 
 int	mb_kernel_cmdline(struct preloaded_file *, struct devdesc *, char **);
 void	multiboot_tramp(uint32_t, vm_offset_t, vm_offset_t);

--- a/usr/src/boot/i386/loader/main.c
+++ b/usr/src/boot/i386/loader/main.c
@@ -197,6 +197,8 @@ main(void)
 	autoload_font(OPT_CHECK(RBX_TEXT_MODE) != 0);
 
 	bi_isadir();
+	bi_basearch();
+	bi_implarch();
 	bios_getsmap();
 
 	interact(NULL);


### PR DESCRIPTION
A small change to improve reusability of `loader.conf` by no longer hardcoding `i86pc`.

This is still not perfect, due to a Forth bug where the `kernel` list processing does not prepend `/platform` for entries past the first one. Once that's addressed we won't need any overrides.

Will be rebased once https://github.com/richlowe/illumos-gate/pull/147 lands.