### PR TITLE
loader(7): 06 of 16 - libefi, common, stdarg

### DIFF
--- a/usr/src/boot/common/misc.c
+++ b/usr/src/boot/common/misc.c
@@ -220,7 +220,7 @@ dev_cleanup(void)
 	    (devsw[i]->dv_cleanup)();
 }
 
-#ifndef BOOT2
+#if !defined(BOOT2) && (defined(__i386) || defined(__amd64))
 /*
  * outb ( port# c -- )
  * Store a byte to I/O port number port#

--- a/usr/src/boot/common/module.c
+++ b/usr/src/boot/common/module.c
@@ -753,6 +753,15 @@ mod_load(char *modname, struct mod_depend *verinfo, int argc, char *argv[])
 	int err;
 	char *filename;
 
+	/*
+	 * On aarch64 systems the first loaded module must be the kernel.
+	 */
+#if defined(__aarch64__)
+	if (file_findfile(NULL, NULL) == NULL) {
+		return (mod_loadkld(modname, argc, argv));
+	}
+#endif
+
 	if (file_havepath(modname)) {
 		printf("Warning: mod_load() called instead of mod_loadkld() "
 		    "for module '%s'\n", modname);

--- a/usr/src/boot/efi/include/arm64/ProcessorBind.h
+++ b/usr/src/boot/efi/include/arm64/ProcessorBind.h
@@ -91,8 +91,13 @@ typedef signed char       INT8;
 //
 // Assume standard AARCH64 alignment.
 //
+#ifndef	ACPI_THREAD_ID			/* ACPI's definitions are fine */
+#if !defined(ACPI_USE_SYSTEM_INTTYPES)
+#define	ACPI_USE_SYSTEM_INTTYPES	/* Tell ACPI we've defined types */
+#endif
 typedef unsigned long long  UINT64;
 typedef long long           INT64;
+#endif
 typedef unsigned int        UINT32;
 typedef int                 INT32;
 typedef unsigned short      UINT16;

--- a/usr/src/boot/efi/libefi/Makefile.com
+++ b/usr/src/boot/efi/libefi/Makefile.com
@@ -13,7 +13,7 @@
 # Copyright 2016 Toomas Soome <tsoome@me.com>
 #
 
-include $(SRC)/Makefile.master
+include $(SRC)/boot/Makefile.master
 include $(SRC)/boot/Makefile.inc
 
 install:

--- a/usr/src/boot/efi/libefi/arm64/Makefile
+++ b/usr/src/boot/efi/libefi/arm64/Makefile
@@ -11,27 +11,19 @@
 
 #
 # Copyright 2016 Toomas Soome <tsoome@me.com>
+# Copyright 2016 RackTop Systems.
+# Copyright 2025 Michael van der Westhuizen
 #
 
-.KEEP_STATE:
+MACHINE=	$(MACH64)
 
-include $(SRC)/boot/Makefile.master
+all:		libefi.a
 
-i386_SUBDIRS = $(MACH) $(MACH64)
-aarch64_SUBDIRS = $(MACH64)
-SUBDIRS = $($(MACH)_SUBDIRS)
+OBJS=	time_event.o
+include ../Makefile.com
 
-all	:=	TARGET = all
-clean	:=	TARGET = clean
-clobber	:=	TARGET = clobber
-install	:=	TARGET = install
+CFLAGS +=	$(CFLAGS64)
 
-all clean clobber: $(SUBDIRS)
+CLEANFILES +=	machine
 
-install: all
-
-.PARALLEL:
-$(SUBDIRS): FRC
-	@cd $@; pwd; $(MAKE) $(TARGET)
-
-FRC:
+$(OBJS): machine

--- a/usr/src/boot/efi/libefi/efi_console.c
+++ b/usr/src/boot/efi/libefi/efi_console.c
@@ -457,8 +457,13 @@ efi_framebuffer_setup(void)
 	}
 	shadow_sz = EFI_SIZE_TO_PAGES(efifb.fb_width * efifb.fb_height *
 	    sizeof (*shadow_fb));
+#if defined(__aarch64__)
+	status = BS->AllocatePages(AllocateAnyPages, EfiLoaderData,
+	    shadow_sz, (EFI_PHYSICAL_ADDRESS *)&shadow_fb);
+#else
 	status = BS->AllocatePages(AllocateMaxAddress, EfiLoaderData,
 	    shadow_sz, (EFI_PHYSICAL_ADDRESS *)&shadow_fb);
+#endif
 	if (status != EFI_SUCCESS)
 		shadow_fb = NULL;
 

--- a/usr/src/boot/include/stdarg.h
+++ b/usr/src/boot/include/stdarg.h
@@ -3,4 +3,8 @@
  */
 /* $FreeBSD$ */
 
+#if defined(__aarch64__)
+#include <machine/stdarg.h>
+#else
 #include <x86/stdarg.h>
+#endif


### PR DESCRIPTION
Adds `aarch64` support for the `loader(7)` `libefi`, `common` code and `stdarg.h` and wires them up to the build.

Will be rebased once https://github.com/richlowe/illumos-gate/pull/150 lands.