### PR TITLE
loader(7): 14 of 16 - deliver loader, add dboot, respect loader consoles

### DIFF
--- a/usr/src/Makefile
+++ b/usr/src/Makefile
@@ -42,7 +42,7 @@ include Targetdirs
 COMMON_SUBDIRS=	data uts lib cmd man test
 sparc_SUBDIRS= psm stand ucblib ucbcmd
 i386_SUBDIRS= grub boot ucblib ucbcmd
-aarch64_SUBDIRS= psm stand
+aarch64_SUBDIRS= boot psm stand
 
 #
 # sparc and aarch64 builds need to build stand before psm

--- a/usr/src/man/man5/Makefile
+++ b/usr/src/man/man5/Makefile
@@ -204,7 +204,8 @@ i386_MANFILES=	bhyve_config.5			\
 		loader.conf.5			\
 		sysbus.5
 
-aarch64_MANFILES=	fdt.5
+aarch64_MANFILES=	fdt.5			\
+			loader.conf.5
 
 MANLINKS=	addresses.5			\
 		devid_cache.5			\

--- a/usr/src/man/man7/Makefile
+++ b/usr/src/man/man7/Makefile
@@ -138,6 +138,18 @@ _MANFILES=	Intro.7			\
 
 sparc_MANFILES=
 
+aarch64_MANFILES=			\
+		beastie.4th.7		\
+		brand.4th.7		\
+		check-password.4th.7	\
+		color.4th.7		\
+		delay.4th.7		\
+		loader.4th.7		\
+		loader.7		\
+		menu.4th.7		\
+		menusets.4th.7		\
+		version.4th.7
+
 i386_MANFILES=	beastie.4th.7		\
 		brand.4th.7		\
 		check-password.4th.7	\

--- a/usr/src/pkg/manifests/system-boot-loader.p5m
+++ b/usr/src/pkg/manifests/system-boot-loader.p5m
@@ -22,6 +22,7 @@
 #
 # Copyright 2016, Toomas Soome <tsoome@me.com>
 # Copyright 2019 OmniOS Community Edition (OmniOSce) Association.
+# Copyright 2025 Michael van der Westhuizen
 #
 
 #
@@ -35,71 +36,72 @@ set name=pkg.fmri \
 set name=pkg.summary value="BootForth Boot Loader"
 set name=pkg.description value="Boot Loader"
 set name=info.classification value=org.opensolaris.category.2008:System/Core
-$(i386_ONLY)dir path=boot group=sys
+dir  path=boot group=sys
 $(i386_ONLY)file path=boot/cdboot group=sys mode=0444
-$(i386_ONLY)dir path=boot/conf.d group=sys
-$(i386_ONLY)dir path=boot/defaults group=sys
-$(i386_ONLY)file path=boot/defaults/loader.conf group=sys mode=0444
-$(i386_ONLY)dir path=boot/forth group=sys
-$(i386_ONLY)file path=boot/forth/beadm.4th group=sys mode=0444
-$(i386_ONLY)file path=boot/forth/beastie.4th group=sys mode=0444
-$(i386_ONLY)file path=boot/forth/brand-illumos.4th group=sys mode=0444
-$(i386_ONLY)file path=boot/forth/brand.4th group=sys mode=0444
-$(i386_ONLY)file path=boot/forth/check-password.4th group=sys mode=0444
-$(i386_ONLY)file path=boot/forth/color.4th group=sys mode=0444
-$(i386_ONLY)file path=boot/forth/delay.4th group=sys mode=0444
-$(i386_ONLY)file path=boot/forth/efi.4th group=sys mode=0444
-$(i386_ONLY)file path=boot/forth/frames.4th group=sys mode=0444
-$(i386_ONLY)file path=boot/forth/loader.4th group=sys mode=0444
-$(i386_ONLY)file path=boot/forth/logo-beastie.4th group=sys mode=0444
-$(i386_ONLY)file path=boot/forth/logo-beastiebw.4th group=sys mode=0444
-$(i386_ONLY)file path=boot/forth/logo-fbsdbw.4th group=sys mode=0444
-$(i386_ONLY)file path=boot/forth/logo-illumos.4th group=sys mode=0444
-$(i386_ONLY)file path=boot/forth/logo-orb.4th group=sys mode=0444
-$(i386_ONLY)file path=boot/forth/logo-orbbw.4th group=sys mode=0444
-$(i386_ONLY)file path=boot/forth/menu-commands.4th group=sys mode=0444
-$(i386_ONLY)file path=boot/forth/menu.4th group=sys mode=0444
-$(i386_ONLY)file path=boot/forth/menu.rc group=sys mode=0444
-$(i386_ONLY)file path=boot/forth/menusets.4th group=sys mode=0444
-$(i386_ONLY)file path=boot/forth/pcibios.4th group=sys mode=0444
-$(i386_ONLY)file path=boot/forth/screen.4th group=sys mode=0444
-$(i386_ONLY)file path=boot/forth/shortcuts.4th group=sys mode=0444
-$(i386_ONLY)file path=boot/forth/support.4th group=sys mode=0444
-$(i386_ONLY)file path=boot/forth/version.4th group=sys mode=0444
+dir  path=boot/conf.d group=sys
+dir  path=boot/defaults group=sys
+file path=boot/defaults/loader.conf group=sys mode=0444
+dir  path=boot/forth group=sys
+file path=boot/forth/beadm.4th group=sys mode=0444
+file path=boot/forth/beastie.4th group=sys mode=0444
+file path=boot/forth/brand-illumos.4th group=sys mode=0444
+file path=boot/forth/brand.4th group=sys mode=0444
+file path=boot/forth/check-password.4th group=sys mode=0444
+file path=boot/forth/color.4th group=sys mode=0444
+file path=boot/forth/delay.4th group=sys mode=0444
+file path=boot/forth/efi.4th group=sys mode=0444
+file path=boot/forth/frames.4th group=sys mode=0444
+file path=boot/forth/loader.4th group=sys mode=0444
+file path=boot/forth/logo-beastie.4th group=sys mode=0444
+file path=boot/forth/logo-beastiebw.4th group=sys mode=0444
+file path=boot/forth/logo-fbsdbw.4th group=sys mode=0444
+file path=boot/forth/logo-illumos.4th group=sys mode=0444
+file path=boot/forth/logo-orb.4th group=sys mode=0444
+file path=boot/forth/logo-orbbw.4th group=sys mode=0444
+file path=boot/forth/menu-commands.4th group=sys mode=0444
+file path=boot/forth/menu.4th group=sys mode=0444
+file path=boot/forth/menu.rc group=sys mode=0444
+file path=boot/forth/menusets.4th group=sys mode=0444
+file path=boot/forth/pcibios.4th group=sys mode=0444
+file path=boot/forth/screen.4th group=sys mode=0444
+file path=boot/forth/shortcuts.4th group=sys mode=0444
+file path=boot/forth/support.4th group=sys mode=0444
+file path=boot/forth/version.4th group=sys mode=0444
 $(i386_ONLY)file path=boot/gptzfsboot group=sys mode=0444
-$(i386_ONLY)file path=boot/illumos-brand.png group=sys mode=0444
-$(i386_ONLY)file path=boot/illumos-logo.png group=sys mode=0444
+file path=boot/illumos-brand.png group=sys mode=0444
+file path=boot/illumos-logo.png group=sys mode=0444
 $(i386_ONLY)file path=boot/isoboot group=sys mode=0444
 $(i386_ONLY)file path=boot/loader group=sys mode=0444
+# hides in an i386-only directory
 $(i386_ONLY)file path=boot/loader.help group=sys mode=0444
-$(i386_ONLY)file path=boot/loader.rc group=sys mode=0444
+file path=boot/loader.rc group=sys mode=0444
 $(i386_ONLY)file path=boot/loader32.efi group=sys mode=0555
-$(i386_ONLY)file path=boot/loader64.efi group=sys mode=0555
+file path=boot/loader64.efi group=sys mode=0555
 $(i386_ONLY)file path=boot/pmbr group=sys mode=0444
 $(i386_ONLY)file path=boot/pxeboot group=sys mode=0444
-$(i386_ONLY)dir path=usr/share/man
-$(i386_ONLY)dir path=usr/share/man/man3
-$(i386_ONLY)dir path=usr/share/man/man5
-$(i386_ONLY)file path=usr/share/man/man5/loader.conf.5
-$(i386_ONLY)dir path=usr/share/man/man7
-$(i386_ONLY)file path=usr/share/man/man7/beastie.4th.7
-$(i386_ONLY)file path=usr/share/man/man7/brand.4th.7
-$(i386_ONLY)file path=usr/share/man/man7/check-password.4th.7
-$(i386_ONLY)file path=usr/share/man/man7/color.4th.7
-$(i386_ONLY)file path=usr/share/man/man7/delay.4th.7
+dir  path=usr/share/man
+dir  path=usr/share/man/man3
+dir  path=usr/share/man/man5
+file path=usr/share/man/man5/loader.conf.5
+dir  path=usr/share/man/man7
+file path=usr/share/man/man7/beastie.4th.7
+file path=usr/share/man/man7/brand.4th.7
+file path=usr/share/man/man7/check-password.4th.7
+file path=usr/share/man/man7/color.4th.7
+file path=usr/share/man/man7/delay.4th.7
 $(i386_ONLY)file path=usr/share/man/man7/gptzfsboot.7
 $(i386_ONLY)file path=usr/share/man/man7/isoboot.7
-$(i386_ONLY)file path=usr/share/man/man7/loader.4th.7
-$(i386_ONLY)file path=usr/share/man/man7/loader.7
-$(i386_ONLY)file path=usr/share/man/man7/menu.4th.7
-$(i386_ONLY)file path=usr/share/man/man7/menusets.4th.7
+file path=usr/share/man/man7/loader.4th.7
+file path=usr/share/man/man7/loader.7
+file path=usr/share/man/man7/menu.4th.7
+file path=usr/share/man/man7/menusets.4th.7
 $(i386_ONLY)file path=usr/share/man/man7/pxeboot.7
-$(i386_ONLY)file path=usr/share/man/man7/version.4th.7
+file path=usr/share/man/man7/version.4th.7
 license lic_CDDL license=lic_CDDL
-$(i386_ONLY)license usr/src/boot/COPYRIGHT license=usr/src/boot/COPYRIGHT
-$(i386_ONLY)license usr/src/boot/common/linenoise/LICENSE \
+license usr/src/boot/COPYRIGHT license=usr/src/boot/COPYRIGHT
+license usr/src/boot/common/linenoise/LICENSE \
     license=usr/src/boot/common/linenoise/LICENSE
-$(i386_ONLY)license usr/src/common/crypto/skein/THIRDPARTYLICENSE \
+license usr/src/common/crypto/skein/THIRDPARTYLICENSE \
     license=usr/src/common/crypto/skein/THIRDPARTYLICENSE
-$(i386_ONLY)license usr/src/common/pnglite/THIRDPARTYLICENSE \
+license usr/src/common/pnglite/THIRDPARTYLICENSE \
     license=usr/src/common/pnglite/THIRDPARTYLICENSE

