### PR TITLE
loader(7): 12 of 16 - acpica

### DIFF
--- a/usr/src/boot/efi/libacpica/Makefile
+++ b/usr/src/boot/efi/libacpica/Makefile
@@ -10,28 +10,28 @@
 #
 
 #
-# Copyright 2015 Toomas Soome <tsoome@me.com>
+# Copyright 2025 Michael van der Westhuizen
 #
-
-.KEEP_STATE:
 
 include $(SRC)/boot/Makefile.master
 
 i386_SUBDIRS =
-aarch64_SUBDIRS = libmmio_uart libfdt libfdtutil libfdtuart libacpica
-
-SUBDIRS = libefi $($(MACH)_SUBDIRS) loader
-
-all install clean clobber: $(SUBDIRS)
+aarch64_SUBDIRS = $(MACH64)
+SUBDIRS = $($(MACH)_SUBDIRS)
 
 all	:=	TARGET = all
 clean	:=	TARGET = clean
 clobber	:=	TARGET = clobber
 install	:=	TARGET = install
 
-loader:	libefi $($(MACH)_SUBDIRS)
+.KEEP_STATE:
+
+all clean clobber: $(SUBDIRS)
+
+install: all
 
 .PARALLEL:
+
 $(SUBDIRS): FRC
 	@cd $@; pwd; $(MAKE) $(TARGET)
 

--- a/usr/src/boot/efi/libacpica/Makefile.com
+++ b/usr/src/boot/efi/libacpica/Makefile.com
@@ -1,0 +1,170 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 Michael van der Westhuizen
+#
+
+include $(SRC)/boot/Makefile.master
+include $(SRC)/boot/Makefile.inc
+
+MACHINCLUDE = $(MACH64)
+
+install:
+
+#
+# On the next ACPI update, add exserial.c and utcksum.c
+#
+
+SRCS += \
+	acpi_efi.c \
+	\
+	osstub.c \
+	\
+	oseficlib.c osefitbl.c osefixf.c \
+	\
+	dsargs.c dscontrol.c dsdebug.c dsfield.c dsinit.c \
+	dsmethod.c dsmthdat.c dsobject.c dsopcode.c dsutils.c \
+	dswexec.c dswload.c dswload2.c dswscope.c dswstate.c \
+	dspkginit.c \
+	\
+	evevent.c evglock.c evgpe.c evgpeblk.c evgpeinit.c \
+	evgpeutil.c evhandler.c evmisc.c evregion.c evrgnini.c \
+	evsci.c evxface.c evxfevnt.c evxfgpe.c evxfregn.c \
+	\
+	exconcat.c exconfig.c exconvrt.c excreate.c exdebug.c \
+	exdump.c exfield.c exfldio.c exmisc.c exmutex.c exnames.c \
+	exoparg1.c exoparg2.c exoparg3.c exoparg6.c exprep.c \
+	exregion.c exresnte.c exresolv.c exresop.c \
+	exstore.c exstoren.c exstorob.c exsystem.c extrace.c \
+	exutils.c \
+	\
+	hwacpi.c hwesleep.c hwgpe.c hwpci.c hwregs.c hwsleep.c \
+	hwtimer.c hwvalid.c hwxface.c hwxfsleep.c \
+	\
+	psargs.c psloop.c psobject.c psopcode.c psopinfo.c \
+	psparse.c psscope.c pstree.c psutils.c pswalk.c psxface.c \
+	\
+	nsaccess.c nsalloc.c nsarguments.c nsconvert.c nsdump.c \
+	nsdumpdv.c nseval.c nsinit.c nsload.c nsnames.c nsobject.c \
+	nsparse.c nspredef.c nsprepkg.c nsrepair.c nsrepair2.c \
+	nssearch.c nsutils.c nswalk.c nsxfeval.c nsxfname.c \
+	nsxfobj.c \
+	\
+	tbdata.c tbfadt.c tbfind.c tbinstal.c tbprint.c tbutils.c \
+	tbxface.c tbxfload.c tbxfroot.c \
+	\
+	utaddress.c utalloc.c utascii.c utbuffer.c utcache.c \
+	utclib.c utcopy.c utdebug.c utdecode.c utdelete.c \
+	uterror.c uteval.c utexcep.c utglobal.c uthex.c utids.c \
+	utinit.c utlock.c utmath.c utmisc.c utmutex.c utnonansi.c \
+	utobject.c utosi.c utownerid.c utpredef.c utresrc.c \
+	utstate.c utstring.c uttrack.c utuuid.c utxface.c \
+	utxferror.c utxfinit.c utxfmutex.c utresdecode.c \
+	utstrsuppt.c utstrtoul64.c
+
+DISASSEMBLER_SOURCES = \
+	dmbuffer.c dmcstyle.c dmdeferred.c dmnames.c dmopcode.c \
+	dmresrc.c dmresrcl.c dmresrcl2.c dmresrcs.c dmutils.c \
+	dmwalk.c
+
+DEBUGGER_SOURCES = \
+	rsaddr.c rscalc.c rscreate.c rsdump.c rsdumpinfo.c \
+	rsinfo.c rsio.c rsirq.c rslist.c rsmemory.c rsmisc.c \
+	rsserial.c rsutils.c rsxface.c
+
+XDEBUGGER_SOURCES = \
+	rsaddr.c rscalc.c rscreate.c rsdumpinfo.c \
+	rsinfo.c rsio.c rsirq.c rslist.c rsmemory.c rsmisc.c \
+	rsserial.c rsutils.c rsxface.c
+
+SRCS += $(XDEBUGGER_SOURCES)
+
+OBJS=	$(SRCS:%.c=%.o)
+
+CPPFLAGS += -U__sun
+CPPFLAGS += -DEFI
+CPPFLAGS += -D_EDK2_EFI
+CPPFLAGS += -DUSE_STDLIB
+CPPFLAGS += -DACPI_USE_LOCAL_CACHE
+
+# CPPFLAGS += -DACPI_DISASSEMBLER
+# CPPFLAGS += -DACPI_DEBUGGER
+
+CPPFLAGS += -DEFI -I.
+CPPFLAGS += -I$(SRC)/uts/common/sys/acpi
+CPPFLAGS += -I$(BOOTSRC)/sys
+CPPFLAGS += -I$(BOOTSRC)/common
+CPPFLAGS += -I$(BOOTSRC)/libsa
+CPPFLAGS += -I$(BOOTSRC)/include
+CPPFLAGS += -I$(BOOTSRC)/efi/include
+CPPFLAGS += -I$(BOOTSRC)/efi/include/$(MACHINCLUDE)
+
+# needed for tbl - I'm sure we can get rid of a lot of this
+CPPFLAGS += -I$(SRC)/cmd/acpi/acpidump
+
+include ../../Makefile.inc
+
+CFLAGS +=       $(CFLAGS64)
+
+libacpica.a: $(OBJS)
+	$(AR) $(ARFLAGS) $@ $(OBJS)
+
+clean: clobber
+clobber:
+	$(RM) $(CLEANFILES) $(OBJS) libacpica.a
+
+machine:
+	$(RM) machine
+	$(SYMLINK) ../../../sys/$(MACHINE)/include machine
+
+x86:
+	$(RM) x86
+	$(SYMLINK) ../../../sys/x86/include x86
+
+%.o:	../%.c
+	$(COMPILE.c) $<
+
+%.o:	../../../common/%.c
+	$(COMPILE.c) $<
+
+%.o:	$(PNGLITE)/%.c
+	$(COMPILE.c) $<
+
+%.o:	$(SRC)/common/acpica/events/%.c
+	$(COMPILE.c) $<
+
+%.o:	$(SRC)/common/acpica/hardware/%.c
+	$(COMPILE.c) $<
+
+%.o:	$(SRC)/common/acpica/dispatcher/%.c
+	$(COMPILE.c) $<
+
+%.o:	$(SRC)/common/acpica/executer/%.c
+	$(COMPILE.c) $<
+
+%.o:	$(SRC)/common/acpica/parser/%.c
+	$(COMPILE.c) $<
+
+%.o:	$(SRC)/common/acpica/namespace/%.c
+	$(COMPILE.c) $<
+
+%.o:	$(SRC)/common/acpica/resources/%.c
+	$(COMPILE.c) $<
+
+%.o:	$(SRC)/common/acpica/tables/%.c
+	$(COMPILE.c) $<
+
+%.o:	$(SRC)/common/acpica/utilities/%.c
+	$(COMPILE.c) $<
+
+%.o:	$(SRC)/common/acpica/disassembler/%.c
+	$(COMPILE.c) $<

--- a/usr/src/boot/efi/libacpica/acpi_efi.c
+++ b/usr/src/boot/efi/libacpica/acpi_efi.c
@@ -1,0 +1,98 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2025 Michael van der Westhuizen
+ */
+
+/*
+ * ACPICA initialisation for UEFI in the illumos loader
+ */
+
+#include <acpi.h>
+#include <aclocal.h>
+#include <acobject.h>
+#include <acstruct.h>
+#include <acnamesp.h>
+#include <acutils.h>
+#include <acmacros.h>
+#include <acevents.h>
+#include <actbl.h>
+#include <actbl1.h>
+#include <actbl3.h>
+
+#include "acpi_efi.h"
+
+typedef enum {
+	ACPI_EFI_UNINITIALISED,
+	ACPI_EFI_INIT_FAILED,
+	ACPI_EFI_INIT_SUCCESS
+} acpi_efi_init_status_t;
+
+static acpi_efi_init_status_t acpica_init_status = ACPI_EFI_UNINITIALISED;
+
+bool
+acpi_efi_init(void)
+{
+	ACPI_STATUS status;
+
+	switch (acpica_init_status) {
+	case ACPI_EFI_UNINITIALISED:
+		break;
+	case ACPI_EFI_INIT_FAILED:
+		return (false);
+	case ACPI_EFI_INIT_SUCCESS:
+		return (true);
+	}
+
+	acpica_init_status = ACPI_EFI_INIT_FAILED;
+
+	status = AcpiInitializeSubsystem();
+	if (ACPI_FAILURE(status))
+		return (false);
+
+	status = AcpiInitializeTables(NULL, 16, TRUE);
+	if (ACPI_FAILURE(status))
+		return (false);
+
+	status = AcpiLoadTables();
+	if (ACPI_FAILURE(status))
+		return (false);
+
+	status = AcpiEnableSubsystem(ACPI_FULL_INITIALIZATION);
+	if (ACPI_FAILURE(status))
+		return (false);
+
+	status = AcpiInitializeObjects(ACPI_FULL_INITIALIZATION);
+	if (ACPI_FAILURE(status))
+		return (false);
+
+	acpica_init_status = ACPI_EFI_INIT_SUCCESS;
+	return (true);
+}
+
+bool
+acpi_efi_fini(void)
+{
+	ACPI_STATUS status;
+
+	if (acpica_init_status == ACPI_EFI_UNINITIALISED)
+		return (true);
+
+	status = AcpiTerminate();
+	if (ACPI_FAILURE(status)) {
+		acpica_init_status = ACPI_EFI_INIT_FAILED;
+		return (false);
+	}
+
+	acpica_init_status = ACPI_EFI_UNINITIALISED;
+	return (true);
+}

