### PR TITLE
loader(7): 09 of 16 - MMIO UART framework

### DIFF
--- a/usr/src/boot/efi/libmmio_uart/Makefile
+++ b/usr/src/boot/efi/libmmio_uart/Makefile
@@ -10,28 +10,28 @@
 #
 
 #
-# Copyright 2015 Toomas Soome <tsoome@me.com>
+# Copyright 2025 Michael van der Westhuizen
 #
-
-.KEEP_STATE:
 
 include $(SRC)/boot/Makefile.master
 
 i386_SUBDIRS =
-aarch64_SUBDIRS = libmmio_uart
-
-SUBDIRS = libefi $($(MACH)_SUBDIRS) loader
-
-all install clean clobber: $(SUBDIRS)
+aarch64_SUBDIRS = $(MACH64)
+SUBDIRS = $($(MACH)_SUBDIRS)
 
 all	:=	TARGET = all
 clean	:=	TARGET = clean
 clobber	:=	TARGET = clobber
 install	:=	TARGET = install
 
-loader:	libefi $($(MACH)_SUBDIRS)
+.KEEP_STATE:
+
+all clean clobber: $(SUBDIRS)
+
+install: all
 
 .PARALLEL:
+
 $(SUBDIRS): FRC
 	@cd $@; pwd; $(MAKE) $(TARGET)
 

--- a/usr/src/boot/efi/libmmio_uart/Makefile.com
+++ b/usr/src/boot/efi/libmmio_uart/Makefile.com
@@ -1,0 +1,52 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 Michael van der Westhuizen
+#
+
+include $(SRC)/boot/Makefile.master
+include $(SRC)/boot/Makefile.inc
+
+install:
+
+SRCS += efi_mmio_uart.c mmio_uart.c pl011.c
+OBJS=	$(SRCS:%.c=%.o)
+
+CPPFLAGS += -I.
+CPPFLAGS += -I$(BOOTSRC)/sys
+CPPFLAGS += -I$(BOOTSRC)/common
+CPPFLAGS += -I$(BOOTSRC)/libsa
+CPPFLAGS += -I$(BOOTSRC)/efi/libmmio_uart
+CPPFLAGS += -I$(BOOTSRC)/efi/include
+CPPFLAGS += -I$(BOOTSRC)/include
+
+include ../../Makefile.inc
+
+CFLAGS +=       $(CFLAGS64)
+
+libmmio_uart.a: $(OBJS)
+	$(AR) $(ARFLAGS) $@ $(OBJS)
+
+clean: clobber
+clobber:
+	$(RM) $(CLEANFILES) $(OBJS) libmmio_uart.a
+
+machine:
+	$(RM) machine
+	$(SYMLINK) ../../../sys/$(MACHINE)/include machine
+
+x86:
+	$(RM) x86
+	$(SYMLINK) ../../../sys/x86/include x86
+
+%.o:	../%.c
+	$(COMPILE.c) $<

--- a/usr/src/boot/efi/libmmio_uart/arm64/Makefile
+++ b/usr/src/boot/efi/libmmio_uart/arm64/Makefile
@@ -1,0 +1,27 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 Michael van der Westhuizen
+#
+
+MACHINE=	$(MACH64)
+
+all:		libmmio_uart.a
+
+include ../Makefile.com
+
+CFLAGS +=	$(CFLAGS64)
+CPPFLAGS +=	-I$(BOOTSRC)/efi/include/$(MACHINE)
+
+CLEANFILES +=	machine
+
+$(OBJS): machine

--- a/usr/src/boot/efi/libmmio_uart/efi_mmio_uart.c
+++ b/usr/src/boot/efi/libmmio_uart/efi_mmio_uart.c
@@ -1,0 +1,96 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2025 Michael van der Westhuizen
+ */
+
+/*
+ * Helper utilities for MMIO UARTs and discovery libraries.
+ */
+
+#include <efi.h>
+#include <efilib.h>
+
+#include "mmio_uart.h"
+
+/*
+ * Print a string using the UEFI console output device.
+ *
+ * Used in debugging.
+ */
+void
+mmio_uart_puts(const char *s)
+{
+	while (*s) {
+		CHAR16 buf[2];
+		EFI_STATUS status;
+
+		buf[0] = *s;
+		buf[1] = 0;
+
+		status = ST->ConOut->TestString(ST->ConOut, buf);
+		if (EFI_ERROR(status))
+			buf[0] = '?';
+		if (buf[0] == '\n')
+			mmio_uart_puts("\r");
+		ST->ConOut->OutputString(ST->ConOut, buf);
+		++s;
+	}
+}
+
+/*
+ * Print an unsigned integer n in base b using the UEFI console output device.
+ *
+ * Used in debugging.
+ */
+void
+mmio_uart_putn(unsigned long n, int b)
+{
+	unsigned long a;
+	char buf[2];
+
+	if ((a = n/b))
+		mmio_uart_putn(a, b);
+	buf[0] = "0123456789abcdef"[n % b];
+	buf[1] = '\0';
+	mmio_uart_puts(buf);
+}
+
+/*
+ * Allocate a physical memory page below the 4GiB mark.
+ *
+ * Allows for a 64KiB page size.
+ *
+ * WARNING: This is not a portable function, and will only succeed for systems
+ * that have available physical memory below 4GiB (such as rpi4).
+ */
+void *
+mmio_uart_alloc_low_page(void)
+{
+	EFI_PHYSICAL_ADDRESS pa = 0xFFFEFFFF;
+	if (BS->AllocatePages(AllocateMaxAddress,
+	    EfiLoaderData, 1, &pa) != EFI_SUCCESS)
+		return (NULL);
+	return ((void *)pa);
+}
+
+/*
+ * Free a memory page allocated by 'mmio_uart_alloc_low_page`.
+ */
+void
+mmio_uart_free_low_page(void *addr)
+{
+	EFI_PHYSICAL_ADDRESS pa = (EFI_PHYSICAL_ADDRESS)addr;
+	if (pa == 0)
+		return;
+	BS->FreePages(pa, 1);
+}

