### PR TITLE
loader(7): 07 of 16 - loader arch support

### DIFF
--- a/usr/src/boot/efi/loader/arch/arm64/Makefile.inc
+++ b/usr/src/boot/efi/loader/arch/arm64/Makefile.inc
@@ -1,24 +1,34 @@
-# $FreeBSD$
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
 
-LOADER_FDT_SUPPORT=yes
-SRCS+=	exec.c \
+#
+# Copyright 2025 Michael van der Westhuizen
+#
+
+SRCS +=	bootsvcs.c \
+	cache.c \
+	exec.c \
+	isadir.c \
 	start.S
 
-.PATH:	${.CURDIR}/../../arm64/libarm64
-CFLAGS+=-I${.CURDIR}/../../arm64/libarm64
-SRCS+=	cache.c
+OBJS +=	bootsvcs.o \
+	cache.o \
+	exec.o \
+	isadir.o \
+	start.o
 
-CFLAGS+=	-msoft-float -mgeneral-regs-only
+SRCS += nullconsole.c \
+	spinconsole.c
 
-CLEANFILES+=	loader.help
+OBJS += nullconsole.o \
+	spinconsole.o
 
-loader.help: help.common
-	cat ${.ALLSRC} | \
-	    awk -f ${.CURDIR}/../../common/merge_help.awk > ${.TARGET}
-
-.if !defined(LOADER_ONLY)
-.PATH: ${.CURDIR}/../../forth
-.include	"${.CURDIR}/../../forth/Makefile.inc"
-
-FILES+=	loader.rc
-.endif
+start.o := CCASFLAGS += $(C_BIGPICFLAGS)

--- a/usr/src/boot/efi/loader/arch/arm64/bootsvcs.c
+++ b/usr/src/boot/efi/loader/arch/arm64/bootsvcs.c
@@ -1,0 +1,18 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2025 Michael van der Westhuizen
+ */
+
+#include <efi.h>
+
+bool has_boot_services = true;

--- a/usr/src/boot/efi/loader/arch/arm64/cache.c
+++ b/usr/src/boot/efi/loader/arch/arm64/cache.c
@@ -1,0 +1,95 @@
+/*-
+ * Copyright (c) 2014 The FreeBSD Foundation
+ * All rights reserved.
+ *
+ * This software was developed by Semihalf under
+ * the sponsorship of the FreeBSD Foundation.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+__FBSDID("$FreeBSD$");
+
+#include <sys/param.h>
+
+#include <machine/armreg.h>
+
+#include <stand.h>
+#include <efi.h>
+
+#include "cache.h"
+
+static unsigned int
+get_dcache_line_size(void)
+{
+	uint64_t ctr;
+	unsigned int dcl_size;
+
+	/* Accessible from all security levels */
+	ctr = READ_SPECIALREG(ctr_el0);
+
+	/*
+	 * Relevant field [19:16] is LOG2
+	 * of the number of words in DCache line
+	 */
+	dcl_size = CTR_DLINE_SIZE(ctr);
+
+	/* Size of word shifted by cache line size */
+	return (sizeof (int) << dcl_size);
+}
+
+void
+cpu_flush_dcache(const void *ptr, size_t len)
+{
+
+	uint64_t cl_size;
+	vm_offset_t addr, end;
+
+	cl_size = get_dcache_line_size();
+
+	/* Calculate end address to clean */
+	end = (vm_offset_t)ptr + (vm_offset_t)len;
+	/* Align start address to cache line */
+	addr = (vm_offset_t)ptr;
+	addr = rounddown2(addr, cl_size);
+
+	for (; addr < end; addr += cl_size)
+		__asm __volatile("dc	civac, %0" : : "r" (addr) : "memory");
+	/* Full system DSB */
+	__asm __volatile("dsb	sy" : : : "memory");
+}
+
+void
+cpu_inval_icache(const void *ptr, size_t len)
+{
+
+	/* NULL ptr or 0 len means all */
+	if (ptr == NULL || len == 0) {
+		__asm __volatile(
+		    "ic		ialluis	\n"
+		    "dsb	ish	\n"
+		    : : : "memory");
+		return;
+	}
+
+	/* TODO: Other cache ranges if necessary */
+}

--- a/usr/src/boot/efi/loader/arch/arm64/cache.h
+++ b/usr/src/boot/efi/loader/arch/arm64/cache.h
@@ -1,0 +1,38 @@
+/*-
+ * Copyright (c) 2014 The FreeBSD Foundation
+ * All rights reserved.
+ *
+ * This software was developed by Semihalf under
+ * the sponsorship of the FreeBSD Foundation.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+#ifndef _CACHE_H_
+#define	_CACHE_H_
+
+/* cache.c */
+void cpu_flush_dcache(const void *, size_t);
+void cpu_inval_icache(const void *, size_t);
+
+#endif /* _CACHE_H_ */

