### PR TITLE
autoconf: Reintroduce impl_bus_reprobe

### DIFF
--- a/usr/src/uts/armv8/os/ddi_impl.c
+++ b/usr/src/uts/armv8/os/ddi_impl.c
@@ -71,6 +71,7 @@ size_t dma_max_copybuf_size = 0x101000;		/* 1M + 4K */
 uint64_t ramdisk_start, ramdisk_end;
 
 static void impl_bus_initialprobe(void);
+static void impl_bus_reprobe(void);
 
 static void i_ddi_free_unitintr(unit_intr_t *);
 
@@ -3780,6 +3781,7 @@ configure(void)
 	extern void i_ddi_init_root();
 
 	i_ddi_init_root();
+	impl_bus_reprobe();	/* Reprogram devices not set up by firmware */
 
 	i_ddi_attach_hw_nodes("dld");
 }
@@ -3816,6 +3818,23 @@ impl_bus_initialprobe(void)
 	while (probe) {
 		/* run the probe functions */
 		(*probe->probe)(0);
+		probe = probe->next;
+	}
+}
+
+/*
+ * impl_bus_reprobe
+ *	Reprogram devices not set up by firmware.
+ */
+static void
+impl_bus_reprobe(void)
+{
+	struct bus_probe *probe;
+
+	probe = bus_probes;
+	while (probe) {
+		/* run the probe function */
+		(*probe->probe)(1);
 		probe = probe->next;
 	}
 }


### PR DESCRIPTION
This was lost along the way and has reappeared in this form in both the PCIe and ACPI trees. Let's get it into arm64-gate so that it can be shared.

Given that there are no autoconfig modules in arm64-gate at present this change is a no-op there.