--- a/usr/src/boot/efi/libmmio_uart/mmio_uart.c
+++ b/usr/src/boot/efi/libmmio_uart/mmio_uart.c
@@ -1,0 +1,749 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2025 Michael van der Westhuizen
+ */
+
+/*
+ * The MMIO UART library contains functionality shared between UART
+ * implementations and UART implementation drivers. UART discovery
+ * functionality drives the library by inspecting firmware configuration
+ * tables, creating driver instances and associating them with MMIO UART
+ * instances. The discovery libraries are responsible for locating
+ * information needed for each implementation driver, identifying the UART
+ * ordering (used to name the UART instances) and identifying the system
+ * stdout UART.
+ *
+ * The library provides top-level hooks called by the console subsystem,
+ * wrapping up environment variable management operations and system
+ * console avoidance logic.
+ */
+
+#include "mmio_uart.h"
+#include <stand.h>
+#include <bootstrap.h>
+
+extern struct console efi_console;
+extern int plat_stdout_is_framebuffer(void);
+
+static bool
+mmio_uart_ignore_spcr(struct console *cp)
+{
+	char *name;
+	const char *env;
+	bool ignore_spcr = false;
+
+	/*
+	 * When we're not firmware-specified we will always ignore the
+	 * firmware settings.
+	 */
+	if (asprintf(&name, "%s-spcr-mode", cp->c_name) > 0) {
+		if (getenv(name) == NULL)
+			ignore_spcr = true;
+		free(name);
+	}
+
+	/*
+	 * If we are firmware specified we check if we're supposed to
+	 * ignore firmware-specified settings.
+	 */
+	if (!ignore_spcr) {
+		/* only check when we do have spcr set */
+		env = getenv("ignore-spcr");
+		if (env != NULL)
+			ignore_spcr = strcmp(env, "true") == 0;
+	}
+
+	return (ignore_spcr);
+}
+
+static bool
+mmio_uart_setup(struct console *cp)
+{
+	mmio_uart_t *uart = cp->c_private;
+
+	/*
+	 * Only touch the hardware if we're ignoring firmware-specified
+	 * settings (or there are none). If we have firmware-specified
+	 * settings we simply claim that things have worked.
+	 */
+	if (mmio_uart_ignore_spcr(cp)) {
+		if (uart->mu_ops->op_setup(uart)) {
+			cp->c_flags |= (C_PRESENTIN | C_PRESENTOUT);
+			return (true);
+		}
+	} else {
+		cp->c_flags |= (C_PRESENTIN | C_PRESENTOUT);
+		return (true);
+	}
+
+	return (false);
+}
+
+static char *
+mmio_uart_asprint_mode(mmio_uart_t *uart)
+{
+	char par, *buf;
+	int dbits, sbits;
+
+	if (uart == NULL)
+		return (NULL);
+
+	switch (uart->mu_data_bits) {
+	case MMIO_UART_DATA_BITS_8:
+		dbits = 8;
+		break;
+	case MMIO_UART_DATA_BITS_7:
+		dbits = 7;
+		break;
+	case MMIO_UART_DATA_BITS_6:
+		dbits = 6;
+		break;
+	case MMIO_UART_DATA_BITS_5:
+		dbits = 5;
+		break;
+	default:
+		dbits = 8;
+		break;
+	}
+
+	switch (uart->mu_parity) {
+	case MMIO_UART_PARITY_EVEN:
+		par = 'e';
+		break;
+	case MMIO_UART_PARITY_ODD:
+		par = 'o';
+		break;
+	case MMIO_UART_PARITY_MARK:
+		par = 'm';
+		break;
+	case MMIO_UART_PARITY_SPACE:
+		par = 's';
+		break;
+	case MMIO_UART_PARITY_NONE:
+		par = 'n';
+		break;
+	default:
+		par = 'n';
+		break;
+	}
+
+	switch (uart->mu_stop_bits) {
+	case MMIO_UART_STOP_BITS_2:
+		sbits = 2;
+		break;
+	case MMIO_UART_STOP_BITS_1:
+		sbits = 1;
+		break;
+	case MMIO_UART_STOP_BITS_1_5:
+		sbits = 3;
+		break;
+	default:
+		sbits = 1;
+		break;
+	}
+
+	if (sbits == 3)
+		asprintf(&buf, "%lu,%d,%c,1.5,-",
+		    uart->mu_speed, dbits, par);
+	else
+		asprintf(&buf, "%lu,%d,%c,%d,-",
+		    uart->mu_speed, dbits, par, sbits);
+
+	return (buf);
+}
+
+static int
+mmio_uart_parse_mode(mmio_uart_t *uart, const char *value)
+{
+	unsigned long n;
+	mmio_uart_speed_t speed;
+	mmio_uart_data_bits_t dbits;
+	mmio_uart_parity_t parity;
+	mmio_uart_stop_bits_t sbits;
+
+	char *ep;
+
+	if (value == NULL || *value == '\0')
+		return (CMD_ERROR);
+
+	errno = 0;
+	n = strtoul(value, &ep, 10);
+	if (errno != 0 || *ep != ',')
+		return (CMD_ERROR);
+	speed = (mmio_uart_speed_t)n;
+
+	ep++;
+	errno = 0;
+	n = strtoul(ep, &ep, 10);
+	if (errno != 0 || *ep != ',')
+		return (CMD_ERROR);
+
+	switch (n) {
+	case 5:
+		dbits = MMIO_UART_DATA_BITS_5;
+		break;
+	case 6:
+		dbits = MMIO_UART_DATA_BITS_6;
+		break;
+	case 7:
+		dbits = MMIO_UART_DATA_BITS_7;
+		break;
+	case 8:
+		dbits = MMIO_UART_DATA_BITS_8;
+		break;
+	default:
+		return (CMD_ERROR);
+	}
+
+	ep++;
+	switch (*ep++) {
+	case 'n':
+		parity = MMIO_UART_PARITY_NONE;
+		break;
+	case 'e':
+		parity = MMIO_UART_PARITY_EVEN;
+		break;
+	case 'o':
+		parity = MMIO_UART_PARITY_ODD;
+		break;
+	case 'm':
+		parity = MMIO_UART_PARITY_MARK;
+		break;
+	case 's':
+		parity = MMIO_UART_PARITY_SPACE;
+		break;
+	default:
+		return (CMD_ERROR);
+	}
+
+	if (*ep == ',')
+		ep++;
+	else
+		return (CMD_ERROR);
+
+	switch (*ep++) {
+	case '1':
+		sbits = MMIO_UART_STOP_BITS_1;
+		if (ep[0] == '.') {
+			if (ep[1] != '5')
+				return (CMD_ERROR);
+			ep += 2;
+			sbits = MMIO_UART_STOP_BITS_1_5;
+		}
+
+		break;
+	case '2':
+		sbits = MMIO_UART_STOP_BITS_2;
+		break;
+	default:
+		return (CMD_ERROR);
+	}
+
+	/* handshake is ignored, but we check syntax anyhow */
+	if (*ep == ',')
+		ep++;
+	else
+		return (CMD_ERROR);
+
+	switch (*ep++) {
+	case '-':
+	case 'h':
+	case 's':
+		break;
+	default:
+		return (CMD_ERROR);
+	}
+
+	if (*ep != '\0')
+		return (CMD_ERROR);
+
+	/* only accept the settings if the driver supports them */
+	if (!uart->mu_ops->op_config_check(uart, speed, dbits, parity, sbits))
+		return (CMD_ERROR);
+
+	uart->mu_speed = speed;
+	uart->mu_data_bits = dbits;
+	uart->mu_parity = parity;
+	uart->mu_stop_bits = sbits;
+	return (CMD_OK);
+}
+
+/*
+ * CMD_ERROR will cause set/setenv/setprop command to fail,
+ * when used in loader scripts (forth), this will cause processing
+ * of boot scripts to fail, rendering bootloading impossible.
+ * To prevent such unfortunate situation, we return CMD_OK when
+ * there is no such port, or there is invalid value in mode line.
+ */
+static int
+mmio_uart_mode_set(struct env_var *ev, int flags, const void *value)
+{
+	struct console *cp;
+	mmio_uart_t *uart;
+
+	if (value == NULL)
+		return (CMD_ERROR);
+
+	if ((cp = cons_get_console(ev->ev_name)) == NULL)
+		return (CMD_OK);
+
+	uart = cp->c_private;
+
+	if (mmio_uart_ignore_spcr(cp)) {
+		if (mmio_uart_parse_mode(uart, value) == CMD_ERROR) {
+			printf("%s: invalid mode: %s\n", ev->ev_name,
+			    (char *)value);
+			return (CMD_OK);
+		}
+		(void) mmio_uart_setup(cp);
+		env_setenv(ev->ev_name, flags | EV_NOHOOK, value, NULL, NULL);
+	}
+
+	return (CMD_OK);
+}
+
+/*
+ * CMD_ERROR will cause set/setenv/setprop command to fail,
+ * when used in loader scripts (forth), this will cause processing
+ * of boot scripts to fail, rendering bootloading impossible.
+ * To prevent such unfortunate situation, we return CMD_OK when
+ * there is no such port or invalid value was used.
+ */
+static int
+mmio_uart_cd_set(struct env_var *ev, int flags, const void *value)
+{
+	struct console *cp;
+	mmio_uart_t *uart;
+
+	if (value == NULL)
+		return (CMD_OK);
+
+	if ((cp = cons_get_console(ev->ev_name)) == NULL)
+		return (CMD_OK);
+
+	uart = cp->c_private;
+
+	if (mmio_uart_ignore_spcr(cp)) {
+		if (strcmp(value, "true") == 0) {
+			uart->mu_ignore_cd = true;
+		} else if (strcmp(value, "false") == 0) {
+			uart->mu_ignore_cd = false;
+		} else {
+			printf("%s: invalid value: %s\n", ev->ev_name,
+			    (char *)value);
+			return (CMD_OK);
+		}
+
+		(void) mmio_uart_setup(cp);
+		env_setenv(ev->ev_name, flags | EV_NOHOOK, value, NULL, NULL);
+	}
+
+	return (CMD_OK);
+}
+
+/*
+ * CMD_ERROR will cause set/setenv/setprop command to fail,
+ * when used in loader scripts (forth), this will cause processing
+ * of boot scripts to fail, rendering bootloading impossible.
+ * To prevent such unfortunate situation, we return CMD_OK when
+ * there is no such port, or invalid value was used.
+ */
+static int
+mmio_uart_rtsdtr_set(struct env_var *ev, int flags, const void *value)
+{
+	struct console *cp;
+	mmio_uart_t *uart;
+
+	if (value == NULL)
+		return (CMD_OK);
+
+	if ((cp = cons_get_console(ev->ev_name)) == NULL)
+		return (CMD_OK);
+
+	uart = cp->c_private;
+
+	if (mmio_uart_ignore_spcr(cp)) {
+		if (strcmp(value, "true") == 0) {
+			uart->mu_rtsdtr_off = true;
+		} else if (strcmp(value, "false") == 0) {
+			uart->mu_rtsdtr_off = false;
+		} else {
+			printf("%s: invalid value: %s\n", ev->ev_name,
+			    (char *)value);
+			return (CMD_OK);
+		}
+
+		(void) mmio_uart_setup(cp);
+		env_setenv(ev->ev_name, flags | EV_NOHOOK, value, NULL, NULL);
+	}
+
+	return (CMD_OK);
+}
+
+static void
+mmio_uart_probe(struct console *cp)
+{
+	mmio_uart_t	*uart;
+	char		*env;
+
+	uart = cp->c_private;
+
+	if (!(uart->mu_flags & MMIO_UART_VALID)) {
+		cp->c_flags = 0;
+		return;
+	}
+
+	if (uart->mu_flags & MMIO_UART_PROBED) {
+		cp->c_flags = C_PRESENTIN | C_PRESENTOUT;
+		return;
+	}
+
+	/*
+	 * When this UART has been specified as the system stdout (via
+	 * SPCR or FDT's /chosen/stdout-path) we need to tweak the console
+	 * variable.
+	 */
+	if (uart->mu_flags & MMIO_UART_STDOUT) {
+		/*
+		 * Tweak the consoles list, placing us first if already set.
+		 */
+		if ((env = getenv("console")) != NULL) {
+			char *val;
+
+			if (asprintf(&val, "%s,text", cp->c_name) > 0) {
+				setenv("console", val, 1);
+				free(val);
+			}
+		} else {
+			setenv("console", cp->c_name, 1);
+		}
+	}
+
+	cp->c_flags = 0;
+	if (mmio_uart_setup(cp))
+		cp->c_flags = C_PRESENTIN | C_PRESENTOUT;
+
+	/*
+	 * Set the boot console variables, allowing dboot to pick them
+	 * up, use the UART and pass the values on to the kernel.
+	 */
+	if ((uart->mu_flags & MMIO_UART_STDOUT) &&
+	    (cp->c_flags = C_PRESENTIN | C_PRESENTOUT) &&
+	    (uart->mu_base != 0 && uart->mu_type != 0)) {
+		char *val;
+
+		if (asprintf(&val, "0x%lx", uart->mu_base) > 0) {
+			setenv("bcons.uart.mmio_base", val, 1);
+			free(val);
+
+			if (asprintf(&val, "0x%x", uart->mu_type) > 0) {
+				setenv("bcons.uart.type", val, 1);
+				free(val);
+			}
+
+			setenv("bcons.uart.name", cp->c_name, 1);
+		}
+	}
+
+	uart->mu_flags |= MMIO_UART_PROBED;
+}
+
+static int
+mmio_uart_init(struct console *cp, int arg __attribute((unused)))
+{
+	if (mmio_uart_setup(cp))
+		return (CMD_OK);
+
+	cp->c_flags = 0;
+	return (CMD_ERROR);
+}
+
+static bool
+mmio_uart_carrier_ok(struct console *cp)
+{
+	mmio_uart_t *uart = cp->c_private;
+
+	if (uart->mu_ignore_cd)
+		return (true);
+
+	return (uart->mu_ops->op_has_carrier(uart));
+}
+
+/*
+ * When we're the system stdout and the platform stdout is not the framebuffer
+ * we need to suppress the MMIO UART console functionality so as to not
+ * interfere with the UEFI console.
+ *
+ * - If we're not the firmware-identified stdout we do not suppress.
+ * - If the platform stdout is the framebuffer we do not suppress.
+ * - If the EFI console is inactive we do not suppress.
+ * - Failing the above, we suppress.
+ */
+static bool
+mmio_uart_suppress(mmio_uart_t *uart)
+{
+	if (!(uart->mu_flags & MMIO_UART_STDOUT))
+		return (false);
+
+	if (plat_stdout_is_framebuffer())
+		return (false);
+
+	if ((efi_console.c_flags & (C_ACTIVEIN | C_ACTIVEOUT)) !=
+	    (C_ACTIVEIN | C_ACTIVEOUT))
+		return (false);
+
+	return (true);
+}
+
+/*
+ * For ischar and getchar we defer to the EFI console when we
+ * are the firmware-identifier stdout and the EFI console is active.
+ *
+ * The above logic mirrors what the i86pc code does.
+ *
+ * Also see `mmio_uart_suppress' (above) for the conditions where we
+ * completely suppress the I/O functions.
+ *
+ * When we're using our driver we also check carrier-detect (when
+ * configured to do so), which is another reason I/O could be skipped.
+ */
+
+static void
+mmio_uart_putchar(struct console *cp, int c)
+{
+	mmio_uart_t *uart = cp->c_private;
+
+	if (mmio_uart_suppress(uart))
+		return;
+
+	if (!mmio_uart_carrier_ok(cp))
+		return;
+
+	uart->mu_ops->op_putchar(uart, c);
+}
+
+static int
+mmio_uart_getchar(struct console *cp)
+{
+	mmio_uart_t *uart = cp->c_private;
+
+	if (mmio_uart_suppress(uart))
+		return (-1);
+
+	if ((uart->mu_flags & MMIO_UART_STDOUT) &&
+	    (efi_console.c_flags & C_PRESENTIN))
+		return (efi_console.c_in(&efi_console));
+
+	if (!mmio_uart_carrier_ok(cp))
+		return (-1);
+
+	return (uart->mu_ops->op_getchar(uart));
+}
+
+static int
+mmio_uart_ischar(struct console *cp)
+{
+	mmio_uart_t *uart = cp->c_private;
+
+	if (mmio_uart_suppress(uart))
+		return (0);
+
+	if ((uart->mu_flags & MMIO_UART_STDOUT) &&
+	    !plat_stdout_is_framebuffer() &&
+	    (efi_console.c_flags & C_PRESENTIN))
+		return (efi_console.c_ready(&efi_console));
+
+	if (!mmio_uart_carrier_ok(cp))
+		return (0);
+
+	return (uart->mu_ops->op_ischar(uart));
+}
+
+static int
+mmio_uart_ioctl(struct console *cp __attribute((unused)),
+    int n __attribute((unused)), void *arg __attribute((unused)))
+{
+	return (ENOTTY);
+}
+
+static void
+mmio_uart_devinfo(struct console *cp __attribute((unused)))
+{
+	mmio_uart_t *uart = cp->c_private;
+	uart->mu_ops->op_devinfo(uart);
+}
+
+static void
+mmio_uart_set_environment(struct console *cp)
+{
+	char		name[50];
+	char		name2[50];
+	char		value[30];
+	char		*env;
+	mmio_uart_t	*uart = cp->c_private;
+
+	uart->mu_ops->op_set_environment(cp);
+
+	if (uart->mu_flags & MMIO_UART_CONFIG_LOCKED) {
+		/*
+		 * If we're locked to firmware or hardware specified settings
+		 * we just update the environment variable to match our current
+		 * configuration, overwriting anything that might already exist.
+		 *
+		 * We set ttyX-spcr-mode to communicate to the rest of loader
+		 * that this is a config-specified UART and that the config
+		 * should not be changed unless ignore-spcr is also set.
+		 */
+		snprintf(name, sizeof (name), "%s-mode", cp->c_name);
+		snprintf(name2, sizeof (name2), "%s-spcr-mode", cp->c_name);
+		unsetenv(name);
+		unsetenv(name2);
+		if ((env = mmio_uart_asprint_mode(uart)) != NULL) {
+			env_setenv(name, EV_VOLATILE, env,
+			    mmio_uart_mode_set, env_nounset);
+			env_setenv(name2, EV_VOLATILE, env,
+			    env_noset, env_nounset);
+			free(env);
+		}
+
+		snprintf(name, sizeof (name), "%s-ignore-cd", cp->c_name);
+		snprintf(value, sizeof (value), "%s",
+		    uart->mu_ignore_cd ? "true" : "false");
+		unsetenv(name);
+		env_setenv(name, EV_VOLATILE, value,
+		    mmio_uart_cd_set, env_nounset);
+
+		snprintf(name, sizeof (name), "%s-rts-dtr-off", cp->c_name);
+		snprintf(value, sizeof (value), "%s",
+		    uart->mu_rtsdtr_off ? "true" : "false");
+		unsetenv(name);
+		env_setenv(name, EV_VOLATILE, value,
+		    mmio_uart_rtsdtr_set, env_nounset);
+	} else {
+		/*
+		 * We're not locked to hardware or firmware.
+		 * If a variable not not exist we create it with our current
+		 * values. If it already exists we read it and recreate it
+		 * with our hook.
+		 *
+		 * We explicitly clear ttyX-spcr-mode so that we don't
+		 * accidentally lock the config.
+		 */
+		snprintf(name, sizeof (name), "%s-spcr-mode", cp->c_name);
+		unsetenv(name);
+		snprintf(name, sizeof (name), "%s-mode", cp->c_name);
+		if ((env = getenv(name)) == NULL) {
+			if ((env = mmio_uart_asprint_mode(uart)) != NULL) {
+				env_setenv(name, EV_VOLATILE, env,
+				    mmio_uart_mode_set, env_nounset);
+				free(env);
+			}
+		} else {
+			env = strdup(env);
+			unsetenv(name);
+			env_setenv(name, EV_VOLATILE, env,
+			    mmio_uart_mode_set, env_nounset);
+			free(env);
+		}
+
+		snprintf(name, sizeof (name), "%s-ignore-cd", cp->c_name);
+		if ((env = getenv(name)) == NULL) {
+			snprintf(value, sizeof (value), "%s",
+			    uart->mu_ignore_cd ? "true" : "false");
+			unsetenv(name);
+			env_setenv(name, EV_VOLATILE, value,
+			    mmio_uart_cd_set, env_nounset);
+		} else {
+			env = strdup(env);
+			unsetenv(name);
+			env_setenv(name, EV_VOLATILE, env,
+			    mmio_uart_cd_set, env_nounset);
+			free(env);
+		}
+
+		snprintf(name, sizeof (name), "%s-rts-dtr-off", cp->c_name);
+		if ((env = getenv(name)) == NULL) {
+			snprintf(value, sizeof (value), "%s",
+			    uart->mu_rtsdtr_off ? "true" : "false");
+			unsetenv(name);
+			env_setenv(name, EV_VOLATILE, value,
+			    mmio_uart_rtsdtr_set, env_nounset);
+		} else {
+			env = strdup(env);
+			unsetenv(name);
+			env_setenv(name, EV_VOLATILE, env,
+			    mmio_uart_rtsdtr_set, env_nounset);
+			free(env);
+		}
+	}
+}
+
+/*
+ * Called from the firmware integration UART discovery function to allocate
+ * and set up the discovered UART.
+ */
+struct console *
+mmio_uart_make_tty(mmio_uart_t *uart)
+{
+	struct console *tty;
+	uint32_t idx;
+
+	idx = uart->mu_serial_idx;
+
+	if ((tty = malloc(sizeof (*tty))) == NULL)
+		return (NULL);
+
+	if (asprintf(&tty->c_name, "tty%c", (int)('a' + idx)) < 0) {
+		free(tty);
+		return (NULL);
+	}
+
+	if (asprintf(&tty->c_desc, "%s", uart->mu_fwname) < 0) {
+		free(tty->c_name);
+		free(tty);
+		return (NULL);
+	}
+
+	tty->c_flags = 0;
+	tty->c_probe = mmio_uart_probe;
+	tty->c_init = mmio_uart_init;
+	tty->c_out = mmio_uart_putchar;
+	tty->c_in = mmio_uart_getchar;
+	tty->c_ready = mmio_uart_ischar;
+	tty->c_ioctl = mmio_uart_ioctl;
+	tty->c_devinfo = mmio_uart_devinfo;
+	tty->c_private = uart;
+
+	if (uart->mu_ops->op_make_tty_hook(uart) != 0) {
+		free(tty->c_name);
+		free(tty);
+		return (NULL);
+	}
+
+	mmio_uart_set_environment(tty);
+
+	if (uart->mu_flags & MMIO_UART_STDOUT)
+		return (tty);
+
+	/* Reset terminal to initial normal settings with ESC [ 0 m */
+	uart->mu_ops->op_putchar(uart, 0x1b);
+	uart->mu_ops->op_putchar(uart, '[');
+	uart->mu_ops->op_putchar(uart, '0');
+	uart->mu_ops->op_putchar(uart, 'm');
+
+	/* drain random data from input */
+	while (uart->mu_ops->op_ischar(uart))
+		(void) uart->mu_ops->op_getchar(uart);
+
+	return (tty);
+}