--- a/usr/src/boot/efi/loader/arch/arm64/exec.c
+++ b/usr/src/boot/efi/loader/arch/arm64/exec.c
@@ -32,32 +32,39 @@
 #include <sys/param.h>
 #include <sys/linker.h>
 #include <machine/elf.h>
+#include <machine/metadata.h>
 
 #include <bootstrap.h>
 
 #include <efi.h>
 #include <efilib.h>
+#include <Guid/Acpi.h>
+#include <Guid/Fdt.h>
 
 #include "loader_efi.h"
 #include "cache.h"
+#include "libzfs.h"
 
 #include "platform/acfreebsd.h"
 #include "acconfig.h"
-#define ACPI_SYSTEM_XFACE
-#define ACPI_USE_SYSTEM_INTTYPES
+#define	ACPI_SYSTEM_XFACE
+#if !defined(ACPI_USE_SYSTEM_INTTYPES)
+#define	ACPI_USE_SYSTEM_INTTYPES	1
+#endif
 #include "actypes.h"
 #include "actbl.h"
 
-static EFI_GUID acpi_guid = ACPI_TABLE_GUID;
-static EFI_GUID acpi20_guid = ACPI_20_TABLE_GUID;
+/* #define	ELF_VERBOSE	1 */
+
+extern int bi_load(char *args, vm_offset_t *modulep, vm_offset_t *kernendp);
 
 static int elf64_exec(struct preloaded_file *amp);
-static int elf64_obj_exec(struct preloaded_file *amp);
+static int elf64_loadfile_(char *filename, uint64_t dest,
+    struct preloaded_file **result);
 