--- a/usr/src/uts/aarch64/sys/bootinfo.h
+++ b/usr/src/uts/aarch64/sys/bootinfo.h
@@ -90,13 +90,19 @@ typedef enum uefi_arch_type {
  */
 struct xboot_info {
 	uint64_t		bi_fdt;
+	uint64_t		bi_uefi_systab;
 	uint64_t		bi_cmdline;
 	uint64_t		bi_modules;
-	uint64_t		bi_phys_avail;
 	uint64_t		bi_phys_installed;
+	uint64_t		bi_phys_avail;
 	uint64_t		bi_boot_scratch;
+	uint64_t		bi_fw_code;
+	uint64_t		bi_fw_data;
+	uint64_t		bi_fw_mmio;
+	uint64_t		bi_fw_rsvd;
 	uint64_t		bi_bsvc_uart_mmio_base;
 	uint64_t		bi_arch_timer_freq;
+	uint64_t		bi_framebuffer;
 	xbi_bsvc_uart_type_t	bi_bsvc_uart_type;
 	uint32_t		bi_module_cnt;
 	uint32_t		bi_psci_version;
@@ -105,7 +111,6 @@ struct xboot_info {
 	uint32_t		bi_psci_cpu_off_id;
 	uint32_t		bi_psci_cpu_on_id;
 	uint32_t		bi_psci_migrate_id;
-	uint64_t		bi_framebuffer;
 };
 
 #ifdef	__cplusplus

--- a/usr/src/uts/armv8/Makefile.files
+++ b/usr/src/uts/armv8/Makefile.files
@@ -82,6 +82,11 @@ CORE_OBJS +=			\
 
 CORE_OBJS += $(PCI_STRING_OBJS)
 
+#
+# These get compiled twice:
+# - once in the dboot (direct boot) identity mapped code
+# - once for use during early startup in unix
+#
 BOOT_DRIVER_OBJS =		\
 	boot_console.o		\
 	boot_fb.o		\
@@ -92,6 +97,49 @@ BOOT_DRIVER_OBJS =		\
 	$(FONT_OBJS)
 
 CORE_OBJS += $(BOOT_DRIVER_OBJS)
+
+DBOOT_OBJS +=			\
+	dboot_srt0.o		\
+	dboot_self_reloc.o	\
+	dboot_main.o		\
+	dboot_aarch64_subr.o	\
+	dboot_printf.o		\
+	dboot_conf.o		\
+	dboot_conf_acpi.o	\
+	dboot_conf_fdt.o	\
+	dboot_memlist.o		\
+	dboot_psci.o		\
+	dboot_uefimem.o		\
+	dboot_standalloc.o	\
+	dboot_standalone.o	\
+	dboot_machdep_efi.o	\
+	dboot_heap_kmem.o	\
+	dboot_machdep.o		\
+	dboot_elf_loader.o	\
+	dboot_bootflags.o	\
+	fdt.o                   \
+	fdt_ro.o                \
+	fdt_wip.o               \
+	fdt_sw.o                \
+	fdt_rw.o                \
+	fdt_strerror.o          \
+	fdt_empty_tree.o        \
+	fdt_addresses.o         \
+	fdt_overlay.o           \
+	fdt_check.o		\
+	getoptstr.o		\
+	bitext.o		\
+	bzero.o			\
+	string.o		\
+	strtoul.o		\
+	memchr.o		\
+	memcpy.o		\
+	memmove.o		\
+	memcmp.o		\
+	memset.o		\
+	memlist.o		\
+	standalloc.o		\
+	$(BOOT_DRIVER_OBJS)
 
 PLATMOD_OBJS = platmod.o
 

--- a/usr/src/uts/armv8/Makefile.rules
+++ b/usr/src/uts/armv8/Makefile.rules
@@ -22,6 +22,7 @@
 #
 # Copyright (c) 1992, 2010, Oracle and/or its affiliates. All rights reserved.
 # Copyright 2017 Hayashi Naoyuki
+# Copyright 2025 Michael van der Westhuizen
 #
 
 $(OBJS_DIR)/%.o:		$(UTSBASE)/armv8/io/ns16550a/%.c
@@ -64,6 +65,65 @@ $(OBJS_DIR)/%.o:		$(UTSBASE)/common/io/%.c
 $(OBJS_DIR)/%.o:		$(UTSBASE)/armv8/io/gfx_private/%.c
 	$(COMPILE.c) -o $@ $<
 	$(CTFCONVERT_O)
+
+#
+# Rules for the direct-boot shim.
+#
+DBOOT_OBJS_DIR	= dboot/$(OBJS_DIR)
+DBOOT_MACH_64	= -D_BOOT_TARGET_aarch64
+DBOOT_DEFS	= -D_BOOT $(DBOOT_MACH_$(CLASS))
+DBOOT_DEFS	+= -D_MACHDEP -U_KERNEL
+DBOOT_FLAGS	= $(aarch64_CFLAGS) $(CSTD) $(COPTFLAG) $(C_BIGPICFLAGS)
+DBOOT_FLAGS	+= $(CCVERBOSE) $(CERRWARN) $(CCNOAUTOINLINE)
+DBOOT_FLAGS	+= -_gcc=-march=armv8-a+nofp+nosimd
+DBOOT_ASFLAGS	= $(C_BIGPICFLAGS) $(ASFLAGS_XARCH_64) -D_ASM
+
+DBOOT_CC_INCL	= -I$(SRC)/contrib/libfdt $(INCLUDE_PATH)
+DBOOT_AS_INCL	= $(AS_INC_PATH)
+
+$(DBOOT_OBJS_DIR)/%.o:		$(UTSBASE)/armv8/dboot/%.c
+	$(aarch64_CC) $(DBOOT_FLAGS) -O \
+	    $(DBOOT_DEFS) $(DBOOT_CC_INCL) -c -o $@ $<
+
+$(DBOOT_OBJS_DIR)/%.o:		$(UTSBASE)/armv8/dboot/%.S $(ASSYM_H)
+	$(COMPILE.s) -o $@ $<
+
+$(DBOOT_OBJS_DIR)/%.o:		$(UTSBASE)/armv8/boot/%.c
+	$(aarch64_CC) $(DBOOT_FLAGS) -O \
+	    $(DBOOT_DEFS) $(DBOOT_CC_INCL) -c -o $@ $<
+
+$(DBOOT_OBJS_DIR)/%.o:		$(SRC)/common/font/%.c
+	$(aarch64_CC) $(DBOOT_FLAGS) -O \
+	    $(DBOOT_DEFS) $(DBOOT_CC_INCL) -c -o $@ $<
+
+# dboot fonts: .bdf -> (generated) .c
+$(DBOOT_OBJS_DIR)/$(FONT).c:	$(FONT_DIR)/$(FONT_SRC).bdf
+	$(VTFONTCVT) -f source -o $@ $(FONT_DIR)/$(FONT_SRC).bdf
+
+# dboot fonts: (generated) .c -> .o
+$(DBOOT_OBJS_DIR)/%.o:		$(DBOOT_OBJS_DIR)/%.c
+	$(aarch64_CC) $(DBOOT_FLAGS) -O \
+	    $(DBOOT_DEFS) $(DBOOT_CC_INCL) -c -o $@ $<
+
+# for libfdt objects
+$(DBOOT_OBJS_DIR)/%.o:		$(SRC)/contrib/libfdt/%.c
+	$(aarch64_CC) $(DBOOT_FLAGS) -O \
+	    $(DBOOT_DEFS) $(DBOOT_CC_INCL) -c -o $@ $<
+
+# for getoptstr.o
+$(DBOOT_OBJS_DIR)/%.o:		$(COMMONBASE)/util/%.c
+	$(aarch64_CC) $(DBOOT_FLAGS) -O \
+	    $(DBOOT_DEFS) $(DBOOT_CC_INCL) -c -o $@ $<
+
+# for bitext.o
+$(DBOOT_OBJS_DIR)/%.o:		$(COMMONBASE)/bitext/%.c
+	$(aarch64_CC) $(DBOOT_FLAGS) -O \
+	    $(DBOOT_DEFS) $(DBOOT_CC_INCL) -c -o $@ $<
+
+#
+# NOTE: Linking dboot is also quite special, and is dealt with
+# in the unix Makefile.
+#
 
 $(OBJS_DIR)/dtracestubs.s:	$(UNIX_O) $(LIBS)
 	$(NM) -u $(UNIX_O) $(LIBS) | $(GREP) __dtrace_probe_ | $(SORT) | \

--- a/usr/src/uts/armv8/conf/Mapfile
+++ b/usr/src/uts/armv8/conf/Mapfile
@@ -9,17 +9,33 @@
 # http://www.illumos.org/license/CDDL.
 #
 
+#
 # Copyright 2022 Richard Lowe.
+# Copyright 2025 Michael van der Westhuizen
+#
 
 $mapfile_version 2
+
+#
+# this is the UEFI direct-boot shim
+#
+LOAD_SEGMENT dboot {
+	FLAGS = READ WRITE EXECUTE;
+	VADDR = 0xfffffffffe000000;
+	ASSIGN_SECTION {
+		TYPE = PROGBITS;
+		FLAGS = ALLOC WRITE;
+		FILE_BASENAME = dboot.o;
+	};
+};
 
 #
 # this is the kernel text
 #
 LOAD_SEGMENT text {
 	FLAGS = READ EXECUTE;
+	ALIGN = 0x1000;
 	NOHDR;
-	VADDR = 0xfffffffffe000000;
 	OS_ORDER = .text;
 	ASSIGN_SECTION {
 		TYPE = PROGBITS;

--- a/usr/src/uts/armv8/dboot/dboot.h
+++ b/usr/src/uts/armv8/dboot/dboot.h
@@ -1,0 +1,86 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2025 Michael van der Westhuizen
+ */
+
+#ifndef _DBOOT_DBOOT_H
+#define	_DBOOT_DBOOT_H
+
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern int boothowto;
+extern int verbosemode;
+extern int debug;
+#define	dprintf	if (debug) dboot_printf
+
+struct xboot_info;
+
+struct efi_map_header {
+	size_t		memory_size;
+	size_t		descriptor_size;
+	uint32_t	descriptor_version;
+};
+
+#define	efi_mmap_next(ptr, size) \
+	((EFI_MEMORY_DESCRIPTOR *)(((uint8_t *)(ptr)) + (size)))
+
+#define	RNDUP(x, y)	((x) + ((y) - 1ul) & ~((y) - 1ul))
+#define	RNDDN(x, y)	((x) & ~((y) - 1ul))
+
+struct memlist;
+
+extern struct memlist *pfreelistp;
+extern struct memlist *pscratchlistp;
+extern struct memlist *pinstalledp;
+extern struct memlist *pmappablep;
+extern struct memlist *piolistp;
+extern struct memlist *pldriolistp;
+extern struct memlist *ptmplistp;
+extern struct memlist *pfwcodelistp;
+extern struct memlist *pfwdatalistp;
+extern struct memlist *prsvdlistp;
+
+/*
+ * dboot_conf.c
+ */
+extern int dboot_configure(caddr_t modulep, struct xboot_info *xbi,
+    caddr_t *pkernel, uint64_t *pkernel_size);
+extern const char *dboot_getenv(const char *name);
+
+/*
+ * dboot_conf_fdt.c
+ */
+extern int dboot_configure_fdt(void);
+
+/*
+ * dboot_conf_acpi.c
+ */
+extern int dboot_configure_acpi(void);
+
+/*
+ * dboot_uefimem.c
+ */
+extern int dboot_uefi_init_mem(caddr_t memmap,
+    caddr_t scratch_addr, uint64_t scratch_size);
+
+extern void panic(const char *, ...) __attribute__((noreturn));
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _DBOOT_DBOOT_H */

--- a/usr/src/uts/armv8/dboot/dboot_aarch64_subr.S
+++ b/usr/src/uts/armv8/dboot/dboot_aarch64_subr.S
@@ -1,0 +1,50 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright 2017 Hayashi Naoyuki
+ */
+
+#include <sys/asm_linkage.h>
+#include "assym.h"
+
+/*
+ * splimp()
+ */
+	ENTRY(splimp)
+	mov	x0, #7
+	ret
+	SET_SIZE(splimp)
+
+/*
+ * splnet()
+ */
+	ENTRY(splnet)
+	mov	x0, #7
+	ret
+	SET_SIZE(splnet)
+
+/*
+ * splx()
+ */
+	ENTRY(splx)
+	ret
+	SET_SIZE(splx)
+

--- a/usr/src/uts/armv8/dboot/dboot_bootflags.c
+++ b/usr/src/uts/armv8/dboot/dboot_bootflags.c
@@ -1,0 +1,188 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+ * Use is subject to license terms.
+ */
+/*
+ * Copyright 2017 Hayashi Naoyuki
+ * Copyright 2025 Michael van der Westhuizen
+ */
+
+#include <sys/types.h>
+#include <sys/systm.h>
+#include <sys/bootconf.h>
+#include <sys/reboot.h>
+#include <sys/param.h>
+#include <sys/debug.h>
+#include <sys/sysmacros.h>
+#include <util/getoptstr.h>
+
+#include "dboot.h"
+#include "dboot_printf.h"
+
+/*
+ * Parse the boot arguments, adding the options found to the existing boothowto
+ * value (if any) or other state.  Then rewrite the buffer with arguments for
+ * the standalone.
+ *
+ * NOTE: boothowto may already have bits set when this function is called
+ *
+ * To pass properties to the kernel you'll need to do things the usual
+ * UNIX way, passing the '-B' options after a '--'.
+ */
+void
+bootflags(const char *args, size_t argsz, char *out, size_t outsz)
+{
+	static char newargs[OBP_MAXPATHLEN];
+	struct gos_params params;
+	const char *cp;
+	char *np;
+	size_t npres;
+	int c;
+
+	params.gos_opts = "VadvhkD:B:";
+	params.gos_strp = args;
+	getoptstr_init(&params);
+	while ((c = getoptstr(&params)) != -1) {
+		switch (c) {
+		/*
+		 * Boot flags.
+		 */
+		case 'V':
+			verbosemode = 1;
+			break;
+		case 'a':
+			boothowto |= RB_ASKNAME;
+			break;
+		case 'd':
+			boothowto |= RB_DEBUGENTER;
+			break;
+		case 'v':
+			boothowto |= RB_VERBOSE;
+			verbosemode = 1;
+			break;
+		case 'h':
+			boothowto |= RB_HALT;
+			break;
+
+		/* Consumed by the kernel */
+		case 'k':
+			boothowto |= RB_KMDB;
+			break;
+
+		/*
+		 * Unrecognized flags: stop.
+		 */
+		case 'D':
+		case '?':
+			break;
+		default:
+			dboot_printf("dboot: Ignoring unimplemented "
+			    "option -%c.\n", c);
+		}
+	}
+
+	/*
+	 * Construct the arguments for the standalone.
+	 */
+
+	*newargs = '\0';
+	np = newargs;
+
+	/*
+	 * We need a dash if we encountered an unrecognized option or if we
+	 * need to pass flags on.
+	 */
+	if (c == '?' || (boothowto &
+	    /* These flags are to be passed to the standalone. */
+	    (RB_ASKNAME | RB_DEBUGENTER | RB_VERBOSE | RB_HALT | RB_KMDB))) {
+		*np++ = '-';
+
+		/*
+		 * boot(8) says to pass these on.
+		 */
+		if (boothowto & RB_ASKNAME)
+			*np++ = 'a';
+
+		/*
+		 * boot isn't documented as consuming these flags, so pass
+		 * them on.
+		 */
+		if (boothowto & RB_DEBUGENTER)
+			*np++ = 'd';
+		if (boothowto & RB_KMDB)
+			*np++ = 'k';
+		if (boothowto & RB_VERBOSE)
+			*np++ = 'v';
+		if (boothowto & RB_HALT)
+			*np++ = 'h';
+
+		/*
+		 * If we didn't encounter an unrecognized flag and there's
+		 * more to copy, add a space to separate these flags.
+		 * (Otherwise, unrecognized flags can be appended since we
+		 * started this word with a dash.)
+		 */
+		if (c == -1 && params.gos_strp[0] != '\0')
+			*np++ = ' ';
+	}
+
+	npres = sizeof (newargs) - (size_t)(np - newargs);
+
+	if (c == '?') {
+		/*
+		 * Unrecognized flag: Copy gos_errp to end of line or a "--"
+		 * word.
+		 */
+		cp = params.gos_errp;
+		while (*cp && npres > 0) {
+			if (cp[0] == '-' && cp[1] == '-' &&
+			    (cp[2] == '\0' || ISSPACE(cp[2]))) {
+				cp += 2;
+				SKIP_SPC(cp);
+				break;
+			} else {
+				const char *sp = cp;
+				size_t sz;
+
+				/* Copy until the next word. */
+				while (*cp && !ISSPACE(*cp))
+					cp++;
+				while (ISSPACE(*cp))
+					cp++;
+
+				sz = MIN(npres, (size_t)(cp - sp));
+				npres -= sz;
+				bcopy(sp, np, sz);
+				np += sz;
+			}
+		}
+	} else {
+		cp = params.gos_strp;
+	}
+
+	while (npres > 0 && (*np++ = *cp++) != '\0')
+		npres--;
+
+	newargs[sizeof (newargs) - 1] = '\0';
+	(void) strlcpy(out, newargs, outsz + 1);
+}

--- a/usr/src/uts/armv8/dboot/dboot_conf.c
+++ b/usr/src/uts/armv8/dboot/dboot_conf.c
@@ -1,0 +1,696 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2025 Michael van der Westhuizen
+ */
+
+/*
+ * Boot shim configuration driven by FreeBSD-style modules.
+ */
+
+#include <sys/sysmacros.h>
+#include <sys/types.h>
+#include <sys/systm.h>
+#include <sys/errno.h>
+#include <sys/bootinfo.h>
+#include <sys/framebuffer.h>
+#include <sys/stdbool.h>
+#include <sys/limits.h>
+#include <asm/controlregs.h>
+#include <sys/psci.h>
+
+#if !defined(DCACHE_LINE)
+#define	DCACHE_LINE	64
+#endif
+
+#include <boot/boot_early_uart.h>
+
+#include "dboot.h"
+#include "dboot_printf.h"
+
+#define	MODINFO_END		0x0000	/* End of list */
+#define	MODINFO_NAME		0x0001	/* Name of module (string) */
+#define	MODINFO_TYPE		0x0002	/* Type of module (string) */
+#define	MODINFO_ADDR		0x0003	/* Loaded address */
+#define	MODINFO_SIZE		0x0004	/* Size of module */
+#define	MODINFO_EMPTY		0x0005	/* Has been deleted */
+#define	MODINFO_ARGS		0x0006	/* Parameters string */
+#define	MODINFO_METADATA	0x8000	/* Module-specfic */
+
+#define	MODINFOMD_AOUTEXEC	0x0001	/* a.out exec header */
+#define	MODINFOMD_ELFHDR	0x0002	/* ELF header */
+#define	MODINFOMD_SSYM		0x0003	/* start of symbols */
+#define	MODINFOMD_ESYM		0x0004	/* end of symbols */
+#define	MODINFOMD_DYNAMIC	0x0005	/* _DYNAMIC pointer */
+#define	MODINFOMD_MB2HDR	0x0006	/* MB2 header info */
+#define	MODINFOMD_ENVP		0x0006	/* envp[] */
+#define	MODINFOMD_HOWTO		0x0007	/* boothowto */
+#define	MODINFOMD_KERNEND	0x0008	/* kernend */
+#define	MODINFOMD_SHDR		0x0009	/* section header table */
+#define	MODINFOMD_CTORS_ADDR	0x000a	/* address of .ctors */
+#define	MODINFOMD_CTORS_SIZE	0x000b	/* size of .ctors */
+#define	MODINFOMD_FW_HANDLE	0x000c	/* Firmware dependent handle */
+#define	MODINFOMD_KEYBUF	0x000d	/* Crypto key intake buffer */
+#define	MODINFOMD_FONT		0x000e	/* Console font */
+#define	MODINFOMD_NOCOPY	0x8000	/* don't copy to the kernel */
+
+#define	MODINFOMD_SMAP		0x1001	/* x86 SMAP */
+#define	MODINFOMD_SMAP_XATTR	0x1002	/* x86 SMAP extended attrs */
+#define	MODINFOMD_DTBP		0x1003	/* DTB pointer */
+#define	MODINFOMD_EFI_MAP	0x1004	/* UEFI memory map */
+#define	MODINFOMD_EFI_FB	0x1005	/* UEFI framebuffer */
+#define	MODINFOMD_MODULEP	0x1006
+#define	MODINFOMD_SCRATCH_ADDR	0x1007	/* address of scratch memory */
+#define	MODINFOMD_SCRATCH_SIZE	0x1008	/* size of scratc memory */
+
+#define	ENV_BOOTMOD_NAME	"environment"
+#define	ROOTFS_BOOTMOD_NAME	"rootfs"
+#define	FONT_BOOTMOD_NAME	"console-font"
+
+static const char env_boot_module_name[] = ENV_BOOTMOD_NAME;
+static const char rootfs_boot_module_name[] = ROOTFS_BOOTMOD_NAME;
+static const char font_boot_module_name[] = FONT_BOOTMOD_NAME;
+
+#define	PAYLOAD_CMDLINE_MAX	2048
+static char payload_cmdline[PAYLOAD_CMDLINE_MAX];
+
+#define	MOD_UINT64(x)	(*((uint64_t *)(&(x)[2])))
+
+extern void * memset(void *sp1, int c, size_t n);
+
+static boot_framebuffer_t framebuffer __aligned(16) = {
+	0, /* framebuffer - efi_fb */
+	/* origin.x, origin.y, pos.y, pos.y, visible */
+	{ { 0, 0 }, { 0, 0 }, 0 }
+};
+static boot_framebuffer_t *fb = &framebuffer;
+
+static struct boot_modules boot_modules[MAX_BOOT_MODULES] = {
+	{ 0, 0, 0, BMT_ROOTFS },
+};
+
+extern void exception_vector(void);
+extern void bcons_init(struct xboot_info *);
+extern void bootflags(const char *args, size_t argsz,
+    char *out, size_t outsz);
+
+extern unsigned long strtoul(const char *, char **, int);
+
+extern int errno;
+
+struct module_data_t {
+	uint64_t	maddr;
+	uint64_t	msize;
+	const char	*mtype;
+	const char	*mname;
+	const char	*margs;
+	uint64_t	env_addr;
+	uint64_t	map_addr;
+#ifdef NOT_YET
+	uint64_t	font_addr;
+#endif
+	uint64_t	fb_addr;
+	uint64_t	systab_addr;
+	uint64_t	fdt_addr;
+	uint64_t	scratch_addr;
+	uint64_t	scratch_size;
+};
+
+const char *
+dboot_getenv(const char *name)
+{
+	const char *val;
+	extern const char *find_boot_prop(const char *name);
+
+	if (name == NULL)
+		return (NULL);
+
+	return (find_boot_prop(name));
+}
+
+static bool
+find_boolean_boot_prop(const char *name)
+{
+	const char *val;
+	extern const char *find_boot_prop(const char *name);
+
+	if ((val = find_boot_prop(name)) == NULL)
+		return (false);
+
+	if (strcmp(val, "1") == 0 || strcmp(val, "true") == 0)
+		return (true);
+
+	return (false);
+}
+
+static uint64_t
+find_u64_boot_prop(const char *name, uint64_t defval)
+{
+	const char *val;
+	char *ep;
+	unsigned long ul;
+	extern const char *find_boot_prop(const char *name);
+
+	if ((val = find_boot_prop(name)) == NULL)
+		return (defval);
+
+	errno = 0;
+	ul = strtoul(val, &ep, 0);
+	if (*val == '\0' || *ep != '\0')
+		return (defval);
+	if (errno == ERANGE && ul == ULONG_MAX)
+		return (defval);
+
+	return ((uint64_t)ul);
+}
+
+static int
+prekern_process_module_info(caddr_t mi, struct module_data_t *md)
+{
+	caddr_t		curp;
+	uint32_t	*hdrp;
+	unsigned int	mlen;
+	uint32_t	type;
+	unsigned int	next;
+
+	if (mi == NULL) {
+		dboot_printf("dboot: null module info\n");
+		return (-1);
+	}
+
+	curp = mi;
+	type = 0;
+
+	for (;;) {
+		hdrp = (uint32_t *)curp;
+		mlen = hdrp[1];
+
+		/*
+		 * End of module data? Let the caller deal with it.
+		 */
+		if (hdrp[0] == MODINFO_END && mlen == 0)
+			break;
+
+		/*
+		 * We give up once we've looped back to the type what we were
+		 * looking at first, which is a MODINFO_NAME.
+		 */
+		if (type == 0) {
+			/*
+			 * The first time around we ensure that we're looking
+			 * at MODINFO_NAME, then track that we've seen
+			 * the MODINFO_NAME type.
+			 */
+			if (hdrp[0] != MODINFO_NAME) {
+				dboot_printf("dboot: starting module tag "
+				    "is not a name\n");
+				return (-1);
+			}
+			type = MODINFO_NAME;
+		} else {
+			/*
+			 * On subsequent iterations we see if we've hit another
+			 * MODINFO_NAME - if we have we bail so as to avoid
+			 * looking at the next module.
+			 */
+			if (hdrp[0] == type)
+				break;
+		}
+
+		switch (hdrp[0]) {
+		case MODINFO_NAME:
+			md->mname = (const char *)&hdrp[2];
+			break;
+		case MODINFO_TYPE:
+			md->mtype = (const char *)&hdrp[2];
+			break;
+		case MODINFO_ARGS:
+			md->margs = (const char *)&hdrp[2];
+			break;
+		case MODINFO_ADDR:
+			md->maddr = MOD_UINT64(hdrp);
+			break;
+		case MODINFO_SIZE:
+			md->msize = MOD_UINT64(hdrp);
+			break;
+		default:
+			if (hdrp[0] & MODINFO_METADATA) {
+				switch (hdrp[0] & ~MODINFO_METADATA) {
+				/*
+				 * MODINFOMD_AOUTEXEC
+				 * MODINFOMD_ELFHDR
+				 * MODINFOMD_SSYM
+				 * MODINFOMD_ESYM
+				 * MODINFOMD_DYNAMIC
+				 * MODINFOMD_KERNEND
+				 * MODINFOMD_SHDR
+				 * MODINFOMD_CTORS_ADDR
+				 * MODINFOMD_CTORS_SIZE
+				 * MODINFOMD_KEYBUF
+				 * MODINFOMD_NOCOPY
+				 * MODINFOMD_HOWTO
+				 * MODINFOMD_FONT
+				 */
+				case MODINFOMD_DTBP:
+					md->fdt_addr = MOD_UINT64(hdrp);
+					break;
+				case MODINFOMD_FW_HANDLE:
+					md->systab_addr = MOD_UINT64(hdrp);
+					break;
+				case MODINFOMD_EFI_FB:
+					md->fb_addr = (uint64_t)&hdrp[2];
+					break;
+				case MODINFOMD_ENVP:
+					md->env_addr = MOD_UINT64(hdrp);
+					break;
+				case MODINFOMD_EFI_MAP:
+					md->map_addr = (uint64_t)&hdrp[2];
+					break;
+				case MODINFOMD_SCRATCH_ADDR:
+					md->scratch_addr = MOD_UINT64(hdrp);
+					break;
+				case MODINFOMD_SCRATCH_SIZE:
+					md->scratch_size = MOD_UINT64(hdrp);
+					break;
+				default:
+					break;
+				}
+			}
+
+			break;
+		}
+
+		next = sizeof (uint32_t) * 2 + mlen;
+		next = roundup(next, sizeof (ulong_t));
+		curp += next;
+	}
+
+	if (type == 0) {
+		dboot_printf("dboot: no module processed\n");
+		return (-1);
+	}
+
+	if (md->mtype == NULL || md->mname == NULL ||
+	    md->maddr == 0 || md->msize == 0) {
+		dboot_printf("dboot: malformed module\n");
+		return (-1);
+	}
+
+	return (0);
+}
+
+static int64_t
+prekern_calc_env_size(const char *env)
+{
+	const char	*menv;
+	char		c;
+	char		lastc;
+
+	if (env == NULL)
+		return (-1);
+
+	menv = env;
+
+	for (c = *menv, lastc = 0xff; ; c = *++menv) {
+		if (c == '\0' && lastc == '\0')
+			break;
+		lastc = c;
+	}
+
+	return (int64_t)(((uint64_t)menv) - ((uint64_t)env));
+}
+
+int
+dboot_configure(caddr_t modulep, struct xboot_info *xbi,
+    caddr_t *pkernel, uint64_t *pkernel_size)
+{
+	caddr_t			curp;
+	uint32_t		*hdrp;
+	const char		*bootfile;
+	const char		*cmdline;
+	unsigned int		mlen;
+	unsigned int		next;
+	struct boot_modules	*bm;
+	caddr_t			memmap;
+	caddr_t			scratch_addr;
+	uint64_t		scratch_size;
+
+	if (modulep == NULL || xbi == NULL ||
+	    pkernel == NULL || pkernel_size == NULL)
+		panic("dboot: bad call to dboot_configure\n");
+
+	fb = &framebuffer;
+	memset(xbi, 0, sizeof (*xbi));
+	memmap = NULL;
+	bootfile = NULL;
+	cmdline = NULL;
+	*pkernel = NULL;
+	*pkernel_size = 0;
+
+	xbi->bi_modules = (uint64_t)&boot_modules[0];
+	xbi->bi_module_cnt = 0;
+	xbi->bi_psci_cpu_suspend_id = PSCI_CPU_SUSPEND_ID;
+	xbi->bi_psci_cpu_off_id = PSCI_CPU_OFF_ID;
+	xbi->bi_psci_cpu_on_id = PSCI_CPU_ON_ID;
+	xbi->bi_psci_migrate_id = PSCI_MIGRATE_ID;
+
+	bm = (struct boot_modules *)xbi->bi_modules;
+
+	curp = modulep;
+
+	for (;;) {
+		struct module_data_t moddata = {
+			0, 0, NULL, NULL, NULL, 0, 0, 0,
+		};
+
+		hdrp = (uint32_t *)curp;
+		mlen = hdrp[1];
+
+		/*
+		 * MODINFO_END signals the end of the TLV module list, so we
+		 * use this as an additional input when calculating the last
+		 * used address.
+		 */
+		if (hdrp[0] == MODINFO_END && mlen == 0)
+			break;
+
+		if (hdrp[0] == MODINFO_NAME) {
+			if (prekern_process_module_info(curp, &moddata) != 0)
+				return (-1);
+
+			/*
+			 * The environment is attached to the primary module,
+			 * which is the kernel (unix), as module metadata.
+			 */
+			if (strcmp(moddata.mtype, "elf kernel") == 0 ||
+			    strcmp(moddata.mtype, "elf64 kernel") == 0) {
+				int64_t sz;
+
+				/*
+				 * Stash the module address and size, which is
+				 * later used to load and start the ELF payload.
+				 */
+				*pkernel = (caddr_t)moddata.maddr;
+				*pkernel_size = moddata.msize;
+
+				/*
+				 * It is mandatory for the kernel module to
+				 * include an environment block as module
+				 * metadata. This environment block becomes
+				 * one of the boot modules passed to the
+				 * kernel via bootinfo.
+				 */
+
+				if (moddata.env_addr == 0) {
+					dboot_printf("dboot: no environment "
+					    "attached to the kernel module\n");
+					return (-1);
+				}
+
+				sz = prekern_calc_env_size(
+				    (const char *)moddata.env_addr);
+				if (sz <= 0) {
+					dboot_printf("dboot: invalid or "
+					    "zero-sized environment block\n");
+					return (-1);
+				}
+
+				bm[xbi->bi_module_cnt].bm_addr =
+				    moddata.env_addr;
+				bm[xbi->bi_module_cnt].bm_name =
+				    (uint64_t)&env_boot_module_name[0];
+				bm[xbi->bi_module_cnt].bm_size = (uint64_t)sz;
+				bm[xbi->bi_module_cnt].bm_type = BMT_ENV;
+				xbi->bi_module_cnt++;
+
+				/*
+				 * The path to the kernel is passed via the
+				 * module name, and is always present (already
+				 * validated).
+				 *
+				 * The kernel command-line is passed as module
+				 * metadata, and is optional.
+				 *
+				 * The two are stitched together by prepending
+				 * the bootfile and a space to the payload
+				 * command-line, then having bootflags strip
+				 * out the dboot-specific flags and propagate
+				 * what's left into the tail of the payload
+				 * command-line buffer.
+				 */
+				bootfile = moddata.mname;
+				cmdline = (const char *)(void *)moddata.margs;
+
+				/*
+				 * Now that we have both our bootfile and the
+				 * command-line (if any), parse out our
+				 * arguments, configuring dboot and producing
+				 * the command-line for the kernel.
+				 */
+				payload_cmdline[0] = '\0';
+				if (bootfile != NULL) {
+					if (strlen(bootfile) >
+					    (PAYLOAD_CMDLINE_MAX-2))
+						panic("dboot: bootfile too long"
+						    " (%u), maximum is %u\n",
+						    strlen(bootfile),
+						    (PAYLOAD_CMDLINE_MAX-2));
+					strcpy(payload_cmdline, bootfile);
+					if (cmdline != NULL)
+						strcat(payload_cmdline, " ");
+				}
+
+				if (cmdline != NULL) {
+					bootflags(cmdline, strlen(cmdline),
+					    payload_cmdline +
+					    strlen(payload_cmdline),
+					    sizeof (payload_cmdline) - 1 -
+					    strlen(payload_cmdline));
+				}
+
+				/*
+				 * If we appended a space unnecessarily we
+				 * strip that space now. "Unnecessarily" is
+				 * defined as there being no arguments to
+				 * pass on to the kernel.
+				 */
+				if (bootfile != NULL) {
+					if (strlen(payload_cmdline) ==
+					    (strlen(bootfile) + 1)) {
+						if (payload_cmdline[strlen(
+						    payload_cmdline) - 1] ==
+						    ' ')
+							payload_cmdline[strlen(
+							    payload_cmdline) -
+							    1] = '\0';
+					}
+				}
+
+				xbi->bi_cmdline = (uint64_t)payload_cmdline;
+
+				/*
+				 * This is a no-op for the boot console itself,
+				 * but has the side-effect of initialising the
+				 * boot environment and command-line in the
+				 * bcons code, which lets us use find_boot_prop
+				 * to pick up any debug flags directed at dboot.
+				 */
+				bcons_init(xbi);
+
+				/*
+				 * Now that we have our environment we take
+				 * the opportunity to configure our UART, which
+				 * means that any further errors will have a
+				 * chance of being seen.
+				 */
+				xbi->bi_bsvc_uart_mmio_base =
+				    find_u64_boot_prop("bcons.uart.mmio_base",
+				    EARLY_UART_PA);
+				xbi->bi_bsvc_uart_type = find_u64_boot_prop(
+				    "bcons.uart.type", EARLY_UART_TYPE);
+				bcons_init(xbi);
+
+				/*
+				 * Turn on debugging if requested via the
+				 * `dboot_debug` boolean property.
+				 */
+				if (find_boolean_boot_prop("dboot_debug")) {
+					debug = 1;
+					dprintf(
+					    "dboot: debug output enabled\n");
+				}
+
+				/*
+				 * It is mandatory for the elf kernel to have
+				 * the UEFI memory map passed as module
+				 * metadata.
+				 *
+				 * The memory map is used later in the
+				 * configuration process to bootstrap memory
+				 * management.
+				 */
+				if (moddata.map_addr == 0) {
+					dboot_printf("dboot: no UEFI memory "
+					    "map found\n");
+					return (-1);
+				}
+
+				memmap = (caddr_t)moddata.map_addr;
+
+				/*
+				 * NOT_YET: we need to pick up the loader font
+				 * and pass it on to the kernel. It is
+				 * exceptionally vague how this works today.
+				 */
+
+				/*
+				 * The optional UEFI framebuffer is passed as
+				 * module metadata on the kernel module. If
+				 * present, reinitialise the boot console to
+				 * enable framebuffer output.
+				 */
+				if (moddata.fb_addr != 0) {
+					framebuffer.framebuffer =
+					    moddata.fb_addr;
+					xbi->bi_framebuffer =
+					    (uint64_t)((void *)(&framebuffer));
+					bcons_init(xbi);
+				}
+
+				/*
+				 * ... and since we now have a console of
+				 * some type we can set up our exception
+				 * vector so that any trap has meaningful
+				 * information attached.
+				 *
+				 * We leave this fairly late as the UEFI
+				 * environment will have left a handler
+				 * in place, so we don't want to override
+				 * that until we're fairly sure we can
+				 * provide usable output.
+				 */
+				write_vbar((uint64_t)&exception_vector);
+
+				/*
+				 * The UEFI system table is passed via
+				 * module metadata and is mandatory.
+				 */
+				if (moddata.systab_addr == 0) {
+					dboot_printf("dboot: no UEFI "
+					    "system table found\n");
+					return (-1);
+				}
+
+				xbi->bi_uefi_systab = moddata.systab_addr;
+
+				/*
+				 * A flattened devicetree pointer is only
+				 * present on FDT-based systems. The reason
+				 * we don't pick this up from the UEFI
+				 * system table pointer is that loader will
+				 * have created a writable copy of the FDT,
+				 * mutated it and passed the adjusted version
+				 * to us.
+				 */
+				xbi->bi_fdt = moddata.fdt_addr;
+
+				/*
+				 * loader(7) provides us with a scratch memory
+				 * block for use by the shim. This memory is
+				 * allocated as loader data, so will be freed
+				 * once the kernel has bootstrapped.
+				 */
+				if (moddata.scratch_addr == 0 ||
+				    moddata.scratch_size == 0) {
+					dboot_printf("dboot: no boot scratch "
+					    "memory block found\n");
+					return (-1);
+				}
+
+				scratch_addr = (caddr_t)moddata.scratch_addr;
+				scratch_size = moddata.scratch_size;
+			} else if (strcmp(moddata.mtype, "rootfs") == 0) {
+				bm[xbi->bi_module_cnt].bm_addr = moddata.maddr;
+				bm[xbi->bi_module_cnt].bm_name =
+				    (uint64_t)&rootfs_boot_module_name[0];
+				bm[xbi->bi_module_cnt].bm_size = moddata.msize;
+				bm[xbi->bi_module_cnt].bm_type = BMT_ROOTFS;
+				xbi->bi_module_cnt++;
+			} else if (strcmp(moddata.mtype, "console-font") == 0) {
+				bm[xbi->bi_module_cnt].bm_addr = moddata.maddr;
+				bm[xbi->bi_module_cnt].bm_name =
+				    (uint64_t)&font_boot_module_name[0];
+				bm[xbi->bi_module_cnt].bm_size = moddata.msize;
+				bm[xbi->bi_module_cnt].bm_type = BMT_FONT;
+				xbi->bi_module_cnt++;
+			} else {
+				dprintf("dboot: ignoring unrecognised module "
+				    "type \"%s\"\n", moddata.mtype);
+			}
+		}
+
+		next = sizeof (uint32_t) * 2 + mlen;
+		next = roundup(next, sizeof (ulong_t));
+		curp += next;
+	}
+
+	if (bootfile == NULL || strlen(bootfile) == 0)
+		panic("dboot: null bootfile passed\n");
+
+	/*
+	 * Make some assertions about our data cache line size.
+	 *
+	 * XXXARM: this is a weird limitation in the port, since all of
+	 * this can be discovered at runtime and used to guide the various
+	 * cache manipulation functions. We should spend some time on this
+	 * in the future.
+	 */
+	if ((4u << ((read_ctr_el0() >> 16) & 0xF)) != DCACHE_LINE)
+		panic("dboot: CTR_EL0=%08x DCACHE_LINE=%ld\n",
+		    (uint32_t)read_ctr_el0(), DCACHE_LINE);
+
+	/*
+	 * Configuration from firmware tables
+	 */
+	if (xbi->bi_fdt != 0) {
+		if (dboot_configure_fdt() != 0) {
+			dboot_printf("dboot: failed to perform early "
+			    "configuration via FDT\n");
+			return (-1);
+		}
+	} else {
+		if (dboot_configure_acpi() != 0) {
+			dboot_printf("dboot: failed to perform early "
+			    "configuration via ACPI\n");
+			return (-1);
+		}
+	}
+
+	/*
+	 * If firmware didn't set bi_arch_timer_freq we defer to the hardware,
+	 * but check that a sensible value was set.
+	 */
+	if (xbi->bi_arch_timer_freq == 0)
+		if ((xbi->bi_arch_timer_freq = read_cntfrq()) == 0)
+			panic("dboot: could not determine "
+			    "architected timer frequency\n");
+
+	/*
+	 * Process the UEFI memory map into our memlists.
+	 *
+	 * This uses the scratch regions provided by loader(7).
+	 */
+	if (dboot_uefi_init_mem(memmap, scratch_addr, scratch_size) != 0)
+		panic("dboot: failed to initialise memory subsystem\n");
+
+	return (0);
+}

--- a/usr/src/uts/armv8/dboot/dboot_conf_acpi.c
+++ b/usr/src/uts/armv8/dboot/dboot_conf_acpi.c
@@ -1,0 +1,206 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2025 Michael van der Westhuizen
+ */
+
+#include <sys/types.h>
+#include <sys/systm.h>
+#include <sys/null.h>
+#include <sys/bootinfo.h>
+#include <sys/stdbool.h>
+#include <sys/efi.h>
+#include <sys/psci.h>
+#include <sys/acpi/platform/acsolaris.h>
+#include <sys/acpi/actypes.h>
+#include <sys/acpi/actbl.h>
+
+#include "dboot.h"
+
+extern void boot_psci_init(struct xboot_info *);
+
+static efi_guid_t acpi2 = EFI_ACPI_TABLE_GUID;
+
+
+static const EFI_SYSTEM_TABLE64 *
+get_uefi_systab(void)
+{
+	EFI_SYSTEM_TABLE64 *st;
+	extern struct xboot_info *bi;
+
+	if (bi->bi_uefi_systab == 0)
+		return (NULL);
+
+	st = (EFI_SYSTEM_TABLE64 *)bi->bi_uefi_systab;
+
+	if (st->Hdr.Signature != EFI_SYSTEM_TABLE_SIGNATURE)
+		return (NULL);
+
+	if (st->Hdr.Revision < EFI_REV(2, 5))
+		return (NULL);
+
+	return (st);
+}
+
+static bool
+same_guids(efi_guid_t *g1, efi_guid_t *g2)
+{
+	size_t i;
+
+	if (g1->time_low != g2->time_low)
+		return (false);
+	if (g1->time_mid != g2->time_mid)
+		return (false);
+	if (g1->time_hi_and_version != g2->time_hi_and_version)
+		return (false);
+	if (g1->clock_seq_hi_and_reserved != g2->clock_seq_hi_and_reserved)
+		return (false);
+	if (g1->clock_seq_low != g2->clock_seq_low)
+		return (false);
+	for (i = 0; i < 6; i++)
+		if (g1->node_addr[i] != g2->node_addr[i])
+			return (false);
+
+	return (true);
+}
+
+static const ACPI_TABLE_RSDP *
+get_acpi_rsdp(void)
+{
+	efi_guid_t vguid;
+	const EFI_SYSTEM_TABLE64 *st;
+	const EFI_CONFIGURATION_TABLE64 *cf;
+	const ACPI_TABLE_RSDP *rsdp;
+	UINT32 i;
+
+	if ((st = get_uefi_systab()) == NULL)
+		return (NULL);
+
+	cf = (const EFI_CONFIGURATION_TABLE64 *)st->ConfigurationTable;
+	if (cf == NULL)
+		return (NULL);
+
+	rsdp = NULL;
+
+	for (i = 0; i < st->NumberOfTableEntries; ++i) {
+		memcpy(&vguid, &cf[i].VendorGuid, sizeof (vguid));
+		if (same_guids(&vguid, &acpi2)) {
+			rsdp = (const ACPI_TABLE_RSDP *)cf[i].VendorTable;
+			break;
+		}
+	}
+
+	if (rsdp == NULL)
+		return (NULL);
+
+	if (strncmp(rsdp->Signature, ACPI_SIG_RSDP, strlen(ACPI_SIG_RSDP)) != 0)
+		return (NULL);
+
+	if (rsdp->Revision < 2)
+		return (NULL);
+
+	return (rsdp);
+}
+
+static const ACPI_TABLE_XSDT *
+get_acpi_xsdt(void)
+{
+	const ACPI_TABLE_RSDP *rsdp;
+	const ACPI_TABLE_XSDT *xsdt;
+
+	if ((rsdp = get_acpi_rsdp()) == NULL)
+		return (NULL);
+
+	xsdt = (const ACPI_TABLE_XSDT *)rsdp->XsdtPhysicalAddress;
+	if (xsdt == NULL)
+		return (NULL);
+
+	if (strncmp(xsdt->Header.Signature, ACPI_SIG_XSDT,
+	    strlen(ACPI_SIG_XSDT)) != 0)
+		return (NULL);
+
+	return (xsdt);
+}
+
+static const ACPI_TABLE_HEADER *
+find_acpi_table(const char *sig)
+{
+	const ACPI_TABLE_XSDT *xsdt;
+	ACPI_TABLE_HEADER *tab;
+	const UINT64 *entries;
+	UINT64 entry;
+	UINT32 nentries;
+	UINT32 i;
+	size_t slen;
+
+	if ((xsdt = get_acpi_xsdt()) == NULL)
+		return (NULL);
+
+	slen = strlen(sig);
+	nentries = (xsdt->Header.Length -
+	    sizeof (xsdt->Header)) / ACPI_XSDT_ENTRY_SIZE;
+	entries = &xsdt->TableOffsetEntry[0];
+	tab = NULL;
+
+	for (i = 0; i < nentries; ++i) {
+		/*
+		 * This is disgusting, and exists to avoid alignment issues
+		 * that crop up because we're running without the MMU at this
+		 * point, so the SCTLR.A flag is ignored.
+		 */
+		memcpy(&entry, &entries[i], sizeof (entry));
+		if (entry == 0)
+			continue;
+		tab = (ACPI_TABLE_HEADER *)entry;
+		if (strncmp(tab->Signature, sig, slen) == 0)
+			break;
+		tab = NULL;
+	}
+
+	if (tab == NULL)
+		return (NULL);
+
+	return (tab);
+}
+
+static const ACPI_TABLE_FADT *
+get_fadt(void)
+{
+	const ACPI_TABLE_HEADER *hdr;
+
+	if ((hdr = find_acpi_table(ACPI_SIG_FADT)) == NULL)
+		return (NULL);
+
+	return ((const ACPI_TABLE_FADT *)hdr);
+}
+
+int
+dboot_configure_acpi(void)
+{
+	const ACPI_TABLE_FADT *fadt;
+	extern struct xboot_info *bi;
+	UINT16 flags;
+
+	if ((fadt = get_fadt()) == NULL)
+		panic("dboot: ACPI FADT not found\n");
+
+	/* again, alignment issues */
+	memcpy(&flags, &fadt->ArmBootFlags, sizeof (flags));
+
+	if (!(flags & ACPI_FADT_PSCI_COMPLIANT))
+		panic("dboot: illumos requires PSCI");
+
+	bi->bi_psci_conduit_hvc = (flags & ACPI_FADT_PSCI_USE_HVC) ? 1 : 0;
+
+	boot_psci_init(bi);
+	return (0);
+}

--- a/usr/src/uts/armv8/dboot/dboot_conf_fdt.c
+++ b/usr/src/uts/armv8/dboot/dboot_conf_fdt.c
@@ -1,0 +1,124 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2025 Michael van der Westhuizen
+ */
+
+#include <sys/types.h>
+#include <sys/systm.h>
+#include <sys/null.h>
+#include <sys/bootinfo.h>
+#include <sys/psci.h>
+#include <libfdt.h>
+
+#include "dboot.h"
+
+extern void boot_psci_init(struct xboot_info *);
+
+static const void *
+get_fdtp(void)
+{
+	static const void *fdtp;
+	extern struct xboot_info *bi;
+
+	if (fdtp != NULL)
+		return (fdtp);
+
+	if (bi == NULL)
+		return (NULL);
+
+	if (bi->bi_fdt == 0)
+		return (NULL);
+
+	if (fdt_check_header((const void *)bi->bi_fdt) != 0)
+		return (NULL);
+
+	fdtp = (const void *)bi->bi_fdt;
+	return (fdtp);
+}
+
+int
+dboot_configure_fdt(void)
+{
+	const void *fdtp;
+	int nodeoff;
+	const char *method;
+	const uint32_t *pval;
+	int plen;
+	extern struct xboot_info *bi;
+
+	if (bi == NULL)
+		return (-1);
+
+	if ((fdtp = get_fdtp()) == NULL)
+		return (-1);
+
+	/*
+	 * Extract PSCI configuration from the FDT.
+	 *
+	 * The mandatory configuration here is the PSCI conduit (HVC or SMC),
+	 * while the legacy function identifiers are optional.
+	 */
+
+	nodeoff = fdt_node_offset_by_compatible(fdtp, -1, "arm,psci");
+	if (nodeoff < 0)
+		return (-1);
+
+	if ((method = fdt_getprop(fdtp, nodeoff, "method", &plen)) == NULL ||
+	    plen == 0) {
+		return (-1);
+	}
+
+	bi->bi_psci_conduit_hvc = strcmp(method, "hvc") == 0 ? 1 : 0;
+
+	if ((pval = fdt_getprop(fdtp, nodeoff, "cpu_suspend", &plen)) != NULL) {
+		bi->bi_psci_cpu_suspend_id =
+		    fdt32_to_cpu(*((const uint32_t *)pval));
+	}
+
+	if ((pval = fdt_getprop(fdtp, nodeoff, "cpu_off", &plen)) != NULL) {
+		bi->bi_psci_cpu_off_id =
+		    fdt32_to_cpu(*((const uint32_t *)pval));
+	}
+
+	if ((pval = fdt_getprop(fdtp, nodeoff, "cpu_on", &plen)) != NULL) {
+		bi->bi_psci_cpu_on_id =
+		    fdt32_to_cpu(*((const uint32_t *)pval));
+	}
+
+	if ((pval = fdt_getprop(fdtp, nodeoff, "migrate", &plen)) != NULL) {
+		bi->bi_psci_migrate_id =
+		    fdt32_to_cpu(*((const uint32_t *)pval));
+	}
+
+	boot_psci_init(bi);
+
+	/*
+	 * Extract architected timer configuration from the FDT.
+	 *
+	 * On FDT systems this might not not programmed into cntfrq, so we
+	 * try to read it from FDT first. If it's there we use that value.
+	 *
+	 * If not present in firmware, the caller sets the value from cntfrq
+	 * and claims success if that value is non-zero.
+	 */
+
+	nodeoff = fdt_node_offset_by_compatible(fdtp, -1, "arm,armv8-timer");
+	if (nodeoff >= 0) {
+		if ((pval = fdt_getprop(fdtp, nodeoff,
+		    "clock-frequency", &plen)) != NULL)
+			bi->bi_arch_timer_freq =
+			    fdt32_to_cpu(*((const uint32_t *)pval));
+	}
+
+	return (0);
+}

--- a/usr/src/uts/armv8/dboot/dboot_elf_loader.c
+++ b/usr/src/uts/armv8/dboot/dboot_elf_loader.c
@@ -1,0 +1,466 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+ * Use is subject to license terms.
+ */
+/*
+ * Copyright 2025 Michael van der Westhuizen
+ */
+
+#include <sys/types.h>
+#include <sys/systm.h>
+#include <sys/sysmacros.h>
+#include <sys/elf.h>
+#include <sys/elf_notes.h>
+#include <asm/sunddi.h>
+
+#include "dboot.h"
+#include "dboot_printf.h"
+
+typedef int (*func_t)();
+
+#define	FAIL	((func_t)-1)
+#define	FAIL_READELF64  ((uint64_t)0)
+
+extern void *kmem_alloc(size_t, int);
+extern void kmem_free(void *ptr, size_t nbytes);
+
+extern int verbosemode;
+int	npagesize = 0;
+int	use_align = 0;
+
+extern int get_progmemory(caddr_t vaddr, size_t size, int align);
+
+void
+mod_path_uname_m(char *mod_path, char *ia_name)
+{
+}
+
+int
+cons_gets(char *buf, int sz)
+{
+	return (-1);
+}
+
+void
+setup_aux(void)
+{
+}
+
+void
+prom_enter_mon(void)
+{
+	dboot_printf("prom_enter_mon: unimplemented for this platform\n");
+	for (;;)
+		/* spin forever */;
+}
+
+static uint64_t
+read_elf64(caddr_t payload, size_t payload_size, int print, Elf64_Ehdr *ehdr)
+{
+	Elf64_Phdr *phdr;
+	Elf64_Nhdr *nhdr;
+	caddr_t allphdrs;
+	int nphdrs, phdrsize;
+	caddr_t namep, descp;
+	Elf64_Addr entrypt;			/* entry point of standalone */
+	int i;
+	uintptr_t off;
+	size_t offset = 0;
+	int bss_seen = 0;
+	Elf64_Addr loadaddr, base;
+	Elf64_Phdr *thdr;			/* "text" program header */
+	Elf64_Phdr *dhdr;			/* "data" program header */
+	size_t size;
+
+	allphdrs = NULL;
+	nhdr = NULL;
+
+	if (verbosemode)
+		dprintf("Elf64 client\n");
+
+	if (ehdr->e_phnum == 0 || ehdr->e_phoff == 0)
+		goto elf64error;
+
+	entrypt = ehdr->e_entry;
+	if (verbosemode)
+		dprintf("Entry point: 0x%llx\n", (u_longlong_t)entrypt);
+
+	/*
+	 * Allocate and read in all the program headers.
+	 */
+	nphdrs = ehdr->e_phnum;
+	phdrsize = nphdrs * ehdr->e_phentsize;
+	allphdrs = (caddr_t)kmem_alloc(phdrsize, 0);
+	if (allphdrs == NULL)
+		goto elf64error;
+	memcpy(allphdrs, payload + ehdr->e_phoff, phdrsize);
+
+	/*
+	 * First look for PT_NOTE headers that tell us what pagesize to
+	 * use in allocating program memory.
+	 */
+	npagesize = 0;
+	for (i = 0; i < nphdrs; i++) {
+		void *note_buf;
+
+		phdr = (Elf64_Phdr *)(allphdrs + ehdr->e_phentsize * i);
+		if (phdr->p_type != PT_NOTE)
+			continue;
+		if (verbosemode) {
+			dprintf("allocating 0x%llx bytes for note hdr\n",
+			    (u_longlong_t)phdr->p_filesz);
+		}
+		if ((note_buf = kmem_alloc(phdr->p_filesz, 0)) == NULL)
+			goto elf64error;
+		nhdr = (Elf64_Nhdr *)note_buf;
+		memcpy(nhdr, payload + phdr->p_offset, phdr->p_filesz);
+		if (verbosemode) {
+			dprintf("p_note namesz %x descsz %x type %x\n",
+			    nhdr->n_namesz, nhdr->n_descsz, nhdr->n_type);
+		}
+
+		/*
+		 * Iterate through all ELF PT_NOTE elements looking for
+		 * ELF_NOTE_SOLARIS which, if present, will specify the
+		 * executable's preferred pagesize.
+		 */
+		do {
+			namep = (caddr_t)(nhdr + 1);
+
+			if (nhdr->n_namesz == strlen(ELF_NOTE_SOLARIS) + 1 &&
+			    strcmp(namep, ELF_NOTE_SOLARIS) == 0 &&
+			    nhdr->n_type == ELF_NOTE_PAGESIZE_HINT) {
+				descp = namep + roundup(nhdr->n_namesz, 4);
+				npagesize = *(int *)descp;
+				if (verbosemode)
+					dprintf("pagesize is %x\n", npagesize);
+			}
+
+			offset += sizeof (Elf64_Nhdr) + roundup(nhdr->n_namesz,
+			    4) + roundup(nhdr->n_descsz, 4);
+
+			nhdr = (Elf64_Nhdr *)((char *)note_buf + offset);
+		} while (offset < phdr->p_filesz);
+
+		kmem_free(note_buf, phdr->p_filesz);
+		nhdr = NULL;
+	}
+
+	/*
+	 * Next look for PT_LOAD headers to read in.
+	 */
+	if (print)
+		dboot_printf("Size: ");
+	for (i = 0; i < nphdrs; i++) {
+		phdr = (Elf64_Phdr *)(allphdrs + ehdr->e_phentsize * i);
+		if (verbosemode) {
+			dprintf("Doing header 0x%x\n", i);
+			dprintf("phdr\n");
+			dprintf("\tp_offset = %llx, p_vaddr = %llx\n",
+			    (u_longlong_t)phdr->p_offset,
+			    (u_longlong_t)phdr->p_vaddr);
+			dprintf("\tp_memsz = %llx, p_filesz = %llx\n",
+			    (u_longlong_t)phdr->p_memsz,
+			    (u_longlong_t)phdr->p_filesz);
+			dprintf("\tp_type = %x, p_flags = %x\n",
+			    phdr->p_type, phdr->p_flags);
+		}
+
+		if (phdr->p_type == PT_LOAD) {
+			if (phdr->p_flags == (PF_R | PF_W) &&
+			    phdr->p_vaddr == 0) {
+				/*
+				 * It's a PT_LOAD segment that is RW but
+				 * not executable and has a vaddr
+				 * of zero.  This is relocation info that
+				 * doesn't need to stick around after
+				 * krtld is done with it.  We allocate boot
+				 * memory for this segment, since we don't want
+				 * it mapped in permanently as part of
+				 * the kernel image.
+				 */
+				if ((loadaddr = (Elf64_Addr)(uintptr_t)
+				    kmem_alloc(phdr->p_memsz, 0)) == 0)
+					goto elf64error;
+
+				/*
+				 * Save this to pass on
+				 * to the interpreter.
+				 */
+				phdr->p_vaddr = loadaddr;
+			} else {
+				if (print)
+					dboot_printf("0x%llx+",
+					    (u_longlong_t)phdr->p_filesz);
+				/*
+				 * If we found a new pagesize above, use it
+				 * to adjust the memory allocation.
+				 */
+				loadaddr = phdr->p_vaddr;
+				if (use_align && npagesize != 0) {
+					off = loadaddr & (npagesize - 1);
+					size = roundup(phdr->p_memsz + off,
+					    npagesize);
+					base = loadaddr - off;
+				} else {
+					npagesize = 0;
+					size = phdr->p_memsz;
+					base = loadaddr;
+				}
+				/*
+				 * Check if it's text or data.
+				 */
+				if (phdr->p_flags & PF_W)
+					dhdr = phdr;
+				else
+					thdr = phdr;
+
+				if (verbosemode)
+					dprintf(
+					    "allocating memory: %llx %lx %x\n",
+					    (u_longlong_t)base,
+					    size, npagesize);
+
+				/*
+				 * If memory size is zero just ignore this
+				 * header.
+				 */
+				if (size == 0)
+					continue;
+
+				/*
+				 * We're all set up to read.
+				 * Now let's allocate some memory.
+				 */
+				if (get_progmemory((caddr_t)(uintptr_t)base,
+				    size, npagesize))
+					goto elf64error;
+			}
+			if (print)
+				dboot_printf("thdr: 0x%p, dhdr: 0x%p\n",
+				    thdr, dhdr);
+
+			if (verbosemode) {
+				dprintf("reading 0x%llx bytes into 0x%llx\n",
+				    (u_longlong_t)phdr->p_filesz,
+				    (u_longlong_t)loadaddr);
+			}
+
+			memcpy((void *)loadaddr, payload + phdr->p_offset,
+			    phdr->p_filesz);
+
+			/* zero out BSS */
+			if (phdr->p_memsz > phdr->p_filesz) {
+				loadaddr += phdr->p_filesz;
+				if (verbosemode) {
+					dprintf("bss from 0x%llx size 0x%llx\n",
+					    (u_longlong_t)loadaddr,
+					    (u_longlong_t)(phdr->p_memsz -
+					    phdr->p_filesz));
+				}
+
+				bzero((caddr_t)(uintptr_t)loadaddr,
+				    phdr->p_memsz - phdr->p_filesz);
+				bss_seen++;
+				if (print)
+					dboot_printf("0x%llx Bytes\n",
+					    (u_longlong_t)(phdr->p_memsz -
+					    phdr->p_filesz));
+			}
+
+			/* force instructions to be visible to icache */
+			if (phdr->p_flags & PF_X)
+				sync_instruction_memory((caddr_t)(uintptr_t)
+				    phdr->p_vaddr, phdr->p_memsz);
+
+		} else if (phdr->p_type == PT_INTERP) {
+			panic("unix has an interpreter set - a kernel "
+			    "interpreter is unsupported\n");
+		}
+	}
+
+	if (!bss_seen && print)
+		dboot_printf("0 Bytes\n");
+
+	kmem_free(allphdrs, phdrsize);
+	return ((uint64_t)entrypt);
+
+elf64error:
+	if (allphdrs != NULL)
+		kmem_free(allphdrs, phdrsize);
+	if (nhdr != NULL)
+		kmem_free(nhdr, phdr->p_filesz);
+	dboot_printf("Elf64 read error.\n");
+	return (FAIL_READELF64);
+}
+
+/*
+ * Find the value of a symbol in an ELF payload.
+ *
+ * Returns 0 on error.
+ */
+static uint64_t
+resolve_start_symbol_address(caddr_t payload, size_t payload_size,
+    int print, Elf64_Ehdr *ehdr, const char *symname)
+{
+	Elf64_Shdr *shdr_table;
+	Elf64_Half shi;
+	const char *shstrtab;
+	Elf64_Shdr *symtabh;
+	Elf64_Shdr *strtabh;
+	Elf64_Sym *symtab;
+	const char *strtab;
+	size_t nsyms;
+	size_t i;
+
+	/*
+	 * Section header table and the associated string table.
+	 */
+	shdr_table = (Elf64_Shdr *)(payload + ehdr->e_shoff);
+	shstrtab = (const char *)
+	    (payload + shdr_table[ehdr->e_shstrndx].sh_offset);
+
+	/*
+	 * Now find the SHT_SYMTAB table header for the symbol
+	 * table named ".symtab".
+	 */
+
+	symtabh = NULL;
+	strtabh = NULL;
+
+	for (shi = 0; shi < ehdr->e_shnum; ++shi) {
+		const char *section_name;
+
+		if (shdr_table[shi].sh_type != SHT_SYMTAB)
+			continue;
+
+		section_name = shstrtab + shdr_table[shi].sh_name;
+
+		if (strcmp(section_name, ".symtab") == 0) {
+			symtabh = &shdr_table[shi];
+			break;
+		}
+	}
+
+	if (symtabh == NULL) {
+		dprintf("No symtab\n");
+		return (0);
+	}
+
+	/*
+	 * Use the .symtab table header to locate the corresponding string
+	 * table header (conventionally called .strtab, but this method is
+	 * the most accurate way to find the right table header).
+	 */
+
+	if (symtabh->sh_link == SHT_SYMTAB_SHNDX)
+		strtabh = &shdr_table[symtabh->sh_info];
+	else
+		strtabh = &shdr_table[symtabh->sh_link];
+
+	/*
+	 * Finally, we have both the symbol table header and the
+	 * corresponding string table header. Use this information to
+	 * locate the actual symbol table and the associated names.
+	 */
+
+	symtab = (Elf64_Sym *)(payload + symtabh->sh_offset);
+	nsyms = symtabh->sh_size / sizeof (Elf64_Sym);
+	strtab = (const char *)(payload + strtabh->sh_offset);
+
+	for (i = 0; i < nsyms; ++i) {
+		const char *symbol_name = strtab + symtab[i].st_name;
+
+		if (strcmp(symbol_name, symname) == 0) {
+			dprintf("Symbol: %s, Address: 0x%lx\n",
+			    symbol_name, symtab[i].st_value);
+			return (symtab[i].st_value);
+		}
+	}
+
+	return (0);
+}
+
+static const char *
+start_symbol_name(void)
+{
+	static const char default_start_symbol_name[] = "_start";
+	const char *env;
+
+	if ((env = dboot_getenv("unix-start-symbol-name")) == NULL)
+		return (default_start_symbol_name);
+
+	return (env);
+}
+
+func_t
+load_elf_payload(caddr_t payload, size_t payload_size, int print)
+{
+	uint64_t elf64_go2;
+	uint64_t kernel_entry;
+	Elf64_Ehdr elfhdr;
+	const char *startsym;
+
+	memcpy(&elfhdr, payload, sizeof (Elf64_Ehdr));
+
+	if (*(int *)&elfhdr.e_ident != *(int *)(ELFMAG)) {
+		dboot_printf("load_elf_payload: payload is not ELF\n");
+		return (FAIL);
+	}
+
+	if (elfhdr.e_ident[EI_CLASS] != ELFCLASS64) {
+		dboot_printf("load_elf_payload: only ELF64 is supported\n");
+		return (FAIL);
+	}
+
+	if (verbosemode) {
+		dprintf("calling readelf, elfheader is:\n");
+		dprintf("e_ident\t0x%x, 0x%x, 0x%x, 0x%x\n",
+		    *(int *)&elfhdr.e_ident[0],
+		    *(int *)&elfhdr.e_ident[4],
+		    *(int *)&elfhdr.e_ident[8],
+		    *(int *)&elfhdr.e_ident[12]);
+		dprintf("e_machine\t0x%x\n", elfhdr.e_machine);
+
+		dprintf("e_entry\t\t0x%lx\n", elfhdr.e_entry);
+		dprintf("e_shoff\t\t0x%lx\n", elfhdr.e_shoff);
+		dprintf("e_shnentsize\t%d\n", elfhdr.e_shentsize);
+		dprintf("e_shnum\t\t%d\n", elfhdr.e_shnum);
+		dprintf("e_shstrndx\t%d\n", elfhdr.e_shstrndx);
+	}
+
+	dprintf("ELF file CLASS 0x%x 32 is %x 64 is %x\n",
+	    elfhdr.e_ident[EI_CLASS], ELFCLASS32, ELFCLASS64);
+
+	startsym = start_symbol_name();
+	kernel_entry = resolve_start_symbol_address(
+	    payload, payload_size, print, &elfhdr, startsym);
+	if (kernel_entry == 0)
+		panic("could not find unix entry symbol '%s'\n", startsym);
+	if (verbosemode)
+		dboot_printf("Kernel entry (%s) is 0x%lx\n",
+		    startsym, kernel_entry);
+
+	elf64_go2 = read_elf64(payload, payload_size, print, &elfhdr);
+	return ((elf64_go2 == FAIL_READELF64) ? FAIL : (func_t)kernel_entry);
+}

--- a/usr/src/uts/armv8/dboot/dboot_heap_kmem.c
+++ b/usr/src/uts/armv8/dboot/dboot_heap_kmem.c
@@ -1,0 +1,885 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License, Version 1.0 only
+ * (the "License").  You may not use this file except in compliance
+ * with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright 2005 Sun Microsystems, Inc.  All rights reserved.
+ * Use is subject to license terms.
+ */
+/*
+ * Copyright 2017 Hayashi Naoyuki
+ * Copyright 2025 Michael van der Westhuizen
+ */
+
+#if 1
+#undef DEBUG
+#endif
+
+/*  #define	DEBUG ON */
+
+/*
+ * Conditions on use:
+ * kmem_alloc and kmem_free must not be called from interrupt level,
+ * except from software interrupt level.  This is because they are
+ * not reentrant, and only block out software interrupts.  They take
+ * too long to block any real devices.  There is a routine
+ * kmem_free_intr that can be used to free blocks at interrupt level,
+ * but only up to splimp, not higher.  This is because kmem_free_intr
+ * only spl's to splimp.
+ *
+ * Also, these routines are not that fast, so they should not be used
+ * in very frequent operations (e.g. operations that happen more often
+ * than, say, once every few seconds).
+ */
+
+/*
+ * description:
+ *	Yet another memory allocator, this one based on a method
+ *	described in C.J. Stephenson, "Fast Fits", IBM Sys. Journal
+ *
+ *	The basic data structure is a "Cartesian" binary tree, in which
+ *	nodes are ordered by ascending addresses (thus minimizing free
+ *	list insertion time) and block sizes decrease with depth in the
+ *	tree (thus minimizing search time for a block of a given size).
+ *
+ *	In other words, for any node s, letting D(s) denote
+ *	the set of descendents of s, we have:
+ *
+ *	a. addr(D(left(s))) <  addr(s) <  addr(D(right(s)))
+ *	b. len(D(left(s)))  <= len(s)  >= len(D(right(s)))
+ */
+
+#include <sys/types.h>
+#include <sys/systm.h>
+#include <sys/param.h>
+#include <sys/sysmacros.h>
+#include <sys/stdbool.h>
+
+#include "saio.h"
+#include "dboot_printf.h"
+
+/*
+ * The node header structure.
+ *
+ * To reduce storage consumption, a header block is associated with
+ * free blocks only, not allocated blocks.
+ * When a free block is allocated, its header block is put on
+ * a free header block list.
+ *
+ * This creates a header space and a free block space.
+ * The left pointer of a header blocks is used to chain free header
+ * blocks together.
+ */
+
+typedef struct	freehdr	*Freehdr;
+typedef struct	dblk	*Dblk;
+
+/*
+ * Description of a header for a free block
+ * Only free blocks have such headers.
+ */
+struct freehdr {
+	Freehdr	left;			/* Left tree pointer */
+	Freehdr	right;			/* Right tree pointer */
+	Dblk	block;			/* Ptr to the data block */
+	size_t	size;			/* Size of the data block */
+};
+
+#define	NIL		((Freehdr) 0)
+#define	WORDSIZE	sizeof (int)
+#define	SMALLEST_BLK	1		/* Size of smallest block */
+
+/*
+ * Description of a data block.
+ */
+struct	dblk	{
+	char	data[1];		/* Addr returned to the caller */
+};
+
+/*
+ * weight(x) is the size of a block, in bytes; or 0 if and only if x
+ *	is a null pointer. It is the responsibility of kmem_alloc() and
+ *	kmem_free() to keep zero-length blocks out of the arena.
+ */
+
+#define	weight(x)	((x) == NIL? 0: (x->size))
+#define	nextblk(p, size) ((Dblk) ((char *)(p) + (size)))
+#define	max(a, b)	((a) < (b)? (b): (a))
+
+void		*kmem_alloc(size_t, int);
+void		kmem_free(void *ptr, size_t nbytes);
+Freehdr		getfreehdr(void);
+static bool	morecore(size_t);
+void		insert(Dblk p, size_t len, Freehdr *tree);
+void		freehdr(Freehdr p);
+void		delete(Freehdr *p);
+static void	check_need_to_free(void);
+extern caddr_t	resalloc(enum RESOURCES, size_t, caddr_t, int);
+extern int	splnet(void);
+extern int	splimp(void);
+extern void	splx(int);
+
+/*
+ * Structure containing various info about allocated memory.
+ */
+#define	NEED_TO_FREE_SIZE	5
+struct kmem_info {
+	Freehdr	free_root;
+	Freehdr	free_hdr_list;
+	struct map *map;
+	struct pte *pte;
+	caddr_t	vaddr;
+	struct need_to_free {
+		caddr_t addr;
+		size_t	nbytes;
+	} need_to_free_list, need_to_free[NEED_TO_FREE_SIZE];
+} kmem_info;
+
+
+struct map *kernelmap;
+
+#ifdef DEBUG
+static void prtree(Freehdr, char *);
+#endif
+
+/*
+ * Initialize kernel memory allocator
+ */
+
+void
+kmem_init(void)
+{
+	int i;
+	struct need_to_free *ntf;
+
+#ifdef DEBUG
+dboot_printf("kmem_init entered\n");
+#endif
+
+	kmem_info.free_root = NIL;
+	kmem_info.free_hdr_list = NULL;
+	kmem_info.map = kernelmap;
+	kmem_info.need_to_free_list.addr = 0;
+	ntf = kmem_info.need_to_free;
+	for (i = 0; i < NEED_TO_FREE_SIZE; i++) {
+		ntf[i].addr = 0;
+	}
+#ifdef DEBUG
+dboot_printf("kmem_init returning\n");
+prtree(kmem_info.free_root, "kmem_init");
+#endif
+}
+
+/*
+ * Insert a new node in a cartesian tree or subtree, placing it
+ *	in the correct position with respect to the existing nodes.
+ *
+ * algorithm:
+ *	Starting from the root, a binary search is made for the new
+ *	node. If this search were allowed to continue, it would
+ *	eventually fail (since there cannot already be a node at the
+ *	given address); but in fact it stops when it reaches a node in
+ *	the tree which has a length less than that of the new node (or
+ *	when it reaches a null tree pointer).  The new node is then
+ *	inserted at the root of the subtree for which the shorter node
+ *	forms the old root (or in place of the null pointer).
+ */
+
+
+void
+insert(Dblk p,		/* Ptr to the block to insert */
+    size_t len,		/* Length of new node */
+    Freehdr *tree)	/* Address of ptr to root */
+{
+	Freehdr x;
+	Freehdr *left_hook;	/* Temp for insertion */
+	Freehdr *right_hook;	/* Temp for insertion */
+	Freehdr newhdr;
+
+	x = *tree;
+	/*
+	 * Search for the first node which has a weight less
+	 *	than that of the new node; this will be the
+	 *	point at which we insert the new node.
+	 */
+
+	while (weight(x) >= len) {
+		if (p < x->block)
+			tree = &x->left;
+		else
+			tree = &x->right;
+		x = *tree;
+	}
+
+	/*
+	 * Perform root insertion. The variable x traces a path through
+	 *	the tree, and with the help of left_hook and right_hook,
+	 *	rewrites all links that cross the territory occupied
+	 *	by p.  Note that this improves performance under
+	 *	paging.
+	 */
+
+	newhdr = getfreehdr();
+	*tree = newhdr;
+	left_hook = &newhdr->left;
+	right_hook = &newhdr->right;
+
+	newhdr->left = NIL;
+	newhdr->right = NIL;
+	newhdr->block = p;
+	newhdr->size = len;
+
+	while (x != NIL) {
+		/*
+		 * Remark:
+		 *	The name 'left_hook' is somewhat confusing, since
+		 *	it is always set to the address of a .right link
+		 *	field.  However, its value is always an address
+		 *	below (i.e., to the left of) p. Similarly
+		 *	for right_hook. The values of left_hook and
+		 *	right_hook converge toward the value of p,
+		 *	as in a classical binary search.
+		 */
+		if (x->block < p) {
+			/*
+			 * rewrite link crossing from the left
+			 */
+			*left_hook = x;
+			left_hook = &x->right;
+			x = x->right;
+		} else {
+			/*
+			 * rewrite link crossing from the right
+			 */
+			*right_hook = x;
+			right_hook = &x->left;
+			x = x->left;
+		} /* else */
+	} /* while */
+
+	*left_hook = *right_hook = NIL;		/* clear remaining hooks */
+
+} /* insert */
+
+
+/*
+ * Delete a node from a cartesian tree. p is the address of
+ *	a pointer to the node which is to be deleted.
+ *
+ * algorithm:
+ *	The left and right sons of the node to be deleted define two
+ *	subtrees which are to be merged and attached in place of the
+ *	deleted node.  Each node on the inside edges of these two
+ *	subtrees is examined and longer nodes are placed above the
+ *	shorter ones.
+ *
+ * On entry:
+ *	*p is assumed to be non-null.
+ */
+
+void
+delete(Freehdr *p)
+{
+	Freehdr x;
+	Freehdr left_branch;	/* left subtree of deleted node */
+	Freehdr right_branch;	/* right subtree of deleted node */
+
+	x = *p;
+	left_branch = x->left;
+	right_branch = x->right;
+
+	while (left_branch != right_branch) {
+		/*
+		 * iterate until left branch and right branch are
+		 * both NIL.
+		 */
+		if (weight(left_branch) >= weight(right_branch)) {
+			/*
+			 * promote the left branch
+			 */
+			*p = left_branch;
+			p = &left_branch->right;
+			left_branch = left_branch->right;
+		} else {
+			/*
+			 * promote the right branch
+			 */
+			*p = right_branch;
+			p = &right_branch->left;
+			right_branch = right_branch->left;
+		} /* else */
+	} /* while */
+	*p = NIL;
+	freehdr(x);
+} /* delete */
+
+
+/*
+ * Demote a node in a cartesian tree, if necessary, to establish
+ *	the required vertical ordering.
+ *
+ * algorithm:
+ *	The left and right subtrees of the node to be demoted are to
+ *	be partially merged and attached in place of the demoted node.
+ *	The nodes on the inside edges of these two subtrees are
+ *	examined and the longer nodes are placed above the shorter
+ *	ones, until a node is reached which has a length no greater
+ *	than that of the node being demoted (or until a null pointer
+ *	is reached).  The node is then attached at this point, and
+ *	the remaining subtrees (if any) become its descendants.
+ *
+ * on entry:
+ *   a. All the nodes in the tree, including the one to be demoted,
+ *	must be correctly ordered horizontally;
+ *   b. All the nodes except the one to be demoted must also be
+ *	correctly positioned vertically.  The node to be demoted
+ *	may be already correctly positioned vertically, or it may
+ *	have a length which is less than that of one or both of
+ *	its progeny.
+ *   c. *p is non-null
+ */
+
+
+static void
+demote(Freehdr *p)
+{
+	Freehdr x;		/* addr of node to be demoted */
+	Freehdr left_branch;
+	Freehdr right_branch;
+	size_t    wx;
+
+	x = *p;
+	left_branch = x->left;
+	right_branch = x->right;
+	wx = weight(x);
+
+	while (weight(left_branch) > wx || weight(right_branch) > wx) {
+		/*
+		 * select a descendant branch for promotion
+		 */
+		if (weight(left_branch) >= weight(right_branch)) {
+			/*
+			 * promote the left branch
+			 */
+			*p = left_branch;
+			p = &left_branch->right;
+			left_branch = *p;
+		} else {
+			/*
+			 * promote the right branch
+			 */
+			*p = right_branch;
+			p = &right_branch->left;
+			right_branch = *p;
+		} /* else */
+	} /* while */
+
+	*p = x;				/* attach demoted node here */
+	x->left = left_branch;
+	x->right = right_branch;
+} /* demote */
+
+/*
+ * Allocate a block of storage
+ *
+ * algorithm:
+ *	The freelist is searched by descending the tree from the root
+ *	so that at each decision point the "better fitting" child node
+ *	is chosen (i.e., the shorter one, if it is long enough, or
+ *	the longer one, otherwise).  The descent stops when both
+ *	child nodes are too short.
+ *
+ * function result:
+ *	kmem_alloc returns a pointer to the allocated block; a null
+ *	pointer indicates storage could not be allocated.
+ */
+/*
+ * We need to return blocks that are on word boundaries so that callers
+ * that are putting int's into the area will work.  Since we allow
+ * arbitrary free'ing, we need a weight function that considers
+ * free blocks starting on an odd boundary special.  Allocation is
+ * aligned to 8 byte boundaries (ALIGN).
+ */
+#define	ALIGN		8		/* doubleword aligned .. */
+#define	ALIGNMASK	(ALIGN-1)
+#define	ALIGNMORE(addr)	(ALIGN - ((uintptr_t)(addr) & ALIGNMASK))
+
+/*
+ * If it is empty then weight == 0
+ * If it is aligned then weight == size
+ * If it is unaligned
+ *	if not enough room to align then weight == 0
+ *	else weight == aligned size
+ */
+#define	mweight(x) ((x) == NIL ? 0 : \
+	((((uintptr_t)(x)->block) & ALIGNMASK) == 0 ? (x)->size : \
+		(((x)->size <= ALIGNMORE((x)->block)) ? 0 : \
+			(x)->size - ALIGNMORE((x)->block))))
+
+/*ARGSUSED1*/
+void *
+kmem_alloc(size_t nbytes, int kmflag)
+{
+	Freehdr a;		/* ptr to node to be allocated */
+	Freehdr *p;		/* address of ptr to node */
+	size_t	 left_weight;
+	size_t	 right_weight;
+	Freehdr left_son;
+	Freehdr right_son;
+	char	 *retblock;	/* Address returned to the user */
+	int s;
+#ifdef	DEBUG
+	dboot_printf("kmem_alloc(nbytes 0x%lx)\n", nbytes);
+#endif	/* DEBUG */
+
+	if (nbytes == 0) {
+		return (NULL);
+	}
+	s = splnet();
+
+	if (nbytes < SMALLEST_BLK) {
+		dboot_printf("illegal kmem_alloc call for %lx bytes\n", nbytes);
+		dboot_panic("kmem_alloc");
+	}
+	check_need_to_free();
+
+	/*
+	 * ensure that at least one block is big enough to satisfy
+	 *	the request.
+	 */
+
+	if (mweight(kmem_info.free_root) <= nbytes) {
+		/*
+		 * the largest block is not enough.
+		 */
+		if (!morecore(nbytes)) {
+			dboot_printf("kmem_alloc failed, nbytes %lx\n", nbytes);
+			dboot_panic("kmem_alloc");
+		}
+	}
+
+	/*
+	 * search down through the tree until a suitable block is
+	 *	found.  At each decision point, select the better
+	 *	fitting node.
+	 */
+
+	p = (Freehdr *) &kmem_info.free_root;
+	a = *p;
+	left_son = a->left;
+	right_son = a->right;
+	left_weight = mweight(left_son);
+	right_weight = mweight(right_son);
+
+	while (left_weight >= nbytes || right_weight >= nbytes) {
+		if (left_weight <= right_weight) {
+			if (left_weight >= nbytes) {
+				p = &a->left;
+				a = left_son;
+			} else {
+				p = &a->right;
+				a = right_son;
+			}
+		} else {
+			if (right_weight >= nbytes) {
+				p = &a->right;
+				a = right_son;
+			} else {
+				p = &a->left;
+				a = left_son;
+			}
+		}
+		left_son = a->left;
+		right_son = a->right;
+		left_weight = mweight(left_son);
+		right_weight = mweight(right_son);
+	} /* while */
+
+	/*
+	 * allocate storage from the selected node.
+	 */
+
+	if (a->size - nbytes < SMALLEST_BLK) {
+		/*
+		 * not big enough to split; must leave at least
+		 * a dblk's worth of space.
+		 */
+		retblock = a->block->data;
+		delete(p);
+	} else {
+
+		/*
+		 * split the node, allocating nbytes from the top.
+		 *	Remember we've already accounted for the
+		 *	allocated node's header space.
+		 */
+		Freehdr x;
+		x = getfreehdr();
+		if ((uintptr_t)a->block->data & ALIGNMASK) {
+			size_t size;
+			if (a->size <= ALIGNMORE(a->block->data))
+				dboot_panic("kmem_alloc: short block allocated");
+			size = nbytes + ALIGNMORE(a->block->data);
+			x->block = a->block;
+			x->size = ALIGNMORE(a->block->data);
+			x->left = a->left;
+			x->right = a->right;
+			/*
+			 * the node pointed to by *p has become smaller;
+			 *	move it down to its appropriate place in
+			 *	the tree.
+			 */
+			*p = x;
+			demote(p);
+			retblock = a->block->data + ALIGNMORE(a->block->data);
+			if (a->size > size) {
+				kmem_free((caddr_t)nextblk(a->block, size),
+				    (size_t)(a->size - size));
+			}
+			freehdr(a);
+		} else {
+			x->block = nextblk(a->block, nbytes);
+			x->size = a->size - nbytes;
+			x->left = a->left;
+			x->right = a->right;
+			/*
+			 * the node pointed to by *p has become smaller;
+			 *	move it down to its appropriate place in
+			 *	the tree.
+			 */
+			*p = x;
+			demote(p);
+			retblock = a->block->data;
+			freehdr(a);
+		}
+	}
+#ifdef DEBUG
+	prtree(kmem_info.free_root, "kmem_alloc");
+#endif
+
+	splx(s);
+	bzero(retblock, nbytes);
+#ifdef DEBUG
+	dboot_printf("kmem_alloc  bzero complete - returning %p\n", retblock);
+#endif
+	return (retblock);
+
+} /* kmem_alloc */
+
+void *
+kmem_zalloc(size_t size, int flag)
+{
+	void *ret = kmem_alloc(size, flag);
+
+	if (ret != NULL)
+		bzero(ret, size);
+
+	return (ret);
+}
+
+/*
+ * Return a block to the free space tree.
+ *
+ * algorithm:
+ *	Starting at the root, search for and coalesce free blocks
+ *	adjacent to one given.  When the appropriate place in the
+ *	tree is found, insert the given block.
+ *
+ * Do some sanity checks to avoid total confusion in the tree.
+ * If the block has already been freed, dboot_panic.
+ * If the ptr is not from the arena, dboot_panic.
+ */
+void
+kmem_free(void *ptr, size_t nbytes)
+{
+	Freehdr *np;		/* For deletion from free list */
+	Freehdr neighbor;	/* Node to be coalesced */
+	char	 *neigh_block;	/* Ptr to potential neighbor */
+	size_t	 neigh_size;	/* Size of potential neighbor */
+	int s;
+
+#ifdef DEBUG
+dboot_printf("kmem_free (ptr %p nbytes %lx)\n", ptr, nbytes);
+prtree(kmem_info.free_root, "kmem_free");
+#endif
+
+#ifdef	lint
+	neigh_block = bkmem_zalloc(nbytes);
+	neigh_block = neigh_block;
+#endif
+	if (nbytes == 0) {
+		return;
+	}
+
+	if (ptr == 0) {
+		dboot_panic("kmem_free of 0");
+	}
+	s = splnet();
+
+	/*
+	 * Search the tree for the correct insertion point for this
+	 *	node, coalescing adjacent free blocks along the way.
+	 */
+	np = &kmem_info.free_root;
+	neighbor = *np;
+	while (neighbor != NIL) {
+		neigh_block = (char *)neighbor->block;
+		neigh_size = neighbor->size;
+		if ((char *)ptr < neigh_block) {
+			if ((char *)ptr + nbytes == neigh_block) {
+				/*
+				 * Absorb and delete right neighbor
+				 */
+				nbytes += neigh_size;
+				delete(np);
+			} else if ((char *)ptr + nbytes > neigh_block) {
+				/*
+				 * The block being freed overlaps
+				 * another block in the tree.  This
+				 * is bad news.
+				 */
+				dboot_printf("kmem_free: free block overlap "
+				    "%p+%lx over %p\n", (void *)ptr, nbytes,
+				    (void *)neigh_block);
+				dboot_panic("kmem_free: free block overlap");
+			} else {
+				/*
+				 * Search to the left
+				 */
+				np = &neighbor->left;
+			}
+		} else if ((char *)ptr > neigh_block) {
+			if (neigh_block + neigh_size == ptr) {
+				/*
+				 * Absorb and delete left neighbor
+				 */
+				ptr = neigh_block;
+				nbytes += neigh_size;
+				delete(np);
+			} else if (neigh_block + neigh_size > (char *)ptr) {
+				/*
+				 * This block has already been freed
+				 */
+				dboot_panic("kmem_free block already free");
+			} else {
+				/*
+				 * search to the right
+				 */
+				np = &neighbor->right;
+			}
+		} else {
+			/*
+			 * This block has already been freed
+			 * as "ptr == neigh_block"
+			 */
+			dboot_panic("kmem_free: block already free as neighbor");
+		} /* else */
+		neighbor = *np;
+	} /* while */
+
+	/*
+	 * Insert the new node into the free space tree
+	 */
+	insert((Dblk) ptr, nbytes, &kmem_info.free_root);
+#ifdef DEBUG
+dboot_printf("exiting kmem_free\n");
+prtree(kmem_info.free_root, "kmem_free");
+#endif
+	splx(s);
+} /* kmem_free */
+
+/*
+ *  Sigh.  We include a header file which the kernel
+ *  uses to declare (one of its many) kmem_free prototypes.
+ *  In order not to use the kernel's namespace, then, we must
+ *  define another name here for use by boot.
+ */
+void *
+bkmem_alloc(size_t size)
+{
+	return (kmem_alloc(size, 0));
+}
+
+/*
+ * Boot's kmem_alloc is really kmem_zalloc().
+ */
+void *
+bkmem_zalloc(size_t size)
+{
+	return (kmem_alloc(size, 0));
+}
+
+void
+bkmem_free(void *p, size_t bytes)
+{
+	kmem_free(p, bytes);
+}
+
+static void
+check_need_to_free(void)
+{
+	int i;
+	struct need_to_free *ntf;
+	caddr_t addr;
+	size_t nbytes;
+	int s;
+
+again:
+	s = splimp();
+	ntf = &kmem_info.need_to_free_list;
+	if (ntf->addr) {
+		addr = ntf->addr;
+		nbytes = ntf->nbytes;
+		*ntf = *(struct need_to_free *)ntf->addr;
+		splx(s);
+		kmem_free(addr, nbytes);
+		goto again;
+	}
+	ntf = kmem_info.need_to_free;
+	for (i = 0; i < NEED_TO_FREE_SIZE; i++) {
+		if (ntf[i].addr) {
+			addr = ntf[i].addr;
+			nbytes = ntf[i].nbytes;
+			ntf[i].addr = 0;
+			splx(s);
+			kmem_free(addr, nbytes);
+			goto again;
+		}
+	}
+	splx(s);
+}
+
+/*
+ * Add a block of at least nbytes to the free space tree.
+ *
+ * return value:
+ *	true	if at least nbytes can be allocated
+ *	false	otherwise
+ *
+ * remark:
+ *	free space (delimited by the static variable ubound) is
+ *	extended by an amount determined by rounding nbytes up to
+ *	a multiple of the system page size.
+ */
+
+static bool
+morecore(size_t nbytes)
+{
+	enum RESOURCES type = RES_BOOTSCRATCH;
+	Dblk p;
+#ifdef	DEBUG
+	dboot_printf("morecore(nbytes 0x%lx)\n", nbytes);
+#endif	/* DEBUG */
+
+
+	nbytes = roundup(nbytes, PAGESIZE);
+	p = (Dblk) resalloc(type, nbytes, (caddr_t)0, 0);
+	if (p == 0) {
+		return (false);
+	}
+	kmem_free((caddr_t)p, nbytes);
+#ifdef DEBUG
+	dboot_printf("morecore() returing, p = %p\n", p);
+#endif
+	return (true);
+
+} /* morecore */
+
+/*
+ * Get a free block header
+ * There is a list of available free block headers.
+ * When the list is empty, allocate another pagefull.
+ */
+Freehdr
+getfreehdr(void)
+{
+	Freehdr	r;
+	int	n = 0;
+#ifdef	DEBUG
+	dboot_printf("getfreehdr()\n");
+#endif	/* DEBUG */
+
+	if (kmem_info.free_hdr_list != NIL) {
+		r = kmem_info.free_hdr_list;
+		kmem_info.free_hdr_list = kmem_info.free_hdr_list->left;
+	} else {
+		r = (Freehdr)resalloc(RES_BOOTSCRATCH, PAGESIZE, (caddr_t)0, 0);
+		if (r == 0) {
+			dboot_panic("getfreehdr");
+		}
+		for (n = 1; n < PAGESIZE / sizeof (*r); n++) {
+			freehdr(&r[n]);
+		}
+	}
+#ifdef	DEBUG
+	dboot_printf("getfreehdr: freed %x headers\n", n);
+	dboot_printf("getfreehdr: returning %p\n", r);
+#endif	/* DEBUG */
+	return (r);
+}
+
+/*
+ * Free a free block header
+ * Add it to the list of available headers.
+ */
+
+void
+freehdr(Freehdr p)
+{
+#ifdef	DEBUG
+	dboot_printf("freehdr(%p)\n", p);
+#endif	/* DEBUG */
+	p->left = kmem_info.free_hdr_list;
+	p->right = NIL;
+	p->block = NULL;
+	kmem_info.free_hdr_list = p;
+}
+
+#ifdef DEBUG
+/*
+ * Diagnostic routines
+ */
+static int depth = 0;
+
+static void
+prtree(Freehdr p, char *cp)
+{
+	int n;
+	if (depth == 0) {
+		dboot_printf("prtree(p %p cp %s)\n", p, cp);
+	}
+	if (p != NIL) {
+		depth++;
+		prtree(p->left, (char *)NULL);
+		depth--;
+
+		for (n = 0; n < depth; n++) {
+			dboot_printf("   ");
+		}
+		dboot_printf(
+		    "(%p): (left = %p, right = %p, block = %p, size = %lx)\n",
+		    p, p->left, p->right, p->block, p->size);
+
+		depth++;
+		prtree(p->right, (char *)NULL);
+		depth--;
+	}
+}
+#endif /* DEBUG */

--- a/usr/src/uts/armv8/dboot/dboot_machdep.c
+++ b/usr/src/uts/armv8/dboot/dboot_machdep.c
@@ -1,0 +1,186 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright 2017 Hayashi Naoyuki
+ * Copyright 2025 Michael van der Westhuizen
+ */
+
+#include <sys/types.h>
+#include <sys/null.h>
+#include <sys/controlregs.h>
+#include <sys/bootinfo.h>
+#include <sys/efifb.h>
+#include <sys/framebuffer.h>
+
+#include "dboot.h"
+#include "dboot_printf.h"
+
+extern void memlist_dump(struct memlist *);
+extern void exception_vector(void);
+extern void _reset(void);
+
+void
+dump_exception(uint64_t *regs)
+{
+	uint64_t pc;
+	uint64_t esr;
+	uint64_t far;
+	__asm__ volatile("mrs %0, elr_el1":"=r"(pc));
+	__asm__ volatile("mrs %0, esr_el1":"=r"(esr));
+	__asm__ volatile("mrs %0, far_el1":"=r"(far));
+	dboot_printf("%s\n", __func__);
+	dboot_printf("pc  = %lx\n",  pc);
+	dboot_printf("esr = %lx\n",  esr);
+	dboot_printf("far = %lx\n",  far);
+	for (int i = 0; i < 31; i++)
+		dboot_printf("x%d%s = %lx\n", i, ((i >= 10)?" ":""), regs[i]);
+	_reset();
+}
+
+void
+exitto(int (*entrypoint)(struct xboot_info *), struct xboot_info *bi)
+{
+	boot_framebuffer_t *fb;
+	struct efi_fb *efifb;
+	extern fb_info_t fb_info;
+
+	efifb = NULL;
+
+	bi->bi_phys_installed = (uint64_t)pinstalledp;
+	bi->bi_phys_avail = (uint64_t)pfreelistp;
+	bi->bi_boot_scratch = (uint64_t)pscratchlistp;
+	bi->bi_fw_code = (uint64_t)pfwcodelistp;
+	bi->bi_fw_data = (uint64_t)pfwdatalistp;
+	bi->bi_fw_mmio = (uint64_t)piolistp;
+	bi->bi_fw_rsvd = (uint64_t)prsvdlistp;
+
+	if (verbosemode && debug) {
+		dprintf("Installed Memory List:\n");
+		memlist_dump(pinstalledp);
+
+		dprintf("Free Memory List:\n");
+		memlist_dump(pfreelistp);
+
+		dprintf("Scratch Memory List:\n");
+		memlist_dump(pscratchlistp);
+
+		dprintf("Firmware Code Memory List:\n");
+		memlist_dump(pfwcodelistp);
+
+		dprintf("Firmware Data Memory List:\n");
+		memlist_dump(pfwdatalistp);
+
+		dprintf("Firmware MMIO List:\n");
+		memlist_dump(piolistp);
+
+		dprintf("Firmware Reserved Memory List:\n");
+		memlist_dump(prsvdlistp);
+
+		dprintf("Loader MMIO List:\n");
+		memlist_dump(pldriolistp);
+
+		dprintf("Boot Information:\n");
+		dprintf("  %s: 0x%lx\n", "bi_fdt", bi->bi_fdt);
+		dprintf("  %s: 0x%lx\n", "bi_uefi_systab", bi->bi_uefi_systab);
+		dprintf("  %s: 0x%lx\n", "bi_cmdline", bi->bi_cmdline);
+		dprintf("  %s: 0x%lx\n", "bi_modules", bi->bi_modules);
+		dprintf("  %s: 0x%lx\n", "bi_phys_installed",
+		    bi->bi_phys_installed);
+		dprintf("  %s: 0x%lx\n", "bi_phys_avail", bi->bi_phys_avail);
+		dprintf("  %s: 0x%lx\n", "bi_boot_scratch",
+		    bi->bi_boot_scratch);
+		dprintf("  %s: 0x%lx\n", "bi_fw_code", bi->bi_fw_code);
+		dprintf("  %s: 0x%lx\n", "bi_fw_data", bi->bi_fw_data);
+		dprintf("  %s: 0x%lx\n", "bi_fw_mmio", bi->bi_fw_mmio);
+		dprintf("  %s: 0x%lx\n", "bi_fw_rsvd", bi->bi_fw_rsvd);
+		dprintf("  %s: 0x%lx\n", "bi_bsvc_uart_mmio_base",
+		    bi->bi_bsvc_uart_mmio_base);
+		dprintf("  %s: 0x%lx\n", "bi_arch_timer_freq",
+		    bi->bi_arch_timer_freq);
+		dprintf("  %s: 0x%lx\n", "bi_framebuffer", bi->bi_framebuffer);
+		dprintf("  %s: 0x%x\n", "bi_bsvc_uart_type",
+		    bi->bi_bsvc_uart_type);
+		dprintf("  %s: 0x%x\n", "bi_module_cnt", bi->bi_module_cnt);
+		dprintf("  %s: 0x%x\n", "bi_psci_version", bi->bi_psci_version);
+		dprintf("  %s: 0x%x\n", "bi_psci_conduit_hvc",
+		    bi->bi_psci_conduit_hvc);
+		dprintf("  %s: 0x%x\n", "bi_psci_cpu_suspend_id",
+		    bi->bi_psci_cpu_suspend_id);
+		dprintf("  %s: 0x%x\n", "bi_psci_cpu_off_id",
+		    bi->bi_psci_cpu_off_id);
+		dprintf("  %s: 0x%x\n", "bi_psci_cpu_on_id",
+		    bi->bi_psci_cpu_on_id);
+		dprintf("  %s: 0x%x\n", "bi_psci_migrate_id",
+		    bi->bi_psci_migrate_id);
+		dprintf("Kernel Entrypoint: 0x%p\n", entrypoint);
+	} else if (verbosemode) {
+		dboot_printf("Boot Information:\n");
+		dboot_printf("  %s: %s\n", "Firmware Tables",
+		    bi->bi_fdt == 0 ? "ACPI" : "FDT");
+		dboot_printf("  %s: %s\n", "Command Line",
+		    bi->bi_cmdline == 0 ? "" : (const char *)bi->bi_cmdline);
+		dboot_printf("  %s: %s\n", "Framebuffer",
+		    bi->bi_framebuffer == 0 ? "Absent" : "Present");
+		dboot_printf("  %s: %luHz\n", "Timer Frequency",
+		    bi->bi_arch_timer_freq);
+		dboot_printf("  %s: %u.%u\n", "PSCI Version",
+		    bi->bi_psci_version >> 16, bi->bi_psci_version & 0xffff);
+		dboot_printf("  %s: %s\n", "PSCI Conduit",
+		    bi->bi_psci_conduit_hvc ? "Hypervisor" : "Secure Monitor");
+		dboot_printf("%s: 0x%p\n", "Kernel Entrypoint", entrypoint);
+	}
+
+	/*
+	 * Flush the TLB and caches. This is not strictly necessary.
+	 */
+	isb();
+	tlbi_allis();
+	dsb(ish);
+	isb();
+
+	if (bi->bi_fdt == 0) {
+		dboot_printf(
+		    "dboot: ACPI kernel support is a work in progress\n");
+		for (;;)
+			/* spin forever */;
+	}
+
+	/*
+	 * There can be no more screen output in the nominal case once we've
+	 * copied out cursor information to the data structure the kernel
+	 * will receive.
+	 */
+	if ((fb = (boot_framebuffer_t *)bi->bi_framebuffer) != NULL)
+		efifb = (struct efi_fb *)fb->framebuffer;
+
+	if (fb != NULL && efifb != NULL) {
+		fb->cursor.origin.x = fb_info.cursor.origin.x;
+		fb->cursor.origin.y = fb_info.cursor.origin.y;
+		fb->cursor.pos.x = fb_info.cursor.pos.x;
+		fb->cursor.pos.y = fb_info.cursor.pos.y;
+		fb->cursor.visible = fb_info.cursor.visible;
+	}
+
+	/*
+	 * ... and jump!
+	 */
+	entrypoint(bi);
+}

--- a/usr/src/uts/armv8/dboot/dboot_machdep_efi.c
+++ b/usr/src/uts/armv8/dboot/dboot_machdep_efi.c
@@ -1,0 +1,269 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2025 Michael van der Westhuizen
+ */
+
+#include <sys/types.h>
+#include <sys/null.h>
+#include <sys/machparam.h>
+#include <sys/efi.h>
+#include <sys/memlist.h>
+#include <sys/memlist_impl.h>
+#include <sys/bootinfo.h>
+#include <sys/framebuffer.h>
+#include <sys/efifb.h>
+
+#include "dboot.h"
+#include "dboot_printf.h"
+
+extern struct efi_map_header *efi_map_header;
+
+int pagesize = MMU_PAGESIZE;
+
+extern uintptr_t pa_to_ttbr1(uintptr_t pa);
+
+/*
+ * UEFI Memory Types
+ * =================
+ *
+ * EfiReservedMemoryType
+ *   Not usable.
+ *
+ * EfiLoaderCode
+ *   The code portions of a loaded UEFI application.
+ *
+ * EfiLoaderData
+ *   The data portions of a loaded UEFI application and the default data
+ *   allocation type used by a UEFI application to allocate pool memory.
+ *
+ * EfiRuntimeServicesCode
+ *   The memory in this range is to be preserved by the UEFI OS loader and
+ *   OS in the working and ACPI S1–S3 states.
+ *
+ * EfiRuntimeServicesData
+ *   The memory in this range is to be preserved by the UEFI OS loader and
+ *   OS in the working and ACPI S1–S3 states.
+ *
+ * EfiConventionalMemory
+ *   Memory available for general use.
+ *
+ * EfiUnusableMemory
+ *   Memory that contains errors and is not to be used.
+ *
+ * EfiACPIReclaimMemory
+ *   This memory is to be preserved by the UEFI OS loader and OS until ACPI
+ *   is enabled. Once ACPI is enabled, the memory in this range is available
+ *   for general use.
+ *
+ * EfiACPIMemoryNVS
+ *   This memory is to be preserved by the UEFI OS loader and OS in the
+ *   working and ACPI S1–S3 states.
+ *
+ * EfiMemoryMappedIO
+ *   This memory is not used by the OS. All system memory-mapped IO
+ *   information should come from ACPI tables.
+ *
+ * EfiMemoryMappedIOPortSpace
+ *   This memory is not used by the OS. All system memory-mapped IO port
+ *   space information should come from ACPI tables.
+ *
+ * EfiPalCode
+ *   This memory is to be preserved by the UEFI OS loader and OS in the
+ *   working and ACPI S1–S4 states. This memory may also have other
+ *   attributes that are defined by the processor implementation.
+ *
+ * EfiPersistentMemory
+ *   A memory region that operates as EfiConventionalMemory. However, it
+ *   happens to also support byte-addressable non-volatility.
+ *
+ * EfiUnacceptedMemoryType
+ *   A memory region that represents unaccepted memory, that must be
+ *   accepted by the boot target before it can be used. Unless otherwise
+ *   noted, all other EFI memory types are accepted. For platforms that
+ *   support unaccepted memory, all unaccepted valid memory will be
+ *   reported as unaccepted in the memory map. Unreported physical
+ *   address ranges must be treated as not-present memory.
+ */
+void
+init_physmem(void)
+{
+	struct efi_map_header	*mhdr;
+	size_t			efisz;
+	EFI_MEMORY_DESCRIPTOR	*map;
+	int			ndesc;
+	EFI_MEMORY_DESCRIPTOR	*p;
+	int			i;
+	uint64_t		addr;
+	uint64_t		size;
+	uint64_t		ptot;
+	uint64_t		stot;
+	uint64_t		rtot;
+	uint64_t		rttot;
+
+	extern struct xboot_info *bi;
+
+	if (efi_map_header == NULL)
+		panic("init_physmem: no UEFI memory map header\n");
+
+	ptot = stot = rtot = rttot = 0;
+	mhdr = efi_map_header;
+	efisz = (sizeof (struct efi_map_header) + 0xf) & ~0xf;
+	map = (EFI_MEMORY_DESCRIPTOR *)((uint8_t *)mhdr + efisz);
+	if (mhdr->descriptor_size == 0)
+		panic("init_physmem: invalid memory descriptor size\n");
+
+	ndesc = mhdr->memory_size / mhdr->descriptor_size;
+
+	for (i = 0, p = map; i < ndesc;
+	    i++, p = efi_mmap_next(p, mhdr->descriptor_size)) {
+		switch (p->Type) {
+		case EfiMemoryMappedIO:
+			addr = RNDDN(p->PhysicalStart, MMU_PAGESIZE);
+			size = RNDUP(p->PhysicalStart +
+			    (p->NumberOfPages * MMU_PAGESIZE), MMU_PAGESIZE) -
+			    addr;
+			dprintf("mmio memory add span 0x%lx - 0x%lx\n",
+			    addr, addr + size - 1);
+			memlist_add_span(addr, size, &piolistp);
+			memlist_add_span(addr, size, &pldriolistp);
+			break;
+#if defined(NOT_YET)
+		case EfiUnacceptedMemoryType:	/* fallthrough */
+#endif
+		case EfiPalCode:		/* fallthrough */
+		case EfiACPIMemoryNVS:		/* fallthrough */
+		case EfiACPIReclaimMemory:	/* fallthrough */
+		case EfiUnusableMemory:		/* fallthrough */
+		case EfiReservedMemoryType:	/* fallthrough */
+			addr = RNDDN(p->PhysicalStart, MMU_PAGESIZE);
+			size = RNDUP(p->PhysicalStart +
+			    (p->NumberOfPages * MMU_PAGESIZE), MMU_PAGESIZE) -
+			    addr;
+			dprintf("rsvd memory add span 0x%lx - 0x%lx\n",
+			    addr, addr + size - 1);
+			memlist_add_span(addr, size, &pinstalledp);
+			memlist_add_span(addr, size, &prsvdlistp);
+			rtot += size;
+			ptot += size;
+			break;
+		case EfiLoaderCode:		/* fallthrough */
+		case EfiLoaderData:		/* fallthrough */
+			addr = RNDDN(p->PhysicalStart, MMU_PAGESIZE);
+			size = RNDUP(p->PhysicalStart +
+			    (p->NumberOfPages * MMU_PAGESIZE), MMU_PAGESIZE) -
+			    addr;
+			dprintf("phys memory add span 0x%lx - 0x%lx\n",
+			    addr, addr + size - 1);
+			memlist_add_span(addr, size, &pinstalledp);
+			memlist_add_span(addr, size, &pmappablep);
+			memlist_add_span(addr, size, &pscratchlistp);
+			stot += size;
+			ptot += size;
+			break;
+		case EfiRuntimeServicesCode:	/* fallthrough */
+		case EfiRuntimeServicesData:	/* fallthrough */
+			/*
+			 * Not sure what to do with this yet
+			 */
+			addr = RNDDN(p->PhysicalStart, MMU_PAGESIZE);
+			size = RNDUP(p->PhysicalStart +
+			    (p->NumberOfPages * MMU_PAGESIZE), MMU_PAGESIZE) -
+			    addr;
+			dprintf("rtim memory add span 0x%lx - 0x%lx\n",
+			    addr, addr + size - 1);
+			memlist_add_span(addr, size, &pinstalledp);
+			if (p->Type == EfiRuntimeServicesCode) {
+				memlist_add_span(addr, size, &pfwcodelistp);
+			} else {
+				memlist_add_span(addr, size, &pfwdatalistp);
+			}
+			rttot += size;
+			ptot += size;
+			break;
+		case EfiBootServicesCode:	/* fallthrough */
+		case EfiBootServicesData:	/* fallthrough */
+		case EfiPersistentMemory:	/* fallthrough */
+		case EfiConventionalMemory:
+			addr = RNDUP(p->PhysicalStart, MMU_PAGESIZE);
+			size = RNDDN(p->PhysicalStart +
+			    (p->NumberOfPages * MMU_PAGESIZE), MMU_PAGESIZE) -
+			    addr;
+			dprintf("phys memory add span 0x%lx - 0x%lx\n",
+			    addr, addr + size - 1);
+			memlist_add_span(addr, size, &pinstalledp);
+			memlist_add_span(addr, size, &pmappablep);
+			memlist_add_span(addr, size, &pfreelistp);
+			ptot += size;
+			break;
+		default:
+			dboot_printf("Treating unhandled memory type %u as "
+			    "reserved\n", p->Type);
+
+			addr = RNDDN(p->PhysicalStart, MMU_PAGESIZE);
+			size = RNDUP(p->PhysicalStart +
+			    (p->NumberOfPages * MMU_PAGESIZE), MMU_PAGESIZE) -
+			    addr;
+			dprintf("rsvd memory add span 0x%lx - 0x%lx\n",
+			    addr, addr + size - 1);
+			memlist_add_span(addr, size, &pinstalledp);
+			memlist_add_span(addr, size, &prsvdlistp);
+			rtot += size;
+			ptot += size;
+			break;
+		}
+	}
+
+	/*
+	 * UEFI configuration tables loaded at boot time could be contained
+	 * in memory of type EfiBootServicesdata, which we hand back at this
+	 * point. Ensure that all configuration table memory is reserved.
+	 */
+	/* XXXARM: reserve_firmware_tables(); */
+
+	/*
+	 * There's no guarantee we'll see EfiMemoryMappedIO entries, or which
+	 * devices those will correspond to. The docs even suggest that we
+	 * should never touch entries of this type.
+	 *
+	 * The only device we really need is the UART, so ensure that there's
+	 * an entry for that. Addresses in this list will only be mapped to
+	 * the lower address space.
+	 */
+	if (bi != NULL && bi->bi_bsvc_uart_mmio_base != 0) {
+		addr = RNDDN(bi->bi_bsvc_uart_mmio_base, MMU_PAGESIZE);
+		size = RNDUP(
+		    bi->bi_bsvc_uart_mmio_base + 0x1000, MMU_PAGESIZE) - addr;
+		if (!memlist_find(pldriolistp, addr))
+			memlist_add_span(addr, size, &pldriolistp);
+	}
+
+	if (bi != NULL && bi->bi_framebuffer != 0) {
+		boot_framebuffer_t *bfb =
+		    (boot_framebuffer_t *)bi->bi_framebuffer;
+		if (bfb->framebuffer != 0) {
+			struct efi_fb *fb = (struct efi_fb *)bfb->framebuffer;
+			addr = RNDDN(fb->fb_addr, MMU_PAGESIZE);
+			size = RNDUP(
+			    fb->fb_addr + fb->fb_size, MMU_PAGESIZE) - addr;
+			if (!memlist_find(pldriolistp, addr))
+				memlist_add_span(addr, size, &pldriolistp);
+		}
+	}
+
+	if (verbosemode) {
+		dprintf("physical memory: 0x%lx bytes\n", ptot);
+		dprintf("       reserved: 0x%lx bytes\n", rtot);
+		dprintf("        runtime: 0x%lx bytes\n", rttot);
+		dprintf("        scratch: 0x%lx bytes\n", stot);
+	}
+}

--- a/usr/src/uts/armv8/dboot/dboot_main.c
+++ b/usr/src/uts/armv8/dboot/dboot_main.c
@@ -1,0 +1,124 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2025 Michael van der Westhuizen
+ */
+
+/*
+ * EFI Direct Boot
+ *
+ * The EFI direct-boot shim is compiled as a position independent ELF
+ * binary (i.e. PIE), then extracted into a binary file which is included
+ * verbatim into `unix`, which sets the kernel entrypoint to the binary
+ * extracted from this code.
+ *
+ * By the time the main function in this file is called the shim has been
+ * relocated (see self_reloc), so we're in a fairly normal-looking standalone
+ * environment.
+ *
+ * The main function is passed a modules pointer, which points to a module
+ * table (FreeBSD-style) produced by loader(7). This table is parsed and
+ * partially validated the `dboot_configure` routine. The configure routine
+ * is responsible for all shim configuration, including bootstrapping
+ * memory management.
+ *
+ * Once the configure routine returns the only remaining job is to load
+ * the kernel that encloses this shim to it's final virtual addresses in
+ * KVA and jump to it, passing the `xboot_info` constructed by the
+ * configuration routine.
+ */
+
+#include <sys/types.h>
+#include <sys/null.h>
+#include <sys/stdbool.h>
+#include <sys/bootinfo.h>
+#include <sys/machparam.h>
+#include <sys/psci.h>
+#include <sys/boot_console.h>
+#include <sys/bootsvcs.h>
+
+#include "dboot.h"
+
+#include "dboot_printf.h"
+
+static struct xboot_info xboot_info;
+struct xboot_info *bi = &xboot_info;
+
+int verbosemode = 0;
+
+#if defined(DEBUG)
+int debug = 1;
+#else
+int debug = 0;
+#endif
+
+int boothowto = 0;
+
+#define	LOAD_ELF_FAILED	((func_t)-1)
+typedef int (*func_t)(struct xboot_info *);
+extern func_t load_elf_payload(caddr_t payload, size_t payload_size, int print);
+extern void exitto(func_t entrypoint, struct xboot_info *);
+
+uintptr_t
+pa_to_ttbr1(uintptr_t pa)
+{
+	return (SEGKPM_BASE + pa);
+}
+
+int
+main(caddr_t modulesp)
+{
+	struct boot_modules *bm;
+	caddr_t kernel;
+	uint64_t kernel_size;
+	uint32_t i;
+	func_t func;
+
+	kernel = NULL;
+	kernel_size = 0;
+
+	bcons_init(NULL);
+
+	if (dboot_configure(modulesp, bi, &kernel, &kernel_size) != 0)
+		panic("dboot: configuration failed\n");
+
+	if (bi->bi_modules == 0 || bi->bi_module_cnt == 0)
+		panic("dboot: no boot modules found\n");
+
+	bm = (struct boot_modules *)bi->bi_modules;
+
+	if (verbosemode) {
+		dboot_printf("Kernel at 0x%p, size 0x%lx\n",
+		    kernel, kernel_size);
+		dboot_printf("Kernel arguments: '%s'\n",
+		    (const char *)bi->bi_cmdline);
+
+		for (i = 0; i < bi->bi_module_cnt; ++i) {
+			dboot_printf("Module %u: %s (%u) 0x%lx 0x%lx\n",
+			    i,
+			    (const char *)bm[i].bm_name,
+			    bm[i].bm_type,
+			    bm[i].bm_addr,
+			    bm[i].bm_size);
+		}
+	}
+
+	func = load_elf_payload(kernel, kernel_size, verbosemode);
+	if (func == LOAD_ELF_FAILED)
+		panic("dboot: failed to load elf64 kernel\n");
+
+	if (verbosemode)
+		dboot_printf("Kernel entrypoint address is 0x%p\n", func);
+
+	(void) exitto(func, bi);
+	panic("dboot: kernel entrypoint returned\n");
+}

--- a/usr/src/uts/armv8/dboot/dboot_memlist.c
+++ b/usr/src/uts/armv8/dboot/dboot_memlist.c
@@ -1,0 +1,405 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright 2025 Michael van der Westhuizen
+ * Copyright 2017 Hayashi Naoyuki
+ * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
+ * Use is subject to license terms.
+ */
+
+#include <sys/types.h>
+#include <sys/null.h>
+#include <sys/memlist.h>
+#include <sys/memlist_impl.h>
+
+#include "dboot.h"
+#include "dboot_printf.h"
+
+extern struct memlist *get_memlist_struct(void);
+extern void add_to_freelist(struct memlist *);
+
+void
+memlist_dump(struct memlist *listp)
+{
+	dprintf("memlist 0x%p content\n", (void *)listp);
+	while (listp) {
+		dprintf("(0x%lx, 0x%lx)\n", listp->ml_address, listp->ml_size);
+		listp = listp->ml_next;
+	}
+}
+
+struct memlist *
+memlist_get_one()
+{
+	return (get_memlist_struct());
+}
+
+void
+memlist_free_one(struct memlist *buf)
+{
+	add_to_freelist(buf);
+}
+
+/*
+ * Insert into a sorted memory list.
+ * new = new element to insert
+ * curmemlistp = memory list to which to add segment.
+ */
+void
+memlist_insert(
+	struct memlist *new,
+	struct memlist **curmemlistp)
+{
+	struct memlist *cur, *last;
+	uint64_t start, end;
+
+	start = new->ml_address;
+	end = start + new->ml_size;
+	last = NULL;
+	for (cur = *curmemlistp; cur; cur = cur->ml_next) {
+		last = cur;
+		if (cur->ml_address >= end) {
+			new->ml_next = cur;
+			new->ml_prev = cur->ml_prev;
+			cur->ml_prev = new;
+			if (cur == *curmemlistp)
+				*curmemlistp = new;
+			else
+				new->ml_prev->ml_next = new;
+			return;
+		}
+		if (cur->ml_address + cur->ml_size > start)
+			panic("munged memory list\n");
+	}
+	new->ml_next = NULL;
+	new->ml_prev = last;
+	if (last != NULL)
+		last->ml_next = new;
+}
+
+void
+memlist_del(struct memlist *memlistp, struct memlist **curmemlistp)
+{
+	if (*curmemlistp == memlistp) {
+		*curmemlistp = memlistp->ml_next;
+	}
+	if (memlistp->ml_prev != NULL) {
+		memlistp->ml_prev->ml_next = memlistp->ml_next;
+	}
+	if (memlistp->ml_next != NULL) {
+		memlistp->ml_next->ml_prev = memlistp->ml_prev;
+	}
+}
+
+struct memlist *
+memlist_find(struct memlist *mlp, uint64_t address)
+{
+	for (; mlp != NULL; mlp = mlp->ml_next)
+		if (address >= mlp->ml_address &&
+		    address < (mlp->ml_address + mlp->ml_size))
+			break;
+	return (mlp);
+}
+
+/*
+ * Add a span to a memlist.
+ * Return:
+ * MEML_SPANOP_OK if OK.
+ * MEML_SPANOP_ESPAN if part or all of span already exists
+ * MEML_SPANOP_EALLOC for allocation failure
+ */
+int
+memlist_add_span(
+	uint64_t address,
+	uint64_t bytes,
+	struct memlist **curmemlistp)
+{
+	struct memlist *dst;
+	struct memlist *prev, *next;
+
+	/*
+	 * allocate a new struct memlist
+	 */
+
+	dst = memlist_get_one();
+
+	if (dst == NULL) {
+		return (MEML_SPANOP_EALLOC);
+	}
+
+	dst->ml_address = address;
+	dst->ml_size = bytes;
+
+	/*
+	 * First insert.
+	 */
+	if (*curmemlistp == NULL) {
+		dst->ml_prev = NULL;
+		dst->ml_next = NULL;
+		*curmemlistp = dst;
+		return (MEML_SPANOP_OK);
+	}
+
+	/*
+	 * Insert into sorted list.
+	 */
+	for (prev = NULL, next = *curmemlistp; next != NULL;
+	    prev = next, next = next->ml_next) {
+		if (address > (next->ml_address + next->ml_size))
+			continue;
+
+		/*
+		 * Else insert here.
+		 */
+
+		/*
+		 * Prepend to next.
+		 */
+		if ((address + bytes) == next->ml_address) {
+			memlist_free_one(dst);
+
+			next->ml_address = address;
+			next->ml_size += bytes;
+
+			return (MEML_SPANOP_OK);
+		}
+
+		/*
+		 * Append to next.
+		 */
+		if (address == (next->ml_address + next->ml_size)) {
+			memlist_free_one(dst);
+
+			if (next->ml_next) {
+				/*
+				 * don't overlap with next->ml_next
+				 */
+				if ((address + bytes) >
+				    next->ml_next->ml_address) {
+					return (MEML_SPANOP_ESPAN);
+				}
+				/*
+				 * Concatenate next and next->ml_next
+				 */
+				if ((address + bytes) ==
+				    next->ml_next->ml_address) {
+					struct memlist *mlp = next->ml_next;
+
+					if (next == *curmemlistp)
+						*curmemlistp = next->ml_next;
+
+					mlp->ml_address = next->ml_address;
+					mlp->ml_size += next->ml_size;
+					mlp->ml_size += bytes;
+
+					if (next->ml_prev)
+						next->ml_prev->ml_next = mlp;
+					mlp->ml_prev = next->ml_prev;
+
+					memlist_free_one(next);
+					return (MEML_SPANOP_OK);
+				}
+			}
+
+			next->ml_size += bytes;
+
+			return (MEML_SPANOP_OK);
+		}
+
+		/* don't overlap with next */
+		if ((address + bytes) > next->ml_address) {
+			memlist_free_one(dst);
+			return (MEML_SPANOP_ESPAN);
+		}
+
+		/*
+		 * Insert before next.
+		 */
+		dst->ml_prev = prev;
+		dst->ml_next = next;
+		next->ml_prev = dst;
+		if (prev == NULL) {
+			*curmemlistp = dst;
+		} else {
+			prev->ml_next = dst;
+		}
+		return (MEML_SPANOP_OK);
+	}
+
+	/*
+	 * End of list, prev is valid and next is NULL.
+	 */
+	prev->ml_next = dst;
+	dst->ml_prev = prev;
+	dst->ml_next = NULL;
+
+	return (MEML_SPANOP_OK);
+}
+
+/*
+ * Delete a span from a memlist.
+ * Return:
+ * MEML_SPANOP_OK if OK.
+ * MEML_SPANOP_ESPAN if part or all of span does not exist
+ * MEML_SPANOP_EALLOC for allocation failure
+ */
+int
+memlist_delete_span(
+	uint64_t address,
+	uint64_t bytes,
+	struct memlist **curmemlistp)
+{
+	struct memlist *dst, *next;
+
+	/*
+	 * Find element containing address.
+	 */
+	for (next = *curmemlistp; next != NULL; next = next->ml_next) {
+		if ((address >= next->ml_address) &&
+		    (address < next->ml_address + next->ml_size))
+			break;
+	}
+
+	/*
+	 * If start address not in list.
+	 */
+	if (next == NULL) {
+		return (MEML_SPANOP_ESPAN);
+	}
+
+	/*
+	 * Error if size goes off end of this struct memlist.
+	 */
+	if (address + bytes > next->ml_address + next->ml_size) {
+		return (MEML_SPANOP_ESPAN);
+	}
+
+	/*
+	 * Span at beginning of struct memlist.
+	 */
+	if (address == next->ml_address) {
+		/*
+		 * If start & size match, delete from list.
+		 */
+		if (bytes == next->ml_size) {
+			if (next == *curmemlistp)
+				*curmemlistp = next->ml_next;
+			if (next->ml_prev != NULL)
+				next->ml_prev->ml_next = next->ml_next;
+			if (next->ml_next != NULL)
+				next->ml_next->ml_prev = next->ml_prev;
+
+			memlist_free_one(next);
+		} else {
+			/*
+			 * Increment start address by bytes.
+			 */
+			next->ml_address += bytes;
+			next->ml_size -= bytes;
+		}
+		return (MEML_SPANOP_OK);
+	}
+
+	/*
+	 * Span at end of struct memlist.
+	 */
+	if (address + bytes == next->ml_address + next->ml_size) {
+		/*
+		 * decrement size by bytes
+		 */
+		next->ml_size -= bytes;
+		return (MEML_SPANOP_OK);
+	}
+
+	/*
+	 * Delete a span in the middle of the struct memlist.
+	 */
+	{
+		/*
+		 * create a new struct memlist
+		 */
+		dst = memlist_get_one();
+
+		if (dst == NULL) {
+			return (MEML_SPANOP_EALLOC);
+		}
+
+		/*
+		 * Existing struct memlist gets address
+		 * and size up to start of span.
+		 */
+		dst->ml_address = address + bytes;
+		dst->ml_size =
+		    (next->ml_address + next->ml_size) - dst->ml_address;
+		next->ml_size = address - next->ml_address;
+
+		/*
+		 * New struct memlist gets address starting
+		 * after span, until end.
+		 */
+
+		/*
+		 * link in new memlist after old
+		 */
+		dst->ml_next = next->ml_next;
+		dst->ml_prev = next;
+
+		if (next->ml_next != NULL)
+			next->ml_next->ml_prev = dst;
+		next->ml_next = dst;
+	}
+	return (MEML_SPANOP_OK);
+}
+
+/*
+ * find and claim a memory chunk of given size, first fit
+ */
+uint64_t
+memlist_get(uint64_t size, int align, struct memlist **listp)
+{
+	uint64_t delta, total_size;
+	uint64_t paddr;
+	struct memlist *prev = 0, *next;
+
+	/* find the chunk with sufficient size */
+	next = *listp;
+	while (next) {
+		delta = next->ml_address & ((align != 0) ? (align - 1) : 0);
+		if (delta != 0)
+			total_size = size + align - delta;
+		else
+			total_size = size; /* the addr is already aligned */
+		if (next->ml_size >= total_size)
+			break;
+		prev = next;
+		next = prev->ml_next;
+	}
+
+	if (next == 0)
+		return (0);	/* Not found */
+
+	paddr = next->ml_address;
+	if (delta)
+		paddr += align - delta;
+	memlist_delete_span(paddr, size, listp);
+
+	return (paddr);
+}

--- a/usr/src/uts/armv8/dboot/dboot_printf.c
+++ b/usr/src/uts/armv8/dboot/dboot_printf.c
@@ -1,0 +1,242 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2012 Gary Mills
+ * Copyright 2020 Joyent, Inc.
+ * Copyright 2025 Michael van der Westhuizen
+ *
+ * Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+ * Use is subject to license terms.
+ */
+
+#include <sys/types.h>
+#include <sys/param.h>
+#include <sys/machparam.h>
+#include <sys/archsystm.h>
+#include <sys/boot_console.h>
+#include <sys/varargs.h>
+#include <sys/stdbool.h>
+#include "dboot_printf.h"
+
+/*
+ * This file provides simple output formatting via dboot_printf()
+ */
+
+static void dboot_vprintf(const char *fmt, va_list args);
+
+static char digits[] = "0123456789abcdef";
+
+/*
+ * Primitive version of panic, prints a message then resets the system
+ */
+void
+dboot_panic(const char *fmt, ...)
+{
+	extern void __NORETURN _reset(bool poff);
+	va_list	args;
+
+	va_start(args, fmt);
+	dboot_vprintf(fmt, args);
+	va_end(args);
+
+	if (boot_console_type(NULL) == CONS_SCREEN_TEXT ||
+	    boot_console_type(NULL) == CONS_FRAMEBUFFER) {
+		dboot_printf("Press any key to reboot\n");
+		(void) bcons_getchar();
+	}
+
+	_reset(false);
+}
+
+void
+panic(const char *fmt, ...)
+    __attribute__((alias("dboot_panic"), noreturn));
+void
+prom_panic(const char *fmt, ...)
+    __attribute__((alias("dboot_panic"), noreturn));
+
+/*
+ * printf for boot code
+ */
+void
+dboot_printf(const char *fmt, ...)
+{
+	va_list args;
+
+	va_start(args, fmt);
+	dboot_vprintf(fmt, args);
+	va_end(args);
+}
+
+void prom_printf(const char *fmt, ...) __attribute__((alias("dboot_printf")));
+void printf(const char *fmt, ...) __attribute__((alias("dboot_printf")));
+
+/*
+ * output a string
+ */
+static void
+dboot_puts(const char *s)
+{
+	while (*s != 0) {
+		bcons_putchar(*s);
+		++s;
+	}
+}
+
+void
+prom_writestr(const char *buf, size_t len)
+{
+	size_t written = 0;
+
+	while (written < len)  {
+		bcons_putchar(buf[written]);
+		++written;
+	}
+}
+
+static void
+dboot_putnum(uintmax_t x, boolean_t is_signed, uint8_t base)
+{
+	char buffer[64];	/* digits in reverse order */
+	int i;
+
+	if (is_signed && (intmax_t)x < 0) {
+		bcons_putchar('-');
+		x = -x;
+	}
+
+	for (i  = -1; x != 0 && i <= 63; x /= base)
+		buffer[++i] = digits[x - ((x / base) * base)];
+
+	if (i < 0)
+		buffer[++i] = '0';
+
+	while (i >= 0)
+		bcons_putchar(buffer[i--]);
+}
+
+/*
+ * Very primitive printf - only does a subset of the standard format characters.
+ */
+static void
+dboot_vprintf(const char *fmt, va_list args)
+{
+	char *s;
+	uintmax_t x;
+	uint8_t base;
+	uint8_t size;
+
+	if (fmt == NULL) {
+		dboot_puts("dboot_printf(): 1st arg is NULL\n");
+		return;
+	}
+	for (; *fmt; ++fmt) {
+		if (*fmt != '%') {
+			bcons_putchar(*fmt);
+			continue;
+		}
+
+		size = 0;
+again:
+		++fmt;
+		switch (*fmt) {
+
+		case '%':
+			bcons_putchar(*fmt);
+			break;
+
+		case 'c':
+			x = va_arg(args, int);
+			bcons_putchar(x);
+			break;
+
+		case 'j':
+			size = sizeof (uintmax_t);
+			goto again;
+
+		case 's':
+			s = va_arg(args, char *);
+			if (s == NULL)
+				dboot_puts("*NULL*");
+			else
+				dboot_puts(s);
+			break;
+
+		case 'p':
+			x = va_arg(args, ulong_t);
+			dboot_putnum(x, B_FALSE, 16);
+			break;
+
+		case 'l':
+			if (size == 0)
+				size = sizeof (long);
+			else if (size == sizeof (long))
+				size = sizeof (long long);
+			goto again;
+
+		case 'd':
+			if (size == 0)
+				x = va_arg(args, int);
+			else if (size == sizeof (long))
+				x = va_arg(args, long);
+			else
+				x = va_arg(args, long long);
+			dboot_putnum(x, B_TRUE, 10);
+			break;
+
+		case 'u':
+			base = 10;
+			goto unsigned_num;
+
+		case 'b':
+			base = 2;
+			goto unsigned_num;
+
+		case 'o':
+			base = 8;
+			goto unsigned_num;
+
+		case 'x':
+			base = 16;
+unsigned_num:
+			if (size == 0)
+				x = va_arg(args, uint_t);
+			else if (size == sizeof (ulong_t))
+				x = va_arg(args, ulong_t);
+			else
+				x = va_arg(args, unsigned long long);
+			dboot_putnum(x, B_FALSE, base);
+			break;
+
+		case 'z':
+			size = sizeof (size_t);
+			goto again;
+
+		default:
+			dboot_puts("dboot_printf(): unknown % escape\n");
+		}
+	}
+}
+
+void
+prom_vprintf(const char *fmt, va_list adx)
+    __attribute__((alias("dboot_vprintf")));

--- a/usr/src/uts/armv8/dboot/dboot_printf.h
+++ b/usr/src/uts/armv8/dboot/dboot_printf.h
@@ -1,0 +1,53 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+ * Use is subject to license terms.
+ */
+
+#ifndef	_DBOOT_PRINTF_H
+#define	_DBOOT_PRINTF_H
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+/*
+ * Very primitive printf. This only understands the following simple formats:
+ *        %%, %b, %c, %d, %o, %p, %s, %x and size specifiers l, ll, j, z
+ */
+extern void dboot_printf(const char *fmt, ...)
+    __KPRINTFLIKE(1);
+
+/*
+ * Primitive version of panic, prints a message, waits for a keystroke,
+ * then resets the system
+ */
+extern void dboot_panic(const char *fmt, ...)
+    __KPRINTFLIKE(1) __NORETURN;
+
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif	/* _DBOOT_PRINTF_H */

--- a/usr/src/uts/armv8/dboot/dboot_psci.c
+++ b/usr/src/uts/armv8/dboot/dboot_psci.c
@@ -1,0 +1,131 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+ * Use is subject to license terms.
+ */
+/*
+ * Copyright 2025 Michael van der Westhuizen
+ * Copyright 2017 Hayashi Naoyuki
+ */
+
+#include <sys/types.h>
+#include <sys/null.h>
+#include <sys/bootinfo.h>
+
+#include "dboot.h"
+
+static uint32_t pcsi_version_id = 0x84000000;
+static uint32_t psci_system_off_id = 0x84000008;
+static uint32_t psci_system_reset_id = 0x84000009;
+boolean_t pcsi_method_is_hvc = B_FALSE;
+boolean_t psci_initialized = B_FALSE;
+
+static uint32_t psci_version(void);
+
+static inline uint64_t
+psci_smc64(uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3)
+{
+	register uint64_t x0 __asm__("x0") = a0;
+	register uint64_t x1 __asm__("x1") = a1;
+	register uint64_t x2 __asm__("x2") = a2;
+	register uint64_t x3 __asm__("x3") = a3;
+
+	__asm__ volatile("smc #0"
+	    : "+r"(x0), "+r"(x1), "+r"(x2), "+r"(x3)
+	    :
+	    :
+	    "x4", "x5", "x6", "x7", "x8", "x9", "x10", "x11",
+	    "x12", "x13", "x14", "x15", "x16", "x17", "x18", "memory", "cc");
+
+	return (x0);
+}
+
+static inline uint64_t
+psci_hvc64(uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3)
+{
+	register uint64_t x0 __asm__("x0") = a0;
+	register uint64_t x1 __asm__("x1") = a1;
+	register uint64_t x2 __asm__("x2") = a2;
+	register uint64_t x3 __asm__("x3") = a3;
+
+	__asm__ volatile("hvc #0"
+	    : "+r"(x0), "+r"(x1), "+r"(x2), "+r"(x3)
+	    :
+	    :
+	    "x4", "x5", "x6", "x7", "x8", "x9", "x10", "x11",
+	    "x12", "x13", "x14", "x15", "x16", "x17", "x18", "memory", "cc");
+
+	return (x0);
+}
+
+static inline uint64_t
+psci_call(uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3)
+{
+	if (pcsi_method_is_hvc)
+		return (psci_hvc64(a0, a1, a2, a3));
+	else
+		return (psci_smc64(a0, a1, a2, a3));
+}
+
+int
+psci_init(struct xboot_info *bi)
+{
+	uint32_t val;
+
+	if (bi == NULL)
+		return (-1);
+
+	pcsi_method_is_hvc = bi->bi_psci_conduit_hvc ? B_TRUE : B_FALSE;
+
+	if ((val = psci_version()) & 0x80000000)
+		return (-1);
+
+	bi->bi_psci_version = val;
+	psci_initialized = B_TRUE;
+	return (0);
+}
+
+static uint32_t
+psci_version(void)
+{
+	return (psci_call(pcsi_version_id, 0, 0, 0));
+}
+
+void
+psci_system_off(void)
+{
+	if (psci_initialized != B_TRUE)
+		for (;;)
+			/* spin forever */;
+
+	psci_call(psci_system_off_id, 0, 0, 0);
+}
+
+void
+psci_system_reset(void)
+{
+	if (psci_initialized != B_TRUE)
+		for (;;)
+			/* spin forever */;
+
+	psci_call(psci_system_reset_id, 0, 0, 0);
+}

--- a/usr/src/uts/armv8/dboot/dboot_self_reloc.c
+++ b/usr/src/uts/armv8/dboot/dboot_self_reloc.c
@@ -1,0 +1,89 @@
+/*-
+ * Copyright (c) 2008-2010 Rui Paulo <rpaulo@FreeBSD.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/types.h>
+#include <sys/machelf.h>
+
+void self_reloc(Elf64_Addr baseaddr, Elf64_Dyn *dynamic);
+
+/*
+ * A simple elf relocator.
+ */
+void
+self_reloc(Elf64_Addr baseaddr, Elf64_Dyn *dynamic)
+{
+	Elf64_Word relsz, relent;
+	Elf64_Addr *newaddr;
+	Elf64_Rela *rel = 0;
+	Elf64_Dyn *dynp;
+
+	/*
+	 * Find the relocation address, its size and the relocation entry.
+	 */
+	relsz = 0;
+	relent = 0;
+	for (dynp = dynamic; dynp->d_tag != DT_NULL; dynp++) {
+		switch (dynp->d_tag) {
+		case DT_REL:
+		case DT_RELA:
+			rel = (Elf64_Rela *)(dynp->d_un.d_ptr + baseaddr);
+			break;
+		case DT_RELSZ:
+		case DT_RELASZ:
+			relsz = dynp->d_un.d_val;
+			break;
+		case DT_RELENT:
+		case DT_RELAENT:
+			relent = dynp->d_un.d_val;
+			break;
+		default:
+			break;
+		}
+	}
+
+	/*
+	 * Perform the actual relocation. We rely on the object having been
+	 * linked at 0, so that the difference between the load and link
+	 * address is the same as the load address.
+	 */
+	for (; relsz > 0; relsz -= relent) {
+		switch (ELF64_R_TYPE(rel->r_info)) {
+		case R_AARCH64_NONE:
+			/* No relocation needs be performed. */
+			break;
+
+		case R_AARCH64_RELATIVE:
+			newaddr = (Elf64_Addr *)(rel->r_offset + baseaddr);
+			/* Addend relative to the base address. */
+			*newaddr = baseaddr + rel->r_addend;
+			break;
+		default:
+			/* XXXARM: do we need other relocations ? */
+			break;
+		}
+		rel = (Elf64_Rela *)(void *)((caddr_t)rel + relent);
+	}
+}

--- a/usr/src/uts/armv8/dboot/dboot_srt0.S
+++ b/usr/src/uts/armv8/dboot/dboot_srt0.S
@@ -1,0 +1,445 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright 2017 Hayashi Naoyuki
+ * Copyright 2025 Michael van der Westhuizen
+ */
+#include <sys/asm_linkage.h>
+#include "assym.h"
+
+	.text
+/*
+ * void _start(void)
+ */
+	ENTRY(_start)
+	bl	1f
+	sub	x28, lr, #0x4
+	// bic	x28, x28, #0xfff
+	// brk	#0
+	b	2f
+1:	ret
+2:
+1:
+	mov	x19, x0
+	mov	x20, x1
+	mov	x21, x2
+	mov	x22, x18
+
+	// flush cache (data/inst)
+	bl	dcache_flush_all
+	ic	iallu
+	dsb	sy
+	isb
+
+	mrs	x0, CurrentEL
+	cmp	x0, #0xc
+	b.eq	el3
+
+	cmp	x0, #0x8
+	b.eq	el2
+
+	b	el1
+el3:
+	// not supported
+	b	el3
+
+el2:
+	bl	0f
+	b	el1
+0:
+	ldr	x0, =SCTLR_EL1_RES1
+	msr	sctlr_el1, x0
+	ldr	x0, =SCTLR_EL2_RES1
+	msr	sctlr_el2, x0
+	dsb	sy
+	isb
+
+	ldr	x0, =(CNTHCTL_EL1PCEN | CNTHCTL_EL1PCTEN)
+	msr	cnthctl_el2, x0
+	msr	cntvoff_el2, xzr
+
+	ldr	x0, =CPTR_EL2_RES1
+	msr	cptr_el2, x0
+
+	msr	vttbr_el2, xzr
+	msr	vbar_el2, xzr
+
+	mrs	x0, midr_el1
+	msr	vpidr_el2, x0
+
+	mrs	x0, mpidr_el1
+	msr	vmpidr_el2, x0
+
+	ldr	x0, =HCR_RW
+	msr	hcr_el2, x0
+	mrs	x0, hcr_el2
+
+	msr	hstr_el2, xzr
+	msr	cptr_el2, xzr
+
+	mrs	x0, midr_el1
+	mov	w0, w0
+	lsr	w1, w0, #24	// Implementor
+	cmp	w1, #0x41	// ARM
+	b.ne	not_cortex_0
+	ubfx	w1, w0, #16, #4	// Architecture
+	cmp	w1, #0xF
+	b.ne	not_cortex_0
+	ubfx	w1, w0, #4, #12	// Part
+	cmp	w1, #0xD08	// -A72
+	b.eq	cortex_a72_0
+	cmp	w1, #0xD07	// -A57
+	b.eq	cortex_a57_0
+				// *not* -A55
+	cmp	w1, #0xD03	// -A53
+	b.eq	cortex_a53_0
+	b	not_cortex_0
+cortex_a72_0:
+cortex_a57_0:
+cortex_a53_0:
+	// access L2ACTLR L2ECTLR L2CTLR CPUECTLR CPUACTLR
+	mrs	x0, actlr_el2
+	orr	x0, x0, #0x70
+	orr	x0, x0, #0x3
+	msr	actlr_el2, x0
+not_cortex_0:
+
+	ldr	x0, =(PSR_F | PSR_I | PSR_M_EL1h)
+	msr	spsr_el2, x0
+	msr	elr_el2, x30
+
+	dsb sy
+	isb
+	eret
+
+el1:
+	bl	dcache_clean_all
+
+	/*
+	 * disable mmu, cache
+	 *
+	 * but save the current value so we can turn it all on later
+	 */
+	mrs	x27, sctlr_el1
+	ldr	x0, =SCTLR_EL1_RES1
+	msr	sctlr_el1, x0
+	dsb	sy
+	isb
+
+	// enable cache coherence on Cortex-A5x
+	mrs	x0, midr_el1
+	mov	w0, w0
+	lsr	w1, w0, #24	// Implementor
+	cmp	w1, #0x41	// ARM Inc.
+	b.ne	not_cortex_1
+	ubfx	w1, w0, #16, #4	// Architecture
+	cmp	w1, #0xF
+	b.ne	not_cortex_1
+	ubfx	w1, w0, #4, #12	// Part
+	// XXXARM: The -A72 TRM is wishy washy about whether this is
+	// necessary, but it is _possible_.
+	cmp	w1, #0xD08	// Cortex-A72
+	b.eq	cortex_a72_1
+	cmp	w1, #0xD07	// Cortex-A57
+	b.eq	cortex_a57_1
+	// NB: Explicitly _not_ A55
+	cmp	w1, #0xD03	// Cortex-A53
+	b.eq	cortex_a53_1
+	b	not_cortex_1
+
+cortex_a72_1:
+cortex_a57_1:
+cortex_a53_1:
+	// CPUECTLR_EL1.SMPEN -> 1 (enable cache coherence)
+	mrs	x0, s3_1_c15_c2_1
+	tbnz	x0, #6, not_cortex_1
+	orr	x0, x0, #(1<<6)
+	msr	s3_1_c15_c2_1, x0
+	dsb	sy
+	isb
+not_cortex_1:
+
+	/*
+	 * Re-enable MMU and caches, disable alignment errors.
+	 *
+	 * UEFI boots us with caches on and the MMU configured, so there's
+	 * no need to leave it off.
+	 *
+	 * XXXARM: this is a bit sketchy, should probably remove it
+	 */
+	and	x27, x27, #(SCTLR_I)
+	and	x27, x27, #(SCTLR_C)
+	and	x27, x27, #(SCTLR_M)
+	bic	x27, x27, #(SCTLR_A)
+	mrs	x27, sctlr_el1
+
+	mrs	x0, cpacr_el1
+	bic	x0, x0, #CPACR_FPEN_MASK
+	//orr	x0, x0, #CPACR_FPEN_DIS
+	msr	cpacr_el1, x0
+
+	/*
+	 * The stack still points to the loader stack
+	 */
+	mov	x0, x28
+	adrp	x1, _DYNAMIC
+	add	x1, x1, :lo12:_DYNAMIC
+	bl	self_reloc
+
+	ldr	x1, =_BootStackTop
+	mov	sp, x1
+
+	mov	x0, x19
+	bl	main
+
+	b	_reset
+	SET_SIZE(_start)
+
+	ENTRY(dcache_flush_all)
+	mrs	x0, clidr_el1
+	and	w3, w0, #0x07000000
+	lsr	w3, w3, #23
+	cbz	w3, 4f
+	mov	w10, #0
+	mov	w8, #1
+0:	add	w2, w10, w10, lsr #1
+	lsr	w1, w0, w2
+	and	w1, w1, #0x7
+	cmp	w1, #2
+	b.lt	3f
+	msr	csselr_el1, x10
+	isb
+	mrs	x1, ccsidr_el1
+	and	w2, w1, #7
+	add	w2, w2, #4
+	ubfx	w4, w1, #3, #10
+	clz	w5, w4
+	lsl	w9, w4, w5
+	lsl	w16, w8, w5
+1:	ubfx	w7, w1, #13, #15
+	lsl	w7, w7, w2
+	lsl	w17, w8, w2
+2:	orr	w11, w10, w9
+	orr	w11, w11, w7
+	dc	cisw, x11
+	subs	w7, w7, w17
+	b.ge	2b
+	subs	x9, x9, x16
+	b.ge	1b
+3:	add	w10, w10, #2
+	cmp	w3, w10
+	dsb	sy
+	b.gt	0b
+4:	ret
+	SET_SIZE(dcache_flush_all)
+
+	ENTRY(dcache_clean_all)
+	mrs	x0, clidr_el1
+	and	w3, w0, #0x07000000
+	lsr	w3, w3, #23
+	cbz	w3, 4f
+	mov	w10, #0
+	mov	w8, #1
+0:	add	w2, w10, w10, lsr #1
+	lsr	w1, w0, w2
+	and	w1, w1, #0x7
+	cmp	w1, #2
+	b.lt	3f
+	msr	csselr_el1, x10
+	isb
+	mrs	x1, ccsidr_el1
+	and	w2, w1, #7
+	add	w2, w2, #4
+	ubfx	w4, w1, #3, #10
+	clz	w5, w4
+	lsl	w9, w4, w5
+	lsl	w16, w8, w5
+1:	ubfx	w7, w1, #13, #15
+	lsl	w7, w7, w2
+	lsl	w17, w8, w2
+2:	orr	w11, w10, w9
+	orr	w11, w11, w7
+	dc	csw, x11
+	subs	w7, w7, w17
+	b.ge	2b
+	subs	x9, x9, x16
+	b.ge	1b
+3:	add	w10, w10, #2
+	cmp	w3, w10
+	dsb	sy
+	b.gt	0b
+4:	ret
+	SET_SIZE(dcache_clean_all)
+
+	ENTRY(dcache_invalidate_all)
+	mrs	x0, clidr_el1
+	and	w3, w0, #0x07000000
+	lsr	w3, w3, #23
+	cbz	w3, 4f
+	mov	w10, #0
+	mov	w8, #1
+0:	add	w2, w10, w10, lsr #1
+	lsr	w1, w0, w2
+	and	w1, w1, #0x7
+	cmp	w1, #2
+	b.lt	3f
+	msr	csselr_el1, x10
+	isb
+	mrs	x1, ccsidr_el1
+	and	w2, w1, #7
+	add	w2, w2, #4
+	ubfx	w4, w1, #3, #10
+	clz	w5, w4
+	lsl	w9, w4, w5
+	lsl	w16, w8, w5
+1:	ubfx	w7, w1, #13, #15
+	lsl	w7, w7, w2
+	lsl	w17, w8, w2
+2:	orr	w11, w10, w9
+	orr	w11, w11, w7
+	dc	isw, x11
+	subs	w7, w7, w17
+	b.ge	2b
+	subs	x9, x9, x16
+	b.ge	1b
+3:	add	w10, w10, #2
+	cmp	w3, w10
+	dsb	sy
+	b.gt	0b
+4:	ret
+	SET_SIZE(dcache_invalidate_all)
+
+	.balign	2048
+	ENTRY(exception_vector)
+	/*
+	 * From Current Exception level with SP_EL0
+	 */
+	.balign	0x80
+from_current_el_sp0_sync:
+0:	b	0b
+
+	.balign	0x80
+from_current_el_sp0_irq:
+0:	b	0b
+
+	.balign	0x80
+from_current_el_sp0_fiq:
+0:	b	0b
+
+	.balign	0x80
+from_current_el_sp0_error:
+0:	b	0b
+
+	/*
+	 * From Current Exception level with SP_ELx
+	 */
+	.balign	0x80
+from_current_el_sync:
+	b	from_current_el_sync_handle
+
+	.balign	0x80
+from_current_el_irq:
+0:
+	ldr	x0, =0x021c0600
+	mov	w1, #'X'
+	strb	w1, [x0]
+	b	0b
+
+	.balign	0x80
+from_current_el_fiq:
+0:
+	ldr	x0, =0x021c0600
+	mov	w1, #'Y'
+	strb	w1, [x0]
+	b	0b
+
+	.balign	0x80
+from_current_el_error:
+0:
+	ldr	x0, =0x021c0600
+	mov	w1, #'Z'
+	strb	w1, [x0]
+	b	0b
+
+
+	/*
+	 * From Lower Exception level using aarch64
+	 */
+	.balign	0x80
+from_lower_el_aarch64_sync:
+0:	b	0b
+
+	.balign	0x80
+from_lower_el_aarch64_irq:
+0:	b	0b
+
+	.balign	0x80
+from_lower_el_aarch64_fiq:
+0:	b	0b
+
+	.balign	0x80
+from_lower_el_aarch64_error:
+0:	b	0b
+
+
+	/*
+	 * From Lower Exception level using aarch32
+	 */
+	.balign	0x80
+from_lower_el_aarch32_sync:
+0:	b	0b
+
+	.balign	0x80
+from_lower_el_aarch32_irq:
+0:	b	0b
+
+	.balign	0x80
+from_lower_el_aarch32_fiq:
+0:	b	0b
+
+	.balign	0x80
+from_lower_el_aarch32_error:
+0:	b	0b
+
+	.balign	0x80
+from_current_el_sync_handle:
+	sub	sp, sp, #(16 * 16)
+	stp	x0, x1, [sp, #(0 * 16)]
+	stp	x2, x3, [sp, #(1 * 16)]
+	stp	x4, x5, [sp, #(2 * 16)]
+	stp	x6, x7, [sp, #(3 * 16)]
+	stp	x8, x9, [sp, #(4 * 16)]
+	stp	x10, x11, [sp, #(5 * 16)]
+	stp	x12, x13, [sp, #(6 * 16)]
+	stp	x14, x15, [sp, #(7 * 16)]
+	stp	x16, x17, [sp, #(8 * 16)]
+	stp	x18, x19, [sp, #(9 * 16)]
+	stp	x20, x21, [sp, #(10 * 16)]
+	stp	x22, x23, [sp, #(11 * 16)]
+	stp	x24, x25, [sp, #(12 * 16)]
+	stp	x26, x27, [sp, #(13 * 16)]
+	stp	x28, x29, [sp, #(14 * 16)]
+	str	x30,      [sp, #(15 * 16)]
+	mov	x0, sp
+	bl	dump_exception
+0:	b	0b
+	SET_SIZE(exception_vector)

--- a/usr/src/uts/armv8/dboot/dboot_standalloc.c
+++ b/usr/src/uts/armv8/dboot/dboot_standalloc.c
@@ -1,0 +1,552 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+ * Use is subject to license terms.
+ */
+/*
+ * Copyright 2017 Hayashi Naoyuki
+ * Copyright 2025 Michael van der Westhuizen
+ */
+
+#include <sys/systm.h>
+#include <sys/pte.h>
+#include <sys/machparam.h>
+#include <sys/memlist.h>
+#include <sys/efi.h>
+#include <sys/bootinfo.h>
+#include <sys/controlregs.h>
+#include <sys/cpuid.h>
+#include <sys/sysmacros.h>
+#include <sys/int_fmtio.h>
+#include <sys/bootinfo.h>
+#include <sys/framebuffer.h>
+#include <sys/efifb.h>
+
+#include "saio.h"
+#include "dboot.h"
+#include "dboot_printf.h"
+
+extern void kmem_init(void);
+extern void map_phys(pte_t pte_attr, caddr_t vaddr,
+    uint64_t paddr, size_t bytes);
+extern uint64_t memlist_get(uint64_t size, int align, struct memlist **listp);
+
+#define	IS_KERNEL_MAPPING(__va)	(((uint64_t)(__va)) & (1UL << 55))
+
+extern struct efi_map_header *efi_map_header;
+extern struct memlist *pfreelistp;
+extern caddr_t memlistpage;
+extern caddr_t _BootScratch;
+extern caddr_t _BootScratchEnd;
+
+extern void init_physmem(void);
+
+static caddr_t scratch_used_top;
+static pte_t *l1_ptbl0;
+static pte_t *l1_ptbl1;
+
+static void init_pt(void);
+static void dump_tables(uint64_t tab, uint64_t va_offset);
+
+static inline int
+l1_pteidx(caddr_t vaddr)
+{
+	return ((((uintptr_t)vaddr) >> (PAGESHIFT + 3 * NPTESHIFT)) &
+	    ((1 << NPTESHIFT) - 1));
+}
+
+static inline int
+l2_pteidx(caddr_t vaddr)
+{
+	return ((((uintptr_t)vaddr) >> (PAGESHIFT + 2 * NPTESHIFT)) &
+	    ((1 << NPTESHIFT) - 1));
+}
+
+static inline int
+l3_pteidx(caddr_t vaddr)
+{
+	return ((((uintptr_t)vaddr) >> (PAGESHIFT + 1 * NPTESHIFT)) &
+	    ((1 << NPTESHIFT) - 1));
+}
+
+static inline int
+l4_pteidx(caddr_t vaddr)
+{
+	return ((((uintptr_t)vaddr) >> (PAGESHIFT)) & ((1 << NPTESHIFT) - 1));
+}
+
+
+void
+init_memory(void)
+{
+	kmem_init();
+	init_pt();
+}
+
+void
+init_memlists(void)
+{
+	scratch_used_top = _BootScratch;
+	memlistpage = scratch_used_top;
+	scratch_used_top += MMU_PAGESIZE;
+
+	init_physmem();
+}
+
+/* Page Table Initialization */
+static void
+init_pt(void)
+{
+	uint64_t fbaddr;
+	uintptr_t paddr;
+	uintptr_t pa;
+	uintptr_t sz;
+	struct memlist *ml;
+	extern struct xboot_info *bi;
+
+	fbaddr = 0;
+	if (bi != NULL && bi->bi_framebuffer != 0) {
+		boot_framebuffer_t *bfb =
+		    (boot_framebuffer_t *)bi->bi_framebuffer;
+		if (bfb->framebuffer != 0) {
+			struct efi_fb *fb = (struct efi_fb *)bfb->framebuffer;
+			fbaddr = RNDDN(fb->fb_addr, MMU_PAGESIZE);
+		}
+	}
+
+	if ((paddr = memlist_get(MMU_PAGESIZE, MMU_PAGESIZE, &pfreelistp)) == 0)
+		panic("phy alloc error for L1 PT\n");
+	memset((void *)paddr, 0, MMU_PAGESIZE);
+	l1_ptbl0 = (pte_t *)paddr;
+
+	if ((paddr = memlist_get(MMU_PAGESIZE, MMU_PAGESIZE, &pfreelistp)) == 0)
+		panic("phy alloc error for L1 PT\n");
+	memset((void *)paddr, 0, MMU_PAGESIZE);
+	l1_ptbl1 = (pte_t *)paddr;
+
+	/*
+	 * Memory that can be normally mapped. This is a subset of physical
+	 * memory and removes the reserved, firmware code and firmware data
+	 * spans.
+	 *
+	 * This memory is mapped to both the lower address space and the
+	 * segkpm region. When in the lower region, it's marked as executable,
+	 * since we just don't know at this point. When in segkpm it's simply
+	 * marked as read/write.
+	 */
+	for (ml = pmappablep; ml != NULL; ml = ml->ml_next) {
+		map_phys(PTE_UXN|PTE_AF|PTE_NG|PTE_SH_INNER|
+		    PTE_AP_KRWUNA|PTE_ATTR_NORMEM,
+		    (caddr_t)ml->ml_address,
+		    ml->ml_address, ml->ml_size);
+		map_phys(PTE_UXN|PTE_PXN|PTE_AF|PTE_NG|PTE_SH_INNER|
+		    PTE_AP_KRWUNA|PTE_ATTR_NORMEM,
+		    (caddr_t)(ml->ml_address + SEGKPM_BASE),
+		    ml->ml_address, ml->ml_size);
+	}
+
+	/*
+	 * Memory reserved by UEFI is mapped as read-only.
+	 *
+	 * Under U-Boot this nominally includes the FDT, but loader copies
+	 * the FDT to read/write memory to apply fixups, then passes the
+	 * fixed FDT. Note that this memory is reclaimable, so `unix` creates
+	 * another copy of the FDT once the kernel memory subsystem is up and
+	 * before boot scratch memory is reclaimed.
+	 */
+	for (ml = prsvdlistp; ml != NULL; ml = ml->ml_next) {
+		map_phys(PTE_UXN|PTE_PXN|PTE_AF|PTE_SH_INNER|
+		    PTE_AP_KROUNA|PTE_ATTR_NORMEM,
+		    (caddr_t)ml->ml_address,
+		    ml->ml_address, ml->ml_size);
+		map_phys(PTE_UXN|PTE_PXN|PTE_AF|PTE_SH_INNER|
+		    PTE_AP_KROUNA|PTE_ATTR_NORMEM,
+		    (caddr_t)(ml->ml_address + SEGKPM_BASE),
+		    ml->ml_address, ml->ml_size);
+	}
+
+	/*
+	 * Firmware code is mapped to the lower address space as executable
+	 * by privileged modes and to the segkpm region as read-only.
+	 *
+	 * This memory will be appropriately mapped in via an address space
+	 * when calling UEFI runtime services.
+	 */
+	for (ml = pfwcodelistp; ml != NULL; ml = ml->ml_next) {
+		map_phys(PTE_UXN|PTE_AF|PTE_SH_INNER|
+		    PTE_AP_KRWUNA|PTE_ATTR_NORMEM,
+		    (caddr_t)ml->ml_address,
+		    ml->ml_address, ml->ml_size);
+		map_phys(PTE_UXN|PTE_PXN|PTE_AF|PTE_SH_INNER|
+		    PTE_AP_KROUNA|PTE_ATTR_NORMEM,
+		    (caddr_t)(ml->ml_address + SEGKPM_BASE),
+		    ml->ml_address, ml->ml_size);
+	}
+
+	/*
+	 * Firmware data is mapped to the lower address space as read/write
+	 * and to the segkpm region as read-only.
+	 *
+	 * This memory will be appropriately mapped in via an address space
+	 * when calling UEFI runtime services.
+	 */
+	for (ml = pfwdatalistp; ml != NULL; ml = ml->ml_next) {
+		map_phys(PTE_UXN|PTE_PXN|PTE_AF|PTE_SH_INNER|
+		    PTE_AP_KRWUNA|PTE_ATTR_NORMEM,
+		    (caddr_t)ml->ml_address,
+		    ml->ml_address, ml->ml_size);
+		map_phys(PTE_UXN|PTE_PXN|PTE_AF|PTE_SH_INNER|
+		    PTE_AP_KROUNA|PTE_ATTR_NORMEM,
+		    (caddr_t)(ml->ml_address + SEGKPM_BASE),
+		    ml->ml_address, ml->ml_size);
+	}
+
+	/*
+	 * We do not create device mappings in segkpm. That's for physical
+	 * memory only.
+	 */
+	for (ml = pldriolistp; ml != NULL; ml = ml->ml_next) {
+		if (fbaddr != 0 && ml->ml_address == fbaddr) {
+			/* XXXARM: we need a proper write-combining mapping */
+			map_phys(PTE_UXN|PTE_PXN|PTE_AF|PTE_NG|PTE_SH_INNER|
+			    PTE_AP_KRWUNA|PTE_ATTR_UNORDERED,
+			    (caddr_t)ml->ml_address,
+			    ml->ml_address, ml->ml_size);
+			continue;
+		}
+
+		map_phys(PTE_UXN|PTE_PXN|PTE_AF|PTE_NG|PTE_SH_INNER|
+		    PTE_AP_KRWUNA|PTE_ATTR_DEVICE,
+		    (caddr_t)ml->ml_address,
+		    ml->ml_address, ml->ml_size);
+	}
+
+	uint64_t mair = ((MAIR_ATTR_nGnRnE    << (MAIR_STRONG_ORDER * 8)) |
+	    (MAIR_ATTR_nGnRE	<< (MAIR_DEVICE * 8)) |
+	    (MAIR_ATTR_IWB_OWB	<< (MAIR_NORMAL_MEMORY * 8)) |
+	    (MAIR_ATTR_IWT_OWT	<< (MAIR_NORMAL_MEMORY_WT * 8)) |
+	    (MAIR_ATTR_INC_ONC	<< (MAIR_NORMAL_MEMORY_UC * 8)) |
+	    (MAIR_ATTR_nGRE	<< (MAIR_UNORDERED * 8)));
+
+	uint64_t tcr =
+	    ((uint64_t)MMFR0_PARANGE(read_id_aa64mmfr0()) << TCR_IPS_SHIFT) |
+	    TCR_TG1_4K | TCR_SH1_ISH | TCR_ORGN1_WBWA | TCR_IRGN1_WBWA |
+	    TCR_T1SZ_256T | TCR_TG0_4K | TCR_SH0_ISH | TCR_ORGN0_WBWA |
+	    TCR_IRGN0_WBWA | TCR_T0SZ_256T;
+
+	uint64_t sctlr = SCTLR_EL1_RES1 | SCTLR_UCI | SCTLR_UCT | SCTLR_DZE |
+	    SCTLR_I | SCTLR_C | SCTLR_M;
+
+	write_mair(mair);
+	write_tcr(tcr);
+	write_ttbr0((uint64_t)l1_ptbl0);
+	write_ttbr1((uint64_t)l1_ptbl1);
+	isb();
+
+#if 0
+	if (debug) {
+		dboot_printf("Lower Memory Tables\n");
+		dump_tables((uint64_t)l1_ptbl0, 0);
+		dboot_printf("Upper Memory Tables\n");
+		dump_tables((uint64_t)l1_ptbl1, SEGKPM_BASE);
+	}
+#endif
+
+	tlbi_allis();
+	dsb(ish);
+	isb();
+
+	dsb(ish);
+	write_sctlr(sctlr);
+	isb();
+}
+
+static paddr_t
+alloc_pagetable_page(const char *lvl)
+{
+	paddr_t pa;
+	if ((pa = memlist_get(MMU_PAGESIZE, MMU_PAGESIZE, &pfreelistp)) == 0)
+		panic("phy alloc error for %s PT\n", lvl);
+	memset((void *)(uintptr_t)pa, 0, MMU_PAGESIZE);
+	return (pa);
+}
+
+static void
+map_pages(pte_t pte_attr, caddr_t vaddr, uint64_t paddr, size_t bytes)
+{
+	int l1_idx = l1_pteidx(vaddr);
+	int l2_idx = l2_pteidx(vaddr);
+	int l3_idx = l3_pteidx(vaddr);
+	int l4_idx = l4_pteidx(vaddr);
+
+	pte_t *l1_ptbl = IS_KERNEL_MAPPING(vaddr) ? l1_ptbl1 : l1_ptbl0;
+
+	if ((l1_ptbl[l1_idx] & PTE_TYPE_MASK) == 0)
+		l1_ptbl[l1_idx] = PTE_TABLE_APT_NOUSER|PTE_TABLE_UXNT|
+		    PTE_TABLE|alloc_pagetable_page("L1");
+	if ((l1_ptbl[l1_idx] & PTE_VALID) == 0)
+		panic("invalid L1 PT\n");
+
+	pte_t *l2_ptbl = (pte_t *)(uintptr_t)(l1_ptbl[l1_idx] & PTE_PFN_MASK);
+
+	if (bytes == MMU_PAGESIZE1G) {
+		if ((uintptr_t)vaddr & (MMU_PAGESIZE1G - 1))
+			panic("invalid vaddr slignment (1G)\n");
+		if (paddr & (MMU_PAGESIZE1G - 1))
+			panic("invalid paddr slignment (1G)\n");
+		if (l2_ptbl[l2_idx] & PTE_VALID)
+			panic("invalid L2 PT\n");
+		l2_ptbl[l2_idx] = paddr|pte_attr|PTE_BLOCK;
+		dsb(ish);
+		return;
+	}
+
+	if ((l2_ptbl[l2_idx] & PTE_TYPE_MASK) == 0)
+		l2_ptbl[l2_idx] = PTE_TABLE_APT_NOUSER|PTE_TABLE_UXNT|
+		    PTE_TABLE|alloc_pagetable_page("L2");
+	if ((l2_ptbl[l2_idx] & PTE_TYPE_MASK) != PTE_TABLE)
+		panic("invalid L2 PT\n");
+
+	pte_t *l3_ptbl = (pte_t *)(uintptr_t)(l2_ptbl[l2_idx] & PTE_PFN_MASK);
+
+	if (bytes == MMU_PAGESIZE2M) {
+		if ((uintptr_t)vaddr & (MMU_PAGESIZE2M - 1))
+			panic("invalid vaddr alignment (2M)\n");
+		if (paddr & (MMU_PAGESIZE2M - 1))
+			panic("invalid paddr alignment (2M)\n");
+		if (l3_ptbl[l3_idx] & PTE_VALID)
+			panic("invalid L3 PT\n");
+		l3_ptbl[l3_idx] = paddr|pte_attr|PTE_BLOCK;
+		dsb(ish);
+		return;
+	}
+
+	if ((l3_ptbl[l3_idx] & PTE_TYPE_MASK) == 0)
+		l3_ptbl[l3_idx] = PTE_TABLE_APT_NOUSER|PTE_TABLE_UXNT|
+		    PTE_TABLE|alloc_pagetable_page("L3");
+	if ((l3_ptbl[l3_idx] & PTE_TYPE_MASK) != PTE_TABLE)
+		panic("invalid L3 PT\n");
+
+	pte_t *l4_ptbl = (pte_t *)(uintptr_t)(l3_ptbl[l3_idx] & PTE_PFN_MASK);
+	if (bytes == MMU_PAGESIZE) {
+		if ((uintptr_t)vaddr & (MMU_PAGESIZE - 1))
+			panic("invalid vaddr alignment (4K)\n");
+		if (paddr & (MMU_PAGESIZE - 1))
+			panic("invalid paddr alignment (4K)\n");
+		if (l4_ptbl[l4_idx] & PTE_VALID)
+			panic("invalid L4 PT\n");
+		l4_ptbl[l4_idx] = paddr|pte_attr|PTE_PAGE;
+		dsb(ish);
+		return;
+	}
+
+	panic("invalid size\n");
+}
+
+void
+map_phys(pte_t pte_attr, caddr_t vaddr, uint64_t paddr, size_t bytes)
+{
+	if (((uintptr_t)vaddr % MMU_PAGESIZE) != 0) {
+		panic("map_phys invalid vaddr\n");
+	}
+	if ((paddr % MMU_PAGESIZE) != 0) {
+		panic("map_phys invalid paddr\n");
+	}
+	if ((bytes % MMU_PAGESIZE) != 0) {
+		panic("map_phys invalid size\n");
+	}
+
+	while (bytes) {
+		uintptr_t va = (uintptr_t)vaddr;
+		size_t maxalign = va & (-va);
+		size_t mapsz;
+
+		/*
+		 * XXXARM: These calculations are terribly suspicious
+		 */
+		if (maxalign >= MMU_PAGESIZE1G && bytes >= MMU_PAGESIZE1G &&
+		    paddr >= MMU_PAGESIZE1G) {
+			mapsz = MMU_PAGESIZE1G;
+		} else if (maxalign >= MMU_PAGESIZE2M &&
+		    bytes >= MMU_PAGESIZE2M && paddr >= MMU_PAGESIZE2M) {
+			mapsz = MMU_PAGESIZE2M;
+		} else {
+			mapsz = MMU_PAGESIZE;
+		}
+
+		map_pages(pte_attr, vaddr, paddr, mapsz);
+		bytes -= mapsz;
+		vaddr += mapsz;
+		paddr += mapsz;
+	}
+}
+
+static caddr_t
+get_low_vpage(size_t bytes)
+{
+	caddr_t v;
+
+	if ((scratch_used_top + bytes) <= _BootScratchEnd) {
+		v = scratch_used_top;
+		scratch_used_top += bytes;
+		return (v);
+	}
+
+	return (NULL);
+}
+
+caddr_t
+resalloc(enum RESOURCES type, size_t bytes, caddr_t virthint, int align)
+{
+	caddr_t	vaddr = 0;
+	uintptr_t paddr = 0;
+
+	if (bytes != 0) {
+		/* extend request to fill a page */
+		bytes = roundup(bytes, MMU_PAGESIZE);
+		dprintf("resalloc:  bytes = %lu\n", bytes);
+		switch (type) {
+		case RES_BOOTSCRATCH:
+			vaddr = get_low_vpage(bytes);
+			break;
+		case RES_CHILDVIRT:
+			vaddr = virthint;
+			while (bytes) {
+				uintptr_t va = (uintptr_t)virthint;
+				size_t maxalign = va & (-va);
+				size_t mapsz;
+				if (maxalign >= MMU_PAGESIZE1G &&
+				    bytes >= MMU_PAGESIZE1G) {
+					mapsz = MMU_PAGESIZE1G;
+				} else if (maxalign >= MMU_PAGESIZE2M &&
+				    bytes >= MMU_PAGESIZE2M) {
+					mapsz = MMU_PAGESIZE2M;
+				} else {
+					mapsz = MMU_PAGESIZE;
+				}
+				paddr = memlist_get(mapsz, mapsz, &pfreelistp);
+				if (paddr == 0) {
+					panic("phys mem allocate error\n");
+				}
+				map_phys(PTE_AF | PTE_SH_INNER | PTE_AP_KRWUNA |
+				    PTE_ATTR_NORMEM, virthint, paddr, mapsz);
+				bytes -= mapsz;
+				virthint += mapsz;
+			}
+			break;
+		default:
+			dprintf("Bad resurce type\n");
+			break;
+		}
+	}
+
+	return (vaddr);
+}
+
+void
+reset_alloc(void)
+{
+}
+
+void
+resfree(enum RESOURCES type, caddr_t virtaddr, size_t size)
+{
+}
+
+static void
+dump_tables(uint64_t tab, uint64_t va_offset)
+{
+	uint_t shift_amt[] = {12, 21, 30, 39};
+	uint_t save_index[4];   /* for recursion */
+	char *save_table[4];    /* for recursion */
+	uint_t top_level = 3;
+	uint_t ptes_per_table = 512;
+	uint_t  l;
+	uint64_t va;
+	uint64_t pgsize;
+	int index;
+	int i;
+	pte_t pteval;
+	char *table;
+	static char *tablist = "\t\t\t";
+	char *tabs = tablist + 3 - top_level;
+	paddr_t pa, pa1;
+
+	table = (char *)(uintptr_t)tab;
+	l = top_level;
+	va = va_offset;
+
+	for (index = 0; index < ptes_per_table; ++index) {
+		pgsize = 1ull << shift_amt[l];
+		pteval = ((pte_t *)table)[index];
+		if (!(pteval & PTE_VALID))
+			goto next_entry;
+
+		dboot_printf("%s [L%u] 0x%p[%u] = 0x%" PRIx64 ", va=0x%" PRIx64,
+		    tabs + l, l, (void *)table, index, (uint64_t)pteval, va);
+		pa = pteval & PTE_PFN_MASK;
+		if (l == 0 ||
+		    (l != 0 && (pteval & PTE_TYPE_MASK) == PTE_BLOCK)) {
+			dboot_printf(" physaddr=0x%" PRIx64 "\n", pa);
+		} else {
+			dboot_printf(" => 0x%" PRIx64 "\n", pa);
+		}
+
+		if (l > 0 && (pteval & PTE_TYPE_MASK) == PTE_TABLE) {
+			save_table[l] = table;
+			save_index[l] = index;
+			--l;
+			index = -1;
+			table = (char *)(uintptr_t)(pteval & PTE_PFN_MASK);
+			goto recursion;
+		}
+
+		/*
+		 * shorten dump for consecutive mappings
+		 */
+		for (i = 1; index + i < ptes_per_table; ++i) {
+			pteval = ((pte_t *)table)[index + i];
+			if (!(pteval & PTE_TYPE_MASK))
+				break;
+			pa1 = (pteval & PTE_PFN_MASK);
+			if (pa1 != pa + (i * pgsize))
+				break;
+		}
+
+		if (i > 2) {
+			dboot_printf("%s...\n", tabs + l);
+			va += pgsize * (i - 2);
+			index += i - 2;
+		}
+next_entry:
+		va += pgsize;
+recursion:
+		;
+	}
+
+	if (l < top_level) {
+		++l;
+		index = save_index[l];
+		table = save_table[l];
+		goto recursion;
+	}
+}

--- a/usr/src/uts/armv8/dboot/dboot_standalone.c
+++ b/usr/src/uts/armv8/dboot/dboot_standalone.c
@@ -1,0 +1,16 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2025 Michael van der Westhuizen
+ */
+
+int errno = 0;

--- a/usr/src/uts/armv8/dboot/dboot_uefimem.c
+++ b/usr/src/uts/armv8/dboot/dboot_uefimem.c
@@ -1,0 +1,54 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2025 Michael van der Westhuizen
+ */
+
+#include <sys/types.h>
+#include <sys/bootinfo.h>
+#include <sys/null.h>
+
+#include "dboot.h"
+
+struct efi_map_header *efi_map_header = NULL;
+
+caddr_t _BootScratch;
+caddr_t _BootScratchEnd;
+
+struct memlist *pfreelistp = NULL;
+struct memlist *pscratchlistp = NULL;
+struct memlist *pinstalledp = NULL;
+struct memlist *pmappablep = NULL;
+struct memlist *piolistp = NULL;
+struct memlist *pldriolistp = NULL;
+struct memlist *ptmplistp = NULL;
+struct memlist *pfwcodelistp = NULL;
+struct memlist *pfwdatalistp = NULL;
+struct memlist *prsvdlistp = NULL;
+
+extern void init_memlists(void);
+extern void init_memory(void);
+
+int
+dboot_uefi_init_mem(caddr_t memmap, caddr_t scratch_addr, uint64_t scratch_size)
+{
+	efi_map_header = (struct efi_map_header *)memmap;
+	_BootScratch = scratch_addr;
+	_BootScratchEnd = scratch_addr + scratch_size;
+
+	init_memlists();
+	init_memory();
+
+	/* set the pointers */
+
+	return (0);
+}

--- a/usr/src/uts/armv8/dboot/memlist.c
+++ b/usr/src/uts/armv8/dboot/memlist.c
@@ -1,0 +1,152 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
+ * Use is subject to license terms.
+ */
+/*
+ * Copyright 2017 Hayashi Naoyuki
+ */
+
+#include <sys/types.h>
+#include <sys/systm.h>
+#include <sys/param.h>
+#include <sys/sysmacros.h>
+#include <sys/machparam.h>
+#include <sys/bootconf.h>
+
+#include "dboot.h"
+#include "dboot_printf.h"
+
+extern caddr_t memlistpage;
+
+/* Always pts to the next free link in the headtable */
+/* i.e. it is always memlistpage+tableoffset */
+caddr_t tablep = NULL;
+static int table_freespace;
+
+/*
+ *	Function prototypes
+ */
+extern void 		reset_alloc(void);
+
+void
+print_memlist(struct memlist *av)
+{
+	struct memlist *p = av;
+
+	while (p != NULL) {
+		dboot_printf("addr = 0x%x:0x%x, size = 0x%x:0x%x\n",
+		    (uint_t)(p->ml_address >> 32), (uint_t)p->ml_address,
+		    (uint_t)(p->ml_size >> 32), (uint_t)p->ml_size);
+		p = p->ml_next;
+	}
+
+}
+
+/* allocate room for n bytes, return 8-byte aligned address */
+void *
+getlink(uint_t n)
+{
+	void *p;
+	extern int pagesize;
+
+	if (memlistpage == NULL)
+		reset_alloc();
+
+	if (tablep == NULL) {
+		/*
+		 * Took the following 2 lines out of above test for
+		 * memlistpage == null so we can initialize table_freespace
+		 */
+		table_freespace = pagesize - sizeof (struct bsys_mem);
+		tablep = memlistpage + sizeof (struct bsys_mem);
+		tablep = (caddr_t)roundup((uintptr_t)tablep, 8);
+	}
+
+	if (n == 0)
+		return (NULL);
+
+	n = roundup(n, 8);
+	p = tablep;
+
+	table_freespace -= n;
+	tablep += n;
+	if (table_freespace <= 0) {
+		dboot_panic("Boot getlink(): no memlist space (need %d)\n", n);
+	}
+
+	return (p);
+}
+
+
+/*
+ * This is the number of memlist structures allocated in one shot. kept
+ * to small number to reduce wastage of memory, it should not be too small
+ * to slow down boot.
+ */
+#define		ALLOC_SZ	5
+static struct memlist *free_memlist_ptr = NULL;
+
+/*
+ * Free memory lists are maintained as simple single linked lists.
+ * get_memlist_struct returns a memlist structure without initializing
+ * any of the fields.  It is caller's responsibility to do that.
+ */
+
+struct memlist *
+get_memlist_struct(void)
+{
+	struct memlist *ptr;
+	int i;
+
+	if (free_memlist_ptr == NULL) {
+		ptr = free_memlist_ptr = getlink(ALLOC_SZ *
+		    sizeof (struct memlist));
+		bzero(free_memlist_ptr, (ALLOC_SZ * sizeof (struct memlist)));
+		for (i = 0; i < ALLOC_SZ; i++)
+			ptr[i].ml_next = &ptr[i+1];
+		ptr[i-1].ml_next = NULL;
+	}
+	ptr = free_memlist_ptr;
+	free_memlist_ptr = ptr->ml_next;
+	return (ptr);
+}
+
+/*
+ * Return memlist structure to free list.
+ */
+void
+add_to_freelist(struct memlist *ptr)
+{
+	struct memlist *tmp;
+
+	if (ptr) {
+		ptr->ml_next = NULL;
+	}
+	if (free_memlist_ptr == NULL) {
+		free_memlist_ptr = ptr;
+	} else {
+		for (tmp = free_memlist_ptr; tmp->ml_next; tmp = tmp->ml_next)
+			;
+		tmp->ml_next = ptr;
+	}
+}

--- a/usr/src/uts/armv8/dboot/saio.h
+++ b/usr/src/uts/armv8/dboot/saio.h
@@ -1,0 +1,60 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License, Version 1.0 only
+ * (the "License").  You may not use this file except in compliance
+ * with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright 2005 Sun Microsystems, Inc.  All rights reserved.
+ * Use is subject to license terms.
+ */
+
+#ifndef	_SYS_SAIO_H
+#define	_SYS_SAIO_H
+
+/*
+ * NOTE: This header file is a vestige from a previous era.  The RESOURCES
+ *	 enum should be move somewhere more appropriate (with an accompanying
+ *	 proper prototype for resalloc()) and this should be removed.
+ */
+
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Types of resources that can be allocated by resalloc().
+ */
+enum RESOURCES {
+	RES_MAINMEM,		/* Main memory, accessible to CPU */
+	RES_RAWVIRT,		/* Raw addr space that can be mapped */
+	RES_DMAMEM,		/* Memory acc. by CPU and by all DMA I/O */
+	RES_DMAVIRT,		/* Raw addr space accessible by DMA I/O */
+	RES_PHYSICAL,		/* Physical address */
+	RES_VIRTALLOC,		/* Virtual addresses used */
+	RES_BOOTSCRATCH,	/* Memory <4MB used only by boot. */
+	RES_CHILDVIRT		/* Virt anywhere, phys > 4MB */
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _SYS_SAIO_H */

--- a/usr/src/uts/armv8/dboot/standalloc.c
+++ b/usr/src/uts/armv8/dboot/standalloc.c
@@ -1,0 +1,90 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License, Version 1.0 only
+ * (the "License").  You may not use this file except in compliance
+ * with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright 2005 Sun Microsystems, Inc.  All rights reserved.
+ * Use is subject to license terms.
+ */
+
+#pragma ident	"%Z%%M%	%I%	%E% SMI"
+
+#include <sys/types.h>
+#include <sys/null.h>
+#include <sys/systm.h>
+#include <sys/sysmacros.h>
+#include <sys/bootconf.h>
+
+#include "saio.h"
+#include "dboot_printf.h"
+
+#ifdef DEBUG
+static int	resalloc_debug = 1;
+#else /* DEBUG */
+static int	resalloc_debug = 0;
+#endif /* DEBUG */
+#define	dprintf	if (resalloc_debug) dboot_printf
+
+extern	caddr_t		resalloc(enum RESOURCES type,
+				size_t bytes, caddr_t virthint, int align);
+extern	void		resfree(enum RESOURCES type,
+				caddr_t virtaddr, size_t bytes);
+
+caddr_t		memlistpage;
+extern int	pagesize;
+
+/*
+ *  This routine should be called get_a_page().
+ *  It allocates from the appropriate entity one or
+ *  more pages and maps them in.
+ */
+
+caddr_t
+kern_resalloc(caddr_t virthint, size_t size, int align)
+{
+	if (virthint != 0)
+		return (resalloc(RES_CHILDVIRT, size, virthint, align));
+	else {
+		return (resalloc(RES_BOOTSCRATCH, size, NULL, 0));
+	}
+}
+
+int
+get_progmemory(caddr_t vaddr, size_t size, int align)
+{
+	uintptr_t n;
+
+	/*
+	 * if the vaddr given is not a mult of PAGESIZE,
+	 * then we rounddown to a page, but keep the same
+	 * ending addr.
+	 */
+	n = (uintptr_t)vaddr & (pagesize - 1);
+	if (n) {
+		vaddr -= n;
+		size += n;
+	}
+
+	dprintf("get_progmemory: requesting %lx bytes at %p\n", size,
+	    (void *)vaddr);
+	if (resalloc(RES_CHILDVIRT, size, vaddr, align) != vaddr)
+		return (-1);
+	return (0);
+}

--- a/usr/src/uts/armv8/io/consplat.c
+++ b/usr/src/uts/armv8/io/consplat.c
@@ -20,13 +20,19 @@
  */
 
 /*
- * Copyright 2017 Hayashi Naoyuki
+ * Copyright (c) 2012 Gary Mills
+ *
  * Copyright 2010 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
  */
 
 /*
- * isa-specific console configuration routines
+ * Copyright 2017 Hayashi Naoyuki
+ * Copyright 2025 Michael van der Westhuizen
+ */
+
+/*
+ * console configuration routines
  */
 
 #include <sys/types.h>
@@ -44,6 +50,101 @@
 #include <sys/modctl.h>
 #include <sys/termios.h>
 #include <sys/obpdefs.h>
+#include <sys/boot_console.h>
+#include <sys/framebuffer.h>
+
+char *plat_fbpath(void);
+
+static int
+console_type(int *tnum)
+{
+	static int boot_console = CONS_INVALID;
+	static int tty_num = 0;
+
+	char *cons;
+	dev_info_t *root;
+
+	/* If we already have determined the console, just return it. */
+	if (boot_console != CONS_INVALID) {
+		if (tnum != NULL)
+			*tnum = tty_num;
+		return (boot_console);
+	}
+
+	/*
+	 * The console is defined by the "console" property. This is
+	 * documented as being overridden by the "os_console" property,
+	 * but there is absolutely no code in unix for any platform
+	 * that implements that, so we don't either.
+	 *
+	 * `console` will have been trimmed to exactly one element
+	 * by the early kernel code.
+	 *
+	 * If the console is a TTY, we deviate from i86pc by allowing
+	 * `ttya`-`ttyz` (where i86pc does `ttya`-`ttyd`). This is done
+	 * because there is no architected limit to the number of TTY
+	 * lines we may have.
+	 */
+	root = ddi_root_node();
+	ASSERT3P(root, !=, NULL);
+	if (ddi_prop_lookup_string(DDI_DEV_T_ANY, root,
+	    DDI_PROP_DONTPASS, "console", &cons) == DDI_SUCCESS) {
+		if (strlen(cons) == 4 && strncmp(cons, "tty", 3) == 0 &&
+		    cons[3] >= 'a' && cons[3] <= 'z') {
+			boot_console = CONS_TTY;
+			tty_num = cons[3] - 'a';
+		} else if (strcmp(cons, "usb-serial") == 0) {
+			(void) i_ddi_attach_hw_nodes("xhci");
+			(void) i_ddi_attach_hw_nodes("ehci");
+			(void) i_ddi_attach_hw_nodes("uhci");
+			(void) i_ddi_attach_hw_nodes("ohci");
+
+			/*
+			 * USB device enumerate asynchronously.
+			 * Wait 2 seconds for USB serial devices to attach.
+			 */
+			delay(drv_usectohz(2000000));
+			boot_console = CONS_USBSER;
+		} else if (strcmp(cons, "text") == 0) {
+			boot_console = CONS_SCREEN_TEXT;
+		}
+
+		ddi_prop_free(cons);
+	}
+
+	/*
+	 * If we don't yet have a console type, or if we have a framebuffer
+	 * type and there's no framebuffer available then we fall back to
+	 * the bootloader-provided default UART or boot console UART.
+	 *
+	 * If these are not available then we are out of ideas.
+	 */
+	if (boot_console == CONS_INVALID ||
+	    (boot_console == CONS_SCREEN_TEXT && plat_fbpath() == NULL)) {
+		if (ddi_prop_lookup_string(DDI_DEV_T_ANY, root,
+		    DDI_PROP_DONTPASS, "default-uart-name", &cons) ==
+		    DDI_SUCCESS || ddi_prop_lookup_string(DDI_DEV_T_ANY, root,
+		    DDI_PROP_DONTPASS, "bcons.uart.name", &cons) ==
+		    DDI_SUCCESS) {
+			if (strlen(cons) == 4 && strncmp(cons, "tty", 3) == 0 &&
+			    cons[3] >= 'a' && cons[3] <= 'z') {
+				boot_console = CONS_TTY;
+				tty_num = cons[3] - 'a';
+			} else {
+				boot_console = CONS_INVALID;
+			}
+
+			ddi_prop_free(cons);
+		} else {
+			boot_console = CONS_INVALID;
+		}
+	}
+
+	if (tnum != NULL)
+		*tnum = tty_num;
+
+	return (boot_console);
+}
 
 int
 plat_use_polled_debug()
@@ -60,133 +161,244 @@ plat_support_serial_kbd_and_ms()
 int
 plat_stdin_is_keyboard(void)
 {
-	return (0);
+	return (console_type(NULL) == CONS_SCREEN_TEXT);
 }
 
 int
 plat_stdout_is_framebuffer(void)
 {
-	return (0);
+	return (console_type(NULL) == CONS_SCREEN_TEXT);
+}
+
+static char *
+plat_devpath(char *name, char *path)
+{
+	major_t major;
+	dev_info_t *dip, *pdip;
+
+	if ((major = ddi_name_to_major(name)) == (major_t)-1)
+		return (NULL);
+
+	if ((dip = devnamesp[major].dn_head) == NULL)
+		return (NULL);
+
+	pdip = ddi_get_parent(dip);
+	if (i_ddi_attach_node_hierarchy(pdip) != DDI_SUCCESS)
+		return (NULL);
+	if (ddi_initchild(pdip, dip) != DDI_SUCCESS)
+		return (NULL);
+
+	(void) ddi_pathname(dip, path);
+
+	return (path);
 }
 
 char *
 plat_kbdpath(void)
 {
-	return (NULL);
+	static char kbpath[MAXPATHLEN];
+
+	if (plat_devpath("kb8042", kbpath) == NULL)
+		return (NULL);
+
+	return (kbpath);
 }
 
+/*
+ * For now we're going to keep this very simple and simply find the efifb
+ * device hanging off the root node.
+ */
 char *
 plat_fbpath(void)
 {
+	static char *fbpath = NULL;
+	static char fbpath_buf[MAXPATHLEN];
+
+	dev_info_t *dip;
+	char *cname;
+
+	if (fbpath != NULL)
+		return (fbpath);
+
+	for (dip = ddi_get_child(ddi_root_node()); dip != NULL;
+	    dip = ddi_get_next_sibling(dip)) {
+		if ((cname = ddi_node_name(dip)) == NULL)
+			continue;
+		if (strcmp(cname, "efifb") != 0)
+			continue;
+		if (i_ddi_attach_node_hierarchy(dip) != DDI_SUCCESS)
+			return (NULL);
+
+		(void) ddi_pathname(dip, fbpath_buf);
+		if (fbpath_buf[0] == '\0')
+			return (NULL);
+
+		fbpath = fbpath_buf;
+		return (fbpath);
+	}
+
 	return (NULL);
 }
 
 char *
 plat_mousepath(void)
 {
-	return (NULL);
+	static char mpath[MAXPATHLEN];
+
+	if (plat_devpath("mouse8042", mpath) == NULL)
+		return (NULL);
+
+	return (mpath);
 }
 
 static char *
-plat_ttypath(void)
+plat_ttypath(int inum)
 {
-	int len;
-	static char *ttypath = NULL;
-	char buf[MAXPATHLEN];
+	static char path[MAXPATHLEN];
+	char *bp;
+	major_t major;
+	dev_info_t *dip;
 
-	if (ttypath != NULL)
-		return (ttypath);
-
-	len = prom_getproplen(prom_chosennode(), OBP_STDOUTPATH);
-	if (len <= 0)
+	if (inum < 0 || inum > 25)
 		return (NULL);
 
-
-	prom_getprop(prom_chosennode(), OBP_STDOUTPATH, buf);
-	buf[len] = '\0';
-
-	char *p = strchr(buf, ':');
-	if (p != NULL)
-		*p = '\0';
-
-	/* If the path appears relative, it refers to an alias */
-	if (buf[0] != '/') {
-		pnode_t node = prom_finddevice("/aliases");
-		if (node <= 0) {
-			return (NULL);
-		}
-
-		int nlen = prom_getproplen(node, buf);
-		if (nlen <= 0) {
-			return (NULL);
-		}
-
-		char b[MAXPATHLEN];
-		prom_getprop(node, buf, b);
-		bcopy(b, buf, MAXPATHLEN);
-		len = nlen;
-	}
-
-	ttypath = kmem_zalloc(MAXPATHLEN, KM_SLEEP);
-	if (i_ddi_prompath_to_devfspath(buf, ttypath) != DDI_SUCCESS) {
-		kmem_free(ttypath, MAXPATHLEN);
+	/* XXXARM: we really need to work on asy */
+	if ((major = ddi_name_to_major("ns16550a")) == (major_t)-1)
 		return (NULL);
+
+	if ((dip = devnamesp[major].dn_head) == NULL)
+		return (NULL);
+
+	for (; dip != NULL; dip = ddi_get_next(dip)) {
+		if (i_ddi_attach_node_hierarchy(dip) != DDI_SUCCESS)
+			continue;
+
+		if (DEVI(dip)->devi_minor->ddm_name[0] == ('a' + (char)inum))
+			break;
 	}
 
-	return (ttypath);
+	if (dip == NULL)
+		return (NULL);
+
+	(void) ddi_pathname(dip, path);
+	if (path[0] == '\0')
+		return (NULL);
+
+	bp = path + strlen(path);
+	(void) snprintf(bp, 3, ":%s", DEVI(dip)->devi_minor->ddm_name);
+
+	return (path);
+}
+
+/* return path of first usb serial device */
+static char *
+plat_usbser_path(void)
+{
+	/* XXXARM: let's get USB working before we try to implement this */
+	return (NULL);
 }
 
 char *
 plat_stdinpath(void)
 {
-	return (plat_ttypath());
+	int tty_num = 0;
+
+	switch (console_type(&tty_num)) {
+	case CONS_TTY:
+		return (plat_ttypath(tty_num));
+	case CONS_USBSER:
+		return (plat_usbser_path());
+	case CONS_SCREEN_TEXT:
+		break;
+	default:
+		break;
+	}
+
+	return (plat_kbdpath());
 }
 
 char *
 plat_stdoutpath(void)
 {
-	return (plat_ttypath());
+	int tty_num = 0;
+
+	switch (console_type(&tty_num)) {
+	case CONS_TTY:
+		return (plat_ttypath(tty_num));
+	case CONS_USBSER:
+		return (plat_usbser_path());
+	case CONS_SCREEN_TEXT:
+		break;
+	default:
+		break;
+	}
+
+	return (plat_fbpath());
 }
 
 char *
 plat_diagpath(void)
 {
-	return (plat_stdoutpath());
+	dev_info_t *root;
+	char *diag;
+	int tty_num = -1;
+
+	root = ddi_root_node();
+
+	if (ddi_prop_lookup_string(DDI_DEV_T_ANY, root, DDI_PROP_DONTPASS,
+	    "diag-device", &diag) == DDI_SUCCESS) {
+		if (strlen(diag) == 4 && strncmp(diag, "tty", 3) == 0 &&
+		    diag[3] >= 'a' && diag[3] <= 'z') {
+			tty_num = diag[3] - 'a';
+		}
+
+		ddi_prop_free(diag);
+	}
+
+	if (tty_num != -1)
+		return (plat_ttypath(tty_num));
+
+	return (NULL);
 }
 
 void
 plat_tem_get_colors(uint8_t *fg, uint8_t *bg)
 {
+	*fg = fb_info.fg_color;
+	*bg = fb_info.bg_color;
 }
 
 void
 plat_tem_get_inverses(int *inverse, int *inverse_screen)
 {
-	*inverse = 0;
-	*inverse_screen = 0;
+	*inverse = fb_info.inverse == B_TRUE? 1 : 0;
+	*inverse_screen = fb_info.inverse_screen == B_TRUE? 1 : 0;
 }
 
 void
 plat_tem_get_prom_font_size(int *charheight, int *windowtop)
 {
-	*charheight = 0;
-	*windowtop = 0;
+	*charheight = fb_info.font_height;
+	*windowtop = fb_info.terminal_origin.y;
 }
 
 void
 plat_tem_get_prom_size(size_t *height, size_t *width)
 {
-	panic("unimplemented at line %d of %s", __LINE__, __FILE__);
+	*height = fb_info.terminal.y;
+	*width = fb_info.terminal.x;
 }
 
 void
 plat_tem_hide_prom_cursor(void)
 {
-	panic("unimplemented at line %d of %s", __LINE__, __FILE__);
+	if (boot_console_type(NULL) == CONS_FRAMEBUFFER)
+		boot_fb_cursor(B_FALSE);
 }
 
 void
 plat_tem_get_prom_pos(uint32_t *row, uint32_t *col)
 {
-	panic("unimplemented at line %d of %s", __LINE__, __FILE__);
+	*row = fb_info.cursor.pos.y;
+	*col = fb_info.cursor.pos.x;
 }

--- a/usr/src/uts/armv8/ml/genassym.cf
+++ b/usr/src/uts/armv8/ml/genassym.cf
@@ -139,6 +139,9 @@ define	CP_PHYSIO		offsetof(struct copyops, cp_physio)
 define	PSR_M_MASK		PSR_M_MASK
 define	PSR_M_EL0t		PSR_M_EL0t
 define	PSR_C			PSR_C
+define	PSR_I			PSR_I
+define	PSR_F			PSR_F
+define	PSR_M_EL1h		PSR_M_EL1h
 define	PSR_SS_BIT		PSR_SS_BIT
 define	LMS_SYSTEM		LMS_SYSTEM
 define	LMS_USER		LMS_USER
@@ -211,6 +214,8 @@ define NCPU		NCPU
 
 define SPSR_EL3_VAL	(PSR_F | PSR_I | PSR_M_EL1h)
 define SPSR_EL2_VAL	(PSR_F | PSR_I | PSR_M_EL1h)
+
+define SCTLR_EL1_RES1	SCTLR_EL1_RES1
 
 define HCR_RW		HCR_RW
 define CNTHCTL_EL1PCTEN	CNTHCTL_EL1PCTEN

--- a/usr/src/uts/armv8/unix/Makefile
+++ b/usr/src/uts/armv8/unix/Makefile
@@ -39,6 +39,8 @@ include $(UTSBASE)/../Makefile.master
 #	Define the module and object file sets.
 #
 UNIX		= unix
+DBOOT		= dboot
+DBOOT_MAPFILE	= $(UTSBASE)/armv8/unix/dboot/Mapfile.dboot
 OBJECTS		= $(SPECIAL_OBJS:%=$(OBJS_DIR)/%) \
 		  $(CORE_OBJS:%=$(OBJS_DIR)/%) \
 		  $(MACH_NOT_YET_KMODS:%=$(OBJS_DIR)/%)
@@ -63,6 +65,13 @@ GENOPTS		= -L$(GENUNIX_DIR)/$(OBJS_DIR) -l$(GENUNIX)
 LIBOPTS		= $(GENOPTS) $(PLATOPTS)
 
 CTFEXTRAOBJS	= $(OBJS_DIR)/vers.o
+
+DBOOT_OBJS_DIR	= dboot/$(OBJS_DIR)
+DBOOT_OBJECTS	= $(DBOOT_OBJS:%=$(DBOOT_OBJS_DIR)/%)
+DBOOT_SYMS	= $(DBOOT_OBJS_DIR)/$(DBOOT)
+DBOOT_BIN	= $(DBOOT_OBJS_DIR)/$(DBOOT).bin
+DBOOT_O		= $(OBJS_DIR)/$(DBOOT).o
+DBOOT_S		= $(DBOOT_O:%.o=%.s)
 
 #
 #	Include common rules.
@@ -89,9 +98,13 @@ UNIX_DIR	= .
 #
 CLEANFILES	+= $(UNIX_O) $(MODSTUBS_O) $(KRTLD_O) $(KRTLD_OBJECTS) \
 		   $(OBJS_DIR)/vers.c $(OBJS_DIR)/vers.o \
+		   $(OBJS_DIR)/$(FONT).c $(OBJS_DIR)/$(FONT).o \
 		   $(CPU_OBJ) $(CPULIB) \
 		   $(DTRACESTUBS_O) $(DTRACESTUBS_O:%.o=%.s) $(DTRACESTUBS) \
 		   $(ASSYM_H) $(ZLIB_OBJS:%=$(OBJS_DIR)/%)
+
+CLEANFILES	+= $(DBOOT_O) $(DBOOT_S) $(DBOOT_OBJECTS) \
+		    $(DBOOT_SYMS) $(DBOOT_BIN) $(DBOOT_OBJS_DIR)/$(FONT).c
 
 CLOBBERFILES	= $(CLEANFILES) $(UNIX_BIN)
 
@@ -132,14 +145,16 @@ clean:		$(CLEAN_DEPS)
 
 clobber:	$(CLOBBER_DEPS)
 
-install:  	$(INSTALL_DEPS)
+install:	$(INSTALL_DEPS)
 
 $(UNIX_O):	$(OBJECTS) $(CTFEXTRAOBJS)
 	$(LD) -r -o $@ $(OBJECTS) $(OBJS_DIR)/vers.o
 
-$(UNIX_BIN):	$(UNIX_O) $(MODSTUBS_O) $(KRTLD_O) $(MAPFILE) $(GENLIB) $(DTRACESTUBS)
-	$(LD) -dy -b -o $@ -znointerp -M $(MAPFILE) \
-	    $(UNIX_O) $(MODSTUBS_O) $(KRTLD_O) $(LIBOPTS) $(DTRACESTUBS)
+$(UNIX_BIN):	$(UNIX_O) $(MODSTUBS_O) $(KRTLD_O) $(MAPFILE) $(GENLIB) \
+		$(DTRACESTUBS) $(DBOOT_O)
+	$(LD) -dy -b -o $@ -e dboot_image -znointerp -M $(MAPFILE) \
+	    $(DBOOT_O) $(UNIX_O) $(MODSTUBS_O) $(KRTLD_O) \
+	    $(LIBOPTS) $(DTRACESTUBS)
 	$(CTFMERGE_UNIQUIFY_AGAINST_GENUNIX) $(LIBGEN_OBJS)
 	$(POST_PROCESS)
 
@@ -153,6 +168,38 @@ $(KRTLD_O):	$(KRTLD_OBJECTS)
 $(PLATLIB):
 	?@(cd $(PLAT_DIR); pwd; $(MAKE) all.targ)
 	?@pwd
+
+#
+# dboot rules. For now we use the GNU linker, as we need to create a very
+# specific position-independent executable.
+#
+$(DBOOT_SYMS):	$(DBOOT_OBJS_DIR) $(DBOOT_OBJECTS) \
+		$(DBOOT_MAPFILE)
+	$(GLD) -nostdlib -static -pie --no-dynamic-linker \
+	    --no-warn-rwx-segments -T$(DBOOT_MAPFILE) -o $@ $(DBOOT_OBJECTS)
+
+# XXXARM: GOBJDUMP should be in Makefile.master
+$(DBOOT_BIN):	$(DBOOT_SYMS)
+	if [ `$(GNU_ROOT)/bin/gobjdump -t $(DBOOT_SYMS) | \
+	    fgrep '*UND*' | wc -l` != 0 ]; then \
+		$(GNU_ROOT)/bin/gobjdump -t $(DBOOT_SYMS) | fgrep '*UND*'; \
+		exit 1; \
+	fi
+	$(OBJCOPY) --readonly-text -j .text -j .sdata -j .data \
+	    -j .dynamic -j .dynsym -j .rel.dyn -j .rela.dyn -j .reloc \
+	    -j .eh_frame --output-target=binary $(DBOOT_SYMS) $(DBOOT_BIN)
+
+$(DBOOT_O):	$(DBOOT_BIN)
+	@echo "	.data"					> $(DBOOT_S)
+	@echo "	.globl	dboot_image"			>> $(DBOOT_S)
+	@echo "	.type	dboot_image,@object"		>> $(DBOOT_S)
+	@echo "dboot_image:"				>> $(DBOOT_S)
+	@echo ".incbin \"$(DBOOT_BIN)\""		>> $(DBOOT_S)
+	@echo "	.size	dboot_image, . - dboot_image"	>> $(DBOOT_S)
+	$(COMPILE.s) -o $(DBOOT_O) $(DBOOT_S)
+
+$(DBOOT_OBJS_DIR):
+	-@mkdir -p $@ 2> /dev/null
 
 #
 #	Include common targets.

--- a/usr/src/uts/armv8/unix/dboot/Mapfile.dboot
+++ b/usr/src/uts/armv8/unix/dboot/Mapfile.dboot
@@ -1,0 +1,74 @@
+OUTPUT_ARCH(aarch64)
+ENTRY(_start)
+SECTIONS
+{
+  /* Read-only sections, merged into text segment: */
+  . = 0x0;
+  .text		: {
+    *srt0.o(.text .text.*)
+    *self_reloc.o(.text .text.*)
+    *(.text .stub .text.* .gnu.linkonce.t.*)
+    /* .gnu.warning sections are handled specially by elf32.em. */
+    *(.gnu.warning)
+    *(.plt)
+  }
+  . = ALIGN(16);
+  .data		: {
+    *(.rodata .rodata.* .gnu.linkonce.r.*)
+    *(.rodata1)
+    *(.sdata2 .sdata2.* .gnu.linkonce.s2.*)
+    *(.sbss2 .sbss2.* .gnu.linkonce.sb2.*)
+    *(.opd)
+    *(.data .data.* .gnu.linkonce.d.*)
+    *(.data1)
+    *(.plabel)
+    . = ALIGN(16);
+    __bss_start = .;
+    *(.sbss .sbss.* .gnu.linkonce.sb.*)
+    *(.scommon)
+    *(.dynbss)
+    *(.bss *.bss.*)
+    *(COMMON)
+    . = ALIGN(16);
+    /* 32k of stack */
+    . = . + 0x8000;
+    _BootStackTop = .;
+    __bss_end = .;
+  }
+  . = ALIGN(16);
+  __gp = .;
+  .sdata	: {
+    *(.got.plt .got)
+    *(.sdata .sdata.* .gnu.linkonce.s.*)
+    *(dynsbss)
+    *(.scommon)
+  }
+  . = ALIGN(16);
+  .dynamic	: { *(.dynamic) }
+  . = ALIGN(16);
+  .rela.dyn	: {
+    *(.rela.text .rela.text.* .rela.gnu.linkonce.t.*)
+    *(.rela.rodata .rela.rodata.* .rela.gnu.linkonce.r.*)
+    *(.rela.data .rela.data.* .rela.gnu.linkonce.d.*)
+    *(.rela.got)
+    *(.rela.sdata .rela.sdata.* .rela.gnu.linkonce.s.*)
+    *(.rela.sbss .rela.sbss.* .rela.gnu.linkonce.sb.*)
+    *(.rela.sdata2 .rela.sdata2.* .rela.gnu.linkonce.s2.*)
+    *(.rela.sbss2 .rela.sbss2.* .rela.gnu.linkonce.sb2.*)
+    *(.rela.bss .rela.bss.* .rela.gnu.linkonce.b.*)
+    *(.rela.plt)
+    *(.relset_* .relaset_*)
+    *(.rela.dyn .rela.dyn.*)
+  }
+  . = ALIGN(16);
+  .reloc	: { *(.reloc) }
+  . = ALIGN(16);
+  .dynsym	: { *(.dynsym) }
+  _edata = .;
+
+  /* Unused sections */
+  .interp	: { *(.interp) }
+  .dynstr	: { *(.dynstr) }
+  .hash		: { *(.hash) }
+  _end = .;
+}


### PR DESCRIPTION
Adds `loader(7)` to the build and packaging, then adds `dboot` to the `aarch64` kernel and updates `consplat` to respect loader-provided consoles.

Will be rebased once https://github.com/richlowe/illumos-gate/pull/158 lands.

The build system change in https://github.com/richlowe/arm64-gate/pull/55 needs to be landed at the same time as this change.