--- a/usr/src/boot/efi/libmmio_uart/mmio_uart.h
+++ b/usr/src/boot/efi/libmmio_uart/mmio_uart.h
@@ -1,0 +1,159 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2025 Michael van der Westhuizen
+ */
+
+#ifndef _MMIO_UART_MMIO_UART_H
+#define	_MMIO_UART_MMIO_UART_H
+
+/*
+ * MMIO UART types and declarations.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Flags for the mu_flags field.
+ *
+ * MMIO_UART_VALID
+ *   This UART configuration is valid (fully specified).
+ *
+ * MMIO_UART_STDOUT
+ *   This UART is the firmware-selected stdout device (via
+ *   /chosen/stdout-path in FDT or SPCR is ACPI). This flag is used to avoid
+ *   interacting with this UART, deferring to the UEFI console for interations.
+ *
+ * MMIO_UART_CONFIG_FW_SPECIFIED
+ *   The configuration for this UART was specified by firmware and should not
+ *   be changed. This is the case for SPCR and for parameters specified via
+ *   /chosen/stdout-path. On FDT systems you should update the
+ *   /chosen/stdout-path variable to configure the UART and on ACPI systems
+ *   you should update the communication settings in the UEFI settings.
+ *   When this is set, then MMIO_UART_CONFIG_LOCKED is also set.
+ *
+ * MMIO_UART_CONFIG_FROM_HW
+ *   The UART configuration is managed by firmware but not communicated via
+ *   firmware tables. The configuration should be derived from the hardware
+ *   and otherwise left alone. When this is set, then MMIO_UART_CONFIG_LOCKED
+ *   is also set.
+ *
+ * MMIO_UART_CONFIG_LOCKED
+ *   The UART configuration parameters should not be reprogrammed.
+ *
+ * MMIO_UART_PROBED
+ *   UART has been probed.
+ *
+ * Also note that if the implementation cannot determine the clock frequency
+ * driving the UART it will reject any attempts to change the UART speed. In
+ * this case a default speed will be reported. See MMIO_UART_DEFAULT_COMSPEED
+ * the the default that will be used.
+ */
+#define	MMIO_UART_VALID			0x1
+#define	MMIO_UART_STDOUT		0x2
+#define	MMIO_UART_CONFIG_FW_SPECIFIED	0x4
+#define	MMIO_UART_CONFIG_LOCKED		0x8
+#define	MMIO_UART_CONFIG_FROM_HW	0x10
+#define	MMIO_UART_PROBED		0x20
+
+/*
+ * These values are from the ACPI DBG2 specification, stewarded by Microsoft.
+ *
+ * The values correspond to the debug port subtype, and are reused in the
+ * Serial Port Console Redirect (SPCR) specification, also stewarded by
+ * Microsoft.
+ */
+typedef enum {
+	MMIO_UART_TYPE_NS16550_OLD = 0x01,
+	MMIO_UART_TYPE_PL011 = 0x03,
+	MMIO_UART_TYPE_ARM_GENERIC = 0x0e,	/* limited functionality */
+	MMIO_UART_TYPE_NS16550 = 0x12
+} mmio_uart_type_t;
+
+typedef enum {
+	MMIO_UART_DATA_BITS_8 = 8,
+	MMIO_UART_DATA_BITS_7 = 7,
+	MMIO_UART_DATA_BITS_6 = 6,
+	MMIO_UART_DATA_BITS_5 = 5
+} mmio_uart_data_bits_t;
+
+typedef enum {
+	MMIO_UART_PARITY_EVEN = 1,
+	MMIO_UART_PARITY_ODD = 2,
+	MMIO_UART_PARITY_NONE = 3,
+	MMIO_UART_PARITY_MARK = 4,
+	MMIO_UART_PARITY_SPACE = 5
+} mmio_uart_parity_t;
+
+typedef enum {
+	MMIO_UART_STOP_BITS_1 = 1,
+	MMIO_UART_STOP_BITS_2 = 2,
+	MMIO_UART_STOP_BITS_1_5 = 3
+} mmio_uart_stop_bits_t;
+
+#define	MMIO_UART_DEFAULT_COMSPEED	115200
+
+typedef uint64_t mmio_uart_speed_t;
+
+typedef struct {
+	bool	(*op_setup)(void *);
+	bool	(*op_config_check)(void *, mmio_uart_speed_t,
+	    mmio_uart_data_bits_t, mmio_uart_parity_t, mmio_uart_stop_bits_t);
+	bool	(*op_has_carrier)(void *);
+	void	(*op_putchar)(void *, int);
+	int	(*op_getchar)(void *);
+	int	(*op_getspeed)(void *);
+	int	(*op_ischar)(void *);
+	void	(*op_devinfo)(void *);
+	int	(*op_make_tty_hook)(void *);
+	void	(*op_set_environment)(void *);
+} mmio_uart_ops_t;
+
+typedef void * mmio_uart_ctx_t;
+
+typedef struct {
+	uint64_t mu_base;
+	mmio_uart_type_t mu_type;
+	mmio_uart_speed_t mu_speed;
+	mmio_uart_data_bits_t mu_data_bits;
+	mmio_uart_parity_t mu_parity;
+	mmio_uart_stop_bits_t mu_stop_bits;
+	bool mu_ignore_cd;
+	bool mu_rtsdtr_off;
+	const mmio_uart_ops_t	*mu_ops;
+	mmio_uart_ctx_t	mu_ctx;
+	char *mu_fwpath;
+	uint32_t mu_serial_idx;
+	char *mu_fwname;
+	uint32_t mu_flags;
+} mmio_uart_t;
+
+
+struct console;
+extern struct console *mmio_uart_make_tty(mmio_uart_t *uart);
+
+extern void *mmio_uart_alloc_low_page(void);
+extern void mmio_uart_free_low_page(void *addr);
+
+extern void mmio_uart_puts(const char *s);
+extern void mmio_uart_putn(unsigned long n, int b);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _MMIO_UART_MMIO_UART_H */