--- a/usr/src/boot/efi/libacpica/acpi_efi.h
+++ b/usr/src/boot/efi/libacpica/acpi_efi.h
@@ -1,0 +1,36 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2025 Michael van der Westhuizen
+ */
+
+#ifndef _ACPI_EFI_H
+#define	_ACPI_EFI_H
+
+/*
+ * Loader-specific functions to initialise ACPI.
+ */
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern bool acpi_efi_init(void);
+extern bool acpi_efi_fini(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _ACPI_EFI_H */

--- a/usr/src/boot/efi/libacpica/arm64/Makefile
+++ b/usr/src/boot/efi/libacpica/arm64/Makefile
@@ -1,0 +1,30 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2025 Michael van der Westhuizen
+#
+
+MACHINE=	$(MACH64)
+
+all:		libacpica.a
+
+include ../Makefile.com
+
+CPPFLAGS += -include stdint.h
+CPPFLAGS += -DUINTN=uint64_t
+CPPFLAGS += -DINTN=int64_t
+
+CFLAGS +=	$(CFLAGS64)
+
+CLEANFILES +=	machine
+
+$(OBJS): machine

--- a/usr/src/boot/efi/libacpica/oseficlib.c
+++ b/usr/src/boot/efi/libacpica/oseficlib.c
@@ -1,0 +1,331 @@
+/******************************************************************************
+ *
+ * Module Name: oseficlib - EFI specific CLibrary interfaces
+ *
+ *****************************************************************************/
+
+/******************************************************************************
+ *
+ * 1. Copyright Notice
+ *
+ * Some or all of this work - Copyright (c) 1999 - 2023, Intel Corp.
+ * All rights reserved.
+ *
+ * 2. License
+ *
+ * 2.1. This is your license from Intel Corp. under its intellectual property
+ * rights. You may have additional license terms from the party that provided
+ * you this software, covering your right to use that party's intellectual
+ * property rights.
+ *
+ * 2.2. Intel grants, free of charge, to any person ("Licensee") obtaining a
+ * copy of the source code appearing in this file ("Covered Code") an
+ * irrevocable, perpetual, worldwide license under Intel's copyrights in the
+ * base code distributed originally by Intel ("Original Intel Code") to copy,
+ * make derivatives, distribute, use and display any portion of the Covered
+ * Code in any form, with the right to sublicense such rights; and
+ *
+ * 2.3. Intel grants Licensee a non-exclusive and non-transferable patent
+ * license (with the right to sublicense), under only those claims of Intel
+ * patents that are infringed by the Original Intel Code, to make, use, sell,
+ * offer to sell, and import the Covered Code and derivative works thereof
+ * solely to the minimum extent necessary to exercise the above copyright
+ * license, and in no event shall the patent license extend to any additions
+ * to or modifications of the Original Intel Code. No other license or right
+ * is granted directly or by implication, estoppel or otherwise;
+ *
+ * The above copyright and patent license is granted only if the following
+ * conditions are met:
+ *
+ * 3. Conditions
+ *
+ * 3.1. Redistribution of Source with Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification with rights to further distribute source must include
+ * the above Copyright Notice, the above License, this list of Conditions,
+ * and the following Disclaimer and Export Compliance provision. In addition,
+ * Licensee must cause all Covered Code to which Licensee contributes to
+ * contain a file documenting the changes Licensee made to create that Covered
+ * Code and the date of any change. Licensee must include in that file the
+ * documentation of any changes made by any predecessor Licensee. Licensee
+ * must include a prominent statement that the modification is derived,
+ * directly or indirectly, from Original Intel Code.
+ *
+ * 3.2. Redistribution of Source with no Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification without rights to further distribute source must
+ * include the following Disclaimer and Export Compliance provision in the
+ * documentation and/or other materials provided with distribution. In
+ * addition, Licensee may not authorize further sublicense of source of any
+ * portion of the Covered Code, and must include terms to the effect that the
+ * license from Licensee to its licensee is limited to the intellectual
+ * property embodied in the software Licensee provides to its licensee, and
+ * not to intellectual property embodied in modifications its licensee may
+ * make.
+ *
+ * 3.3. Redistribution of Executable. Redistribution in executable form of any
+ * substantial portion of the Covered Code or modification must reproduce the
+ * above Copyright Notice, and the following Disclaimer and Export Compliance
+ * provision in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * 3.4. Intel retains all right, title, and interest in and to the Original
+ * Intel Code.
+ *
+ * 3.5. Neither the name Intel nor any other trademark owned or controlled by
+ * Intel shall be used in advertising or otherwise to promote the sale, use or
+ * other dealings in products derived from or relating to the Covered Code
+ * without prior written authorization from Intel.
+ *
+ * 4. Disclaimer and Export Compliance
+ *
+ * 4.1. INTEL MAKES NO WARRANTY OF ANY KIND REGARDING ANY SOFTWARE PROVIDED
+ * HERE. ANY SOFTWARE ORIGINATING FROM INTEL OR DERIVED FROM INTEL SOFTWARE
+ * IS PROVIDED "AS IS," AND INTEL WILL NOT PROVIDE ANY SUPPORT, ASSISTANCE,
+ * INSTALLATION, TRAINING OR OTHER SERVICES. INTEL WILL NOT PROVIDE ANY
+ * UPDATES, ENHANCEMENTS OR EXTENSIONS. INTEL SPECIFICALLY DISCLAIMS ANY
+ * IMPLIED WARRANTIES OF MERCHANTABILITY, NONINFRINGEMENT AND FITNESS FOR A
+ * PARTICULAR PURPOSE.
+ *
+ * 4.2. IN NO EVENT SHALL INTEL HAVE ANY LIABILITY TO LICENSEE, ITS LICENSEES
+ * OR ANY OTHER THIRD PARTY, FOR ANY LOST PROFITS, LOST DATA, LOSS OF USE OR
+ * COSTS OF PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES, OR FOR ANY INDIRECT,
+ * SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THIS AGREEMENT, UNDER ANY
+ * CAUSE OF ACTION OR THEORY OF LIABILITY, AND IRRESPECTIVE OF WHETHER INTEL
+ * HAS ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES. THESE LIMITATIONS
+ * SHALL APPLY NOTWITHSTANDING THE FAILURE OF THE ESSENTIAL PURPOSE OF ANY
+ * LIMITED REMEDY.
+ *
+ * 4.3. Licensee shall not export, either directly or indirectly, any of this
+ * software or system incorporating such software without first obtaining any
+ * required license or other approval from the U. S. Department of Commerce or
+ * any other agency or department of the United States Government. In the
+ * event Licensee exports any such software from the United States or
+ * re-exports any such software from a foreign destination, Licensee shall
+ * ensure that the distribution and export/re-export of the software is in
+ * compliance with all laws, regulations, orders, or other restrictions of the
+ * U.S. Export Administration Regulations. Licensee agrees that neither it nor
+ * any of its subsidiaries will export/re-export any technical data, process,
+ * software, or service, directly or indirectly, to any country for which the
+ * United States government or any agency thereof requires an export license,
+ * other governmental approval, or letter of assurance, without first obtaining
+ * such license, approval or letter.
+ *
+ *****************************************************************************
+ *
+ * Alternatively, you may choose to be licensed under the terms of the
+ * following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions, and the following disclaimer,
+ *    without modification.
+ * 2. Redistributions in binary form must reproduce at minimum a disclaimer
+ *    substantially similar to the "NO WARRANTY" disclaimer below
+ *    ("Disclaimer") and any redistribution must be conditioned upon
+ *    including a substantially similar Disclaimer requirement for further
+ *    binary redistribution.
+ * 3. Neither the names of the above-listed copyright holders nor the names
+ *    of any contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Alternatively, you may choose to be licensed under the terms of the
+ * GNU General Public License ("GPL") version 2 as published by the Free
+ * Software Foundation.
+ *
+ *****************************************************************************/
+
+#include "acpi.h"
+#include "accommon.h"
+
+#include <stdio.h>
+#include <sys/errno.h>
+
+#define _COMPONENT          ACPI_OS_SERVICES
+        ACPI_MODULE_NAME    ("oseficlib")
+
+
+/* Local definitions */
+
+#define ACPI_EFI_PRINT_LENGTH   256
+
+#define ACPI_EFI_KEY_ESC        0x0000
+#define ACPI_EFI_KEY_BACKSPACE  0x0008
+#define ACPI_EFI_KEY_ENTER      0x000D
+#define ACPI_EFI_KEY_CTRL_C     0x0003
+
+#define ACPI_EFI_ASCII_NULL     0x00
+#define ACPI_EFI_ASCII_DEL      0x7F
+#define ACPI_EFI_ASCII_ESC      0x1B
+#define ACPI_EFI_ASCII_CR       '\r'
+#define ACPI_EFI_ASCII_NL       '\n'
+
+
+/* Local prototypes */
+
+/* Local variables */
+
+FILE                        *stdin = NULL;
+FILE                        *stdout = NULL;
+FILE                        *stderr = NULL;
+static ACPI_EFI_FILE_HANDLE AcpiGbl_EfiCurrentVolume = NULL;
+ACPI_EFI_GUID               AcpiGbl_LoadedImageProtocol = ACPI_EFI_LOADED_IMAGE_PROTOCOL;
+ACPI_EFI_GUID               AcpiGbl_TextInProtocol = ACPI_SIMPLE_TEXT_INPUT_PROTOCOL;
+ACPI_EFI_GUID               AcpiGbl_TextOutProtocol = ACPI_SIMPLE_TEXT_OUTPUT_PROTOCOL;
+ACPI_EFI_GUID               AcpiGbl_FileSystemProtocol = ACPI_SIMPLE_FILE_SYSTEM_PROTOCOL;
+ACPI_EFI_GUID               AcpiGbl_GenericFileInfo = ACPI_EFI_FILE_INFO_ID;
+
+extern int                         errno;
+
+/*******************************************************************************
+ *
+ * FUNCTION:    fopen
+ *
+ * PARAMETERS:  Path                - File path
+ *              Modes               - File operation type
+ *
+ * RETURN:      File descriptor
+ *
+ * DESCRIPTION: Open a file for reading or/and writing.
+ *
+ ******************************************************************************/
+
+FILE *
+fopen (
+    const char              *Path,
+    const char              *Modes)
+{
+    ACPI_EFI_STATUS         EfiStatus = ACPI_EFI_SUCCESS;
+    UINT64                  OpenModes;
+    ACPI_EFI_FILE_HANDLE    EfiFile = NULL;
+    CHAR16                  *Path16 = NULL;
+    CHAR16                  *Pos16;
+    const char              *Pos;
+    INTN                    Count, i;
+    BOOLEAN                 IsAppend = FALSE;
+    FILE                    *File = NULL;
+
+
+    if (!Path)
+    {
+        errno = EINVAL;
+        return (NULL);
+    }
+
+    /*
+     * Convert modes, EFI says the only 2 read/write modes are read-only,
+     * read+write. Thus set default mode as read-only.
+     */
+    OpenModes = ACPI_EFI_FILE_MODE_READ;
+    switch (*Modes++)
+    {
+    case 'r':
+
+        break;
+
+    case 'w':
+
+        OpenModes |= (ACPI_EFI_FILE_MODE_WRITE | ACPI_EFI_FILE_MODE_CREATE);
+        break;
+
+    case 'a':
+
+        OpenModes |= (ACPI_EFI_FILE_MODE_WRITE | ACPI_EFI_FILE_MODE_CREATE);
+        IsAppend = TRUE;
+        break;
+
+    default:
+
+        errno = EINVAL;
+        return (NULL);
+    }
+
+    for (; *Modes; Modes++)
+    {
+        switch (*Modes)
+        {
+        case '+':
+
+            OpenModes |= (ACPI_EFI_FILE_MODE_WRITE | ACPI_EFI_FILE_MODE_CREATE);
+            break;
+
+        case 'b':
+        case 't':
+
+            break;
+
+        case 'f':
+        default:
+
+            break;
+        }
+    }
+
+    /* Allocate path buffer */
+
+    Count = strlen (Path);
+    Path16 = ACPI_ALLOCATE_ZEROED ((Count + 1) * sizeof (CHAR16));
+    if (!Path16)
+    {
+        EfiStatus = ACPI_EFI_BAD_BUFFER_SIZE;
+        errno = ENOMEM;
+        goto ErrorExit;
+    }
+    Pos = Path;
+    Pos16 = Path16;
+    while (*Pos == '/' || *Pos == '\\')
+    {
+        Pos++;
+        Count--;
+    }
+    for (i = 0; i < Count; i++)
+    {
+        if (*Pos == '/')
+        {
+            *Pos16++ = '\\';
+            Pos++;
+        }
+        else
+        {
+            *Pos16++ = *Pos++;
+        }
+    }
+    *Pos16 = '\0';
+
+    EfiStatus = uefi_call_wrapper (AcpiGbl_EfiCurrentVolume->Open, 5,
+        AcpiGbl_EfiCurrentVolume, &EfiFile, Path16, OpenModes, 0);
+    if (ACPI_EFI_ERROR (EfiStatus))
+    {
+        errno = ENOENT;
+        goto ErrorExit;
+    }
+
+    File = (FILE *) EfiFile;
+    if (IsAppend)
+    {
+        fseek (File, 0, SEEK_END);
+    }
+
+ErrorExit:
+
+    if (Path16)
+    {
+        ACPI_FREE (Path16);
+    }
+
+    return (File);
+}

--- a/usr/src/boot/efi/libacpica/osefitbl.c
+++ b/usr/src/boot/efi/libacpica/osefitbl.c
@@ -1,0 +1,1173 @@
+/******************************************************************************
+ *
+ * Module Name: osefitbl - EFI OSL for obtaining ACPI tables
+ *
+ *****************************************************************************/
+
+/******************************************************************************
+ *
+ * 1. Copyright Notice
+ *
+ * Some or all of this work - Copyright (c) 1999 - 2023, Intel Corp.
+ * All rights reserved.
+ *
+ * 2. License
+ *
+ * 2.1. This is your license from Intel Corp. under its intellectual property
+ * rights. You may have additional license terms from the party that provided
+ * you this software, covering your right to use that party's intellectual
+ * property rights.
+ *
+ * 2.2. Intel grants, free of charge, to any person ("Licensee") obtaining a
+ * copy of the source code appearing in this file ("Covered Code") an
+ * irrevocable, perpetual, worldwide license under Intel's copyrights in the
+ * base code distributed originally by Intel ("Original Intel Code") to copy,
+ * make derivatives, distribute, use and display any portion of the Covered
+ * Code in any form, with the right to sublicense such rights; and
+ *
+ * 2.3. Intel grants Licensee a non-exclusive and non-transferable patent
+ * license (with the right to sublicense), under only those claims of Intel
+ * patents that are infringed by the Original Intel Code, to make, use, sell,
+ * offer to sell, and import the Covered Code and derivative works thereof
+ * solely to the minimum extent necessary to exercise the above copyright
+ * license, and in no event shall the patent license extend to any additions
+ * to or modifications of the Original Intel Code. No other license or right
+ * is granted directly or by implication, estoppel or otherwise;
+ *
+ * The above copyright and patent license is granted only if the following
+ * conditions are met:
+ *
+ * 3. Conditions
+ *
+ * 3.1. Redistribution of Source with Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification with rights to further distribute source must include
+ * the above Copyright Notice, the above License, this list of Conditions,
+ * and the following Disclaimer and Export Compliance provision. In addition,
+ * Licensee must cause all Covered Code to which Licensee contributes to
+ * contain a file documenting the changes Licensee made to create that Covered
+ * Code and the date of any change. Licensee must include in that file the
+ * documentation of any changes made by any predecessor Licensee. Licensee
+ * must include a prominent statement that the modification is derived,
+ * directly or indirectly, from Original Intel Code.
+ *
+ * 3.2. Redistribution of Source with no Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification without rights to further distribute source must
+ * include the following Disclaimer and Export Compliance provision in the
+ * documentation and/or other materials provided with distribution. In
+ * addition, Licensee may not authorize further sublicense of source of any
+ * portion of the Covered Code, and must include terms to the effect that the
+ * license from Licensee to its licensee is limited to the intellectual
+ * property embodied in the software Licensee provides to its licensee, and
+ * not to intellectual property embodied in modifications its licensee may
+ * make.
+ *
+ * 3.3. Redistribution of Executable. Redistribution in executable form of any
+ * substantial portion of the Covered Code or modification must reproduce the
+ * above Copyright Notice, and the following Disclaimer and Export Compliance
+ * provision in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * 3.4. Intel retains all right, title, and interest in and to the Original
+ * Intel Code.
+ *
+ * 3.5. Neither the name Intel nor any other trademark owned or controlled by
+ * Intel shall be used in advertising or otherwise to promote the sale, use or
+ * other dealings in products derived from or relating to the Covered Code
+ * without prior written authorization from Intel.
+ *
+ * 4. Disclaimer and Export Compliance
+ *
+ * 4.1. INTEL MAKES NO WARRANTY OF ANY KIND REGARDING ANY SOFTWARE PROVIDED
+ * HERE. ANY SOFTWARE ORIGINATING FROM INTEL OR DERIVED FROM INTEL SOFTWARE
+ * IS PROVIDED "AS IS," AND INTEL WILL NOT PROVIDE ANY SUPPORT, ASSISTANCE,
+ * INSTALLATION, TRAINING OR OTHER SERVICES. INTEL WILL NOT PROVIDE ANY
+ * UPDATES, ENHANCEMENTS OR EXTENSIONS. INTEL SPECIFICALLY DISCLAIMS ANY
+ * IMPLIED WARRANTIES OF MERCHANTABILITY, NONINFRINGEMENT AND FITNESS FOR A
+ * PARTICULAR PURPOSE.
+ *
+ * 4.2. IN NO EVENT SHALL INTEL HAVE ANY LIABILITY TO LICENSEE, ITS LICENSEES
+ * OR ANY OTHER THIRD PARTY, FOR ANY LOST PROFITS, LOST DATA, LOSS OF USE OR
+ * COSTS OF PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES, OR FOR ANY INDIRECT,
+ * SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THIS AGREEMENT, UNDER ANY
+ * CAUSE OF ACTION OR THEORY OF LIABILITY, AND IRRESPECTIVE OF WHETHER INTEL
+ * HAS ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES. THESE LIMITATIONS
+ * SHALL APPLY NOTWITHSTANDING THE FAILURE OF THE ESSENTIAL PURPOSE OF ANY
+ * LIMITED REMEDY.
+ *
+ * 4.3. Licensee shall not export, either directly or indirectly, any of this
+ * software or system incorporating such software without first obtaining any
+ * required license or other approval from the U. S. Department of Commerce or
+ * any other agency or department of the United States Government. In the
+ * event Licensee exports any such software from the United States or
+ * re-exports any such software from a foreign destination, Licensee shall
+ * ensure that the distribution and export/re-export of the software is in
+ * compliance with all laws, regulations, orders, or other restrictions of the
+ * U.S. Export Administration Regulations. Licensee agrees that neither it nor
+ * any of its subsidiaries will export/re-export any technical data, process,
+ * software, or service, directly or indirectly, to any country for which the
+ * United States government or any agency thereof requires an export license,
+ * other governmental approval, or letter of assurance, without first obtaining
+ * such license, approval or letter.
+ *
+ *****************************************************************************
+ *
+ * Alternatively, you may choose to be licensed under the terms of the
+ * following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions, and the following disclaimer,
+ *    without modification.
+ * 2. Redistributions in binary form must reproduce at minimum a disclaimer
+ *    substantially similar to the "NO WARRANTY" disclaimer below
+ *    ("Disclaimer") and any redistribution must be conditioned upon
+ *    including a substantially similar Disclaimer requirement for further
+ *    binary redistribution.
+ * 3. Neither the names of the above-listed copyright holders nor the names
+ *    of any contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Alternatively, you may choose to be licensed under the terms of the
+ * GNU General Public License ("GPL") version 2 as published by the Free
+ * Software Foundation.
+ *
+ *****************************************************************************/
+
+#include <stdio.h>
+
+#include "acpidump.h"
+
+#define _COMPONENT          ACPI_OS_SERVICES
+        ACPI_MODULE_NAME    ("osefitbl")
+
+
+#ifndef PATH_MAX
+#define PATH_MAX 256
+#endif
+
+#if !defined(ACPI_NAMESEG_SIZE)
+#if !defined(ACPI_NAME_SIZE)
+#error Unknown ACPI name size
+#endif
+#define	ACPI_NAMESEG_SIZE	ACPI_NAME_SIZE
+#endif
+
+#if !defined(ACPI_COPY_NAMESEG)
+#define	ACPI_COPY_NAMESEG(dest,src)	(strncpy (ACPI_CAST_PTR (char, (dest)),\
+    ACPI_CAST_PTR (char, (src)), ACPI_NAMESEG_SIZE))
+#endif
+
+#if !defined(ACPI_COMPARE_NAMESEG)
+#if !defined(ACPI_COMPARE_NAME)
+#error No ACPI compare name function
+#endif
+#define	ACPI_COMPARE_NAMESEG(__a, __b)	ACPI_COMPARE_NAME((__a), (__b))
+#endif
+
+/* List of information about obtained ACPI tables */
+
+typedef struct osl_table_info
+{
+    struct osl_table_info   *Next;
+    UINT32                  Instance;
+    char                    Signature[ACPI_NAMESEG_SIZE];
+} OSL_TABLE_INFO;
+
+/* Local prototypes */
+
+static ACPI_STATUS
+OslTableInitialize (
+    void);
+
+static ACPI_STATUS
+OslAddTableToList (
+    char                    *Signature,
+    UINT32                  Instance);
+
+static ACPI_STATUS
+OslMapTable (
+    ACPI_PHYSICAL_ADDRESS   Address,
+    char                    *Signature,
+    ACPI_TABLE_HEADER       **Table);
+
+static void
+OslUnmapTable (
+    ACPI_TABLE_HEADER       *Table);
+
+static ACPI_STATUS
+OslLoadRsdp (
+    void);
+
+static ACPI_STATUS
+OslListTables (
+    void);
+
+static ACPI_STATUS
+OslGetTable (
+    char                    *Signature,
+    UINT32                  Instance,
+    ACPI_TABLE_HEADER       **Table,
+    ACPI_PHYSICAL_ADDRESS   *Address);
+
+
+/* File locations */
+
+#define EFI_SYSTAB          "/sys/firmware/efi/systab"
+
+/* Initialization flags */
+
+UINT8                   Gbl_TableListInitialized = FALSE;
+
+/* Local copies of main ACPI tables */
+
+ACPI_TABLE_RSDP         Gbl_Rsdp;
+ACPI_TABLE_FADT         *Gbl_Fadt = NULL;
+ACPI_TABLE_RSDT         *Gbl_Rsdt = NULL;
+ACPI_TABLE_XSDT         *Gbl_Xsdt = NULL;
+
+/* Table addresses */
+
+ACPI_PHYSICAL_ADDRESS   Gbl_FadtAddress = 0;
+ACPI_PHYSICAL_ADDRESS   Gbl_RsdpAddress = 0;
+
+/* Revision of RSD PTR */
+
+UINT8                   Gbl_Revision = 0;
+
+OSL_TABLE_INFO          *Gbl_TableListHead = NULL;
+UINT32                  Gbl_TableCount = 0;
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AcpiOsGetTableByAddress
+ *
+ * PARAMETERS:  Address         - Physical address of the ACPI table
+ *              Table           - Where a pointer to the table is returned
+ *
+ * RETURN:      Status; Table buffer is returned if AE_OK.
+ *              AE_NOT_FOUND: A valid table was not found at the address
+ *
+ * DESCRIPTION: Get an ACPI table via a physical memory address.
+ *
+ *****************************************************************************/
+
+ACPI_STATUS
+AcpiOsGetTableByAddress (
+    ACPI_PHYSICAL_ADDRESS   Address,
+    ACPI_TABLE_HEADER       **Table)
+{
+    UINT32                  TableLength;
+    ACPI_TABLE_HEADER       *MappedTable;
+    ACPI_TABLE_HEADER       *LocalTable = NULL;
+    ACPI_STATUS             Status = AE_OK;
+
+
+    /* Get main ACPI tables from memory on first invocation of this function */
+
+    Status = OslTableInitialize ();
+    if (ACPI_FAILURE (Status))
+    {
+        return (Status);
+    }
+
+    /* Map the table and validate it */
+
+    Status = OslMapTable (Address, NULL, &MappedTable);
+    if (ACPI_FAILURE (Status))
+    {
+        return (Status);
+    }
+
+    /* Copy table to local buffer and return it */
+
+    TableLength = ApGetTableLength (MappedTable);
+    if (TableLength == 0)
+    {
+        Status = AE_BAD_HEADER;
+        goto Exit;
+    }
+
+    LocalTable = ACPI_ALLOCATE_ZEROED (TableLength);
+    if (!LocalTable)
+    {
+        Status = AE_NO_MEMORY;
+        goto Exit;
+    }
+
+    memcpy (LocalTable, MappedTable, TableLength);
+
+Exit:
+    OslUnmapTable (MappedTable);
+    *Table = LocalTable;
+    return (Status);
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AcpiOsGetTableByName
+ *
+ * PARAMETERS:  Signature       - ACPI Signature for desired table. Must be
+ *                                a null terminated 4-character string.
+ *              Instance        - Multiple table support for SSDT/UEFI (0...n)
+ *                                Must be 0 for other tables.
+ *              Table           - Where a pointer to the table is returned
+ *              Address         - Where the table physical address is returned
+ *
+ * RETURN:      Status; Table buffer and physical address returned if AE_OK.
+ *              AE_LIMIT: Instance is beyond valid limit
+ *              AE_NOT_FOUND: A table with the signature was not found
+ *
+ * NOTE:        Assumes the input signature is uppercase.
+ *
+ *****************************************************************************/
+
+ACPI_STATUS
+AcpiOsGetTableByName (
+    char                    *Signature,
+    UINT32                  Instance,
+    ACPI_TABLE_HEADER       **Table,
+    ACPI_PHYSICAL_ADDRESS   *Address)
+{
+    ACPI_STATUS             Status;
+
+
+    /* Get main ACPI tables from memory on first invocation of this function */
+
+    Status = OslTableInitialize ();
+    if (ACPI_FAILURE (Status))
+    {
+        return (Status);
+    }
+
+    /* Not a main ACPI table, attempt to extract it from the RSDT/XSDT */
+
+    Status = OslGetTable (Signature, Instance, Table, Address);
+
+    return (Status);
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    OslAddTableToList
+ *
+ * PARAMETERS:  Signature       - Table signature
+ *              Instance        - Table instance
+ *
+ * RETURN:      Status; Successfully added if AE_OK.
+ *              AE_NO_MEMORY: Memory allocation error
+ *
+ * DESCRIPTION: Insert a table structure into OSL table list.
+ *
+ *****************************************************************************/
+
+static ACPI_STATUS
+OslAddTableToList (
+    char                    *Signature,
+    UINT32                  Instance)
+{
+    OSL_TABLE_INFO          *NewInfo;
+    OSL_TABLE_INFO          *Next;
+    UINT32                  NextInstance = 0;
+    BOOLEAN                 Found = FALSE;
+
+
+    NewInfo = ACPI_ALLOCATE_ZEROED (sizeof (OSL_TABLE_INFO));
+    if (!NewInfo)
+    {
+        return (AE_NO_MEMORY);
+    }
+
+    ACPI_COPY_NAMESEG (NewInfo->Signature, Signature);
+
+    if (!Gbl_TableListHead)
+    {
+        Gbl_TableListHead = NewInfo;
+    }
+    else
+    {
+        Next = Gbl_TableListHead;
+        while (1)
+        {
+            if (ACPI_COMPARE_NAMESEG (Next->Signature, Signature))
+            {
+                if (Next->Instance == Instance)
+                {
+                    Found = TRUE;
+                }
+                if (Next->Instance >= NextInstance)
+                {
+                    NextInstance = Next->Instance + 1;
+                }
+            }
+
+            if (!Next->Next)
+            {
+                break;
+            }
+            Next = Next->Next;
+        }
+        Next->Next = NewInfo;
+    }
+
+    if (Found)
+    {
+        Instance = NextInstance;
+    }
+
+    NewInfo->Instance = Instance;
+    Gbl_TableCount++;
+
+    return (AE_OK);
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AcpiOsGetTableByIndex
+ *
+ * PARAMETERS:  Index           - Which table to get
+ *              Table           - Where a pointer to the table is returned
+ *              Instance        - Where a pointer to the table instance no. is
+ *                                returned
+ *              Address         - Where the table physical address is returned
+ *
+ * RETURN:      Status; Table buffer and physical address returned if AE_OK.
+ *              AE_LIMIT: Index is beyond valid limit
+ *
+ * DESCRIPTION: Get an ACPI table via an index value (0 through n). Returns
+ *              AE_LIMIT when an invalid index is reached. Index is not
+ *              necessarily an index into the RSDT/XSDT.
+ *
+ *****************************************************************************/
+
+ACPI_STATUS
+AcpiOsGetTableByIndex (
+    UINT32                  Index,
+    ACPI_TABLE_HEADER       **Table,
+    UINT32                  *Instance,
+    ACPI_PHYSICAL_ADDRESS   *Address)
+{
+    OSL_TABLE_INFO          *Info;
+    ACPI_STATUS             Status;
+    UINT32                  i;
+
+
+    /* Get main ACPI tables from memory on first invocation of this function */
+
+    Status = OslTableInitialize ();
+    if (ACPI_FAILURE (Status))
+    {
+        return (Status);
+    }
+
+    /* Validate Index */
+
+    if (Index >= Gbl_TableCount)
+    {
+        return (AE_LIMIT);
+    }
+
+    /* Point to the table list entry specified by the Index argument */
+
+    Info = Gbl_TableListHead;
+    for (i = 0; i < Index; i++)
+    {
+        Info = Info->Next;
+    }
+
+    /* Now we can just get the table via the signature */
+
+    Status = AcpiOsGetTableByName (Info->Signature, Info->Instance,
+        Table, Address);
+
+    if (ACPI_SUCCESS (Status))
+    {
+        *Instance = Info->Instance;
+    }
+    return (Status);
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    OslLoadRsdp
+ *
+ * PARAMETERS:  None
+ *
+ * RETURN:      Status
+ *
+ * DESCRIPTION: Scan and load RSDP.
+ *
+ *****************************************************************************/
+
+static ACPI_STATUS
+OslLoadRsdp (
+    void)
+{
+    ACPI_TABLE_HEADER       *MappedTable;
+    UINT8                   *RsdpAddress;
+    ACPI_PHYSICAL_ADDRESS   RsdpBase;
+    ACPI_SIZE               RsdpSize;
+
+
+    /* Get RSDP from memory */
+
+    RsdpSize = sizeof (ACPI_TABLE_RSDP);
+    if (Gbl_RsdpBase)
+    {
+        RsdpBase = Gbl_RsdpBase;
+    }
+    else
+    {
+        RsdpBase = AcpiOsGetRootPointer ();
+    }
+
+    if (!RsdpBase)
+    {
+        RsdpBase = ACPI_HI_RSDP_WINDOW_BASE;
+        RsdpSize = ACPI_HI_RSDP_WINDOW_SIZE;
+    }
+
+    RsdpAddress = AcpiOsMapMemory (RsdpBase, RsdpSize);
+    if (!RsdpAddress)
+    {
+        return (AE_BAD_ADDRESS);
+    }
+
+    /* Search low memory for the RSDP */
+
+    MappedTable = ACPI_CAST_PTR (ACPI_TABLE_HEADER,
+        AcpiTbScanMemoryForRsdp (RsdpAddress, (UINT32) RsdpSize));
+    if (!MappedTable)
+    {
+        AcpiOsUnmapMemory (RsdpAddress, RsdpSize);
+        return (AE_NOT_FOUND);
+    }
+
+    Gbl_RsdpAddress = RsdpBase + (ACPI_CAST8 (MappedTable) - RsdpAddress);
+
+    memcpy (&Gbl_Rsdp, MappedTable, sizeof (ACPI_TABLE_RSDP));
+    AcpiOsUnmapMemory (RsdpAddress, RsdpSize);
+
+    return (AE_OK);
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    OslCanUseXsdt
+ *
+ * PARAMETERS:  None
+ *
+ * RETURN:      TRUE if XSDT is allowed to be used.
+ *
+ * DESCRIPTION: This function collects logic that can be used to determine if
+ *              XSDT should be used instead of RSDT.
+ *
+ *****************************************************************************/
+
+static BOOLEAN
+OslCanUseXsdt (
+    void)
+{
+    if (Gbl_Revision && !AcpiGbl_DoNotUseXsdt)
+    {
+        return (TRUE);
+    }
+    else
+    {
+        return (FALSE);
+    }
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    OslTableInitialize
+ *
+ * PARAMETERS:  None
+ *
+ * RETURN:      Status
+ *
+ * DESCRIPTION: Initialize ACPI table data. Get and store main ACPI tables to
+ *              local variables. Main ACPI tables include RSDT, FADT, RSDT,
+ *              and/or XSDT.
+ *
+ *****************************************************************************/
+
+static ACPI_STATUS
+OslTableInitialize (
+    void)
+{
+    ACPI_STATUS             Status;
+    ACPI_PHYSICAL_ADDRESS   Address;
+
+
+    if (Gbl_TableListInitialized)
+    {
+        return (AE_OK);
+    }
+
+    /* Get RSDP from memory */
+
+    Status = OslLoadRsdp ();
+    if (ACPI_FAILURE (Status))
+    {
+        return (Status);
+    }
+
+    /* Get XSDT from memory */
+
+    if (Gbl_Rsdp.Revision && !Gbl_DoNotDumpXsdt)
+    {
+        if (Gbl_Xsdt)
+        {
+            ACPI_FREE (Gbl_Xsdt);
+            Gbl_Xsdt = NULL;
+        }
+
+        Gbl_Revision = 2;
+        Status = OslGetTable (ACPI_SIG_XSDT, 0,
+            ACPI_CAST_PTR (ACPI_TABLE_HEADER *, &Gbl_Xsdt), &Address);
+        if (ACPI_FAILURE (Status))
+        {
+            return (Status);
+        }
+    }
+
+    /* Get RSDT from memory */
+
+    if (Gbl_Rsdp.RsdtPhysicalAddress)
+    {
+        if (Gbl_Rsdt)
+        {
+            ACPI_FREE (Gbl_Rsdt);
+            Gbl_Rsdt = NULL;
+        }
+
+        Status = OslGetTable (ACPI_SIG_RSDT, 0,
+            ACPI_CAST_PTR (ACPI_TABLE_HEADER *, &Gbl_Rsdt), &Address);
+        if (ACPI_FAILURE (Status))
+        {
+            return (Status);
+        }
+    }
+
+    /* Get FADT from memory */
+
+    if (Gbl_Fadt)
+    {
+        ACPI_FREE (Gbl_Fadt);
+        Gbl_Fadt = NULL;
+    }
+
+    Status = OslGetTable (ACPI_SIG_FADT, 0,
+        ACPI_CAST_PTR (ACPI_TABLE_HEADER *, &Gbl_Fadt), &Gbl_FadtAddress);
+    if (ACPI_FAILURE (Status))
+    {
+        return (Status);
+    }
+
+    /* Add mandatory tables to global table list first */
+
+    Status = OslAddTableToList (ACPI_RSDP_NAME, 0);
+    if (ACPI_FAILURE (Status))
+    {
+        return (Status);
+    }
+
+    Status = OslAddTableToList (ACPI_SIG_RSDT, 0);
+    if (ACPI_FAILURE (Status))
+    {
+        return (Status);
+    }
+
+    if (Gbl_Revision == 2)
+    {
+        Status = OslAddTableToList (ACPI_SIG_XSDT, 0);
+        if (ACPI_FAILURE (Status))
+        {
+            return (Status);
+        }
+    }
+
+    Status = OslAddTableToList (ACPI_SIG_DSDT, 0);
+    if (ACPI_FAILURE (Status))
+    {
+        return (Status);
+    }
+
+    Status = OslAddTableToList (ACPI_SIG_FACS, 0);
+    if (ACPI_FAILURE (Status))
+    {
+        return (Status);
+    }
+
+    /* Add all tables found in the memory */
+
+    Status = OslListTables ();
+    if (ACPI_FAILURE (Status))
+    {
+        return (Status);
+    }
+
+    Gbl_TableListInitialized = TRUE;
+    return (AE_OK);
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    OslListTables
+ *
+ * PARAMETERS:  None
+ *
+ * RETURN:      Status; Table list is initialized if AE_OK.
+ *
+ * DESCRIPTION: Add ACPI tables to the table list from memory.
+ *
+ *****************************************************************************/
+
+static ACPI_STATUS
+OslListTables (
+    void)
+{
+    ACPI_TABLE_HEADER       *MappedTable = NULL;
+    UINT8                   *TableData;
+    UINT8                   NumberOfTables;
+    UINT8                   ItemSize;
+    ACPI_PHYSICAL_ADDRESS   TableAddress = 0;
+    ACPI_STATUS             Status = AE_OK;
+    UINT32                  i;
+
+
+    if (OslCanUseXsdt ())
+    {
+        ItemSize = sizeof (UINT64);
+        TableData = ACPI_CAST8 (Gbl_Xsdt) + sizeof (ACPI_TABLE_HEADER);
+        NumberOfTables =
+            (UINT8) ((Gbl_Xsdt->Header.Length - sizeof (ACPI_TABLE_HEADER))
+            / ItemSize);
+    }
+    else /* Use RSDT if XSDT is not available */
+    {
+        ItemSize = sizeof (UINT32);
+        TableData = ACPI_CAST8 (Gbl_Rsdt) + sizeof (ACPI_TABLE_HEADER);
+        NumberOfTables =
+            (UINT8) ((Gbl_Rsdt->Header.Length - sizeof (ACPI_TABLE_HEADER))
+            / ItemSize);
+    }
+
+    /* Search RSDT/XSDT for the requested table */
+
+    for (i = 0; i < NumberOfTables; ++i, TableData += ItemSize)
+    {
+        if (OslCanUseXsdt ())
+        {
+            TableAddress =
+                (ACPI_PHYSICAL_ADDRESS) (*ACPI_CAST64 (TableData));
+        }
+        else
+        {
+            TableAddress =
+                (ACPI_PHYSICAL_ADDRESS) (*ACPI_CAST32 (TableData));
+        }
+
+        /* Skip NULL entries in RSDT/XSDT */
+
+        if (TableAddress == 0)
+        {
+            continue;
+        }
+
+        Status = OslMapTable (TableAddress, NULL, &MappedTable);
+        if (ACPI_FAILURE (Status))
+        {
+            return (Status);
+        }
+
+        OslAddTableToList (MappedTable->Signature, 0);
+        OslUnmapTable (MappedTable);
+    }
+
+    return (AE_OK);
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    OslGetTable
+ *
+ * PARAMETERS:  Signature       - ACPI Signature for common table. Must be
+ *                                a null terminated 4-character string.
+ *              Instance        - Multiple table support for SSDT/UEFI (0...n)
+ *                                Must be 0 for other tables.
+ *              Table           - Where a pointer to the table is returned
+ *              Address         - Where the table physical address is returned
+ *
+ * RETURN:      Status; Table buffer and physical address returned if AE_OK.
+ *              AE_LIMIT: Instance is beyond valid limit
+ *              AE_NOT_FOUND: A table with the signature was not found
+ *
+ * DESCRIPTION: Get a BIOS provided ACPI table
+ *
+ * NOTE:        Assumes the input signature is uppercase.
+ *
+ *****************************************************************************/
+
+static ACPI_STATUS
+OslGetTable (
+    char                    *Signature,
+    UINT32                  Instance,
+    ACPI_TABLE_HEADER       **Table,
+    ACPI_PHYSICAL_ADDRESS   *Address)
+{
+    ACPI_TABLE_HEADER       *LocalTable = NULL;
+    ACPI_TABLE_HEADER       *MappedTable = NULL;
+    UINT8                   *TableData;
+    UINT8                   NumberOfTables;
+    UINT8                   ItemSize;
+    UINT32                  CurrentInstance = 0;
+    ACPI_PHYSICAL_ADDRESS   TableAddress;
+    ACPI_PHYSICAL_ADDRESS   FirstTableAddress = 0;
+    UINT32                  TableLength = 0;
+    ACPI_STATUS             Status = AE_OK;
+    UINT32                  i;
+
+
+    /* Handle special tables whose addresses are not in RSDT/XSDT */
+
+    if (ACPI_COMPARE_NAMESEG (Signature, ACPI_RSDP_NAME) ||
+        ACPI_COMPARE_NAMESEG (Signature, ACPI_SIG_RSDT) ||
+        ACPI_COMPARE_NAMESEG (Signature, ACPI_SIG_XSDT) ||
+        ACPI_COMPARE_NAMESEG (Signature, ACPI_SIG_DSDT) ||
+        ACPI_COMPARE_NAMESEG (Signature, ACPI_SIG_FACS))
+    {
+
+FindNextInstance:
+
+        TableAddress = 0;
+
+        /*
+         * Get the appropriate address, either 32-bit or 64-bit. Be very
+         * careful about the FADT length and validate table addresses.
+         * Note: The 64-bit addresses have priority.
+         */
+        if (ACPI_COMPARE_NAMESEG (Signature, ACPI_SIG_DSDT))
+        {
+            if (CurrentInstance < 2)
+            {
+                if ((Gbl_Fadt->Header.Length >= MIN_FADT_FOR_XDSDT) &&
+                    Gbl_Fadt->XDsdt && CurrentInstance == 0)
+                {
+                    TableAddress = (ACPI_PHYSICAL_ADDRESS) Gbl_Fadt->XDsdt;
+                }
+                else if ((Gbl_Fadt->Header.Length >= MIN_FADT_FOR_DSDT) &&
+                    Gbl_Fadt->Dsdt != FirstTableAddress)
+                {
+                    TableAddress = (ACPI_PHYSICAL_ADDRESS) Gbl_Fadt->Dsdt;
+                }
+            }
+        }
+        else if (ACPI_COMPARE_NAMESEG (Signature, ACPI_SIG_FACS))
+        {
+            if (CurrentInstance < 2)
+            {
+                if ((Gbl_Fadt->Header.Length >= MIN_FADT_FOR_XFACS) &&
+                    Gbl_Fadt->XFacs && CurrentInstance == 0)
+                {
+                    TableAddress = (ACPI_PHYSICAL_ADDRESS) Gbl_Fadt->XFacs;
+                }
+                else if ((Gbl_Fadt->Header.Length >= MIN_FADT_FOR_FACS) &&
+                    Gbl_Fadt->Facs != FirstTableAddress)
+                {
+                    TableAddress = (ACPI_PHYSICAL_ADDRESS) Gbl_Fadt->Facs;
+                }
+            }
+        }
+        else if (ACPI_COMPARE_NAMESEG (Signature, ACPI_SIG_XSDT))
+        {
+            if (!Gbl_Revision)
+            {
+                return (AE_BAD_SIGNATURE);
+            }
+            if (CurrentInstance == 0)
+            {
+                TableAddress =
+                    (ACPI_PHYSICAL_ADDRESS) Gbl_Rsdp.XsdtPhysicalAddress;
+            }
+        }
+        else if (ACPI_COMPARE_NAMESEG (Signature, ACPI_SIG_RSDT))
+        {
+            if (CurrentInstance == 0)
+            {
+                TableAddress =
+                    (ACPI_PHYSICAL_ADDRESS) Gbl_Rsdp.RsdtPhysicalAddress;
+            }
+        }
+        else
+        {
+            if (CurrentInstance == 0)
+            {
+                TableAddress = (ACPI_PHYSICAL_ADDRESS) Gbl_RsdpAddress;
+                Signature = ACPI_SIG_RSDP;
+            }
+        }
+
+        if (TableAddress == 0)
+        {
+            goto ExitFindTable;
+        }
+
+        /* Now we can get the requested special table */
+
+        Status = OslMapTable (TableAddress, Signature, &MappedTable);
+        if (ACPI_FAILURE (Status))
+        {
+            return (Status);
+        }
+
+        TableLength = ApGetTableLength (MappedTable);
+        if (FirstTableAddress == 0)
+        {
+            FirstTableAddress = TableAddress;
+        }
+
+        /* Match table instance */
+
+        if (CurrentInstance != Instance)
+        {
+            OslUnmapTable (MappedTable);
+            MappedTable = NULL;
+            CurrentInstance++;
+            goto FindNextInstance;
+        }
+    }
+    else /* Case for a normal ACPI table */
+    {
+        if (OslCanUseXsdt ())
+        {
+            ItemSize = sizeof (UINT64);
+            TableData = ACPI_CAST8 (Gbl_Xsdt) + sizeof (ACPI_TABLE_HEADER);
+            NumberOfTables =
+                (UINT8) ((Gbl_Xsdt->Header.Length - sizeof (ACPI_TABLE_HEADER))
+                / ItemSize);
+        }
+        else /* Use RSDT if XSDT is not available */
+        {
+            ItemSize = sizeof (UINT32);
+            TableData = ACPI_CAST8 (Gbl_Rsdt) + sizeof (ACPI_TABLE_HEADER);
+            NumberOfTables =
+                (UINT8) ((Gbl_Rsdt->Header.Length - sizeof (ACPI_TABLE_HEADER))
+                / ItemSize);
+        }
+
+        /* Search RSDT/XSDT for the requested table */
+
+        for (i = 0; i < NumberOfTables; ++i, TableData += ItemSize)
+        {
+            if (OslCanUseXsdt ())
+            {
+                TableAddress =
+                    (ACPI_PHYSICAL_ADDRESS) (*ACPI_CAST64 (TableData));
+            }
+            else
+            {
+                TableAddress =
+                    (ACPI_PHYSICAL_ADDRESS) (*ACPI_CAST32 (TableData));
+            }
+
+            /* Skip NULL entries in RSDT/XSDT */
+
+            if (TableAddress == 0)
+            {
+                continue;
+            }
+
+            Status = OslMapTable (TableAddress, NULL, &MappedTable);
+            if (ACPI_FAILURE (Status))
+            {
+                return (Status);
+            }
+            TableLength = MappedTable->Length;
+
+            /* Does this table match the requested signature? */
+
+            if (!ACPI_COMPARE_NAMESEG (MappedTable->Signature, Signature))
+            {
+                OslUnmapTable (MappedTable);
+                MappedTable = NULL;
+                continue;
+            }
+
+            /* Match table instance (for SSDT/UEFI tables) */
+
+            if (CurrentInstance != Instance)
+            {
+                OslUnmapTable (MappedTable);
+                MappedTable = NULL;
+                CurrentInstance++;
+                continue;
+            }
+
+            break;
+        }
+    }
+
+ExitFindTable:
+
+    if (!MappedTable)
+    {
+        return (AE_LIMIT);
+    }
+
+    if (TableLength == 0)
+    {
+        Status = AE_BAD_HEADER;
+        goto Exit;
+    }
+
+    /* Copy table to local buffer and return it */
+
+    LocalTable = ACPI_ALLOCATE_ZEROED (TableLength);
+    if (!LocalTable)
+    {
+        Status = AE_NO_MEMORY;
+        goto Exit;
+    }
+
+    memcpy (LocalTable, MappedTable, TableLength);
+    *Address = TableAddress;
+    *Table = LocalTable;
+
+Exit:
+    OslUnmapTable (MappedTable);
+    return (Status);
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    OslMapTable
+ *
+ * PARAMETERS:  Address             - Address of the table in memory
+ *              Signature           - Optional ACPI Signature for desired table.
+ *                                    Null terminated 4-character string.
+ *              Table               - Where a pointer to the mapped table is
+ *                                    returned
+ *
+ * RETURN:      Status; Mapped table is returned if AE_OK.
+ *              AE_NOT_FOUND: A valid table was not found at the address
+ *
+ * DESCRIPTION: Map entire ACPI table into caller's address space.
+ *
+ *****************************************************************************/
+
+static ACPI_STATUS
+OslMapTable (
+    ACPI_PHYSICAL_ADDRESS   Address,
+    char                    *Signature,
+    ACPI_TABLE_HEADER       **Table)
+{
+    ACPI_TABLE_HEADER       *MappedTable;
+    UINT32                  Length;
+
+
+    if (!Address)
+    {
+        return (AE_BAD_ADDRESS);
+    }
+
+    /*
+     * Map the header so we can get the table length.
+     * Use sizeof (ACPI_TABLE_HEADER) as:
+     * 1. it is bigger than 24 to include RSDP->Length
+     * 2. it is smaller than sizeof (ACPI_TABLE_RSDP)
+     */
+    MappedTable = AcpiOsMapMemory (Address, sizeof (ACPI_TABLE_HEADER));
+    if (!MappedTable)
+    {
+        return (AE_BAD_ADDRESS);
+    }
+
+    /* If specified, signature must match */
+
+    if (Signature)
+    {
+        if (ACPI_VALIDATE_RSDP_SIG (Signature))
+        {
+            if (!ACPI_VALIDATE_RSDP_SIG (MappedTable->Signature))
+            {
+                AcpiOsUnmapMemory (MappedTable, sizeof (ACPI_TABLE_HEADER));
+                return (AE_BAD_SIGNATURE);
+            }
+        }
+        else if (!ACPI_COMPARE_NAMESEG (Signature, MappedTable->Signature))
+        {
+            AcpiOsUnmapMemory (MappedTable, sizeof (ACPI_TABLE_HEADER));
+            return (AE_BAD_SIGNATURE);
+        }
+    }
+
+    /* Map the entire table */
+
+    Length = ApGetTableLength (MappedTable);
+    AcpiOsUnmapMemory (MappedTable, sizeof (ACPI_TABLE_HEADER));
+    if (Length == 0)
+    {
+        return (AE_BAD_HEADER);
+    }
+
+    MappedTable = AcpiOsMapMemory (Address, Length);
+    if (!MappedTable)
+    {
+        return (AE_INVALID_TABLE_LENGTH);
+    }
+
+    (void) ApIsValidChecksum (MappedTable);
+
+    *Table = MappedTable;
+    return (AE_OK);
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    OslUnmapTable
+ *
+ * PARAMETERS:  Table               - A pointer to the mapped table
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Unmap entire ACPI table.
+ *
+ *****************************************************************************/
+
+static void
+OslUnmapTable (
+    ACPI_TABLE_HEADER       *Table)
+{
+    if (Table)
+    {
+        AcpiOsUnmapMemory (Table, ApGetTableLength (Table));
+    }
+}

--- a/usr/src/boot/efi/libacpica/osefixf.c
+++ b/usr/src/boot/efi/libacpica/osefixf.c
@@ -1,0 +1,1031 @@
+/******************************************************************************
+ *
+ * Module Name: osefixf - EFI OSL interfaces
+ *
+ *****************************************************************************/
+
+/******************************************************************************
+ *
+ * 1. Copyright Notice
+ *
+ * Some or all of this work - Copyright (c) 1999 - 2023, Intel Corp.
+ * All rights reserved.
+ *
+ * 2. License
+ *
+ * 2.1. This is your license from Intel Corp. under its intellectual property
+ * rights. You may have additional license terms from the party that provided
+ * you this software, covering your right to use that party's intellectual
+ * property rights.
+ *
+ * 2.2. Intel grants, free of charge, to any person ("Licensee") obtaining a
+ * copy of the source code appearing in this file ("Covered Code") an
+ * irrevocable, perpetual, worldwide license under Intel's copyrights in the
+ * base code distributed originally by Intel ("Original Intel Code") to copy,
+ * make derivatives, distribute, use and display any portion of the Covered
+ * Code in any form, with the right to sublicense such rights; and
+ *
+ * 2.3. Intel grants Licensee a non-exclusive and non-transferable patent
+ * license (with the right to sublicense), under only those claims of Intel
+ * patents that are infringed by the Original Intel Code, to make, use, sell,
+ * offer to sell, and import the Covered Code and derivative works thereof
+ * solely to the minimum extent necessary to exercise the above copyright
+ * license, and in no event shall the patent license extend to any additions
+ * to or modifications of the Original Intel Code. No other license or right
+ * is granted directly or by implication, estoppel or otherwise;
+ *
+ * The above copyright and patent license is granted only if the following
+ * conditions are met:
+ *
+ * 3. Conditions
+ *
+ * 3.1. Redistribution of Source with Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification with rights to further distribute source must include
+ * the above Copyright Notice, the above License, this list of Conditions,
+ * and the following Disclaimer and Export Compliance provision. In addition,
+ * Licensee must cause all Covered Code to which Licensee contributes to
+ * contain a file documenting the changes Licensee made to create that Covered
+ * Code and the date of any change. Licensee must include in that file the
+ * documentation of any changes made by any predecessor Licensee. Licensee
+ * must include a prominent statement that the modification is derived,
+ * directly or indirectly, from Original Intel Code.
+ *
+ * 3.2. Redistribution of Source with no Rights to Further Distribute Source.
+ * Redistribution of source code of any substantial portion of the Covered
+ * Code or modification without rights to further distribute source must
+ * include the following Disclaimer and Export Compliance provision in the
+ * documentation and/or other materials provided with distribution. In
+ * addition, Licensee may not authorize further sublicense of source of any
+ * portion of the Covered Code, and must include terms to the effect that the
+ * license from Licensee to its licensee is limited to the intellectual
+ * property embodied in the software Licensee provides to its licensee, and
+ * not to intellectual property embodied in modifications its licensee may
+ * make.
+ *
+ * 3.3. Redistribution of Executable. Redistribution in executable form of any
+ * substantial portion of the Covered Code or modification must reproduce the
+ * above Copyright Notice, and the following Disclaimer and Export Compliance
+ * provision in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * 3.4. Intel retains all right, title, and interest in and to the Original
+ * Intel Code.
+ *
+ * 3.5. Neither the name Intel nor any other trademark owned or controlled by
+ * Intel shall be used in advertising or otherwise to promote the sale, use or
+ * other dealings in products derived from or relating to the Covered Code
+ * without prior written authorization from Intel.
+ *
+ * 4. Disclaimer and Export Compliance
+ *
+ * 4.1. INTEL MAKES NO WARRANTY OF ANY KIND REGARDING ANY SOFTWARE PROVIDED
+ * HERE. ANY SOFTWARE ORIGINATING FROM INTEL OR DERIVED FROM INTEL SOFTWARE
+ * IS PROVIDED "AS IS," AND INTEL WILL NOT PROVIDE ANY SUPPORT, ASSISTANCE,
+ * INSTALLATION, TRAINING OR OTHER SERVICES. INTEL WILL NOT PROVIDE ANY
+ * UPDATES, ENHANCEMENTS OR EXTENSIONS. INTEL SPECIFICALLY DISCLAIMS ANY
+ * IMPLIED WARRANTIES OF MERCHANTABILITY, NONINFRINGEMENT AND FITNESS FOR A
+ * PARTICULAR PURPOSE.
+ *
+ * 4.2. IN NO EVENT SHALL INTEL HAVE ANY LIABILITY TO LICENSEE, ITS LICENSEES
+ * OR ANY OTHER THIRD PARTY, FOR ANY LOST PROFITS, LOST DATA, LOSS OF USE OR
+ * COSTS OF PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES, OR FOR ANY INDIRECT,
+ * SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THIS AGREEMENT, UNDER ANY
+ * CAUSE OF ACTION OR THEORY OF LIABILITY, AND IRRESPECTIVE OF WHETHER INTEL
+ * HAS ADVANCE NOTICE OF THE POSSIBILITY OF SUCH DAMAGES. THESE LIMITATIONS
+ * SHALL APPLY NOTWITHSTANDING THE FAILURE OF THE ESSENTIAL PURPOSE OF ANY
+ * LIMITED REMEDY.
+ *
+ * 4.3. Licensee shall not export, either directly or indirectly, any of this
+ * software or system incorporating such software without first obtaining any
+ * required license or other approval from the U. S. Department of Commerce or
+ * any other agency or department of the United States Government. In the
+ * event Licensee exports any such software from the United States or
+ * re-exports any such software from a foreign destination, Licensee shall
+ * ensure that the distribution and export/re-export of the software is in
+ * compliance with all laws, regulations, orders, or other restrictions of the
+ * U.S. Export Administration Regulations. Licensee agrees that neither it nor
+ * any of its subsidiaries will export/re-export any technical data, process,
+ * software, or service, directly or indirectly, to any country for which the
+ * United States government or any agency thereof requires an export license,
+ * other governmental approval, or letter of assurance, without first obtaining
+ * such license, approval or letter.
+ *
+ *****************************************************************************
+ *
+ * Alternatively, you may choose to be licensed under the terms of the
+ * following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions, and the following disclaimer,
+ *    without modification.
+ * 2. Redistributions in binary form must reproduce at minimum a disclaimer
+ *    substantially similar to the "NO WARRANTY" disclaimer below
+ *    ("Disclaimer") and any redistribution must be conditioned upon
+ *    including a substantially similar Disclaimer requirement for further
+ *    binary redistribution.
+ * 3. Neither the names of the above-listed copyright holders nor the names
+ *    of any contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Alternatively, you may choose to be licensed under the terms of the
+ * GNU General Public License ("GPL") version 2 as published by the Free
+ * Software Foundation.
+ *
+ *****************************************************************************/
+
+#include "acpi.h"
+#include "accommon.h"
+
+#include <stdio.h>
+
+#define _COMPONENT          ACPI_OS_SERVICES
+        ACPI_MODULE_NAME    ("osefixf")
+
+/* Local prototypes */
+
+static ACPI_EFI_PCI_IO *
+AcpiEfiGetPciDev (
+    ACPI_PCI_ID             *PciId);
+
+
+/* Global variables */
+
+#ifdef _EDK2_EFI
+extern struct _ACPI_EFI_SYSTEM_TABLE        *ST;
+extern struct _ACPI_EFI_BOOT_SERVICES       *BS;
+struct _ACPI_EFI_RUNTIME_SERVICES    *RT;
+#endif
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AcpiOsGetRootPointer
+ *
+ * PARAMETERS:  None
+ *
+ * RETURN:      RSDP physical address
+ *
+ * DESCRIPTION: Gets the ACPI root pointer (RSDP)
+ *
+ *****************************************************************************/
+
+ACPI_PHYSICAL_ADDRESS
+AcpiOsGetRootPointer (
+    void)
+{
+    ACPI_PHYSICAL_ADDRESS   Address;
+    ACPI_EFI_GUID           Guid10 = ACPI_TABLE_GUID;
+    ACPI_EFI_GUID           Guid20 = ACPI_20_TABLE_GUID;
+
+    extern void *efi_get_table(void *);
+
+    Address = (ACPI_PHYSICAL_ADDRESS) efi_get_table (&Guid20);
+    if (!Address)
+    {
+        Address = (ACPI_PHYSICAL_ADDRESS) efi_get_table (&Guid10);
+    }
+
+    return (Address);
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AcpiOsPredefinedOverride
+ *
+ * PARAMETERS:  InitVal             - Initial value of the predefined object
+ *              NewVal              - The new value for the object
+ *
+ * RETURN:      Status, pointer to value. Null pointer returned if not
+ *              overriding.
+ *
+ * DESCRIPTION: Allow the OS to override predefined names
+ *
+ *****************************************************************************/
+
+ACPI_STATUS
+AcpiOsPredefinedOverride (
+    const ACPI_PREDEFINED_NAMES *InitVal,
+    ACPI_STRING                 *NewVal)
+{
+
+    if (!InitVal || !NewVal)
+    {
+        return (AE_BAD_PARAMETER);
+    }
+
+    *NewVal = NULL;
+    return (AE_OK);
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AcpiOsMapMemory
+ *
+ * PARAMETERS:  where               - Physical address of memory to be mapped
+ *              length              - How much memory to map
+ *
+ * RETURN:      Pointer to mapped memory. Null on error.
+ *
+ * DESCRIPTION: Map physical memory into caller's address space
+ *
+ *****************************************************************************/
+
+void *
+AcpiOsMapMemory (
+    ACPI_PHYSICAL_ADDRESS   where,
+    ACPI_SIZE               length)
+{
+    return (void *)where;
+    /* return (ACPI_TO_POINTER ((ACPI_SIZE) where)); */
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AcpiOsUnmapMemory
+ *
+ * PARAMETERS:  where               - Logical address of memory to be unmapped
+ *              length              - How much memory to unmap
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Delete a previously created mapping. Where and Length must
+ *              correspond to a previous mapping exactly.
+ *
+ *****************************************************************************/
+
+void
+AcpiOsUnmapMemory (
+    void                    *where,
+    ACPI_SIZE               length)
+{
+
+    return;
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    Single threaded stub interfaces
+ *
+ * DESCRIPTION: No-op on single threaded BIOS
+ *
+ *****************************************************************************/
+
+ACPI_STATUS
+AcpiOsCreateLock (
+    ACPI_SPINLOCK           *OutHandle)
+{
+    return (AE_OK);
+}
+
+void
+AcpiOsDeleteLock (
+    ACPI_SPINLOCK           Handle)
+{
+}
+
+ACPI_CPU_FLAGS
+AcpiOsAcquireLock (
+    ACPI_SPINLOCK           Handle)
+{
+    return (0);
+}
+
+void
+AcpiOsReleaseLock (
+    ACPI_SPINLOCK           Handle,
+    ACPI_CPU_FLAGS          Flags)
+{
+}
+
+ACPI_STATUS
+AcpiOsCreateSemaphore (
+    UINT32              MaxUnits,
+    UINT32              InitialUnits,
+    ACPI_HANDLE         *OutHandle)
+{
+    *OutHandle = (ACPI_HANDLE) 1;
+    return (AE_OK);
+}
+
+ACPI_STATUS
+AcpiOsDeleteSemaphore (
+    ACPI_HANDLE         Handle)
+{
+    return (AE_OK);
+}
+
+ACPI_STATUS
+AcpiOsWaitSemaphore (
+    ACPI_HANDLE         Handle,
+    UINT32              Units,
+    UINT16              Timeout)
+{
+    return (AE_OK);
+}
+
+ACPI_STATUS
+AcpiOsSignalSemaphore (
+    ACPI_HANDLE         Handle,
+    UINT32              Units)
+{
+    return (AE_OK);
+}
+
+ACPI_THREAD_ID
+AcpiOsGetThreadId (
+    void)
+{
+    return (1);
+}
+
+ACPI_STATUS
+AcpiOsExecute (
+    ACPI_EXECUTE_TYPE       Type,
+    ACPI_OSD_EXEC_CALLBACK  Function,
+    void                    *Context)
+{
+    return (AE_OK);
+}
+
+void
+AcpiOsWaitEventsComplete (
+    void)
+{
+    return;
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AcpiOsInstallInterruptHandler
+ *
+ * PARAMETERS:  InterruptNumber     - Level handler should respond to.
+ *              ServiceRoutine      - Address of the ACPI interrupt handler
+ *              Context             - Where status is returned
+ *
+ * RETURN:      Handle to the newly installed handler.
+ *
+ * DESCRIPTION: Install an interrupt handler. Used to install the ACPI
+ *              OS-independent handler.
+ *
+ *****************************************************************************/
+
+UINT32
+AcpiOsInstallInterruptHandler (
+    UINT32                  InterruptNumber,
+    ACPI_OSD_HANDLER        ServiceRoutine,
+    void                    *Context)
+{
+
+    return (AE_OK);
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AcpiOsRemoveInterruptHandler
+ *
+ * PARAMETERS:  InterruptNumber     - Level handler should respond to.
+ *              ServiceRoutine      - Address of the ACPI interrupt handler
+ *
+ * RETURN:      Status
+ *
+ * DESCRIPTION: Uninstalls an interrupt handler.
+ *
+ *****************************************************************************/
+
+ACPI_STATUS
+AcpiOsRemoveInterruptHandler (
+    UINT32                  InterruptNumber,
+    ACPI_OSD_HANDLER        ServiceRoutine)
+{
+
+    return (AE_OK);
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AcpiOsGetTimer
+ *
+ * PARAMETERS:  None
+ *
+ * RETURN:      Current time in 100 nanosecond units
+ *
+ * DESCRIPTION: Get the current system time
+ *
+ *****************************************************************************/
+
+UINT64
+AcpiOsGetTimer (
+    void)
+{
+    /*
+     * For aarch64 systems we go straight to the architected timer. This is
+     * needed because runtime services should only be called after they are
+     * relocated and should only ever be called from one EL, and we don't
+     * yet know where we'll be running the kernel, which might not be where
+     * we're running right now.
+     *
+     * Boot services calls are fine.
+     */
+#if defined(__aarch64__)
+    static uint64_t ticks_per_100ns = 0;
+    static uint64_t elx = 0;
+    uint64_t cval;
+
+    if (elx == 0) {
+        uint64_t t;
+        __asm__ __volatile__("mrs %0, CurrentEL" : "=r"(t) : : "memory");
+        elx = (t >> 2) & 0x3;
+    }
+
+    if (elx == 0) {
+        return (0);
+    }
+
+    if (elx != 1 && elx != 2) {
+        return (0);
+    }
+
+    if (ticks_per_100ns == 0) {
+        uint64_t t;
+        __asm__ __volatile__("mrs %0, cntfrq_el0" : "=r" (t) : : "memory");
+        ticks_per_100ns = t / 10000000;
+        if ((t % 10000000) != 0)
+            ticks_per_100ns += 1;
+        if (ticks_per_100ns == 0)
+            ticks_per_100ns = 1;
+    }
+
+    if (elx == 1) {
+        __asm__ __volatile__("mrs %0, cntvct_el0" : "=r" (cval) : : "memory");
+    } else {
+        __asm__ __volatile__("mrs %0, cntpct_el0" : "=r" (cval) : : "memory");
+    }
+
+    return (cval / ticks_per_100ns);
+#else
+    ACPI_EFI_STATUS         EfiStatus;
+    ACPI_EFI_TIME           EfiTime;
+    int                     Year, Month, Day;
+    int                     Hour, Minute, Second;
+    UINT64                  Timer;
+
+
+    EfiStatus = uefi_call_wrapper (RT->GetTime, 2, &EfiTime, NULL);
+    if (ACPI_EFI_ERROR (EfiStatus))
+    {
+        return ((UINT64) -1);
+    }
+
+    Year = EfiTime.Year;
+    Month = EfiTime.Month;
+    Day = EfiTime.Day;
+    Hour = EfiTime.Hour;
+    Minute = EfiTime.Minute;
+    Second = EfiTime.Second;
+
+    /* 1..12 -> 11,12,1..10 */
+
+    if (0 >= (int) (Month -= 2))
+    {
+        /* Feb has leap days */
+
+        Month += 12;
+        Year -= 1;
+    }
+
+    /* Calculate days */
+
+    Timer = ((UINT64) (Year/4 - Year/100 + Year/400 + 367*Month/12 + Day) +
+                       Year*365 - 719499);
+
+    /* Calculate seconds */
+
+    (void) AcpiUtShortMultiply (Timer, 24, &Timer);
+    Timer += Hour;
+    (void) AcpiUtShortMultiply (Timer, 60, &Timer);
+    Timer += Minute;
+    (void) AcpiUtShortMultiply (Timer, 60, &Timer);
+    Timer += Second;
+
+    /* Calculate 100 nanoseconds */
+
+    (void) AcpiUtShortMultiply (Timer, ACPI_100NSEC_PER_SEC, &Timer);
+    return (Timer + (EfiTime.Nanosecond / 100));
+#endif
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AcpiOsStall
+ *
+ * PARAMETERS:  microseconds        - Time to sleep
+ *
+ * RETURN:      Blocks until sleep is completed.
+ *
+ * DESCRIPTION: Sleep at microsecond granularity
+ *
+ *****************************************************************************/
+
+void
+AcpiOsStall (
+    UINT32                  microseconds)
+{
+
+    if (microseconds)
+    {
+        uefi_call_wrapper (BS->Stall, 1, microseconds);
+    }
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AcpiOsSleep
+ *
+ * PARAMETERS:  milliseconds        - Time to sleep
+ *
+ * RETURN:      Blocks until sleep is completed.
+ *
+ * DESCRIPTION: Sleep at millisecond granularity
+ *
+ *****************************************************************************/
+
+void
+AcpiOsSleep (
+    UINT64                  milliseconds)
+{
+    UINT64                  microseconds;
+
+
+    AcpiUtShortMultiply (milliseconds, ACPI_USEC_PER_MSEC, &microseconds);
+    while (microseconds > ACPI_UINT32_MAX)
+    {
+        AcpiOsStall (ACPI_UINT32_MAX);
+        microseconds -= ACPI_UINT32_MAX;
+    }
+    AcpiOsStall ((UINT32) microseconds);
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AcpiOsAllocate
+ *
+ * PARAMETERS:  Size                - Amount to allocate, in bytes
+ *
+ * RETURN:      Pointer to the new allocation. Null on error.
+ *
+ * DESCRIPTION: Allocate memory. Algorithm is dependent on the OS.
+ *
+ *****************************************************************************/
+
+void *
+AcpiOsAllocate (
+    ACPI_SIZE               Size)
+{
+    ACPI_EFI_STATUS         EfiStatus;
+    void                    *Mem;
+
+
+    EfiStatus = uefi_call_wrapper (BS->AllocatePool, 3,
+        AcpiEfiLoaderData, Size, &Mem);
+    if (ACPI_EFI_ERROR (EfiStatus))
+    {
+        return (NULL);
+    }
+
+    return (Mem);
+}
+
+
+#ifdef USE_NATIVE_ALLOCATE_ZEROED
+/******************************************************************************
+ *
+ * FUNCTION:    AcpiOsAllocateZeroed
+ *
+ * PARAMETERS:  Size                - Amount to allocate, in bytes
+ *
+ * RETURN:      Pointer to the new allocation. Null on error.
+ *
+ * DESCRIPTION: Allocate and zero memory. Algorithm is dependent on the OS.
+ *
+ *****************************************************************************/
+
+void *
+AcpiOsAllocateZeroed (
+    ACPI_SIZE               Size)
+{
+    void                    *Mem;
+
+
+    Mem = AcpiOsAllocate (Size);
+    if (Mem)
+    {
+        memset (Mem, 0, Size);
+    }
+
+    return (Mem);
+}
+#endif
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AcpiOsFree
+ *
+ * PARAMETERS:  Mem                 - Pointer to previously allocated memory
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Free memory allocated via AcpiOsAllocate
+ *
+ *****************************************************************************/
+
+void
+AcpiOsFree (
+    void                    *Mem)
+{
+
+    uefi_call_wrapper (BS->FreePool, 1, Mem);
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AcpiOsPrintf
+ *
+ * PARAMETERS:  Format, ...         - Standard printf format
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Formatted output.
+ *
+ *****************************************************************************/
+
+void ACPI_INTERNAL_VAR_XFACE
+AcpiOsPrintf (
+    const char              *Format,
+    ...)
+{
+    va_list                 Args;
+
+
+    va_start (Args, Format);
+    AcpiOsVprintf (Format, Args);
+    va_end (Args);
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AcpiOsVprintf
+ *
+ * PARAMETERS:  Format              - Standard printf format
+ *              Args                - Argument list
+ *
+ * RETURN:      None
+ *
+ * DESCRIPTION: Formatted output with arguments list pointer.
+ *
+ *****************************************************************************/
+
+void
+AcpiOsVprintf (
+    const char              *Format,
+    va_list                 Args)
+{
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AcpiOsInitialize, AcpiOsTerminate
+ *
+ * PARAMETERS:  None
+ *
+ * RETURN:      Status
+ *
+ * DESCRIPTION: Initialize/terminate this module.
+ *
+ *****************************************************************************/
+
+ACPI_STATUS
+AcpiOsInitialize (
+    void)
+{
+
+    return (AE_OK);
+}
+
+
+ACPI_STATUS
+AcpiOsTerminate (
+    void)
+{
+
+    return (AE_OK);
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AcpiOsSignal
+ *
+ * PARAMETERS:  Function            - ACPI A signal function code
+ *              Info                - Pointer to function-dependent structure
+ *
+ * RETURN:      Status
+ *
+ * DESCRIPTION: Miscellaneous functions. Example implementation only.
+ *
+ *****************************************************************************/
+
+ACPI_STATUS
+AcpiOsSignal (
+    UINT32                  Function,
+    void                    *Info)
+{
+
+    switch (Function)
+    {
+    case ACPI_SIGNAL_FATAL:
+
+        break;
+
+    case ACPI_SIGNAL_BREAKPOINT:
+
+        break;
+
+    default:
+
+        break;
+    }
+
+    return (AE_OK);
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AcpiOsReadable
+ *
+ * PARAMETERS:  Pointer             - Area to be verified
+ *              Length              - Size of area
+ *
+ * RETURN:      TRUE if readable for entire length
+ *
+ * DESCRIPTION: Verify that a pointer is valid for reading
+ *
+ *****************************************************************************/
+
+BOOLEAN
+AcpiOsReadable (
+    void                    *Pointer,
+    ACPI_SIZE               Length)
+{
+
+    return (TRUE);
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AcpiOsWritable
+ *
+ * PARAMETERS:  Pointer             - Area to be verified
+ *              Length              - Size of area
+ *
+ * RETURN:      TRUE if writable for entire length
+ *
+ * DESCRIPTION: Verify that a pointer is valid for writing
+ *
+ *****************************************************************************/
+
+BOOLEAN
+AcpiOsWritable (
+    void                    *Pointer,
+    ACPI_SIZE               Length)
+{
+
+    return (TRUE);
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AcpiOsReadPciConfiguration
+ *
+ * PARAMETERS:  PciId               - Seg/Bus/Dev
+ *              PciRegister         - Device Register
+ *              Value               - Buffer where value is placed
+ *              Width               - Number of bits
+ *
+ * RETURN:      Status
+ *
+ * DESCRIPTION: Read data from PCI configuration space
+ *
+ *****************************************************************************/
+
+ACPI_STATUS
+AcpiOsReadPciConfiguration (
+    ACPI_PCI_ID             *PciId,
+    UINT32                  PciRegister,
+    UINT64                  *Value64,
+    UINT32                  Width)
+{
+    ACPI_EFI_PCI_IO         *PciIo;
+    ACPI_EFI_STATUS         EfiStatus;
+    UINT8                   Value8;
+    UINT16                  Value16;
+    UINT32                  Value32;
+
+
+    *Value64 = 0;
+    PciIo = AcpiEfiGetPciDev (PciId);
+    if (PciIo == NULL)
+    {
+        return (AE_NOT_FOUND);
+    }
+
+    switch (Width)
+    {
+    case 8:
+        EfiStatus = uefi_call_wrapper (PciIo->Pci.Read, 5, PciIo,
+            AcpiEfiPciIoWidthUint8, PciRegister, 1, (VOID *) &Value8);
+        *Value64 = Value8;
+        break;
+
+    case 16:
+        EfiStatus = uefi_call_wrapper (PciIo->Pci.Read, 5, PciIo,
+            AcpiEfiPciIoWidthUint16, PciRegister, 1, (VOID *) &Value16);
+        *Value64 = Value16;
+        break;
+
+    case 32:
+        EfiStatus = uefi_call_wrapper (PciIo->Pci.Read, 5, PciIo,
+            AcpiEfiPciIoWidthUint32, PciRegister, 1, (VOID *) &Value32);
+        *Value64 = Value32;
+        break;
+
+    case 64:
+        EfiStatus = uefi_call_wrapper (PciIo->Pci.Read, 5, PciIo,
+            AcpiEfiPciIoWidthUint64, PciRegister, 1, (VOID *) Value64);
+        break;
+
+    default:
+        return (AE_BAD_PARAMETER);
+    }
+
+    return (ACPI_EFI_ERROR (EfiStatus)) ? (AE_ERROR) : (AE_OK);
+}
+
+
+/******************************************************************************
+ *
+ * FUNCTION:    AcpiOsWritePciConfiguration
+ *
+ * PARAMETERS:  PciId               - Seg/Bus/Dev
+ *              PciRegister         - Device Register
+ *              Value               - Value to be written
+ *              Width               - Number of bits
+ *
+ * RETURN:      Status.
+ *
+ * DESCRIPTION: Write data to PCI configuration space
+ *
+ *****************************************************************************/
+
+ACPI_STATUS
+AcpiOsWritePciConfiguration (
+    ACPI_PCI_ID             *PciId,
+    UINT32                  PciRegister,
+    UINT64                  Value64,
+    UINT32                  Width)
+{
+    ACPI_EFI_PCI_IO         *PciIo;
+    ACPI_EFI_STATUS         EfiStatus;
+    UINT8                   Value8;
+    UINT16                  Value16;
+    UINT32                  Value32;
+
+
+    PciIo = AcpiEfiGetPciDev (PciId);
+    if (PciIo == NULL)
+    {
+        return (AE_NOT_FOUND);
+    }
+
+    switch (Width)
+    {
+    case 8:
+        Value8 = (UINT8) Value64;
+        EfiStatus = uefi_call_wrapper (PciIo->Pci.Write, 5, PciIo,
+            AcpiEfiPciIoWidthUint8, PciRegister, 1, (VOID *) &Value8);
+        break;
+
+    case 16:
+        Value16 = (UINT16) Value64;
+        EfiStatus = uefi_call_wrapper (PciIo->Pci.Write, 5, PciIo,
+            AcpiEfiPciIoWidthUint16, PciRegister, 1, (VOID *) &Value16);
+        break;
+
+    case 32:
+        Value32 = (UINT32) Value64;
+        EfiStatus = uefi_call_wrapper (PciIo->Pci.Write, 5, PciIo,
+            AcpiEfiPciIoWidthUint32, PciRegister, 1, (VOID *) &Value32);
+        break;
+
+    case 64:
+        EfiStatus = uefi_call_wrapper (PciIo->Pci.Write, 5, PciIo,
+            AcpiEfiPciIoWidthUint64, PciRegister, 1, (VOID *) &Value64);
+        break;
+
+    default:
+        return (AE_BAD_PARAMETER);
+    }
+
+    return (ACPI_EFI_ERROR (EfiStatus)) ? (AE_ERROR) : (AE_OK);
+}
+
+/******************************************************************************
+ *
+ * FUNCTION:    AcpiEfiGetPciDev
+ *
+ * PARAMETERS:  PciId               - Seg/Bus/Dev
+ *
+ * RETURN:      ACPI_EFI_PCI_IO that matches PciId. Null on error.
+ *
+ * DESCRIPTION: Find ACPI_EFI_PCI_IO for the given PciId.
+ *
+ *****************************************************************************/
+
+static ACPI_EFI_PCI_IO *
+AcpiEfiGetPciDev (
+    ACPI_PCI_ID             *PciId)
+{
+    ACPI_EFI_STATUS         EfiStatus;
+    UINTN                   i;
+    UINTN                   HandlesCount = 0;
+    ACPI_EFI_HANDLE         *Handles = NULL;
+    ACPI_EFI_GUID           EfiPciIoProtocol = ACPI_EFI_PCI_IO_PROTOCOL;
+    ACPI_EFI_PCI_IO         *PciIoProtocol = NULL;
+    UINTN                   Bus;
+    UINTN                   Device;
+    UINTN                   Function;
+    UINTN                   Segment;
+
+
+    EfiStatus = uefi_call_wrapper (BS->LocateHandleBuffer, 5, AcpiEfiByProtocol,
+        &EfiPciIoProtocol, NULL, &HandlesCount, &Handles);
+    if (ACPI_EFI_ERROR (EfiStatus))
+    {
+        return (NULL);
+    }
+
+    for (i = 0; i < HandlesCount; i++)
+    {
+        EfiStatus = uefi_call_wrapper (BS->HandleProtocol, 3, Handles[i],
+            &EfiPciIoProtocol, (VOID **) &PciIoProtocol);
+        if (!ACPI_EFI_ERROR (EfiStatus))
+        {
+            EfiStatus = uefi_call_wrapper (PciIoProtocol->GetLocation, 5,
+                PciIoProtocol, &Segment, &Bus, &Device, &Function);
+            if (!ACPI_EFI_ERROR (EfiStatus) &&
+                Bus == PciId->Bus &&
+                Device == PciId->Device &&
+                Function == PciId->Function &&
+                Segment == PciId->Segment)
+            {
+                uefi_call_wrapper (BS->FreePool, 1, Handles);
+                return (PciIoProtocol);
+            }
+        }
+    }
+
+    uefi_call_wrapper (BS->FreePool, 1, Handles);
+    return (NULL);
+}

--- a/usr/src/boot/efi/libacpica/osstub.c
+++ b/usr/src/boot/efi/libacpica/osstub.c
@@ -1,0 +1,93 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2025 Michael van der Westhuizen
+ */
+
+/*
+ * OS Layer stub functions for ACPI in the aarch64 illumos loader.
+ */
+#include <acpi.h>
+#include <stdio.h>
+
+ACPI_STATUS
+AcpiOsPhysicalTableOverride(ACPI_TABLE_HEADER *ExistingTable,
+    ACPI_PHYSICAL_ADDRESS *NewAddress, UINT32 *NewTableLength)
+{
+	return (AE_SUPPORT);
+}
+
+ACPI_STATUS
+AcpiOsWritePort(ACPI_IO_ADDRESS Address, UINT32 Value, UINT32 Width)
+{
+	return (AE_SUPPORT);
+}
+
+ACPI_STATUS
+AcpiOsReadPort(ACPI_IO_ADDRESS Address, UINT32 *Value, UINT32 Width)
+{
+	return (AE_SUPPORT);
+}
+
+#define	OSL_RW(ptr, val, type, rw) \
+	{ if (rw) *((type *)(ptr)) = *((type *) val); \
+	else *((type *) val) = *((type *)(ptr)); }
+
+static void
+osl_rw_memory(ACPI_PHYSICAL_ADDRESS Address, UINT64 *Value,
+    UINT32 Width, int write)
+{
+	char *ptr = (char *)Address;
+
+	switch (Width / 8) {
+	case 1:
+		OSL_RW(ptr, Value, uint8_t, write);
+		break;
+	case 2:
+		OSL_RW(ptr, Value, uint16_t, write);
+		break;
+	case 4:
+		OSL_RW(ptr, Value, uint32_t, write);
+		break;
+	case 8:
+		OSL_RW(ptr, Value, uint64_t, write);
+		break;
+	default:
+		break;
+	}
+}
+
+ACPI_STATUS
+AcpiOsReadMemory(ACPI_PHYSICAL_ADDRESS Address, UINT64 *Value, UINT32 Width)
+{
+	osl_rw_memory(Address, Value, Width, 0);
+	return (AE_OK);
+}
+
+ACPI_STATUS
+AcpiOsWriteMemory(ACPI_PHYSICAL_ADDRESS Address, UINT64 Value, UINT32 Width)
+{
+	osl_rw_memory(Address, &Value, Width, 1);
+	return (AE_OK);
+}
+
+ACPI_STATUS
+AcpiOsTableOverride(ACPI_TABLE_HEADER *ExistingTable,
+    ACPI_TABLE_HEADER **NewTable)
+{
+	if (!ExistingTable || !NewTable) {
+		return (AE_BAD_PARAMETER);
+	}
+
+	*NewTable = NULL;
+	return (AE_NO_ACPI_TABLES);
+}

--- a/usr/src/boot/include/ctype.h
+++ b/usr/src/boot/include/ctype.h
@@ -45,7 +45,12 @@
 #include <sys/_types.h>
 #include <_ctype.h>
 
+#if defined(__aarch64__)
+#include <stand.h>
+#endif
+
 __BEGIN_DECLS
+#if !defined(__aarch64__)
 int	isalnum(int);
 int	isalpha(int);
 int	iscntrl(int);
@@ -78,6 +83,7 @@ int	isphonogram(int);
 int	isrune(int);
 int	isspecial(int);
 #endif
+#endif
 
 #if __POSIX_VISIBLE >= 200809 || defined(_XLOCALE_H_)
 #include <xlocale/_ctype.h>
@@ -85,6 +91,7 @@ int	isspecial(int);
 __END_DECLS
 
 #ifndef __cplusplus
+#if !defined(__aarch64__)
 #define	isalnum(c)	__sbistype((c), _CTYPE_A|_CTYPE_D|_CTYPE_N)
 #define	isalpha(c)	__sbistype((c), _CTYPE_A)
 #define	iscntrl(c)	__sbistype((c), _CTYPE_C)
@@ -98,6 +105,7 @@ __END_DECLS
 #define	isxdigit(c)	__sbistype((c), _CTYPE_X)
 #define	tolower(c)	__sbtolower(c)
 #define	toupper(c)	__sbtoupper(c)
+#endif
 #endif /* !__cplusplus */
 
 #if __XSI_VISIBLE

--- a/usr/src/boot/include/runetype.h
+++ b/usr/src/boot/include/runetype.h
@@ -89,18 +89,24 @@ extern const _RuneLocale *_CurrentRuneLocale;
 #if defined(__NO_TLS) || defined(__RUNETYPE_INTERNAL)
 extern const _RuneLocale *__getCurrentRuneLocale(void);
 #else
+#if !defined(__aarch64__)
 extern _Thread_local const _RuneLocale *_ThreadRuneLocale;
+#endif
 static __inline const _RuneLocale *__getCurrentRuneLocale(void)
 {
 
+#if !defined(__aarch64__)
 	if (_ThreadRuneLocale)
 		return _ThreadRuneLocale;
+#endif
 	if (_CurrentRuneLocale)
 		return _CurrentRuneLocale;
 	return &_DefaultRuneLocale;
 }
 #endif /* __NO_TLS || __RUNETYPE_INTERNAL */
+#if !defined(__aarch64__)
 #define _CurrentRuneLocale (__getCurrentRuneLocale())
+#endif
 __END_DECLS
 
 #endif	/* !_RUNETYPE_H_ */

--- a/usr/src/boot/include/stdio.h
+++ b/usr/src/boot/include/stdio.h
@@ -254,12 +254,16 @@ int	 fsetpos(FILE *, const fpos_t *);
 long	 ftell(FILE *);
 size_t	 fwrite(const void * __restrict, size_t, size_t, FILE * __restrict);
 int	 getc(FILE *);
+#if !defined(__aarch64__)
 int	 getchar(void);
 char	*gets(char *);
+#endif
 void	 perror(const char *);
 int	 printf(const char * __restrict, ...);
 int	 putc(int, FILE *);
+#if !defined(__aarch64__)
 int	 putchar(int);
+#endif
 int	 puts(const char *);
 int	 remove(const char *);
 int	 rename(const char *, const char *);
@@ -274,9 +278,11 @@ char	*tmpnam(char *);
 int	 ungetc(int, FILE *);
 int	 vfprintf(FILE * __restrict, const char * __restrict,
 	    __va_list);
+#if !defined(__aarch64__)
 int	 vprintf(const char * __restrict, __va_list);
 int	 vsprintf(char * __restrict, const char * __restrict,
 	    __va_list);
+#endif
 
 #if __ISO_C_VISIBLE >= 1999
 int	 snprintf(char * __restrict, size_t, const char * __restrict,
@@ -284,8 +290,10 @@ int	 snprintf(char * __restrict, size_t, const char * __restrict,
 int	 vfscanf(FILE * __restrict, const char * __restrict, __va_list)
 	    __scanflike(2, 0);
 int	 vscanf(const char * __restrict, __va_list) __scanflike(1, 0);
+#if !defined(__aarch64__)
 int	 vsnprintf(char * __restrict, size_t, const char * __restrict,
 	    __va_list) __printflike(3, 0);
+#endif
 int	 vsscanf(const char * __restrict, const char * __restrict, __va_list)
 	    __scanflike(2, 0);
 #endif
@@ -495,14 +503,16 @@ extern int __isthreaded;
 #define	clearerr(p)	(!__isthreaded ? __sclearerr(p) : (clearerr)(p))
 
 #if __POSIX_VISIBLE
+#if !defined(__aarch64__)
 #define	fileno(p)	(!__isthreaded ? __sfileno(p) : (fileno)(p))
-#endif
 
 #define	getc(fp)	(!__isthreaded ? __sgetc(fp) : (getc)(fp))
 #define	putc(x, fp)	(!__isthreaded ? __sputc(x, fp) : (putc)(x, fp))
 
 #define	getchar()	getc(stdin)
 #define	putchar(x)	putc(x, stdout)
+#endif
+#endif
 
 #if __BSD_VISIBLE
 /*

--- a/usr/src/boot/include/stdlib.h
+++ b/usr/src/boot/include/stdlib.h
@@ -217,8 +217,12 @@ long	 mrand48(void);
 long	 nrand48(unsigned short[3]);
 int	 posix_openpt(int);
 char	*ptsname(int);
+#if defined(__aarch64__)
+extern int	putenv(const char *);
+#else
 int	 putenv(char *);
 long	 random(void);
+#endif
 unsigned short
 	*seed48(unsigned short[3]);
 #ifndef _SETKEY_DECLARED

--- a/usr/src/boot/libsa/stand.h
+++ b/usr/src/boot/libsa/stand.h
@@ -202,6 +202,13 @@ extern struct open_file *fd2open_file(int);
 
 #define	isascii(c)	(((c) & ~0x7F) == 0)
 
+#if defined(__aarch64__)
+static __inline int isprint(int c)
+{
+	return (c >= ' ' && c <= '~');
+}
+#endif
+
 static __inline int isupper(int c)
 {
 	return (c >= 'A' && c <= 'Z');


### PR DESCRIPTION
Add acpica for `loader(7)` on `aarch64`. Most of this code is from `acpica` itself, and is pretty ugly. I've changed the GetTime functionality to not call UEFI Runtime Services, as those are only supposed to be called from a single exception level, and we're not necessarily at our final EL at this point. A lot of other functionality was gutted, as it makes no sense in this environment.

This integration includes a wrapper to initialise and finalise acpica.

Will be rebased once https://github.com/richlowe/illumos-gate/pull/156 lands.