### PR TITLE
loader(7): 04 of 16 - build support and libficl

### DIFF
--- a/usr/src/boot/Makefile
+++ b/usr/src/boot/Makefile
@@ -15,9 +15,11 @@
 
 .KEEP_STATE:
 
-include $(SRC)/Makefile.master
+include $(SRC)/boot/Makefile.master
 
-INSTDIRS = i386 efi forth
+i386_INSTDIRS = i386
+aarch64_INSTDIRS =
+INSTDIRS = $($(MACH)_INSTDIRS) efi forth
 SUBDIRS = libsa libficl $(INSTDIRS)
 
 all	:=	TARGET = all

--- a/usr/src/boot/Makefile.inc
+++ b/usr/src/boot/Makefile.inc
@@ -43,19 +43,29 @@ LZ4=		$(SRC)/common/lz4
 # set standard values
 AS_CPPFLAGS=
 CPPFLAGS=	-D_STANDALONE -_gcc=-nostdinc
-CFLAGS64=	-_gcc=-mno-red-zone
+i386_CFLAGS64=	-_gcc=-mno-red-zone
+aarch64_CFLAGS64=
+CFLAGS64=	$($(MACH)_CFLAGS64)
 
-CFLAGS=		-_gcc=-Os -_gcc=-ffreestanding -_gcc=-fno-builtin
+i386_CFLAGS=	-_gcc=-mno-mmx -_gcc=-mno-3dnow -_gcc=-mno-sse -_gcc=-mno-sse2
+i386_CFLAGS +=	-_gcc=-mno-sse3 -_gcc=-msoft-float
+i386_CFLAGS +=	-_gcc=-mno-avx -_gcc=-mno-aes
+aarch64_CFLAGS=
+CFLAGS=		$($(MACH)_CFLAGS)
+CFLAGS +=	-_gcc=-Os -_gcc=-ffreestanding -_gcc=-fno-builtin
 CFLAGS +=	-_gcc=-ffunction-sections -_gcc=-fdata-sections
-CFLAGS +=	-_gcc=-mno-mmx -_gcc=-mno-3dnow -_gcc=-mno-sse -_gcc=-mno-sse2
-CFLAGS +=	-_gcc=-mno-sse3 -_gcc=-msoft-float
-CFLAGS +=	-_gcc=-mno-avx -_gcc=-mno-aes
 CFLAGS +=	-_gcc=-Wall -_gcc=-Werror
 CFLAGS +=	$(CCNOAUTOINLINE) $(CCNOREORDER) $(CSTD_GNU99)
 CFLAGS +=	$(CSOURCEDEBUGFLAGS)
-CCASFLAGS=	-Wa,--divide
-ASFLAGS=	-Wa,--divide
-ASFLAGS64=	-Wa,--divide
+i386_CCASFLAGS=	-Wa,--divide
+aarch64_CCASFLAGS=
+CCASFLAGS =	$($(MACH)_CCASFLAGS)
+i386_ASFLAGS=	-Wa,--divide
+aarch64_ASFLAGS=
+ASFLAGS=	$($(MACH)_ASFLAGS)
+i386_ASFLAGS64=	-Wa,--divide
+aarch64_ASFLAGS64=
+ASFLAGS64=	$($(MACH)_ASFLAGS64)
 
 SMATCH_ =
 SMATCH_on =

--- a/usr/src/boot/Makefile.master
+++ b/usr/src/boot/Makefile.master
@@ -1,0 +1,19 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 Michael van der Westhuizen
+#
+
+include $(SRC)/Makefile.master
+
+# maintain the FreeBSD names for aarch64
+aarch64_MACH64		= arm64

--- a/usr/src/boot/efi/Makefile
+++ b/usr/src/boot/efi/Makefile
@@ -15,9 +15,12 @@
 
 .KEEP_STATE:
 
-include $(SRC)/Makefile.master
+include $(SRC)/boot/Makefile.master
 
-SUBDIRS = libefi loader
+i386_SUBDIRS =
+aarch64_SUBDIRS =
+
+SUBDIRS = libefi $($(MACH)_SUBDIRS) loader
 
 all install clean clobber: $(SUBDIRS)
 
@@ -26,7 +29,7 @@ clean	:=	TARGET = clean
 clobber	:=	TARGET = clobber
 install	:=	TARGET = install
 
-loader:	libefi
+loader:	libefi $($(MACH)_SUBDIRS)
 
 .PARALLEL:
 $(SUBDIRS): FRC

--- a/usr/src/boot/libficl/Makefile
+++ b/usr/src/boot/libficl/Makefile
@@ -13,9 +13,11 @@
 # Copyright 2016 Toomas Soome <tsoome@me.com>
 #
 
-include $(SRC)/Makefile.master
+include $(SRC)/boot/Makefile.master
 
-SUBDIRS = softcore $(MACH) $(MACH64)
+i386_SUBDIRS = $(MACH) $(MACH64)
+aarch64_SUBDIRS = $(MACH64)
+SUBDIRS = softcore $($(MACH)_SUBDIRS)
 
 all	:=	TARGET = all
 install	:=	TARGET = install
@@ -25,7 +27,7 @@ clobber	:=	TARGET = clobber
 all install: $(SUBDIRS)
 clean clobber: $(SUBDIRS)
 
-$(MACH) $(MACH64): softcore
+$($(MACH)_SUBDIRS): softcore
 
 .PARALLEL:
 

--- a/usr/src/boot/libficl/amd64/Makefile
+++ b/usr/src/boot/libficl/amd64/Makefile
@@ -14,7 +14,7 @@
 # Copyright 2016 RackTop Systems.
 #
 
-include $(SRC)/Makefile.master
+include $(SRC)/boot/Makefile.master
 
 MACHINE=	$(MACH64)
 DYNLIB=		libficl_pics.a

--- a/usr/src/boot/libficl/arm64/Makefile
+++ b/usr/src/boot/libficl/arm64/Makefile
@@ -10,25 +10,22 @@
 #
 
 #
-# Copyright 2018 Toomas Soome <tsoome@me.com>
+# Copyright 2016 Toomas Soome <tsoome@me.com>
+# Copyright 2016 RackTop Systems.
+# Copyright 2025 Michael van der Westhuizen
 #
 
 include $(SRC)/boot/Makefile.master
 
-install all: softcore.c
+MACHINE=	$(MACH64)
+DYNLIB=		libficl_pics.a
 
-SOFTCORE=	$(SRC)/common/ficl/softcore
-PROG=		$(ONBLD_TOOLS)/bin/$(NATIVE_MACH)/makesoftcore
+all install: $(DYNLIB)
 
-#
-# not needed: file access
-#
-FR = softcore.fr ifbrack.fr prefix.fr ficl.fr jhlocal.fr marker.fr
-FR += freebsd.fr ficllocal.fr oo.fr classes.fr string.fr wordsets.fr
-SOURCES=	$(FR:%=$(SOFTCORE)/%)
+include ../Makefile.com
 
-softcore.c: $(SOURCES)
-	$(PROG) $(SOURCES)
+CFLAGS += $(CFLAGS64)
 
-clobber clean:
-	$(RM) softcore.c
+include $(BOOTSRC)/Makefile.lib
+
+FRC:


### PR DESCRIPTION
Add support for building an `aarch64` loader and add `aarch64` support to libficl. Loader itself will not build for `aarch64` at this point in the stack.

Note the addition of `usr/src/boot/Makefile.master`, which is used to override `MACH64` for the subtree, keeping the FreeBSD name (`arm64`).

Will be rebased once https://github.com/richlowe/illumos-gate/pull/148 lands.