--- a/usr/src/boot/efi/libmmio_uart/pl011.c
+++ b/usr/src/boot/efi/libmmio_uart/pl011.c
@@ -1,0 +1,727 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2025 Michael van der Westhuizen
+ */
+
+/*
+ * MMIO UART implementation for Arm PL011 compatible UARTs.
+ *
+ * The registers are programmed in the same way as EDK2, as driven
+ * by the efiserialio driver.
+ */
+#include "pl011.h"
+#include "mmio_uart.h"
+
+#include <bootstrap.h>
+#include <stand.h>
+
+#define	IS_GENERIC_UART(__u)	(((__u) != NULL) && \
+				((__u)->mu_type == MMIO_UART_TYPE_ARM_GENERIC))
+
+/*
+ * Register offsets and definitions taken from DEN0094D (BSA).
+ *
+ * §B.2 Generic UART register frame
+ *
+ * Additional register offsets from the PL011 TRM (DDI0183) - these, along
+ * with the reason they are elided from the generic UART, are:
+ * - UARTILPR_REG: IrDA is unused
+ * - UARTIBRD_REG: BAUD selection is unsupported
+ * - UARTFBRD_REG: BAUD selection is unsupported
+ * - UARTLCR_H_REG: Line Control is unsupported
+ * - UARTCR_REG: UART configuration is fixed
+ * - UARTIFLS_REG: FIFO configuration is fixed
+ * - UARTDMACR_REG: FIFO DMA is unsupported
+ * - UARTPeriphID[0-3]: Not documented
+ * - UARTPCellID[0-3]: Not documented
+ */
+#define	UARTDR_REG	0x000	/* Data Register			*/
+#define	UARTDR_OE			(1U << 11)
+#define	UARTDR_BE			(1U << 10)
+#define	UARTDR_PE			(1U << 9)
+#define	UARTDR_FE			(1U << 8)
+#define	UARTDR_DATA			(0xFFU)
+#define	UARTRSR_REG	0x004	/* Receive Status Register		*/
+#define	UARTRSR_OE			(1U << 3)
+#define	UARTRSR_BE			(1U << 2)
+#define	UARTRSR_PE			(1U << 1)
+#define	UARTRSR_FE			(1U << 0)
+#define	UARTECR_REG	0x004	/* Error Clear Register			*/
+#define	UARTECR_CLR			(0xFFU)
+#define	UARTFR_REG	0x018	/* Flag Register			*/
+#define	UARTFR_RI			(1U << 8)
+#define	UARTFR_TXFE			(1U << 7)
+#define	UARTFR_RXFF			(1U << 6)
+#define	UARTFR_TXFF			(1U << 5)
+#define	UARTFR_RXFE			(1U << 4)
+#define	UARTFR_BUSY			(1U << 3)
+#define	UARTFR_DCD			(1U << 2)
+#define	UARTFR_DSR			(1U << 1)
+#define	UARTFR_CTS			(1U << 0)
+#define	UARTILPR_REG	0x020	/* IrDA Lower-Power Counter Register	*/
+#define	UARTIBRD_REG	0x024	/* Integer Baud Rate Register		*/
+#define	UARTIBRD_DIVINT			(0xFFFFU)
+#define	UARTFBRD_REG	0x028	/* Fractional Baud Rate Register	*/
+#define	UARTFBRD_DIVFRAC		(0x3FU)
+#define	UARTLCR_H_REG	0x02C	/* Line Control Register		*/
+#define	UARTLCR_H_SPS			(1U << 7)
+#define	UARTLCR_H_WLEN			(3U << 5)
+#define	UARTLCR_H_FEN			(1U << 4)
+#define	UARTLCR_H_STP2			(1U << 3)
+#define	UARTLCR_H_EPS			(1U << 2)
+#define	UARTLCR_H_PEN			(1U << 1)
+#define	UARTLCR_H_BRK			(1U << 0)
+#define	UARTCR_REG	0x030	/* Control Register			*/
+#define	UARTCR_CTSEn			(1U << 15)
+#define	UARTCR_RTSEn			(1U << 14)
+#define	UARTCR_Out2			(1U << 13)
+#define	UARTCR_Out1			(1U << 12)
+#define	UARTCR_RTS			(1U << 11)
+#define	UARTCR_DTR			(1U << 10)
+#define	UARTCR_RXE			(1U << 9)
+#define	UARTCR_TXE			(1U << 8)
+#define	UARTCR_LBE			(1U << 7)
+#define	UARTCR_SIRLP			(1U << 2)
+#define	UARTCR_SIREN			(1U << 1)
+#define	UARTCR_UARTEN			(1U << 0)
+#define	UARTIFLS_REG	0x034	/* Interrupt FIFO Level Select Register	*/
+#define	UARTIFLS_RXIFLSEL		(7U << 3)
+#define	UARTIFLS_TXIFLSEL		(7U << 0)
+#define	UARTIMSC_REG	0x038	/* Interrupt Mask Set/Clear Register	*/
+#define	UARTIMSC_OEIM			(1U << 10)
+#define	UARTIMSC_BEIM			(1U << 9)
+#define	UARTIMSC_PEIM			(1U << 8)
+#define	UARTIMSC_FEIM			(1U << 7)
+#define	UARTIMSC_RTIM			(1U << 6)
+#define	UARTIMSC_TXIM			(1U << 5)
+#define	UARTIMSC_RXIM			(1U << 4)
+#define	UARTIMSC_DSRMIM			(1U << 3)
+#define	UARTIMSC_DCDMIM			(1U << 2)
+#define	UARTIMSC_CTSMIM			(1U << 1)
+#define	UARTIMSC_RIMIM			(1U << 0)
+#define	UARTRIS_REG	0x03c	/* Raw Interrupt Status Register	*/
+#define	UARTRIS_OERIS			(1U << 10)
+#define	UARTRIS_BERIS			(1U << 9)
+#define	UARTRIS_PERIS			(1U << 8)
+#define	UARTRIS_FERIS			(1U << 7)
+#define	UARTRIS_RTRIS			(1U << 6)
+#define	UARTRIS_TXRIS			(1U << 5)
+#define	UARTRIS_RXRIS			(1U << 4)
+#define	UARTRIS_DSRRMIS			(1U << 3)
+#define	UARTRIS_DCDRMIS			(1U << 2)
+#define	UARTRIS_CTSRMIS			(1U << 1)
+#define	UARTRIS_RIRMIS			(1U << 0)
+#define	UARTMIS_REG	0x040	/* Masked Interrupt Status Register	*/
+#define	UARTMIS_OEMIS			(1U << 10)
+#define	UARTMIS_BEMIS			(1U << 9)
+#define	UARTMIS_PEMIS			(1U << 8)
+#define	UARTMIS_FEMIS			(1U << 7)
+#define	UARTMIS_RTMIS			(1U << 6)
+#define	UARTMIS_TXMIS			(1U << 5)
+#define	UARTMIS_RXMIS			(1U << 4)
+#define	UARTMIS_DSRMMIS			(1U << 3)
+#define	UARTMIS_DCDMMIS			(1U << 2)
+#define	UARTMIS_CTSMMIS			(1U << 1)
+#define	UARTMIS_RIMMIS			(1U << 0)
+#define	UARTICR_REG	0x044	/* Interrupt Clear Register		*/
+#define	UARTICR_OEIC			(1U << 10)
+#define	UARTICR_BEIC			(1U << 9)
+#define	UARTICR_PEIC			(1U << 8)
+#define	UARTICR_FEIC			(1U << 7)
+#define	UARTICR_RTIC			(1U << 6)
+#define	UARTICR_TXIC			(1U << 5)
+#define	UARTICR_RXIC			(1U << 4)
+#define	UARTICR_DSRMIC			(1U << 3)
+#define	UARTICR_DCDMIC			(1U << 2)
+#define	UARTICR_CTSMIC			(1U << 1)
+#define	UARTICR_RIMIC			(1U << 0)
+#define	UARTDMACR_REG	0x048	/* DMA Control Register			*/
+#define	UARTDMACR_DMAONERR		(1U << 2)
+#define	UARTDMACR_TXDMAE		(1U << 1)
+#define	UARTDMACR_RXDMAE		(1U << 0)
+#define	UARTPeriphID0	0xFE0	/* Peripheral Identification Register 0	*/
+#define	UARTPeriphID0_PartNumber0	(0xFFU)
+#define	UARTPeriphID1	0xFE4	/* Peripheral Identification Register 1	*/
+#define	UARTPeriphID1_Designer0		(0xF0U)
+#define	UARTPeriphID1_PartNumber1	(0x0FU)
+#define	UARTPeriphID2	0xFE8	/* Peripheral Identification Register 2	*/
+#define	UARTPeriphID2_Revision		(0xF0U)
+#define	UARTPeriphID2_Designer1		(0x0FU)
+#define	UARTPeriphID3	0xFEC	/* Peripheral Identification Register 3	*/
+#define	UARTPeriphID3_Configuration	(0xFFU)
+#define	UARTPCellID0	0xFF0	/* PrimeCell Identification Register 0	*/
+#define	UARTPCellID0_UARTPCellID0	(0x0FU)
+#define	UARTPCellID1	0xFF4	/* PrimeCell Identification Register 1	*/
+#define	UARTPCellID1_UARTPCellID1	(0x0FU)
+#define	UARTPCellID2	0xFF8	/* PrimeCell Identification Register 2	*/
+#define	UARTPCellID2_UARTPCellID2	(0x0FU)
+#define	UARTPCellID3	0xFFC	/* PrimeCell Identification Register 3	*/
+#define	UARTPCellID3_UARTPCellID3	(0x0FU)
+
+typedef struct {
+	double		bm_min;
+	double		bm_max;
+	uint64_t	bm_val;
+} pl011_baud_match_t;
+
+/*
+ * The maximum error rate is 1.56%, so we allow for 1.57% either side.
+ */
+#define	BAUDMATCH_FUZZ_LO	0.9843
+#define	BAUDMATCH_FUZZ_HI	1.0157
+
+#define	BAUDMATCH_ENTRY(__b)	{		\
+	.bm_min = (__b) * (BAUDMATCH_FUZZ_LO),	\
+	.bm_max = (__b) * (BAUDMATCH_FUZZ_HI),	\
+	.bm_val = (__b)				\
+}
+
+static const pl011_baud_match_t pl011_baud_matchers[] = {
+	BAUDMATCH_ENTRY(UINT64_C(115200)),
+	BAUDMATCH_ENTRY(UINT64_C(57600)),
+	BAUDMATCH_ENTRY(UINT64_C(19200)),
+	BAUDMATCH_ENTRY(UINT64_C(9600)),
+	BAUDMATCH_ENTRY(UINT64_C(50)),
+	BAUDMATCH_ENTRY(UINT64_C(75)),
+	BAUDMATCH_ENTRY(UINT64_C(110)),
+	BAUDMATCH_ENTRY(UINT64_C(134)),
+	BAUDMATCH_ENTRY(UINT64_C(150)),
+	BAUDMATCH_ENTRY(UINT64_C(200)),
+	BAUDMATCH_ENTRY(UINT64_C(300)),
+	BAUDMATCH_ENTRY(UINT64_C(600)),
+	BAUDMATCH_ENTRY(UINT64_C(1200)),
+	BAUDMATCH_ENTRY(UINT64_C(1800)),
+	BAUDMATCH_ENTRY(UINT64_C(2400)),
+	BAUDMATCH_ENTRY(UINT64_C(4800)),
+	BAUDMATCH_ENTRY(UINT64_C(38400)),
+	BAUDMATCH_ENTRY(UINT64_C(76800)),
+	BAUDMATCH_ENTRY(UINT64_C(153600)),
+	BAUDMATCH_ENTRY(UINT64_C(230400)),
+	BAUDMATCH_ENTRY(UINT64_C(307200)),
+	BAUDMATCH_ENTRY(UINT64_C(460800)),
+	BAUDMATCH_ENTRY(UINT64_C(921600)),
+	BAUDMATCH_ENTRY(UINT64_C(1000000)),
+	BAUDMATCH_ENTRY(UINT64_C(1152000)),
+	BAUDMATCH_ENTRY(UINT64_C(1500000)),
+	BAUDMATCH_ENTRY(UINT64_C(2000000)),
+	BAUDMATCH_ENTRY(UINT64_C(2500000)),
+	BAUDMATCH_ENTRY(UINT64_C(3000000)),
+	BAUDMATCH_ENTRY(UINT64_C(3500000)),
+	BAUDMATCH_ENTRY(UINT64_C(4000000)),
+};
+static const size_t num_pl011_baud_matchers =
+    sizeof (pl011_baud_matchers) / sizeof (pl011_baud_matchers[0]);
+
+static uint64_t
+pl011_match_baud(const double baud)
+{
+	size_t n;
+
+	for (n = 0; n < num_pl011_baud_matchers; ++n) {
+		if (pl011_baud_matchers[n].bm_min <= baud &&
+		    pl011_baud_matchers[n].bm_max >= baud) {
+			return (pl011_baud_matchers[n].bm_val);
+		}
+	}
+
+	return (0);
+}
+
+static uint16_t
+pl011_read16(pl011_info_t *pl011, uint16_t reg)
+{
+	return (*(volatile uint16_t *)(pl011->pl_addr + reg));
+}
+
+static void
+pl011_write16(pl011_info_t *pl011, uint16_t reg, uint16_t val)
+{
+	(*(volatile uint16_t *)(pl011->pl_addr + reg)) = val;
+}
+
+static uint8_t
+pl011_read8(pl011_info_t *pl011, uint16_t reg)
+{
+	return (*(volatile uint8_t *)(pl011->pl_addr + reg));
+}
+
+static void
+pl011_write8(pl011_info_t *pl011, uint16_t reg, uint8_t val)
+{
+	(*(volatile uint8_t *)(pl011->pl_addr + reg)) = val;
+}
+
+static bool
+pl011_setup(void *ctx)
+{
+	uint16_t		tmp_cr;
+	uint16_t		ibrd = 0;
+	uint8_t			fbrd = 0;
+	uint8_t			lcr = 0;
+	uint16_t		cr = 0;
+	mmio_uart_t		*uart = ctx;
+	pl011_info_t		*pl011 = uart->mu_ctx;
+
+	if (IS_GENERIC_UART(uart)) {
+		/*
+		 * There's no way to change the speed (or any other meaningful
+		 * settings) for the generic UART, so we just bail.
+		 */
+		return (true);
+	}
+
+	cr = pl011->pl_cr = pl011_read16(pl011, UARTCR_REG);
+	lcr = pl011->pl_lcr = pl011_read8(pl011, UARTLCR_H_REG);
+	ibrd = pl011->pl_ibrd = pl011_read16(pl011, UARTIBRD_REG);
+	fbrd = pl011->pl_fbrd = pl011_read8(pl011, UARTFBRD_REG);
+
+	/*
+	 * If we have both a clock frequency and a desired speed we can
+	 * calculate our required IBRD and FBRD. If we can't we just use
+	 * the current values.
+	 */
+	if (pl011->pl_frequency != 0 && uart->mu_speed != 0) {
+		uint64_t	denominator;
+		uint64_t	divisor;
+		uint64_t	remainder;
+
+		/*
+		 * This ingenious way of working out the integer and
+		 * fractional values is from NetBSD.
+		 */
+		denominator = 16 * uart->mu_speed;
+		divisor = pl011->pl_frequency / denominator;
+		remainder = pl011->pl_frequency % denominator;
+
+		ibrd = divisor << 6;
+		fbrd = (((8 * remainder) / uart->mu_speed) + 1) / 2;
+
+		/*
+		 * - The minimum divide ratio possible is 1 and the maximum is
+		 *   65535(216 - 1). That is, UARTIBRD = 0 is invalid and
+		 *   UARTFBRD is ignored when this is the case.
+		 * - Similarly, when UARTIBRD = 65535 (that is 0xFFFF), then
+		 *   UARTFBRD must not be greater than zero. If this is
+		 *   exceeded it results in an aborted transmission or
+		 *   reception.
+		 */
+		if (ibrd == 0) {
+			ibrd = 1;
+			fbrd = 0;
+		} else if (ibrd == 0xFFFF) {
+			fbrd = 0;
+		}
+	}
+
+	lcr &= ~(UARTLCR_H_WLEN);
+	switch (uart->mu_data_bits) {
+	case MMIO_UART_DATA_BITS_8:
+		lcr |= 0x60;
+		break;
+	case MMIO_UART_DATA_BITS_7:
+		lcr |= 0x40;
+		break;
+	case MMIO_UART_DATA_BITS_6:
+		lcr |= 0x20;
+		break;
+	case MMIO_UART_DATA_BITS_5:
+		/* nothing to set, bits 6:5 are b00 */
+		break;
+	default:
+		return (false);
+	}
+
+	lcr &= ~(UARTLCR_H_PEN|UARTLCR_H_EPS|UARTLCR_H_SPS);
+	switch (uart->mu_parity) {
+	case MMIO_UART_PARITY_SPACE:
+		lcr |= (UARTLCR_H_PEN|UARTLCR_H_EPS|UARTLCR_H_SPS);
+		break;
+	case MMIO_UART_PARITY_MARK:
+		lcr |= (UARTLCR_H_PEN|UARTLCR_H_SPS);
+		break;
+	case MMIO_UART_PARITY_NONE:
+		/* i.e. do not set UARTLCR_H_PEN */
+		break;
+	case MMIO_UART_PARITY_EVEN:
+		lcr |= (UARTLCR_H_PEN|UARTLCR_H_EPS);
+		break;
+	case MMIO_UART_PARITY_ODD:
+		lcr |= (UARTLCR_H_PEN);
+		break;
+	default:
+		return (false);
+	}
+
+	lcr &= ~(UARTLCR_H_STP2);
+	switch (uart->mu_stop_bits) {
+	case MMIO_UART_STOP_BITS_1:
+		/* i.e. do not set UARTLCR_H_STP2 */
+		break;
+	case MMIO_UART_STOP_BITS_2:
+		lcr |= UARTLCR_H_STP2;
+		break;
+	default:
+		return (false);
+	}
+
+	/*
+	 * We only touch the FIFO-enable bit if we're not the stdout.
+	 *
+	 * This seems weird, but the idea is that UEFI will set them
+	 * how it likes and we want to avoid changing what it thinks
+	 * is the ground truth.
+	 */
+	if (!(uart->mu_flags & MMIO_UART_STDOUT)) {
+		lcr |= UARTLCR_H_FEN;
+	}
+
+	if (uart->mu_rtsdtr_off) {
+		cr &= ~(UARTCR_RTS|UARTCR_DTR);
+	} else {
+		cr |= UARTCR_RTS;	/* DTR? this is what efiserialio does */
+	}
+
+	cr |= (UARTCR_RXE|UARTCR_TXE|UARTCR_UARTEN);
+
+	if (ibrd == pl011->pl_ibrd && fbrd == pl011->pl_fbrd &&
+	    lcr == pl011->pl_lcr && cr == pl011->pl_cr)
+		return (true);
+
+	/*
+	 * If enabled we must disable and drain before reprogramming
+	 */
+	if ((tmp_cr = pl011_read16(pl011, UARTCR_REG)) & UARTCR_UARTEN) {
+		if ((tmp_cr & UARTCR_TXE) && (tmp_cr & UARTCR_UARTEN)) {
+			while (!(pl011_read16(pl011, UARTFR_REG) & UARTFR_TXFE))
+				/* drain the TX FIFO */;
+			/* disable the UART */
+			pl011_write16(pl011, UARTCR_REG,
+			    tmp_cr & ~(UARTCR_UARTEN));
+			while (pl011_read16(pl011, UARTFR_REG) & UARTFR_BUSY)
+				/* drain the output buffer */;
+		} else {
+			/* disable the UART */
+			pl011_write16(pl011, UARTCR_REG,
+			    tmp_cr & ~(UARTCR_UARTEN));
+		}
+	}
+
+	/* clear errors */
+	pl011_write8(pl011, UARTECR_REG, 0xF);
+
+	/*
+	 * IBRD, FBRD and LCR_H form a single logical 30bit register which
+	 * is strobed when LCR_H is written.
+	 */
+	if (ibrd != 0 && ibrd != pl011->pl_ibrd) {
+		pl011_write16(pl011, UARTIBRD_REG, ibrd);
+		pl011->pl_ibrd = ibrd;
+	}
+
+	if (fbrd != 0 && fbrd != pl011->pl_fbrd) {
+		pl011_write8(pl011, UARTFBRD_REG, fbrd);
+		pl011->pl_fbrd = fbrd;
+	}
+
+	if ((ibrd != 0 && ibrd != pl011->pl_ibrd) ||
+	    (fbrd != 0 && fbrd != pl011->pl_fbrd) ||
+	    lcr != pl011->pl_lcr) {
+		pl011_write8(pl011, UARTLCR_H_REG, lcr);
+		pl011->pl_lcr = lcr;
+	}
+
+	/*
+	 * Our calculated CR also re-enables the UART.
+	 */
+	pl011_write16(pl011, UARTCR_REG, cr);
+	pl011->pl_cr = cr;
+
+	return (true);
+}
+
+static bool
+pl011_config_check(void *ctx, mmio_uart_speed_t speed,
+    mmio_uart_data_bits_t dbits, mmio_uart_parity_t parity,
+    mmio_uart_stop_bits_t sbits)
+{
+	/*
+	 * PL011 does not support 1.5 stop bits.
+	 */
+	if (sbits == MMIO_UART_STOP_BITS_1_5)
+		return (false);
+
+	return (true);
+}
+
+static bool
+pl011_has_carrier(void *ctx)
+{
+	mmio_uart_t	*uart = ctx;
+	pl011_info_t	*pl011 = uart->mu_ctx;
+
+	return ((pl011_read16(pl011, UARTFR_REG) & UARTFR_DCD) ? true : false);
+}
+
+static void
+pl011_putchar(void *ctx, int c)
+{
+	mmio_uart_t	*uart = ctx;
+	pl011_info_t	*pl011 = uart->mu_ctx;
+
+	while (pl011_read16(pl011, UARTFR_REG) & UARTFR_TXFF)
+		/* just polling... */;
+	pl011_write8(pl011, UARTDR_REG, (uint8_t)(c & 0xFF));
+}
+
+static int
+pl011_ischar(void *ctx)
+{
+	mmio_uart_t	*uart = ctx;
+	pl011_info_t	*pl011 = uart->mu_ctx;
+
+	if (pl011_read16(pl011, UARTFR_REG) & UARTFR_RXFE)
+		return (0);
+
+	return (1);
+}
+
+static int
+pl011_getchar(void *ctx)
+{
+	mmio_uart_t	*uart = ctx;
+	pl011_info_t	*pl011 = uart->mu_ctx;
+
+	if (pl011_ischar(ctx) == 0)
+		return (-1);
+
+	return ((int)pl011_read8(pl011, UARTDR_REG));
+}
+
+static int
+pl011_getspeed(void *ctx)
+{
+	mmio_uart_t	*uart = ctx;
+	return (uart->mu_speed);
+}
+
+static void
+pl011_devinfo(void *ctx)
+{
+	mmio_uart_t	*uart = ctx;
+	pl011_info_t	*pl011 = uart->mu_ctx;
+
+	printf("\tmmio %#lx", pl011->pl_addr);
+}
+
+static int
+pl011_make_tty_hook(void *ctx)
+{
+	mmio_uart_speed_t	speed;
+	mmio_uart_data_bits_t	data_bits;
+	mmio_uart_parity_t	parity;
+	mmio_uart_stop_bits_t	stop_bits;
+	bool			ignore_cd;
+	bool			rtsdtr_off;
+	mmio_uart_t		*uart = ctx;
+	pl011_info_t		*pl011 = uart->mu_ctx;
+
+	if (pl011->pl_addr == 0 || pl011->pl_addr_len == 0)
+		return (-1);
+
+	/* ensure that all interrupts are masked and cleared */
+	if ((pl011_read16(pl011, UARTIMSC_REG) & 0x7FF) != 0x7FF) {
+		pl011_write16(pl011, UARTIMSC_REG, 0x7FF);
+		pl011_write16(pl011, UARTICR_REG, 0x7FF);
+	}
+
+	if (IS_GENERIC_UART(uart)) {
+		/*
+		 * Set up per DEN0094D §B.4 (Control and setup)
+		 *
+		 * There's not much we can do with a generic UART other
+		 * than simply use it.
+		 */
+		pl011->pl_lcr = 0x60|UARTLCR_H_FEN;
+		pl011->pl_cr = UARTCR_RXE|UARTCR_TXE|UARTCR_UARTEN;
+		pl011->pl_ibrd = 0;
+		pl011->pl_fbrd = 0;
+
+		uart->mu_data_bits = MMIO_UART_DATA_BITS_8;
+		uart->mu_parity = MMIO_UART_PARITY_NONE;
+		uart->mu_stop_bits = MMIO_UART_STOP_BITS_1;
+		uart->mu_ignore_cd = true;
+		uart->mu_rtsdtr_off = true;
+
+		/*
+		 * Speed is configured in FDT or SPCR for a generic UART,
+		 * so leave setting this to the discovery code in the happy
+		 * path, but if that has not set anything reasonable, set
+		 * our default.
+		 */
+		if (uart->mu_speed == 0)
+			uart->mu_speed = MMIO_UART_DEFAULT_COMSPEED;
+
+		return (0);
+	}
+
+	pl011->pl_cr = pl011_read16(pl011, UARTCR_REG);
+	pl011->pl_lcr = pl011_read8(pl011, UARTLCR_H_REG);
+	pl011->pl_ibrd = pl011_read16(pl011, UARTIBRD_REG);
+	pl011->pl_fbrd = pl011_read8(pl011, UARTFBRD_REG);
+
+	/*
+	 * We can only determine the BAUD rate if we know the clock frequency.
+	 */
+	speed = uart->mu_speed;
+	if (pl011->pl_frequency != 0) {
+		/*
+		 * If we have the frequency we can read the current speed from
+		 * the integer and fractional BAUD register values.
+		 *
+		 * Given a 6bit UARTFBRD the maximum error rate is 1.56%,
+		 * which we account for in `pl011_match_baud'.
+		 */
+		uint64_t baud;
+
+		speed = 0;
+		if (pl011->pl_ibrd != 0) {
+			baud = (pl011->pl_frequency /
+			    ((((uint32_t)pl011->pl_ibrd) << 6) +
+			    pl011->pl_fbrd)) << 2;
+			speed = pl011_match_baud(baud);
+		}
+
+		if (speed == 0)
+			speed = uart->mu_speed;
+	}
+
+	switch (pl011->pl_lcr & UARTLCR_H_WLEN) {
+	case 0x60:
+		data_bits = MMIO_UART_DATA_BITS_8;
+		break;
+	case 0x40:
+		data_bits = MMIO_UART_DATA_BITS_7;
+		break;
+	case 0x20:
+		data_bits = MMIO_UART_DATA_BITS_6;
+		break;
+	case 0x00:	/* fallthrough */
+	default:
+		data_bits = MMIO_UART_DATA_BITS_5;
+		break;
+	}
+
+	if (pl011->pl_lcr & UARTLCR_H_PEN) {
+		if (pl011->pl_lcr & UARTLCR_H_EPS) {
+			if (pl011->pl_lcr & UARTLCR_H_SPS) {
+				parity = MMIO_UART_PARITY_SPACE;
+			} else {
+				parity = MMIO_UART_PARITY_EVEN;
+			}
+		} else {
+			if (pl011->pl_lcr & UARTLCR_H_SPS) {
+				parity = MMIO_UART_PARITY_MARK;
+			} else {
+				parity = MMIO_UART_PARITY_ODD;
+			}
+		}
+
+	} else {
+		parity = MMIO_UART_PARITY_NONE;
+	}
+
+	if (pl011->pl_lcr & UARTLCR_H_STP2) {
+		stop_bits = MMIO_UART_STOP_BITS_2;
+	} else {
+		stop_bits = MMIO_UART_STOP_BITS_1;
+	}
+
+	/*
+	 * Ignoring carrier detect is a purely software function, done by
+	 * checking the DCD bit in the UARTLCR register. We can't divine an
+	 * intention here, so just set a default.
+	 */
+	ignore_cd = true;
+
+	if ((pl011->pl_cr & (UARTCR_RTS|UARTCR_DTR)) ==
+	    (UARTCR_RTS|UARTCR_DTR)) {
+		rtsdtr_off = false;
+	} else {
+		rtsdtr_off = true;
+	}
+
+	/*
+	 * Update the configuration to match the hardware when required.
+	 */
+	if (uart->mu_flags & MMIO_UART_CONFIG_FROM_HW) {
+		if (speed != 0 || uart->mu_speed == 0)
+			uart->mu_speed = speed;
+		if (uart->mu_speed == 0)
+			uart->mu_speed = MMIO_UART_DEFAULT_COMSPEED;
+		uart->mu_data_bits = data_bits;
+		uart->mu_parity = parity;
+		uart->mu_stop_bits = stop_bits;
+		uart->mu_ignore_cd = ignore_cd;
+		uart->mu_rtsdtr_off = rtsdtr_off;
+	}
+
+	return (0);
+}
+
+static int
+pl011_no_set(struct env_var *ev __attribute((unused)),
+    int flags __attribute((unused)), const void *value __attribute((unused)))
+{
+	return (CMD_OK);
+}
+
+static void
+pl011_set_environment(void *ctx)
+{
+	char		name[50];
+	char		value[30];
+	struct console	*cp = ctx;
+	mmio_uart_t	*uart = cp->c_private;
+	pl011_info_t	*pl011 = uart->mu_ctx;
+
+	snprintf(name, sizeof (name), "%s-mmio-base", cp->c_name);
+	snprintf(value, sizeof (value), "0x%llx",
+	    (unsigned long long)pl011->pl_addr);
+	unsetenv(name);
+	env_setenv(name, EV_VOLATILE, value, pl011_no_set, env_nounset);
+
+	snprintf(name, sizeof (name), "%s-mmio-size", cp->c_name);
+	snprintf(value, sizeof (value), "0x%llx",
+	    (unsigned long long)pl011->pl_addr_len);
+	unsetenv(name);
+	env_setenv(name, EV_VOLATILE, value, pl011_no_set, env_nounset);
+
+	snprintf(name, sizeof (name), "%s-clock-frequency", cp->c_name);
+	snprintf(value, sizeof (value), "%llu",
+	    (unsigned long long)pl011->pl_frequency);
+	unsetenv(name);
+	env_setenv(name, EV_VOLATILE, value, pl011_no_set, env_nounset);
+}
+
+const mmio_uart_ops_t mmio_uart_pl011_ops = {
+	.op_setup		= pl011_setup,
+	.op_config_check	= pl011_config_check,
+	.op_has_carrier		= pl011_has_carrier,
+	.op_putchar		= pl011_putchar,
+	.op_getchar		= pl011_getchar,
+	.op_ischar		= pl011_ischar,
+	.op_getspeed		= pl011_getspeed,
+	.op_devinfo		= pl011_devinfo,
+	.op_make_tty_hook	= pl011_make_tty_hook,
+	.op_set_environment	= pl011_set_environment,
+};