-int bi_load(char *args, vm_offset_t *modulep, vm_offset_t *kernendp);
-
-static struct file_format arm64_elf = {
-	elf64_loadfile,
+static
+struct file_format arm64_elf = {
+	elf64_loadfile_,
 	elf64_exec
 };
 
@@ -66,6 +73,320 @@ struct file_format *file_formats[] = {
 	NULL
 };
 
+/*
+ * illumos/aarch64 is a bit different to other platforms. The kernel is
+ * compiled with VA set to the final KVA and PA set to 0. Embedded into the
+ * kernel, and pointed to by the e_entry member of the ELF header, is dboot.
+ * This is a self-relocating shim that decodes the FreeBSD-style bootinfo
+ * passed by loader, sets up KPM, loads the kernel to the final VA and jumps
+ * to the kernel itself. Of note is that dboot embeds an ELF loader that
+ * copies the kernel data to suitably aligned memory pages prior to execution,
+ * so loader doesn't even need to worry about BSS.
+ *
+ * This all means that the kernel is treated as a blob of data from the
+ * point of view of loader, so it's loaded as such. Once in memory, the
+ * ELF header is read to find the dboot entrypoint and the program headers
+ * are inspected to find the physical address for that entrypoint.
+ *
+ * When loader executes the loaded kernel it hits the dboot entrypoint,
+ * which discovers where it was loaded and relocates itself (it's an
+ * embedded standalone) before proceeding with execution. The relocation
+ * logic has a requirement that the entrypoint itself must be page-aligned.
+ */
+
+int
+elf64_loadfile_(char *filename, uint64_t dest, struct preloaded_file **result)
+{
+	Elf_Ehdr *ehdr;
+	Elf_Phdr *phdr;
+	struct preloaded_file *fp;
+	caddr_t firstpage;
+	size_t firstlen;
+	ssize_t nread;
+	int fd;
+	int err;
+	ssize_t got;
+	struct stat st;
+	int i;
+	uint64_t ldest = dest;
+	size_t scratch_size;
+	uint64_t scratch_addr;
+
+	static const char kerneltype[] = "elf kernel";
+
+	err = EFTYPE;	/* allow the next handler to run */
+	firstpage = NULL;
+	fd = -1;
+	fp = NULL;
+
+	/*
+	 * We're always called with a fully qualified path, so no need to
+	 * search for the file.
+	 */
+
+	if (filename == NULL)
+		goto out;
+
+	if ((fd = open(filename, O_RDONLY)) < 0)
+		goto out;
+
+	if ((firstpage = malloc(PAGE_SIZE)) == NULL) {
+		err = ENOMEM;
+		goto out;
+	}
+
+	nread = read(fd, firstpage, PAGE_SIZE);
+	(void) close(fd);
+	fd = -1;
+	firstlen = (size_t)nread;
+	if (nread < 0 || firstlen <= sizeof (*ehdr))
+		goto out;
+	ehdr = (Elf_Ehdr *)firstpage;
+
+	if (!IS_ELF(*ehdr))
+		goto out;
+
+	/*
+	 * We only load valid ELF files of type ET_EXEC with the Solaris
+	 * OS ABI and that target aarch64. Furthermore, we only perform the
+	 * loading when we are on aarch64.
+	 */
+	if (ehdr->e_ident[EI_CLASS] != ELF_TARG_CLASS ||
+	    ehdr->e_ident[EI_DATA] != ELF_TARG_DATA ||
+	    ehdr->e_ident[EI_VERSION] != EV_CURRENT ||
+	    ehdr->e_version != EV_CURRENT ||
+	    ehdr->e_type != ET_EXEC ||
+	    ehdr->e_ident[EI_OSABI] != ELFOSABI_SOLARIS ||
+	    ehdr->e_machine != EM_AARCH64 ||
+	    ehdr->e_machine != ELF_TARG_MACH)
+		goto out;
+
+	if (file_findfile(NULL, kerneltype) != NULL) {
+		err = EPERM;
+		goto out;
+	}
+
+	if ((fd = open(filename, O_RDONLY)) < 0) {
+		err = ENOENT;
+		goto out;
+	}
+
+	if (fstat(fd, &st) < 0) {
+		err = errno;
+		goto out;
+	}
+
+	printf("%s", filename);
+
+	/*
+	 * Our load address (passed in dest) was allocated with an extra
+	 * page to allow us to align the dboot entrypoint, which in turn
+	 * let's the dboot embedded standalone easily self-relocate.
+	 *
+	 * For the sake of simplicity, assume that kernel program header
+	 * addresses are page aligned (a safe assumption, given we
+	 * maintain the mapfile). This means that we can assume that
+	 * the offset can be determined with a simple mask, which means
+	 * that it's trivial to calculate the load destination that will
+	 * place the dboot entrypoint at a page-aligned address.
+	 */
+	ldest = dest + (PAGE_SIZE - (ehdr->e_entry & 0xfff));
+
+	got = archsw.arch_readin(fd, ldest, st.st_size);
+	if ((size_t)got != st.st_size) {
+		err = errno;
+		goto out;
+	}
+
+	fp = file_alloc();
+	if (fp == NULL) {
+		err = ENOMEM;
+		goto out;
+	}
+
+	fp->f_name = strdup(filename);
+	fp->f_type = strdup(kerneltype);
+	fp->f_addr = ldest;	/* so that loader can find it */
+	fp->f_size = st.st_size;
+
+	if (fp->f_type == NULL || fp->f_name == NULL) {
+		err = ENOMEM;
+		goto out;
+	}
+
+	if ((ehdr->e_phoff + ehdr->e_phnum * sizeof (*phdr)) > firstlen)
+		goto out;
+	phdr = (Elf_Phdr *)(firstpage + ehdr->e_phoff);
+
+	for (i = 0; i < ehdr->e_phnum; i++) {
+		/*
+		 * We are only interested in loadable segments.
+		 */
+		if (phdr[i].p_type != PT_LOAD)
+			continue;
+
+		/*
+		 * We're only interested in the segment that contains our
+		 * entrypoint.
+		 */
+		if (ehdr->e_entry < phdr[i].p_vaddr ||
+		    ehdr->e_entry + 4 >= phdr[i].p_vaddr + phdr[i].p_memsz)
+			continue;
+
+		/*
+		 * Found the segment containing our entrypoint, adjust the
+		 * entrypoint to point to an offset from the physical address
+		 * the kernel was loaded at. When executed, dboot (the entry
+		 * code) will self-relocate to this address.
+		 */
+		ehdr->e_entry = (ldest + phdr[i].p_offset) +
+		    (ehdr->e_entry - phdr[i].p_vaddr);
+		break;
+	}
+
+	/*
+	 * Something is very wrong if we can't find the segment containing
+	 * our entrypoint.
+	 */
+	if (i >= ehdr->e_phnum)
+		goto out;
+
+	/*
+	 * 64MiB of scratch
+	 *
+	 * XXXARM: this seems generous - should it be configurable? What
+	 * should the default be?
+	 */
+	scratch_size = (64 * 1024 * 1024);
+	scratch_addr = archsw.arch_loadaddr(LOAD_MEM, &scratch_size, 0);
+	if (scratch_addr == 0)
+		panic("failed to allocate boot scratch\n");
+	file_addmetadata(fp, MODINFOMD_SCRATCH_ADDR,
+	    sizeof (scratch_addr), &scratch_addr);
+	file_addmetadata(fp, MODINFOMD_SCRATCH_SIZE,
+	    sizeof (scratch_size), &scratch_size);
+
+	/*
+	 * MODINFOMD_ELFHDR is used by elf64_exec to locate the entrypoint
+	 * that it needs to jump to. There are no other uses of this
+	 * metadata.
+	 */
+	file_addmetadata(fp, MODINFOMD_ELFHDR, sizeof (*ehdr), ehdr);
+
+	err = 0;
+
+out:
+	if (err == 0) {
+		*result = fp;
+#ifdef ELF_VERBOSE
+		printf(" loadaddr 0x%jx+0x%jx,",
+		    (uintmax_t)ldest, (uintmax_t)st.st_size);
+		printf(" entry at 0x%jx\n",
+		    (uintmax_t)ehdr->e_entry);
+#else
+		printf("\n");
+#endif
+	} else {
+		if (err != EFTYPE)
+			printf(": %s\n", strerror(err));
+		file_discard(fp);
+	}
+
+	if (firstpage != NULL)
+		free(firstpage);
+
+	if (fd != -1)
+		(void) close(fd);
+
+	return (err);
+}
+
+/*
+ * Search the command line for named property.
+ *
+ * Return codes:
+ *	0	The name is found, we return the data in value and len.
+ *	ENOENT	The name is not found.
+ *	EINVAL	The provided command line is badly formed.
+ */
+static int
+find_property_value(const char *cmd, const char *name, const char **value,
+    size_t *len)
+{
+	const char *namep, *valuep;
+	size_t name_len, value_len;
+	int quoted;
+
+	*value = NULL;
+	*len = 0;
+
+	if (cmd == NULL)
+		return (ENOENT);
+
+	while (*cmd != '\0') {
+		if (cmd[0] != '-' || cmd[1] != 'B') {
+			cmd++;
+			continue;
+		}
+		cmd += 2;	/* Skip -B */
+		while (cmd[0] == ' ' || cmd[0] == '\t')
+			cmd++;	/* Skip whitespaces. */
+		while (*cmd != '\0' && cmd[0] != ' ' && cmd[0] != '\t') {
+			namep = cmd;
+			valuep = strchr(cmd, '=');
+			if (valuep == NULL)
+				break;
+			name_len = valuep - namep;
+			valuep++;
+			value_len = 0;
+			quoted = 0;
+			for (; ; ++value_len) {
+				if (valuep[value_len] == '\0')
+					break;
+
+				/* Is this value quoted? */
+				if (value_len == 0 &&
+				    (valuep[0] == '\'' || valuep[0] == '"')) {
+					quoted = valuep[0];
+					++value_len;
+				}
+
+				/*
+				 * In the quote accept any character,
+				 * but look for ending quote.
+				 */
+				if (quoted != 0) {
+					if (valuep[value_len] == quoted)
+						quoted = 0;
+					continue;
+				}
+
+				/* A comma or white space ends the value. */
+				if (valuep[value_len] == ',' ||
+				    valuep[value_len] == ' ' ||
+				    valuep[value_len] == '\t')
+					break;
+			}
+			if (quoted != 0) {
+				printf("Missing closing '%c' in \"%s\"\n",
+				    quoted, valuep);
+				return (EINVAL);
+			}
+			if (value_len != 0) {
+				if (strncmp(namep, name, name_len) == 0) {
+					*value = valuep;
+					*len = value_len;
+					return (0);
+				}
+			}
+			cmd = valuep + value_len;
+			while (*cmd == ',')
+				cmd++;
+		}
+	}
+	return (ENOENT);
+}
+
 static int
 elf64_exec(struct preloaded_file *fp)
 {
@@ -73,36 +394,61 @@ elf64_exec(struct preloaded_file *fp)
 	vm_offset_t clean_addr;
 	size_t clean_size;
 	struct file_metadata *md;
-	ACPI_TABLE_RSDP *rsdp;
 	Elf_Ehdr *ehdr;
-	char buf[24];
-	int err, revision;
+	int err;
+	int rv;
+	size_t len;
 	void (*entry)(vm_offset_t);
+	bool zfs_root = false;
+	struct devdesc *rootdev;
+	const char *fs;
 
-	rsdp = efi_get_table(&acpi20_guid);
-	if (rsdp == NULL) {
-		rsdp = efi_get_table(&acpi_guid);
+	/*
+	 * With multiple console devices and "os_console" variable not
+	 * set, set os_console to last input device.
+	 */
+	rv = cons_inputdev();
+	if (rv != -1)
+		(void) setenv("os_console", consoles[rv]->c_name, 0);
+
+	efi_getdev((void **)(&rootdev), NULL, NULL);
+	if (rootdev == NULL) {
+		printf("can't determine root device\n");
+		return (EFTYPE);	/* XXX: need a better code */
 	}
-	if (rsdp != NULL) {
-		sprintf(buf, "0x%016llx", (unsigned long long)rsdp);
-		setenv("hint.acpi.0.rsdp", buf, 1);
-		revision = rsdp->Revision;
-		if (revision == 0)
-			revision = 1;
-		sprintf(buf, "%d", revision);
-		setenv("hint.acpi.0.revision", buf, 1);
-		strncpy(buf, rsdp->OemId, sizeof(rsdp->OemId));
-		buf[sizeof(rsdp->OemId)] = '\0';
-		setenv("hint.acpi.0.oem", buf, 1);
-		sprintf(buf, "0x%016x", rsdp->RsdtPhysicalAddress);
-		setenv("hint.acpi.0.rsdt", buf, 1);
-		if (revision >= 2) {
-			/* XXX extended checksum? */
-			sprintf(buf, "0x%016llx",
-			    (unsigned long long)rsdp->XsdtPhysicalAddress);
-			setenv("hint.acpi.0.xsdt", buf, 1);
-			sprintf(buf, "%d", rsdp->Length);
-			setenv("hint.acpi.0.xsdt_length", buf, 1);
+	if (rootdev->d_dev->dv_type == DEVT_ZFS)
+		zfs_root = true;
+
+	/* If we have fstype set in env, reset zfs_root if needed. */
+	fs = getenv("fstype");
+	if (fs != NULL && strcmp(fs, "zfs") != 0)
+		zfs_root = false;
+
+	/*
+	 * If we have fstype set on the command line,
+	 * reset zfs_root if needed.
+	 */
+	rv = find_property_value(fp->f_args, "fstype", &fs, &len);
+	if (rv != 0 && rv != ENOENT)
+		return (rv);
+
+	if (fs != NULL && strncmp(fs, "zfs", len) != 0)
+		zfs_root = false;
+
+	/* zfs_bootfs() will set the environment, it must be called. */
+	if (zfs_root == true)
+		fs = zfs_bootfs(rootdev);
+
+	/*
+	 * aarch64 systems can only have ACPI 2.0 tables.
+	 *
+	 * We have to have either ACPI or FDT. If both are present we'll
+	 * only present ACPI to the OS.
+	 */
+	if (efi_get_table(&gEfiAcpi20TableGuid) == NULL) {
+		if (efi_get_table(&gFdtTableGuid) == NULL) {
+			printf("can't determine firmware table type\n");
+			return (EFTYPE);
 		}
 	}
 
@@ -111,6 +457,9 @@ elf64_exec(struct preloaded_file *fp)
 
 	ehdr = (Elf_Ehdr *)&(md->md_data);
 	entry = efi_translate(ehdr->e_entry);
+#if defined(ELF_VERBOSE)
+	printf("elf64_exec: Jumping to entrypoint %p\n", entry);
+#endif
 
 	efi_time_fini();
 	err = bi_load(fp->f_args, &modulep, &kernendp);
@@ -118,6 +467,10 @@ elf64_exec(struct preloaded_file *fp)
 		efi_time_init();
 		return (err);
 	}
+
+	/*
+	 * Thou shalt not print after bi_load.
+	 */
 
 	dev_cleanup();
 
@@ -131,13 +484,3 @@ elf64_exec(struct preloaded_file *fp)
 	(*entry)(modulep);
 	panic("exec returned");
 }
-
-static int
-elf64_obj_exec(struct preloaded_file *fp)
-{
-
-	printf("%s called for preloaded file %p (=%s):\n", __func__, fp,
-	    fp->f_name);
-	return (ENOSYS);
-}
-

--- a/usr/src/boot/efi/loader/arch/arm64/isadir.c
+++ b/usr/src/boot/efi/loader/arch/arm64/isadir.c
@@ -1,0 +1,50 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2025 Michael van der Westhuizen
+ */
+
+#include <stand.h>
+
+void
+bi_isadir(void)
+{
+	int rc;
+
+	rc = setenv("ISADIR", "aarch64", 1);
+	if (rc != 0) {
+		printf("Warning: failed to set ISADIR environment "
+		    "variable: %d\n", rc);
+	}
+}
+
+void
+bi_basearch(void)
+{
+	int rc;
+
+	if ((rc = setenv("BASEARCH", "armv8", 1)) != 0) {
+		printf("Warning: failed to set BASEARCH environment "
+		    "variable: %d\n", rc);
+	}
+}
+
+void
+bi_implarch(void)
+{
+	int rc;
+
+	if ((rc = setenv("IMPLARCH", "armv8", 1)) != 0) {
+		printf("Warning: failed to set IMPLARCH environment "
+		    "variable: %d\n", rc);
+	}
+}

--- a/usr/src/boot/efi/loader/arch/arm64/ldscript.arm64
+++ b/usr/src/boot/efi/loader/arch/arm64/ldscript.arm64
@@ -26,7 +26,6 @@ SECTIONS
     *(.data .data.* .gnu.linkonce.d.*)
     *(.data1)
     *(.plabel)
-
     . = ALIGN(16);
     __bss_start = .;
     *(.sbss .sbss.* .gnu.linkonce.sb.*)
@@ -43,7 +42,7 @@ SECTIONS
     *(set_Xcommand_set)
     __stop_set_Xcommand_set = .;
   }
-  set_Xficl_compile_set : {
+  set_Xficl_compile_set	: {
     __start_set_Xficl_compile_set = .;
     *(set_Xficl_compile_set)
     __stop_set_Xficl_compile_set = .;
@@ -70,7 +69,7 @@ SECTIONS
     *(.rela.sbss2 .rela.sbss2.* .rela.gnu.linkonce.sb2.*)
     *(.rela.bss .rela.bss.* .rela.gnu.linkonce.b.*)
     *(.rela.plt)
-    *(.relset_*)
+    *(.relset_* .relaset_*)
     *(.rela.dyn .rela.dyn.*)
   }
   . = ALIGN(16);
@@ -80,6 +79,7 @@ SECTIONS
   _edata = .;
 
   /* Unused sections */
+  .interp	: { *(.interp) }
   .dynstr	: { *(.dynstr) }
   .hash		: { *(.hash) }
 }

--- a/usr/src/boot/efi/loader/arch/arm64/nullconsole.c
+++ b/usr/src/boot/efi/loader/arch/arm64/nullconsole.c
@@ -1,0 +1,97 @@
+/*
+ * nullconsole.c
+ *
+ * Author: Doug Ambrisko <ambrisko@whistle.com>
+ * Copyright (c) 2000 Whistle Communications, Inc.
+ * All rights reserved.
+ *
+ * Subject to the following obligations and disclaimer of warranty, use and
+ * redistribution of this software, in source or object code forms, with or
+ * without modifications are expressly permitted by Whistle Communications;
+ * provided, however, that:
+ * 1. Any and all reproductions of the source or object code must include the
+ *    copyright notice above and the following disclaimer of warranties; and
+ * 2. No rights are granted, in any manner or form, to use Whistle
+ *    Communications, Inc. trademarks, including the mark "WHISTLE
+ *    COMMUNICATIONS" on advertising, endorsements, or otherwise except as
+ *    such appears in the above copyright notice or in the software.
+ *
+ * THIS SOFTWARE IS BEING PROVIDED BY WHISTLE COMMUNICATIONS "AS IS", AND
+ * TO THE MAXIMUM EXTENT PERMITTED BY LAW, WHISTLE COMMUNICATIONS MAKES NO
+ * REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, REGARDING THIS SOFTWARE,
+ * INCLUDING WITHOUT LIMITATION, ANY AND ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.
+ * WHISTLE COMMUNICATIONS DOES NOT WARRANT, GUARANTEE, OR MAKE ANY
+ * REPRESENTATIONS REGARDING THE USE OF, OR THE RESULTS OF THE USE OF THIS
+ * SOFTWARE IN TERMS OF ITS CORRECTNESS, ACCURACY, RELIABILITY OR OTHERWISE.
+ * IN NO EVENT SHALL WHISTLE COMMUNICATIONS BE LIABLE FOR ANY DAMAGES
+ * RESULTING FROM OR ARISING OUT OF ANY USE OF THIS SOFTWARE, INCLUDING
+ * WITHOUT LIMITATION, ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * PUNITIVE, OR CONSEQUENTIAL DAMAGES, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES, LOSS OF USE, DATA OR PROFITS, HOWEVER CAUSED AND UNDER ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF WHISTLE COMMUNICATIONS IS ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+
+#include <stand.h>
+#include <bootstrap.h>
+
+static void	nullc_probe(struct console *cp);
+static int	nullc_init(struct console *, int arg);
+static void	nullc_putchar(struct console *, int c);
+static int	nullc_getchar(struct console *);
+static int	nullc_ischar(struct console *);
+static void	nullc_devinfo(struct console *);
+
+struct console nullconsole = {
+	.c_name = "null",
+	.c_desc = "null port",
+	.c_flags = 0,
+	.c_probe = nullc_probe,
+	.c_init = nullc_init,
+	.c_out = nullc_putchar,
+	.c_in = nullc_getchar,
+	.c_ready = nullc_ischar,
+	.c_ioctl = NULL,
+	.c_devinfo = nullc_devinfo,
+	.c_private = NULL
+};
+
+static void
+nullc_devinfo(struct console *cp __unused)
+{
+	printf("\tsoftware device");
+}
+
+static void
+nullc_probe(struct console *cp)
+{
+	cp->c_flags |= (C_PRESENTIN | C_PRESENTOUT);
+}
+
+static int
+nullc_init(struct console *cp __unused, int arg __unused)
+{
+	return (0);
+}
+
+static void
+nullc_putchar(struct console *cp __unused, int c __unused)
+{
+}
+
+static int
+nullc_getchar(struct console *cp __unused)
+{
+	return (-1);
+}
+
+static int
+nullc_ischar(struct console *cp __unused)
+{
+	return (0);
+}

--- a/usr/src/boot/efi/loader/arch/arm64/spinconsole.c
+++ b/usr/src/boot/efi/loader/arch/arm64/spinconsole.c
@@ -1,0 +1,134 @@
+/*
+ * spinconsole.c
+ *
+ * Author: Maksym Sobolyev <sobomax@sippysoft.com>
+ * Copyright (c) 2009 Sippy Software, Inc.
+ * All rights reserved.
+ *
+ * Subject to the following obligations and disclaimer of warranty, use and
+ * redistribution of this software, in source or object code forms, with or
+ * without modifications are expressly permitted by Whistle Communications;
+ * provided, however, that:
+ * 1. Any and all reproductions of the source or object code must include the
+ *    copyright notice above and the following disclaimer of warranties; and
+ * 2. No rights are granted, in any manner or form, to use Whistle
+ *    Communications, Inc. trademarks, including the mark "WHISTLE
+ *    COMMUNICATIONS" on advertising, endorsements, or otherwise except as
+ *    such appears in the above copyright notice or in the software.
+ *
+ * THIS SOFTWARE IS BEING PROVIDED BY WHISTLE COMMUNICATIONS "AS IS", AND
+ * TO THE MAXIMUM EXTENT PERMITTED BY LAW, WHISTLE COMMUNICATIONS MAKES NO
+ * REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, REGARDING THIS SOFTWARE,
+ * INCLUDING WITHOUT LIMITATION, ANY AND ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.
+ * WHISTLE COMMUNICATIONS DOES NOT WARRANT, GUARANTEE, OR MAKE ANY
+ * REPRESENTATIONS REGARDING THE USE OF, OR THE RESULTS OF THE USE OF THIS
+ * SOFTWARE IN TERMS OF ITS CORRECTNESS, ACCURACY, RELIABILITY OR OTHERWISE.
+ * IN NO EVENT SHALL WHISTLE COMMUNICATIONS BE LIABLE FOR ANY DAMAGES
+ * RESULTING FROM OR ARISING OUT OF ANY USE OF THIS SOFTWARE, INCLUDING
+ * WITHOUT LIMITATION, ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * PUNITIVE, OR CONSEQUENTIAL DAMAGES, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES, LOSS OF USE, DATA OR PROFITS, HOWEVER CAUSED AND UNDER ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF WHISTLE COMMUNICATIONS IS ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+
+#include <stand.h>
+#include <bootstrap.h>
+
+
+static void	spinc_probe(struct console *cp);
+static int	spinc_init(struct console *cp, int arg);
+static void	spinc_putchar(struct console *cp, int c);
+static int	spinc_getchar(struct console *cp);
+static int	spinc_ischar(struct console *cp);
+static void	spinc_devinfo(struct console *cp);
+
+struct console spinconsole = {
+	.c_name = "spin",
+	.c_desc = "spin port",
+	.c_flags = 0,
+	.c_probe = spinc_probe,
+	.c_init = spinc_init,
+	.c_out = spinc_putchar,
+	.c_in = spinc_getchar,
+	.c_ready = spinc_ischar,
+	.c_ioctl = NULL,
+	.c_devinfo = spinc_devinfo,
+	.c_private = NULL
+};
+
+static void
+spinc_devinfo(struct console *cp __unused)
+{
+	printf("\tsoftware device");
+}
+
+static void
+spinc_probe(struct console *cp)
+{
+	int i;
+	struct console *parent;
+
+	if (cp->c_private == NULL) {
+		for (i = 0; consoles[i] != NULL; i++)
+			if (strcmp(consoles[i]->c_name, "text") == 0)
+				break;
+		cp->c_private = consoles[i];
+	}
+
+	parent = cp->c_private;
+	if (parent != NULL)
+		parent->c_probe(cp);
+}
+
+static int
+spinc_init(struct console *cp, int arg)
+{
+	struct console *parent;
+
+	parent = cp->c_private;
+	if (parent != NULL)
+		return (parent->c_init(cp, arg));
+	else
+		return (0);
+}
+
+static void
+spinc_putchar(struct console *cp, int c __unused)
+{
+	static unsigned tw_chars = 0x5C2D2F7C;    /* "\-/|" */
+	static time_t lasttime = 0;
+	struct console *parent;
+	time_t now;
+
+	now = time(NULL);
+	if (now < (lasttime + 1))
+		return;
+	lasttime = now;
+	parent = cp->c_private;
+	if (parent == NULL)
+		return;
+
+	parent->c_out(parent, (char)tw_chars);
+	parent->c_out(parent, '\b');
+	tw_chars = (tw_chars >> 8) | ((tw_chars & (unsigned long)0xFF) << 24);
+}
+
+static int
+spinc_getchar(struct console *cp __unused)
+{
+
+	return (-1);
+}
+
+static int
+spinc_ischar(struct console *cp __unused)
+{
+
+	return (0);
+}

--- a/usr/src/boot/efi/loader/arch/arm64/start.S
+++ b/usr/src/boot/efi/loader/arch/arm64/start.S
@@ -27,6 +27,14 @@
  */
 
 /*
+ * Code required to produce something approximating a PE32+ EFI executable is
+ * protected by this define, in the hope that we'll have aarch64 PE32+ support
+ * in our objcopy at some point in the future.
+ */
+#define LOADER_USE_HANDCRAFTED_PE_COFF_HEADER
+
+#if defined(LOADER_USE_HANDCRAFTED_PE_COFF_HEADER)
+/*
  * We need to be a PE32+ file for EFI. On some architectures we can use
  * objcopy to create the correct file, however on arm64 we need to do
  * it ourselves.
@@ -40,7 +48,7 @@
 #define	IMAGE_SCN_MEM_EXECUTE		0x20000000
 #define	IMAGE_SCN_MEM_READ		0x40000000
 
-	.section .peheader
+	.section .peheader,"a"
 efi_start:
 	/* The MS-DOS Stub, only used to get the offset of the COFF header */
 	.ascii	"MZ"
@@ -135,6 +143,7 @@ section_table:
 	.long	(IMAGE_SCN_CNT_CODE | IMAGE_SCN_MEM_EXECUTE | \
 		 IMAGE_SCN_MEM_READ)		/* Characteristics */
 _end_header:
+#endif
 
 	.text
 	.globl	_start
@@ -142,8 +151,10 @@ _start:
 	/* Save the boot params to the stack */
 	stp	x0, x1, [sp, #-16]!
 
-	adr	x0, __bss_start
-	adr	x1, __bss_end
+	adrp	x0, __bss_start
+	add	x0, x0, :lo12:__bss_start
+	adrp	x1, __bss_end
+	add	x1, x1, :lo12:__bss_end
 
 	b 2f
 
@@ -153,13 +164,41 @@ _start:
 	cmp	x0, x1
 	b.lo	1b
 
-	adr	x0, ImageBase
-	adr	x1, _DYNAMIC
+	adrp	x0, ImageBase
+	add	x0, x0, :lo12:ImageBase
+	adrp	x1, _DYNAMIC
+	add	x1, x1, :lo12:_DYNAMIC
 
 	bl	self_reloc
 
 	ldp	x0, x1, [sp], #16
 
+	/*
+	 * Load the stack to use. The default stack may be too small for
+	 * the ficl interpreter.
+	 */
+	adrp	x2, initstack_end
+	add	x2, x2, :lo12:initstack_end
+	mov	sp, x2
+
 	bl	efi_main
 
 1:	b	1b
+
+#if !defined(LOADER_USE_HANDCRAFTED_PE_COFF_HEADER)
+	/*
+	 * hand-craft a dummy .reloc section so EFI knows it's a relocatable
+	 * executable:
+	 */
+.data
+	.section .reloc, "a"
+	.long	0
+	.long	10
+	.word	0
+#endif
+
+.bss
+	.align	4
+initstack:
+	.space	(64 * 1024)
+initstack_end:


### PR DESCRIPTION
Adds supporting files to the `loader(7)` `arch` directory for `aarch64`.

Some of these files are transplants from FreeBSD (`cache.c`, `cache.h`), some are transplants from unshareable parts of our own tree (`nullconsole.c`, `spinconsole.c`) and some are unique to our port (`bootsvcs.c`, `isadir.c`, `exec.c`). Some are modified from FreeBSD (`start.S` and `ldscript.arm64`).

Note that `start.S` is a bit weird, because we create the PE header ourselves, which is preserved when extracting the built ELF file to a binary, making the resulting binary file a valid, relocatable, PE file. This is fairly hideous, but works around `binutils` limitations and bugs when transforming ELF to PE on aarch64.

Will be rebased once https://github.com/richlowe/illumos-gate/pull/151 lands.