--- a/usr/src/boot/efi/libmmio_uart/pl011.h
+++ b/usr/src/boot/efi/libmmio_uart/pl011.h
@@ -1,0 +1,48 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2025 Michael van der Westhuizen
+ */
+
+#ifndef _MMIO_UART_PL011_H
+#define	_MMIO_UART_PL011_H
+
+#include <mmio_uart.h>
+
+/*
+ * MMIO UART declarations for Arm PL011 compatible UARTs.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+	uint64_t		pl_addr;
+	uint64_t		pl_addr_len;
+	uint64_t		pl_frequency;
+	mmio_uart_type_t	pl_variant;
+
+	/* cached register values */
+	uint16_t		pl_ibrd;
+	uint8_t			pl_fbrd;
+	uint8_t			pl_lcr;
+	uint16_t		pl_cr;
+} pl011_info_t;
+
+extern const mmio_uart_ops_t mmio_uart_pl011_ops;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _MMIO_UART_PL011_H */

--- a/usr/src/boot/efi/loader/Makefile.com
+++ b/usr/src/boot/efi/loader/Makefile.com
@@ -139,8 +139,15 @@ loader.bin: loader.sym
 DPLIBEFI=	../../libefi/$(MACHINE)/libefi.a
 LIBEFI=		-L../../libefi/$(MACHINE) -lefi
 
-DPADD=		$(DPLIBFICL) $(DPLIBEFI) $(DPLIBSA) $(LDSCRIPT)
-LDADD=		$(LIBFICL) $(LIBEFI) $(LIBSA)
+aarch64_DPLIBMMIOUART=	../../libmmio_uart/$(MACHINE)/libmmio_uart.a
+aarch64_LIBMMIOUART=	-L../../libmmio_uart/$(MACHINE) -lmmio_uart
+DPLIBMMIOUART=		$($(MACH)_DPLIBMMIOUART)
+LIBMMIOUART=		$($(MACH)_LIBMMIOUART)
+
+DPADD=		$(DPLIBFICL) $(DPLIBMMIOUART) \
+		$(DPLIBEFI) $(DPLIBSA) $(LDSCRIPT)
+LDADD=		$(LIBFICL) $(LIBMMIOUART) \
+		$(LIBEFI) $(LIBSA)
 
 loader.sym:	$(OBJS) $(DPADD)
 	$(GLD) $(LDFLAGS) -o $@ $(OBJS) $(LDADD)


### PR DESCRIPTION
Introduce a "mediator" layer between UART firmware discovery and `loader(7)` console management. This layer provides console hooks to `loader(7)` and performs environment variable management in addition to avoiding conflicts with the efi_console (when that is used to drive the UART).

The framework is driven by firmware-specific UART discovery and registration code, which is added in subsequent PRs.

Will be rebased once https://github.com/richlowe/illumos-gate/pull/153 lands.