### PR TITLE
Make it possible to run unix at EL2

### DIFF
--- a/usr/src/uts/aarch64/sys/bootinfo.h
+++ b/usr/src/uts/aarch64/sys/bootinfo.h
@@ -103,6 +103,7 @@ struct xboot_info {
 	uint64_t		bi_bsvc_uart_mmio_base;
 	uint64_t		bi_arch_timer_freq;
 	uint64_t		bi_framebuffer;
+	uint64_t		bi_hyp_stubs;
 	xbi_bsvc_uart_type_t	bi_bsvc_uart_type;
 	uint32_t		bi_module_cnt;
 	uint32_t		bi_psci_version;

--- a/usr/src/uts/aarch64/sys/controlregs.h
+++ b/usr/src/uts/aarch64/sys/controlregs.h
@@ -21,7 +21,7 @@
 
 /*
  * Copyright 2017 Hayashi Naoyuki
- * Copyright 2024 Michael van der Westhuizen
+ * Copyright 2025 Michael van der Westhuizen
  */
 
 #ifndef _SYS_CONTROLREGS_H
@@ -32,34 +32,278 @@
 #include <sys/types.h>
 #include <asm/controlregs.h>
 
-#define	SCTLR_EL1_RES1	(0x30d00800)
-#define	SCTLR_EL2_RES1	(0x30C50830)
-#define	SCTLR_EL3_RES1	(0x30C50830)
-#define	SCTLR_UCI	(1<<26)
-#define	SCTLR_EE	(1<<25)
-#define	SCTLR_E0E	(1<<24)
-#define	SCTLR_WXN	(1<<19)
-#define	SCTLR_nTWE	(1<<18)
-#define	SCTLR_nTWI	(1<<16)
-#define	SCTLR_UCT	(1<<15)
-#define	SCTLR_DZE	(1<<14)
-#define	SCTLR_I		(1<<12)
-#define	SCTLR_UMA	(1<<9)
-#define	SCTLR_SED	(1<<8)
-#define	SCTLR_ITD	(1<<7)
-#define	SCTLR_CP15BEN	(1<<5)
-#define	SCTLR_SA0	(1<<4)
-#define	SCTLR_SA	(1<<3)
-#define	SCTLR_C		(1<<2)
-#define	SCTLR_A		(1<<1)
-#define	SCTLR_M		(1<<0)
+/*
+ * System Control Register (EL2)
+ */
+#define	SCTLR_EL2_TIDCP		(0x1ul << 63)
+#define	SCTLR_EL2_SPINTMASK	(0x1ul << 62)
+#define	SCTLR_EL2_NMI		(0x1ul << 61)
+#define	SCTLR_EL2_EnTP2		(0x1ul << 60)
+#define	SCTLR_EL2_TCSO		(0x1ul << 59)
+#define	SCTLR_EL2_TCSO0		(0x1ul << 58)
+#define	SCTLR_EL2_EPAN		(0x1ul << 57)
+#define	SCTLR_EL2_EnALS		(0x1ul << 56)
+#define	SCTLR_EL2_EnAS0		(0x1ul << 55)
+#define	SCTLR_EL2_EnASR		(0x1ul << 54)
+#define	SCTLR_EL2_TME		(0x1ul << 53)
+#define	SCTLR_EL2_TME0		(0x1ul << 52)
+#define	SCTLR_EL2_TMT		(0x1ul << 51)
+#define	SCTLR_EL2_TMT0		(0x1ul << 50)
+#define	SCTLR_EL2_TWEDEL	(0xful << 46)
+#define	SCTLR_EL2_TWEDEn	(0x1ul << 45)
+#define	SCTLR_EL2_DSSBS		(0x1ul << 44)
+#define	SCTLR_EL2_ATA		(0x1ul << 43)
+#define	SCTLR_EL2_ATA0		(0x1ul << 42)
+#define	SCTLR_EL2_TCF		(0x3ul << 40)
+#define	SCTLR_EL2_TCF0		(0x3ul << 38)
+#define	SCTLR_EL2_ITFSB		(0x1ul << 37)
+#define	SCTLR_EL2_BT		(0x1ul << 36)
+#define	SCTLR_EL2_BT0		(0x1ul << 35)
+#define	SCTLR_EL2_EnFPM		(0x1ul << 34)
+#define	SCTLR_EL2_MSCEn		(0x1ul << 33)
+#define	SCTLR_EL2_CMOW		(0x1ul << 32)
+#define	SCTLR_EL2_EnIA		(0x1ul << 31)
+#define	SCTLR_EL2_EnIB		(0x1ul << 30)
+#define	SCTLR_EL2_LSMAOE	(0x1ul << 29)
+#define	SCTLR_EL2_nTLSMD	(0x1ul << 28)
+#define	SCTLR_EL2_EnDA		(0x1ul << 27)
+#define	SCTLR_EL2_UCI		(0x1ul << 26)
+#define	SCTLR_EL2_EE		(0x1ul << 25)
+#define	SCTLR_EL2_E0E		(0x1ul << 24)
+#define	SCTLR_EL2_SPAN		(0x1ul << 23)
+#define	SCTLR_EL2_EIS		(0x1ul << 22)
+#define	SCTLR_EL2_IESB		(0x1ul << 21)
+#define	SCTLR_EL2_TSCXT		(0x1ul << 20)
+#define	SCTLR_EL2_WXN		(0x1ul << 19)
+#define	SCTLR_EL2_nTWE		(0x1ul << 18)
+/* bit 17 is reserved */
+#define	SCTLR_EL2_nTWI		(0x1ul << 16)
+#define	SCTLR_EL2_UCT		(0x1ul << 15)
+#define	SCTLR_EL2_DZE		(0x1ul << 14)
+#define	SCTLR_EL2_EnDB		(0x1ul << 13)
+#define	SCTLR_EL2_I		(0x1ul << 12)
+#define	SCTLR_EL2_EOS		(0x1ul << 11)
+#define	SCTLR_EL2_EnRCTX	(0x1ul << 10)
+/* bit 9 is reserved in EL2 */
+#define	SCTLR_EL2_SED		(0x1ul << 8)
+#define	SCTLR_EL2_ITD		(0x1ul << 7)
+#define	SCTLR_EL2_nAA		(0x1ul << 6)
+#define	SCTLR_EL2_CP15BEN	(0x1ul << 5)
+#define	SCTLR_EL2_SA0		(0x1ul << 4)
+#define	SCTLR_EL2_SA		(0x1ul << 3)
+#define	SCTLR_EL2_C		(0x1ul << 2)
+#define	SCTLR_EL2_A		(0x1ul << 1)
+#define	SCTLR_EL2_M		(0x1ul << 0)
 
-#define	HCR_RW		(1<<31)
-#define	CNTHCTL_EL1PCTEN	(1 << 0)
-#define	CNTHCTL_EL1PCEN		(1 << 1)
+#define	SCTLR_EL2_RES1		(SCTLR_EL2_LSMAOE | SCTLR_EL2_nTLSMD | \
+	SCTLR_EL2_SPAN | SCTLR_EL2_EIS | SCTLR_EL2_nTWE | SCTLR_EL2_nTWI | \
+	SCTLR_EL2_EOS | SCTLR_EL2_CP15BEN | SCTLR_EL2_SA0)
 
-#define	CPTR_EL2_RES1	(0x33ff)
+/*
+ * System Control Register (EL1)
+ */
+#define	SCTLR_EL1_TIDCP		(0x1ul << 63)
+#define	SCTLR_EL1_SPINTMASK	(0x1ul << 62)
+#define	SCTLR_EL1_NMI		(0x1ul << 61)
+#define	SCTLR_EL1_EnTP2		(0x1ul << 60)
+#define	SCTLR_EL1_TCSO		(0x1ul << 59)
+#define	SCTLR_EL1_TCSO0		(0x1ul << 58)
+#define	SCTLR_EL1_EPAN		(0x1ul << 57)
+#define	SCTLR_EL1_EnALS		(0x1ul << 56)
+#define	SCTLR_EL1_EnAS0		(0x1ul << 55)
+#define	SCTLR_EL1_EnASR		(0x1ul << 54)
+#define	SCTLR_EL1_TME		(0x1ul << 53)
+#define	SCTLR_EL1_TME0		(0x1ul << 52)
+#define	SCTLR_EL1_TMT		(0x1ul << 51)
+#define	SCTLR_EL1_TMT0		(0x1ul << 50)
+#define	SCTLR_EL1_TWEDEL	(0xful << 46)
+#define	SCTLR_EL1_TWEDEn	(0x1ul << 45)
+#define	SCTLR_EL1_DSSBS		(0x1ul << 44)
+#define	SCTLR_EL1_ATA		(0x1ul << 43)
+#define	SCTLR_EL1_ATA0		(0x1ul << 42)
+#define	SCTLR_EL1_TCF		(0x3ul << 40)
+#define	SCTLR_EL1_TCF0		(0x3ul << 38)
+#define	SCTLR_EL1_ITFSB		(0x1ul << 37)
+#define	SCTLR_EL1_BT1		(0x1ul << 36)
+#define	SCTLR_EL1_BT0		(0x1ul << 35)
+#define	SCTLR_EL1_EnFPM		(0x1ul << 34)
+#define	SCTLR_EL1_MSCEn		(0x1ul << 33)
+#define	SCTLR_EL1_CMOW		(0x1ul << 32)
+#define	SCTLR_EL1_EnIA		(0x1ul << 31)
+#define	SCTLR_EL1_EnIB		(0x1ul << 30)
+#define	SCTLR_EL1_LSMAOE	(0x1ul << 29)
+#define	SCTLR_EL1_nTLSMD	(0x1ul << 28)
+#define	SCTLR_EL1_EnDA		(0x1ul << 27)
+#define	SCTLR_EL1_UCI		(0x1ul << 26)
+#define	SCTLR_EL1_EE		(0x1ul << 25)
+#define	SCTLR_EL1_E0E		(0x1ul << 24)
+#define	SCTLR_EL1_SPAN		(0x1ul << 23)
+#define	SCTLR_EL1_EIS		(0x1ul << 22)
+#define	SCTLR_EL1_IESB		(0x1ul << 21)
+#define	SCTLR_EL1_TSCXT		(0x1ul << 20)
+#define	SCTLR_EL1_WXN		(0x1ul << 19)
+#define	SCTLR_EL1_nTWE		(0x1ul << 18)
+/* bit 17 is reserved */
+#define	SCTLR_EL1_nTWI		(0x1ul << 16)
+#define	SCTLR_EL1_UCT		(0x1ul << 15)
+#define	SCTLR_EL1_DZE		(0x1ul << 14)
+#define	SCTLR_EL1_EnDB		(0x1ul << 13)
+#define	SCTLR_EL1_I		(0x1ul << 12)
+#define	SCTLR_EL1_EOS		(0x1ul << 11)
+#define	SCTLR_EL1_EnRCTX	(0x1ul << 10)
+#define	SCTLR_EL1_EL1_UMA	(0x1ul << 9)
+#define	SCTLR_EL1_SED		(0x1ul << 8)
+#define	SCTLR_EL1_ITD		(0x1ul << 7)
+#define	SCTLR_EL1_nAA		(0x1ul << 6)
+#define	SCTLR_EL1_CP15BEN	(0x1ul << 5)
+#define	SCTLR_EL1_SA0		(0x1ul << 4)
+#define	SCTLR_EL1_SA		(0x1ul << 3)
+#define	SCTLR_EL1_C		(0x1ul << 2)
+#define	SCTLR_EL1_A		(0x1ul << 1)
+#define	SCTLR_EL1_M		(0x1ul << 0)
 
+#define	SCTLR_EL1_RES1		(SCTLR_EL1_LSMAOE | SCTLR_EL1_nTLSMD | \
+	SCTLR_EL1_SPAN | SCTLR_EL1_EIS | SCTLR_EL1_TSCXT | SCTLR_EL1_EOS)
+
+#define	INIT_SCTLR_EL1		(SCTLR_EL1_LSMAOE | SCTLR_EL1_nTLSMD | \
+	SCTLR_EL1_EIS | SCTLR_EL1_TSCXT | SCTLR_EL1_EOS)
+
+/*
+ * Hypervisor Configuration Register
+ */
+#define	HCR_TWEDEL		(0xful << 60)
+#define	HCR_TWEDEn		(0x1ul << 59)
+#define	HCR_TID5		(0x1ul << 58)
+#define	HCR_DCT			(0x1ul << 57)
+#define	HCR_ATA			(0x1ul << 56)
+#define	HCR_TTLBOS		(0x1ul << 55)
+#define	HCR_TTLBIS		(0x1ul << 54)
+#define	HCR_EnSCXT		(0x1ul << 53)
+#define	HCR_TOCU		(0x1ul << 52)
+#define	HCR_AMVOFFEN		(0x1ul << 51)
+#define	HCR_TICAB		(0x1ul << 50)
+#define	HCR_TID4		(0x1ul << 49)
+#define	HCR_GPF			(0x1ul << 48)
+#define	HCR_FIEN		(0x1ul << 47)
+#define	HCR_FWB			(0x1ul << 46)
+#define	HCR_NV2			(0x1ul << 45)
+#define	HCR_AT			(0x1ul << 44)
+#define	HCR_NV1			(0x1ul << 43)
+#define	HCR_NV			(0x1ul << 42)
+#define	HCR_API			(0x1ul << 41)
+#define	HCR_APK			(0x1ul << 40)
+#define	HCR_TME			(0x1ul << 39)
+#define	HCR_MIOCNCE		(0x1ul << 38)
+#define	HCR_TEA			(0x1ul << 37)
+#define	HCR_TERR		(0x1ul << 36)
+#define	HCR_TLOR		(0x1ul << 35)
+#define	HCR_E2H			(0x1ul << 34)
+#define	HCR_ID			(0x1ul << 33)
+#define	HCR_CD			(0x1ul << 32)
+#define	HCR_RW			(0x1ul << 31)
+#define	HCR_TRVM		(0x1ul << 30)
+#define	HCR_HCD			(0x1ul << 29)
+#define	HCR_TDZ			(0x1ul << 28)
+#define	HCR_TGE			(0x1ul << 27)
+#define	HCR_TVM			(0x1ul << 26)
+#define	HCR_TTLB		(0x1ul << 25)
+#define	HCR_TPU			(0x1ul << 24)
+#define	HCR_TPCP		(0x1ul << 23)
+#define	HCR_TSW			(0x1ul << 22)
+#define	HCR_TACR		(0x1ul << 21)
+#define	HCR_TIDCP		(0x1ul << 20)
+#define	HCR_TSC			(0x1ul << 19)
+#define	HCR_TID3		(0x1ul << 18)
+#define	HCR_TID2		(0x1ul << 17)
+#define	HCR_TID1		(0x1ul << 16)
+#define	HCR_TID0		(0x1ul << 15)
+#define	HCR_TWE			(0x1ul << 14)
+#define	HCR_TWI			(0x1ul << 13)
+#define	HCR_DC			(0x1ul << 12)
+#define	HCR_BSU			(0x3ul << 10)
+#define	HCR_FB			(0x1ul << 9)
+#define	HCR_VSE			(0x1ul << 8)
+#define	HCR_VI			(0x1ul << 7)
+#define	HCR_VF			(0x1ul << 6)
+#define	HCR_AMO			(0x1ul << 5)
+#define	HCR_IMO			(0x1ul << 4)
+#define	HCR_FMO			(0x1ul << 3)
+#define	HCR_PTW			(0x1ul << 2)
+#define	HCR_SWIO		(0x1ul << 1)
+#define	HCR_VM			(0x1ul << 0)
+
+/*
+ * Counter-timer Hypervisor Control Register
+ */
+#define	CNTHCTL_CNTPMASK	(0x1ul << 19)
+#define	CNTHCTL_CNTVMASK	(0x1ul << 18)
+#define	CNTHCTL_EVNTIS		(0x1ul << 17)
+#define	CNTHCTL_EL1NVVCT	(0x1ul << 16)
+#define	CNTHCTL_EL1NVPCT	(0x1ul << 15)
+#define	CNTHCTL_EL1TVCT		(0x1ul << 14)
+#define	CNTHCTL_EL1TVT		(0x1ul << 13)
+#define	CNTHCTL_ECV		(0x1ul << 12)
+/* valid when HCR_EL2.E2H is 1 */
+#define	CNTHCTL_E2H_EL1PTEN	(0x1ul << 11)
+#define	CNTHCTL_E2H_EL1PCTEN	(0x1ul << 10)
+#define	CNTHCTL_E2H_EL0PTEN	(0x1ul << 9)
+#define	CNTHCTL_E2H_EL0VTEN	(0x1ul << 8)
+/* always valid */
+#define	CNTHCTL_EVNTI		(0xful << 4)
+#define	CNTHCTL_EVNTDIR		(0x1ul << 3)
+#define	CNTHCTL_EVNTEN		(0x1ul << 2)
+/* valid when HCR_EL2.E2H is 1 */
+#define	CNTHCTL_E2H_EL0VCTEN	(0x1ul << 1)
+#define	CNTHCTL_E2H_EL0PCTEN	(0x1ul << 0)
+/* valid when HCR_EL2.E2H is 0 */
+#define	CNTHCTL_EL1PCEN		(0x1ul << 1)
+#define	CNTHCTL_EL1PCTEN	(0x1ul << 0)
+
+/*
+ * Architectural Feature Trap Register (EL2)
+ */
+#define	CPTR_EL2_TCPAC		(0x1ul << 31)
+#define	CPTR_EL2_TAM		(0x1ul << 30)
+#define	CPTR_EL2_E0POE		(0x1ul << 29)
+#define	CPTR_EL2_TTA		(0x1ul << 28)
+#define	CPTR_EL2_SMEN		(0x3ul << 24)
+#define	CPTR_EL2_FPEN		(0x3ul << 20)
+#define	CPTR_EL2_ZEN		(0x3ul << 16)
+
+/*
+ * XXXARM: cptr_el2 initialisation is sketchy at best, and can easily set
+ * res0 bits when certain features are not implemented. We should do this
+ * a little bit better, in code and querying features.
+ *
+ * For now we just assume that it's ok to set these bits, which is what
+ * FreeBSD does.
+ */
+
+/*
+ * CPTR_EL2 when E2H is enabled.
+ *
+ * Does not cause any known activity to be trapped to EL2 via these control.
+ * This is necessary (for now), since we're not really doing anything special
+ * at EL2 yet.
+ */
+#define	INIT_CPTR_EL2_E2H	(0x23330000ul)
+
+/*
+ * CPTR_EL2 value when E2H is not enabled.
+ *
+ * This was defined as 0x33ff, which causes SVE and SME to be trapped (via
+ * bits 8 and 12 respectively), which is not our intention at all.
+ *
+ * FreeBSD seems to be unaware of SME at present.
+ */
+#define	CPTR_EL2_NO_E2H_TCPAC	(0x1ul << 31)
+#define	CPTR_EL2_NO_E2H_TAM	(0x1ul << 30)
+#define	CPTR_EL2_NO_E2H_TTA	(0x1ul << 20)
+#define	CPTR_EL2_NO_E2H_TSM	(0x1ul << 12)
+#define	CPTR_EL2_NO_E2H_TFP	(0x1ul << 10)
+#define	CPTR_EL2_NO_E2H_TZ	(0x1ul << 8)
+#define	CPTR_EL2_NO_E2H_RES1	(0x22fful)
+#define	INIT_CPTR_EL2_NO_E2H	(CPTR_EL2_NO_E2H_RES1)
 
 #define	CPUECTLR_SMP	(1<<6)
 
@@ -137,9 +381,9 @@
 #define	PSR_USERINIT	PSR_M_EL0t
 #define	PSR_USERMASK	(PSR_N | PSR_Z | PSR_C | PSR_V | PSR_SS)
 
-#define	CPACR_FPEN_MASK	(3<<20)
-#define	CPACR_FPEN_EN	(3<<20)
-#define	CPACR_FPEN_DIS	(0<<20)
+#define	CPACR_FPEN_MASK	(0x3ul << 20)
+#define	CPACR_FPEN_EN	(0x3ul << 20)
+#define	CPACR_FPEN_DIS	(0x0ul << 20)
 
 #define	PAR_ATTR_MASK	(0xFF00000000000000ul)
 #define	PAR_PA_MASK	(0x0000FFFFFFFFF000ul)
@@ -210,8 +454,6 @@
 
 /* hypervisor.h in FreeBSD */
 #define	CPTR_RES1		(0x000033ff)
-#define	ICC_SRE_EL2_EN		(1U << 3)
-#define	ICC_SRE_EL2_SRE		(1U << 0)
 
 #define	SCTLR_RES1		0x30d00800	/* Reserved ARMv8.0, write 1 */
 

--- a/usr/src/uts/armv8/dboot/dboot_machdep.c
+++ b/usr/src/uts/armv8/dboot/dboot_machdep.c
@@ -58,6 +58,7 @@ dump_exception(uint64_t *regs)
 void
 exitto(int (*entrypoint)(struct xboot_info *), struct xboot_info *bi)
 {
+	uint64_t el;
 	boot_framebuffer_t *fb;
 	struct efi_fb *efifb;
 	extern fb_info_t fb_info;
@@ -71,6 +72,10 @@ exitto(int (*entrypoint)(struct xboot_info *), struct xboot_info *bi)
 	bi->bi_fw_data = (uint64_t)pfwdatalistp;
 	bi->bi_fw_mmio = (uint64_t)piolistp;
 	bi->bi_fw_rsvd = (uint64_t)prsvdlistp;
+
+	el = read_CurrentEL();
+	el >>= 2;
+	el &= 0x3;
 
 	if (verbosemode && debug) {
 		dprintf("Installed Memory List:\n");
@@ -116,6 +121,7 @@ exitto(int (*entrypoint)(struct xboot_info *), struct xboot_info *bi)
 		dprintf("  %s: 0x%lx\n", "bi_arch_timer_freq",
 		    bi->bi_arch_timer_freq);
 		dprintf("  %s: 0x%lx\n", "bi_framebuffer", bi->bi_framebuffer);
+		dprintf("  %s: 0x%lx\n", "bi_hyp_stubs", bi->bi_hyp_stubs);
 		dprintf("  %s: 0x%x\n", "bi_bsvc_uart_type",
 		    bi->bi_bsvc_uart_type);
 		dprintf("  %s: 0x%x\n", "bi_module_cnt", bi->bi_module_cnt);
@@ -130,6 +136,7 @@ exitto(int (*entrypoint)(struct xboot_info *), struct xboot_info *bi)
 		    bi->bi_psci_cpu_on_id);
 		dprintf("  %s: 0x%x\n", "bi_psci_migrate_id",
 		    bi->bi_psci_migrate_id);
+		dprintf("Exception Level: %lu\n", el);
 		dprintf("Kernel Entrypoint: 0x%p\n", entrypoint);
 	} else if (verbosemode) {
 		dboot_printf("Boot Information:\n");
@@ -137,6 +144,8 @@ exitto(int (*entrypoint)(struct xboot_info *), struct xboot_info *bi)
 		    bi->bi_fdt == 0 ? "ACPI" : "FDT");
 		dboot_printf("  %s: %s\n", "Command Line",
 		    bi->bi_cmdline == 0 ? "" : (const char *)bi->bi_cmdline);
+		dboot_printf("  %s: %s\n", "Hypervisor Stubs",
+		    bi->bi_hyp_stubs == 0 ? "Absent" : "Present");
 		dboot_printf("  %s: %s\n", "Framebuffer",
 		    bi->bi_framebuffer == 0 ? "Absent" : "Present");
 		dboot_printf("  %s: %luHz\n", "Timer Frequency",
@@ -145,6 +154,7 @@ exitto(int (*entrypoint)(struct xboot_info *), struct xboot_info *bi)
 		    bi->bi_psci_version >> 16, bi->bi_psci_version & 0xffff);
 		dboot_printf("  %s: %s\n", "PSCI Conduit",
 		    bi->bi_psci_conduit_hvc ? "Hypervisor" : "Secure Monitor");
+		dboot_printf("Exception Level: %lu\n", el);
 		dboot_printf("%s: 0x%p\n", "Kernel Entrypoint", entrypoint);
 	}
 

--- a/usr/src/uts/armv8/dboot/dboot_main.c
+++ b/usr/src/uts/armv8/dboot/dboot_main.c
@@ -75,7 +75,7 @@ pa_to_ttbr1(uintptr_t pa)
 }
 
 int
-main(caddr_t modulesp)
+main(caddr_t modulesp, uint64_t hyp_stubs_present)
 {
 	struct boot_modules *bm;
 	caddr_t kernel;
@@ -90,6 +90,8 @@ main(caddr_t modulesp)
 
 	if (dboot_configure(modulesp, bi, &kernel, &kernel_size) != 0)
 		panic("dboot: configuration failed\n");
+
+	bi->bi_hyp_stubs = hyp_stubs_present == 0 ? 0 : 1;
 
 	if (bi->bi_modules == 0 || bi->bi_module_cnt == 0)
 		panic("dboot: no boot modules found\n");

--- a/usr/src/uts/armv8/dboot/dboot_srt0.S
+++ b/usr/src/uts/armv8/dboot/dboot_srt0.S
@@ -28,169 +28,283 @@
 
 	.text
 /*
- * void _start(void)
+ * void _start(caddr_t modulep)
+ *
+ * - x28 contains our physical entry address, used for relocation.
+ * - x27 contains our booted exception level, used to select the
+ *       correct initialisation sequence.
+ * - x26 contains our argument, the loader(7) modules pointer.
+ * - x25 contains a boolean, indicating that the kernel should make
+ *       a hypervisor call to replace hypervisor trap stubs.
  */
 	ENTRY(_start)
+	/* this little dance leaves the physical entry address in x28 */
 	bl	1f
 	sub	x28, lr, #0x4
-	// bic	x28, x28, #0xfff
-	// brk	#0
 	b	2f
 1:	ret
 2:
 1:
-	mov	x19, x0
-	mov	x20, x1
-	mov	x21, x2
-	mov	x22, x18
+	/*
+	 * Stash the booted exception-level to x27, then ensure that it's
+	 * EL1 or EL2.
+	 */
+	mrs	x27, CurrentEL
+	ubfx	x27, x27, #2, #2
+	cmp	x27, #0x2
+	b.eq	1f
+	cmp	x27, #0x1
+	b.eq	1f
+2:	b	2b
 
-	// flush cache (data/inst)
+1:	/*
+	 * At this point we're in either EL1 or EL2. Our entry address is in
+	 * x28 and our booted EL is in x27.
+	 *
+	 * Save our argument to x26.
+	 */
+	mov	x26, x0
+
+	/*
+	 * Flush the data and instruction caches.
+	 */
 	bl	dcache_flush_all
 	ic	iallu
 	dsb	sy
 	isb
 
-	mrs	x0, CurrentEL
-	cmp	x0, #0xc
-	b.eq	el3
+	/*
+	 * Choose our initialisation sequence.
+	 * EL1 is straightforward and simply initialises the EL1 environemnt.
+	 * EL2 is a little more complicated, as it leaves us in a unified EL2
+	 * environment when VHE is present, but drops us to EL1 with a stub
+	 * HVC trap table in place when VHE is not present.
+	 */
+	cmp	x27, #0x1
+	b.ne	2f
+	bl	.Lel1_entry
+	b	.Lrun_dboot
+2:
+	bl	.Lel2_entry
+	b	.Lrun_dboot
 
-	cmp	x0, #0x8
-	b.eq	el2
-
-	b	el1
-el3:
-	// not supported
-	b	el3
-
-el2:
-	bl	0f
-	b	el1
-0:
-	ldr	x0, =SCTLR_EL1_RES1
-	msr	sctlr_el1, x0
-	ldr	x0, =SCTLR_EL2_RES1
-	msr	sctlr_el2, x0
-	dsb	sy
+.Lel1_entry:
+	/* el1 initialisation */
+	ldr	x2, =INIT_SCTLR_EL1
+	msr	sctlr_el1, x2
 	isb
 
-	ldr	x0, =(CNTHCTL_EL1PCEN | CNTHCTL_EL1PCTEN)
-	msr	cnthctl_el2, x0
+	/*
+	 * Apply known errata applicable at EL1.
+	 */
+
+	/*
+	 * Ensure that PSTATE and SPSR_EL1 are in sync. We do this by updating
+	 * SPSR_EL1 and executing an exception return (to EL1), which then
+	 * transfers us to the code that runs dboot.
+	 */
+	mov	x2, #(PSR_D | PSR_A | PSR_I | PSR_F | PSR_M_EL1h)
+	msr	spsr_el1, x2
+	msr	elr_el1, lr
+	eret
+
+.Lel2_entry:
+	/* el2 initialisation */
+	dsb	sy
+
+	ldr	x2, =(SCTLR_EL2_RES1 | SCTLR_EL2_EIS | SCTLR_EL2_EOS)
+	msr	sctlr_el2, x2
+	isb
+
+	/* hypervisor configuration */
+	ldr	x2, =(HCR_RW | HCR_APK | HCR_API | HCR_E2H)
+	msr	hcr_el2, x2
+	/* we might tweak hcr_el2 later, so save it */
+	isb
+	mrs	x4, hcr_el2
+
+	/*
+	 * Load the Virtualization Processor ID Register from the Main ID
+	 * Register.
+	 */
+	mrs	x2, midr_el1
+	msr	vpidr_el2, x2
+
+	/*
+	 * Load the Virtualization Multiprocessor ID Register from the
+	 * Multiprocessor Affinity Register.
+	 */
+	mrs	x2, mpidr_el1
+	msr	vmpidr_el2, x2
+
+	/*
+	 * Set SCTLR_EL1 to a known value so that we can successfully drop
+	 * to EL1 if/when needed.
+	 */
+	ldr	x2, =INIT_SCTLR_EL1
+	msr	sctlr_el1, x2
+
+	/*
+	 * Check if the E2H flag is set in the Hypervisor Control Register.
+	 *
+	 * We attempted to set this bit above, and if it stuck we can use
+	 * virtualisation host extensions (FEAT_VHE) and run the kernel at
+	 * EL2 - otherwise we'll run at EL1.
+	 */
+	tst	x4, #HCR_E2H
+	b.eq	.Lno_vhe
+	mov	x25, #0		/* no HVC stubs necessary */
+
+	/*
+	 * We'll be running the kernel at EL2. Route exceptions that would
+	 * normally be delivered to EL1 to EL2.
+	 */
+	orr	x4, x4, #(HCR_TGE)
+	msr	hcr_el2, x4
+	isb
+
+	/* x2 still contains the value we set in sctlr_el1 */
+	msr	s3_5_c1_c0_0, x2	/* sctlr_el12 */
+	isb
+	ldr	x2, =(INIT_CPTR_EL2_E2H)
+	ldr	x3, =(CNTHCTL_E2H_EL1PCTEN | CNTHCTL_E2H_EL1PTEN)
+	ldr	x5, =(PSR_D | PSR_A | PSR_I | PSR_F | PSR_M_EL2h)
+	b	.Ldone_vhe
+
+.Lno_vhe:
+	/*
+	 * Install a stub Hypervisor trap table that can replace itself
+	 * with a proper function once the kernel is up.
+	 */
+	adrp	x2, hyp_stub_vectors
+	add	x2, x2, :lo12:hyp_stub_vectors
+	msr	vbar_el2, x2
+	mov	x25, #1		/* HVC stubs are installed */
+
+	ldr	x2, =(INIT_CPTR_EL2_NO_E2H)
+	ldr	x3, =(CNTHCTL_EL1PCTEN | CNTHCTL_EL1PCEN)
+	ldr	x5, =(PSR_D | PSR_A | PSR_I | PSR_F | PSR_M_EL1h)
+
+.Ldone_vhe:
+	msr	cptr_el2, x2
+	msr	cnthctl_el2, x3
+	msr	spsr_el2, x5
+
+	/*
+	 * Configure the Extended Hypervisor Configuration Register when
+	 * FEAT_HCX is available.
+	 */
+	mrs	x2, id_aa64mmfr1_el1
+	ubfx	x2, x2, #40, #4
+	cmp	x2, #0
+	b.eq	2f
+	mov	x2, xzr
+	msr	s3_4_c1_c2_2, x2
+	isb
+
+2:
+	/* don't trap to EL2 for CP15 traps */
+	msr	hstr_el2, xzr
+
+	/* set the counter offset to a known value */
 	msr	cntvoff_el2, xzr
 
-	ldr	x0, =CPTR_EL2_RES1
-	msr	cptr_el2, x0
-
+	/*
+	 * There's no vttbr in our setup - we're either a small stub at EL2
+	 * that dispatches to the host at EL1 or we're a unified EL1/EL2, in
+	 * which case we use the EL1 TTBR[01].
+	 */
 	msr	vttbr_el2, xzr
-	msr	vbar_el2, xzr
 
+	/*
+	 * Enable GICv3+ system register access where that's applicable.
+	 */
+	mrs	x2, id_aa64pfr0_el1
+	ubfx	x2, x2, #24, #4
+	cmp	x2, #0
+	b.eq	3f
+	mrs	x2, icc_sre_el2
+	orr	x2, x2, #ICC_SRE_EL2_EN
+	orr	x2, x2, #ICC_SRE_EL2_SRE
+	msr	icc_sre_el2, x2
+
+3:
+	/*
+	 * Apply known errata applicable at EL2.
+	 */
 	mrs	x0, midr_el1
-	msr	vpidr_el2, x0
+	/* examine implementer, must be Arm (0x41) */
+	ubfx	x1, x0, #24, #8
+	cmp	x1, #(MIDR_IMPL_ARM)
+	b.ne	.Lnot_cortex_a5x_0
+	/* examine the architecture, must be 0xf */
+	ubfx	x1, x0, #15, #4
+	cmp	x1, #0xF
+	b.ne	.Lnot_cortex_a5x_0
+	/* examine the part */
+	ubfx	x1, x0, #4, #12
+	cmp	x1, #(MIDR_PART_ARM_CORTEX_A72)
+	b.eq	.Lcortex_a72_0
+	cmp	x1, #(MIDR_PART_ARM_CORTEX_A57)
+	b.eq	.Lcortex_a57_0
+	/* Explicitly _not_ Cortex-A55 */
+	cmp	x1, #(MIDR_PART_ARM_CORTEX_A53)
+	b.eq	.Lcortex_a53_0
+	b	.Lnot_cortex_a5x_0
 
-	mrs	x0, mpidr_el1
-	msr	vmpidr_el2, x0
-
-	ldr	x0, =HCR_RW
-	msr	hcr_el2, x0
-	mrs	x0, hcr_el2
-
-	msr	hstr_el2, xzr
-	msr	cptr_el2, xzr
-
-	mrs	x0, midr_el1
-	mov	w0, w0
-	lsr	w1, w0, #24	// Implementor
-	cmp	w1, #0x41	// ARM
-	b.ne	not_cortex_0
-	ubfx	w1, w0, #16, #4	// Architecture
-	cmp	w1, #0xF
-	b.ne	not_cortex_0
-	ubfx	w1, w0, #4, #12	// Part
-	cmp	w1, #0xD08	// -A72
-	b.eq	cortex_a72_0
-	cmp	w1, #0xD07	// -A57
-	b.eq	cortex_a57_0
-				// *not* -A55
-	cmp	w1, #0xD03	// -A53
-	b.eq	cortex_a53_0
-	b	not_cortex_0
-cortex_a72_0:
-cortex_a57_0:
-cortex_a53_0:
+.Lcortex_a72_0:
+.Lcortex_a57_0:
+.Lcortex_a53_0:
 	// access L2ACTLR L2ECTLR L2CTLR CPUECTLR CPUACTLR
 	mrs	x0, actlr_el2
 	orr	x0, x0, #0x70
 	orr	x0, x0, #0x3
 	msr	actlr_el2, x0
-not_cortex_0:
+.Lnot_cortex_a5x_0:
 
-	ldr	x0, =(PSR_F | PSR_I | PSR_M_EL1h)
-	msr	spsr_el2, x0
+	/*
+	 * Set up and execute an exception return to our target exception
+	 * level, which is either EL1 or EL2. This also synchronises PSTATE.
+	 */
 	msr	elr_el2, x30
-
-	dsb sy
 	isb
 	eret
 
-el1:
-	bl	dcache_clean_all
-
+.Lrun_dboot:
 	/*
-	 * disable mmu, cache
-	 *
-	 * but save the current value so we can turn it all on later
+	 * Apply known errata applicable at EL1 or unified EL1/EL2.
 	 */
-	mrs	x27, sctlr_el1
-	ldr	x0, =SCTLR_EL1_RES1
-	msr	sctlr_el1, x0
-	dsb	sy
-	isb
-
-	// enable cache coherence on Cortex-A5x
 	mrs	x0, midr_el1
-	mov	w0, w0
-	lsr	w1, w0, #24	// Implementor
-	cmp	w1, #0x41	// ARM Inc.
-	b.ne	not_cortex_1
-	ubfx	w1, w0, #16, #4	// Architecture
-	cmp	w1, #0xF
-	b.ne	not_cortex_1
-	ubfx	w1, w0, #4, #12	// Part
-	// XXXARM: The -A72 TRM is wishy washy about whether this is
-	// necessary, but it is _possible_.
-	cmp	w1, #0xD08	// Cortex-A72
-	b.eq	cortex_a72_1
-	cmp	w1, #0xD07	// Cortex-A57
-	b.eq	cortex_a57_1
-	// NB: Explicitly _not_ A55
-	cmp	w1, #0xD03	// Cortex-A53
-	b.eq	cortex_a53_1
-	b	not_cortex_1
+	/* examine implementer, must be Arm (0x41) */
+	ubfx	x1, x0, #24, #8
+	cmp	x1, #(MIDR_IMPL_ARM)
+	b.ne	.Lnot_cortex_a5x_1
+	/* examine the architecture, must be 0xf */
+	ubfx	x1, x0, #15, #4
+	cmp	x1, #0xF
+	b.ne	.Lnot_cortex_a5x_1
+	/* examine the part */
+	ubfx	x1, x0, #4, #12
+	cmp	x1, #(MIDR_PART_ARM_CORTEX_A72)
+	b.eq	.Lcortex_a72_1
+	cmp	x1, #(MIDR_PART_ARM_CORTEX_A57)
+	b.eq	.Lcortex_a57_1
+	/* explicitly _not_ Cortex-A55 */
+	cmp	x1, #(MIDR_PART_ARM_CORTEX_A53)
+	b.eq	.Lcortex_a53_1
+	b	.Lnot_cortex_a5x_1
 
-cortex_a72_1:
-cortex_a57_1:
-cortex_a53_1:
-	// CPUECTLR_EL1.SMPEN -> 1 (enable cache coherence)
+.Lcortex_a72_1:
+.Lcortex_a57_1:
+.Lcortex_a53_1:
+	/* CPUECTLR_EL1.SMPEN -> 1 (enable cache coherence) */
 	mrs	x0, s3_1_c15_c2_1
-	tbnz	x0, #6, not_cortex_1
+	tbnz	x0, #6, .Lnot_cortex_a5x_1
 	orr	x0, x0, #(1<<6)
 	msr	s3_1_c15_c2_1, x0
 	dsb	sy
 	isb
-not_cortex_1:
-
-	/*
-	 * Re-enable MMU and caches, disable alignment errors.
-	 *
-	 * UEFI boots us with caches on and the MMU configured, so there's
-	 * no need to leave it off.
-	 *
-	 * XXXARM: this is a bit sketchy, should probably remove it
-	 */
-	and	x27, x27, #(SCTLR_I)
-	and	x27, x27, #(SCTLR_C)
-	and	x27, x27, #(SCTLR_M)
-	bic	x27, x27, #(SCTLR_A)
-	mrs	x27, sctlr_el1
+.Lnot_cortex_a5x_1:
 
 	mrs	x0, cpacr_el1
 	bic	x0, x0, #CPACR_FPEN_MASK
@@ -208,7 +322,8 @@ not_cortex_1:
 	ldr	x1, =_BootStackTop
 	mov	sp, x1
 
-	mov	x0, x19
+	mov	x0, x26
+	mov	x1, x25
 	bl	main
 
 	b	_reset
@@ -443,3 +558,50 @@ from_current_el_sync_handle:
 	bl	dump_exception
 0:	b	0b
 	SET_SIZE(exception_vector)
+
+	/*
+	 * This set of Hypervisor stub vectors is used during early boot to
+	 * install the kernel's Hypervisor vectors.
+	 *
+	 * The only implemented trap is Synchronous 64-bit EL1, and the only
+	 * thing this does is to install the address passed in x0 to vbar_el2.
+	 */
+	.align	11
+	ENTRY(hyp_stub_vectors)
+	.align	7	/* Synchronous EL2t */
+1:	b	1b
+	.align	7	/* IRQ EL2t */
+1:	b	1b
+	.align	7	/* FIQ EL2t */
+1:	b	1b
+	.align	7	/* SError EL2t */
+1:	b	1b
+
+	.align	7	/* Synchronous EL2h */
+1:	b	1b
+	.align	7	/* IRQ EL2h */
+1:	b	1b
+	.align	7	/* FIQ EL2h */
+1:	b	1b
+	.align	7	/* SError EL2h */
+1:	b	1b
+
+	.align	7	/* Synchronous 64-bit EL1 */
+	msr	vbar_el2, x0
+	eret
+	.align	7	/* IRQ 64-bit EL1 */
+1:	b	1b
+	.align	7	/* FIQ 64-bit EL1 */
+1:	b	1b
+	.align	7	/* SError 64-bit EL1 */
+1:	b	1b
+
+	.align	7	/* Synchronous 32-bit EL1 */
+1:	b	1b
+	.align	7	/* IRQ 32-bit EL1 */
+1:	b	1b
+	.align	7	/* FIQ 32-bit EL1 */
+1:	b	1b
+	.align	7	/* SError 32-bit EL1 */
+1:	b	1b
+	SET_SIZE(hyp_stub_vectors)

--- a/usr/src/uts/armv8/dboot/dboot_standalloc.c
+++ b/usr/src/uts/armv8/dboot/dboot_standalloc.c
@@ -253,8 +253,8 @@ init_pt(void)
 	    TCR_T1SZ_256T | TCR_TG0_4K | TCR_SH0_ISH | TCR_ORGN0_WBWA |
 	    TCR_IRGN0_WBWA | TCR_T0SZ_256T;
 
-	uint64_t sctlr = SCTLR_EL1_RES1 | SCTLR_UCI | SCTLR_UCT | SCTLR_DZE |
-	    SCTLR_I | SCTLR_C | SCTLR_M;
+	uint64_t sctlr = SCTLR_EL1_RES1 | SCTLR_EL1_UCI | SCTLR_EL1_UCT |
+	    SCTLR_EL1_DZE | SCTLR_EL1_I | SCTLR_EL1_C | SCTLR_EL1_M;
 
 	write_mair(mair);
 	write_tcr(tcr);

--- a/usr/src/uts/armv8/io/arm_gtmr.c
+++ b/usr/src/uts/armv8/io/arm_gtmr.c
@@ -26,7 +26,7 @@
 
 /*
  * Copyright 2017 Hayashi Naoyuki
- * Copyright 2024 Michael van der Westhuizen
+ * Copyright 2025 Michael van der Westhuizen
  */
 
 /*
@@ -59,7 +59,7 @@
 #include <sys/xc_levels.h>
 
 #define	EXPECTED_NINTRS		4
-#define	ARM_GTMR_INUM_PHYS_NS	1
+#define	ARM_GTMR_INUM_HYP	3
 #define	ARM_GTMR_INUM_VIRTUAL	2
 
 static ddi_softint_hdl_impl_t cbe_low_hdl =
@@ -378,12 +378,12 @@ arm_gtmr_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 	 * - 2: virtual
 	 * - 3: hypervisor
 	 *
-	 * If booted at EL1 we use the virtual timer (index 2), otherwise we
-	 * use the non-secure physical timer (index 1). We only ever use one
-	 * of the offered interrupts.
+	 * If booted at EL2 we use the hypervisor timer (index 3), otherwise
+	 * we use the virtual timer (index 2). We only ever use one of the
+	 * offered interrupts.
 	 *
-	 * While it is possible to defined a driver.conf(5) for this driver,
-	 * it is highly discouraged, as the only proprty that may make sense
+	 * While it is possible to define a driver.conf(5) for this driver,
+	 * it is highly discouraged, as the only property that may make sense
 	 * is `interrupt-priorities'. If present, `interrupt-priorities' must
 	 * contain an array of four integers and each integer must have the
 	 * value 14 (corresponding to CBE_HIGH_PIL), or the cyclic backend
@@ -401,7 +401,7 @@ arm_gtmr_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 
 	iwanted = 1;
 
-	inum = ARM_GTMR_INUM_PHYS_NS;
+	inum = ARM_GTMR_INUM_HYP;
 	if (CPU->cpu_m.mcpu_boot_el == 1)
 		inum = ARM_GTMR_INUM_VIRTUAL;
 

--- a/usr/src/uts/armv8/ml/genassym.cf
+++ b/usr/src/uts/armv8/ml/genassym.cf
@@ -23,7 +23,8 @@ include <sys/kdi_regs.h>
 include <sys/kdi_svc.h>
 include <sys/cpuid.h>
 
-include <asm/controlregs.h>
+include <sys/controlregs.h>
+include <sys/gic_reg.h>
 
 define	MODS_SIZE		sizeof(struct mod_stub_info)
 define	MODS_INSTFCN		offsetof(struct mod_stub_info, mods_func_adr)
@@ -139,10 +140,19 @@ define	CP_PHYSIO		offsetof(struct copyops, cp_physio)
 define	PSR_M_MASK		PSR_M_MASK
 define	PSR_M_EL0t		PSR_M_EL0t
 define	PSR_C			PSR_C
+define	PSR_D			PSR_D
+define	PSR_A			PSR_A
 define	PSR_I			PSR_I
 define	PSR_F			PSR_F
 define	PSR_M_EL1h		PSR_M_EL1h
+define	PSR_M_EL2h		PSR_M_EL2h
 define	PSR_SS_BIT		PSR_SS_BIT
+
+define	ICC_SRE_EL2_EN		ICC_SRE_EL2_EN
+define	ICC_SRE_EL2_SRE		ICC_SRE_EL2_SRE
+
+define	ICC_SRE_EL1_SRE		ICC_SRE_EL1_SRE
+
 define	LMS_SYSTEM		LMS_SYSTEM
 define	LMS_USER		LMS_USER
 define	NSYSCALL		NSYSCALL
@@ -203,25 +213,46 @@ define	STARTUP_TCR	offsetof(struct cpu_startup_data, tcr)
 define	STARTUP_TTBR0	offsetof(struct cpu_startup_data, ttbr0)
 define	STARTUP_TTBR1	offsetof(struct cpu_startup_data, ttbr1)
 define	STARTUP_SCTLR	offsetof(struct cpu_startup_data, sctlr)
+define	STARTUP_VBAR	offsetof(struct cpu_startup_data, vbar)
 
 define	CPU_AFFINITY	offsetof(struct cpu, cpu_m.affinity)
 
-define SCTLR_I		SCTLR_I
-define SCTLR_C		SCTLR_C
-define SCTLR_A		SCTLR_A
-define SCTLR_M		SCTLR_M
+define SCTLR_EL2_RES1		SCTLR_EL2_RES1
+
+define SCTLR_EL2_I		SCTLR_EL2_I
+define SCTLR_EL2_C		SCTLR_EL2_C
+define SCTLR_EL2_A		SCTLR_EL2_A
+define SCTLR_EL2_M		SCTLR_EL2_M
+define SCTLR_EL2_EIS		SCTLR_EL2_EIS
+define SCTLR_EL2_EOS		SCTLR_EL2_EOS
+
+define INIT_SCTLR_EL1		INIT_SCTLR_EL1
+define SCTLR_EL1_RES1		SCTLR_EL1_RES1
+define SCTLR_EL1_I		SCTLR_EL1_I
+define SCTLR_EL1_C		SCTLR_EL1_C
+define SCTLR_EL1_A		SCTLR_EL1_A
+define SCTLR_EL1_M		SCTLR_EL1_M
+
+define HCR_RW			HCR_RW
+define HCR_APK			HCR_APK
+define HCR_API			HCR_API
+define HCR_E2H			HCR_E2H
+define HCR_TGE			HCR_TGE
+
 define NCPU		NCPU
 
 define SPSR_EL3_VAL	(PSR_F | PSR_I | PSR_M_EL1h)
 define SPSR_EL2_VAL	(PSR_F | PSR_I | PSR_M_EL1h)
 
-define SCTLR_EL1_RES1	SCTLR_EL1_RES1
+define CNTHCTL_E2H_EL1PCTEN	CNTHCTL_E2H_EL1PCTEN
+define CNTHCTL_E2H_EL1PTEN	CNTHCTL_E2H_EL1PTEN
+define CNTHCTL_EL1PCEN		CNTHCTL_EL1PCEN
+define CNTHCTL_EL1PCTEN		CNTHCTL_EL1PCTEN
 
-define HCR_RW		HCR_RW
-define CNTHCTL_EL1PCTEN	CNTHCTL_EL1PCTEN
-define CNTHCTL_EL1PCEN	CNTHCTL_EL1PCEN
-define CPTR_EL2_RES1	CPTR_EL2_RES1
-define SCTLR_EL2_RES1	SCTLR_EL2_RES1
+define CPTR_EL2_NO_E2H_RES1	CPTR_EL2_NO_E2H_RES1
+define INIT_CPTR_EL2_E2H	INIT_CPTR_EL2_E2H
+define INIT_CPTR_EL2_NO_E2H	INIT_CPTR_EL2_NO_E2H
+
 define MPIDR_AFF_MASK	MPIDR_AFF_MASK
 
 define DTRACE_INVOP_NOP	DTRACE_INVOP_NOP

--- a/usr/src/uts/armv8/ml/locore.S
+++ b/usr/src/uts/armv8/ml/locore.S
@@ -21,7 +21,7 @@
  */
 /*
  * Copyright 2017 Hayashi Naoyuki
- * Copyright 2024 Michael van der Westhuizen
+ * Copyright 2025 Michael van der Westhuizen
  */
 
 #include <sys/asm_linkage.h>
@@ -63,117 +63,316 @@ t0:
 
 	.balign 4096
 	ENTRY(secondary_vec_start)
-	// enable SMP cache affinity
-	mrs	x0, midr_el1
-	mov	w0, w0
-	lsr	w1, w0, #24	// Implementator
-	cmp	w1, #MIDR_IMPL_ARM
-	b.ne	not_cortex_1
-	ubfx	w1, w0, #16, #4	// Architecture
-	cmp	w1, #0xF
-	b.ne	not_cortex_1
-	ubfx	w1, w0, #4, #12	// Part
-	// XXXARM: The -A72 TRM is wishy washy about whether this is
-	// necessary, but it is _possible_.
-	cmp	w1, #MIDR_PART_ARM_CORTEX_A72
-	b.eq	cortex_a72_1
-	cmp	w1, #MIDR_PART_ARM_CORTEX_A57
-	b.eq	cortex_a57_1
-	// NB: Explicitly _not_ A55
-	cmp	w1, #MIDR_PART_ARM_CORTEX_A53
-	b.eq	cortex_a53_1
-	b	not_cortex_1
+	/*
+	 * Stash the booted exception-level to x27, then ensure that it's
+	 * EL1 or EL2.
+	 */
+	mrs	x27, CurrentEL
+	ubfx	x27, x27, #2, #2
+	cmp	x27, #0x2
+	b.eq	.Lel2_entry
+	cmp	x27, #0x1
+	b.eq	1f
+3:	b	3b
 
-cortex_a72_1:
-cortex_a57_1:
-cortex_a53_1:
-	// CPUECTLR_EL1.SMPEN -> 1
+.Lel2_entry:
+	bl	.Lel2_body
+	b	.Lel_agnostic
+.Lel2_body:
+	/*
+	 * We're at EL2.
+	 */
+	dsb	sy
+	ldr	x2, =(SCTLR_EL2_RES1 | SCTLR_EL2_EIS | SCTLR_EL2_EOS)
+	msr	sctlr_el2, x2
+	isb
+
+	/*
+	 * Invalidate all caches and the TLB.
+	 */
+	mov	x19, lr
+	bl	dcache_invalidate_all
+	ic	iallu
+	dsb	ish
+	isb
+	tlbi	vmalle1is
+	dsb	ish
+	isb
+	mov	x30, x19
+
+	/* hypervisor configuration */
+	ldr	x2, =(HCR_RW | HCR_APK | HCR_API | HCR_E2H)
+	msr	hcr_el2, x2
+	/* we might tweak hcr_el2 later, so save it */
+	isb
+	mrs	x4, hcr_el2
+
+	/*
+	 * Load the Virtualization Processor ID Register from the Main ID
+	 * Register.
+	 */
+	mrs	x2, midr_el1
+	msr	vpidr_el2, x2
+
+	/*
+	 * Load the Virtualization Multiprocessor ID Register from the
+	 * Multiprocessor Affinity Register.
+	 */
+	mrs	x2, mpidr_el1
+	msr	vmpidr_el2, x2
+
+	/*
+	 * Set SCTLR_EL1 to a known value so that we can successfully drop
+	 * to EL1 if/when needed.
+	 */
+	ldr	x2, =INIT_SCTLR_EL1
+	msr	sctlr_el1, x2
+
+	/*
+	 * Check if the E2H flag is set in the Hypervisor Control Register.
+	 *
+	 * We attempted to set this bit above, and if it stuck we can use
+	 * virtualisation host extensions (FEAT_VHE) and run the kernel at
+	 * EL2 - otherwise we'll run at EL1.
+	 */
+	tst	x4, #HCR_E2H
+	b.eq	.Lno_vhe
+	mov	x25, #0		/* no HVC stubs necessary */
+
+	/*
+	 * We'll be running the kernel at EL2. Route exceptions that would
+	 * normally be delivered to EL1 to EL2.
+	 */
+	orr	x4, x4, #(HCR_TGE)
+	msr	hcr_el2, x4
+	isb
+
+	/* x2 still contains the value we set in sctlr_el1 */
+	msr	s3_5_c1_c0_0, x2	/* sctlr_el12 */
+	isb
+	ldr	x2, =(INIT_CPTR_EL2_E2H)
+	ldr	x3, =(CNTHCTL_E2H_EL1PCTEN | CNTHCTL_E2H_EL1PTEN)
+	ldr	x5, =(PSR_D | PSR_A | PSR_I | PSR_F | PSR_M_EL2h)
+	b	.Ldone_vhe
+
+.Lno_vhe:
+	/*
+	 * Install a stub Hypervisor trap table that can replace itself
+	 * with a proper function once the kernel is up.
+	 *
+	 * The kernel itself will run at EL1.
+	 */
+	adrp	x2, hyp_stub_vectors
+	add	x2, x2, :lo12:hyp_stub_vectors
+	msr	vbar_el2, x2
+	mov	x25, #1		/* HVC stubs are installed */
+
+	ldr	x2, =(INIT_CPTR_EL2_NO_E2H)
+	ldr	x3, =(CNTHCTL_EL1PCTEN | CNTHCTL_EL1PCEN)
+	ldr	x5, =(PSR_D | PSR_A | PSR_I | PSR_F | PSR_M_EL1h)
+
+.Ldone_vhe:
+	msr	cptr_el2, x2
+	msr	cnthctl_el2, x3
+	msr	spsr_el2, x5
+
+	/*
+	 * Configure the Extended Hypervisor Configuration Register when
+	 * FEAT_HCX is available.
+	 */
+	mrs	x2, id_aa64mmfr1_el1
+	ubfx	x2, x2, #40, #4
+	cmp	x2, #0
+	b.eq	2f
+	mov	x2, xzr
+	msr	s3_4_c1_c2_2, x2
+	isb
+
+2:
+	/* don't trap to EL2 for CP15 traps */
+	msr	hstr_el2, xzr
+
+	/* set the counter offset to a known value */
+	msr	cntvoff_el2, xzr
+
+	/*
+	 * There's no vttbr in our setup - we're either a small stub at EL2
+	 * that dispatches to the host at EL1 or we're a unified EL1/EL2, in
+	 * which case we use the EL1 TTBR[01].
+	 */
+	msr	vttbr_el2, xzr
+
+	/*
+	 * Enable GICv3+ system register access where that's applicable.
+	 */
+	mrs	x2, id_aa64pfr0_el1
+	ubfx	x2, x2, #24, #4
+	cmp	x2, #0
+	b.eq	3f
+	mrs	x2, icc_sre_el2
+	orr	x2, x2, #ICC_SRE_EL2_EN
+	orr	x2, x2, #ICC_SRE_EL2_SRE
+	msr	icc_sre_el2, x2
+
+3:
+	/*
+	 * Set up and execute an exception return to our target exception
+	 * level, which is either EL1 or EL2. This also synchronises PSTATE.
+	 */
+	msr	elr_el2, x30
+	isb
+	eret
+
+.Lel1_entry:
+	bl	.Lel1_body
+	b	.Lel_agnostic
+.Lel1_body:
+	ldr	x2, =INIT_SCTLR_EL1
+	msr	sctlr_el1, x2
+	isb
+
+	/*
+	 * Ensure that PSTATE and SPSR_EL1 are in sync. We do this by updating
+	 * SPSR_EL1 and executing an exception return (to EL1), which then
+	 * transfers us to the EL-agnostic CPU startup.
+	 */
+	mov	x2, #(PSR_D | PSR_A | PSR_I | PSR_F | PSR_M_EL1h)
+	msr	spsr_el1, x2
+	msr	elr_el1, lr
+	eret
+
+.Lel_agnostic:
+	/*
+	 * Invalidate all caches and the TLB.
+	 */
+	mov	x19, lr
+	bl	dcache_invalidate_all
+	ic	iallu
+	dsb	ish
+	isb
+	tlbi	vmalle1is
+	dsb	ish
+	isb
+	mov	x30, x19
+
+	/*
+	 * Enable GICv3+ system register access where that's applicable.
+	 */
+	mrs	x2, id_aa64pfr0_el1
+	ubfx	x2, x2, #24, #4
+	cmp	x2, #0
+	b.eq	1f
+	mrs	x2, icc_sre_el1
+	orr	x2, x2, #ICC_SRE_EL1_SRE
+	msr	icc_sre_el1, x2
+1:
+
+	/*
+	 * Enable SMP cache coherence.
+	 */
+	mrs	x0, midr_el1
+	/* examine implementer, must be Arm (0x41) */
+	ubfx	x1, x0, #24, #8
+	cmp	x1, #(MIDR_IMPL_ARM)
+	b.ne	.Lnot_cortex_a5x_1
+	/* examine the architecture, must be 0xf */
+	ubfx	x1, x0, #15, #4
+	cmp	x1, #0xF
+	b.ne	.Lnot_cortex_a5x_1
+	/* examine the part */
+	ubfx	x1, x0, #4, #12
+	cmp	x1, #(MIDR_PART_ARM_CORTEX_A72)
+	b.eq	.Lcortex_a72_1
+	cmp	x1, #(MIDR_PART_ARM_CORTEX_A57)
+	b.eq	.Lcortex_a57_1
+	/* explicitly _not_ Cortex-A55 */
+	cmp	x1, #(MIDR_PART_ARM_CORTEX_A53)
+	b.eq	.Lcortex_a53_1
+	b	.Lnot_cortex_a5x_1
+
+.Lcortex_a72_1:
+.Lcortex_a57_1:
+.Lcortex_a53_1:
+	/* CPUECTLR_EL1.SMPEN -> 1 (enable cache coherence) */
 	mrs	x0, s3_1_c15_c2_1
-	tbnz	x0, #6, not_cortex_1
+	tbnz	x0, #6, .Lnot_cortex_a5x_1
 	orr	x0, x0, #(1<<6)
 	msr	s3_1_c15_c2_1, x0
 	dsb	sy
 	isb
-not_cortex_1:
-	// invalidate cache (data/inst)
+.Lnot_cortex_a5x_1:
+
+	/*
+	 * NOTE: we don't set cpacr_el1 here, which is something we do in
+	 * dboot for the boot processor. Might need to revisit this as we
+	 * get deeper into the bootstrap process, but for now we're booting
+	 * into a kernel that has the correct traps in place already, so it
+	 * is unlikely we'll need this.
+	 */
+#if 0
+	mrs	x0, cpacr_el1
+	bic	x0, x0, #CPACR_FPEN_MASK
+	//orr	x0, x0, #CPACR_FPEN_DIS
+	msr	cpacr_el1, x0
+#endif
+
+	/*
+	 * Invalidate all caches and the TLB (again).
+	 */
+	mov	x19, lr
 	bl	dcache_invalidate_all
 	ic	iallu
 	dsb	ish
 	isb
-
-	tlbi vmalle1is
+	tlbi	vmalle1is
 	dsb	ish
 	isb
+	mov	x30, x19
 
-	// copy to secondary_vec_end from cpu_startup_data
+	/*
+	 * Load up system registers stashed by mp_startup.
+	 *
+	 * These are stored in a `struct cpu_startup_data` that is placed
+	 * at `secondary_vec_end`.
+	 */
 	adr	x0, secondary_vec_end
+
+	/* memory attribute indirection */
 	ldr	x1, [x0, #STARTUP_MAIR]
 	msr	mair_el1, x1
+
+	/* translation control */
 	ldr	x1, [x0, #STARTUP_TCR]
 	msr	tcr_el1, x1
+
+	/* translation table base address for lower mappings */
 	ldr	x1, [x0, #STARTUP_TTBR0]
 	msr	ttbr0_el1, x1
+
+	/* translation table base address for upper mappings */
 	ldr	x1, [x0, #STARTUP_TTBR1]
 	msr	ttbr1_el1, x1
-	isb
+
+	/* system control */
 	ldr	x1, [x0, #STARTUP_SCTLR]
+	isb
 	msr	sctlr_el1, x1
 	isb
 
-	mrs	x0, CurrentEL
-	cmp	x0, #0xc
-	b.eq	el3
+	/* replace the hypervisor stub if appropriate */
+	cbz	x25, 1f
+	ldr	x1, [x0, #STARTUP_VBAR]
+	cbz	x1, 1f
+	mov	x0, x1
+	hvc	#0
+1:
 
-	cmp	x0, #0x8
-	b.eq	el2
-
-	b	el1
-el3:
-	b	el3
-
-el2:
-	bl	0f
-	b	el1
-0:
-	adr	x0, .Lcnthctl_el2_val
-	ldr	x0, [x0]
-	msr	cnthctl_el2, x0
-	msr	cntvoff_el2, xzr
-
-	mov	x0, #CPTR_EL2_RES1
-	msr	cptr_el2, x0
-
-	msr	vttbr_el2, xzr
-	msr	vbar_el2, xzr
-
-	mrs	x0, midr_el1
-	msr	vpidr_el2, x0
-
-	mrs	x0, mpidr_el1
-	msr	vmpidr_el2, x0
-
-	mov	x0, #HCR_RW
-	msr	hcr_el2, x0
-
-	mov	x0, #SPSR_EL2_VAL
-	msr	spsr_el2, x0
-	msr	elr_el2, x30
-	eret
-	.balign 8
-.Lcnthctl_el2_val:
-	.quad (CNTHCTL_EL1PCEN | CNTHCTL_EL1PCTEN)
-el1:
-	// invalidate cache (data/inst)
-	bl	dcache_invalidate_all
-	ic	iallu
-	dsb	sy
-	isb
-
-	tlbi vmalle1is
-	dsb	sy
-	isb
-
-	// can access kernel data
+	/*
+	 * We can now access kernel data, but we can't jump into KVA yet,
+	 * as this code has been copied to a CPU startup page. The jump to
+	 * KVA happens once we've found our CPU and as we return from this
+	 * function into the kernel code.
+	 */
 	ldr	x0, =cpu
 	mov	x1, #0
 
@@ -201,7 +400,7 @@ cpu_found:
 	ldr	x30, [x1, #T_LABEL_PC]
 	ldr	x0,  [x1, #T_LABEL_SP]
 	mov	sp, x0
-	// return entry point
+	/* return to the entry point with the new stack */
 	ret
 
 faild:
@@ -250,3 +449,50 @@ dcache_invalidate_all:
 secondary_vec_end:
 	.balign 4096
 SET_SIZE(secondary_vec_start)
+
+/*
+ * This set of Hypervisor stub vectors is used during early boot to
+ * install the kernel's Hypervisor vectors.
+ *
+ * The only implemented trap is Synchronous 64-bit EL1, and the only
+ * thing this does is to install the address passed in x0 to vbar_el2.
+ */
+	.align	11
+	ENTRY(hyp_stub_vectors)
+	.align	7	/* Synchronous EL2t */
+1:	b	1b
+	.align	7	/* IRQ EL2t */
+1:	b	1b
+	.align	7	/* FIQ EL2t */
+1:	b	1b
+	.align	7	/* SError EL2t */
+1:	b	1b
+
+	.align	7	/* Synchronous EL2h */
+1:	b	1b
+	.align	7	/* IRQ EL2h */
+1:	b	1b
+	.align	7	/* FIQ EL2h */
+1:	b	1b
+	.align	7	/* SError EL2h */
+1:	b	1b
+
+	.align	7	/* Synchronous 64-bit EL1 */
+	msr	vbar_el2, x0
+	eret
+	.align	7	/* IRQ 64-bit EL1 */
+1:	b	1b
+	.align	7	/* FIQ 64-bit EL1 */
+1:	b	1b
+	.align	7	/* SError 64-bit EL1 */
+1:	b	1b
+
+	.align	7	/* Synchronous 32-bit EL1 */
+1:	b	1b
+	.align	7	/* IRQ 32-bit EL1 */
+1:	b	1b
+	.align	7	/* FIQ 32-bit EL1 */
+1:	b	1b
+	.align	7	/* SError 32-bit EL1 */
+1:	b	1b
+	SET_SIZE(hyp_stub_vectors)

--- a/usr/src/uts/armv8/os/mp_startup.c
+++ b/usr/src/uts/armv8/os/mp_startup.c
@@ -572,10 +572,15 @@ int
 mach_cpucontext_init(void)
 {
 	uint64_t pa;
-	extern void secondary_vec_start();
-	extern void secondary_vec_end();
+	uint64_t pa_hvc_stub;
+	extern void secondary_vec_start(void);
+	extern void secondary_vec_end(void);
+	extern void hyp_stub_vectors(void);
 
 	if (translate_to_pa((uint64_t)secondary_vec_start, &pa) != 0)
+		return (-1);
+
+	if (translate_to_pa((uint64_t)hyp_stub_vectors, &pa_hvc_stub) != 0)
 		return (-1);
 
 	hat_devload(kas.a_hat,
@@ -590,6 +595,7 @@ mach_cpucontext_init(void)
 	cpu_data->ttbr0 = read_ttbr0();
 	cpu_data->ttbr1 = read_ttbr1();
 	cpu_data->sctlr = read_sctlr();
+	cpu_data->vbar = pa_hvc_stub;
 
 	size_t data_line_size = CTR_DMINLINE_SIZE(read_ctr_el0());
 	for (uintptr_t addr = P2ALIGN((uintptr_t)cpu_data, data_line_size);

--- a/usr/src/uts/armv8/sys/gic_reg.h
+++ b/usr/src/uts/armv8/sys/gic_reg.h
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2024 Michael van der Westhuizen
+ * Copyright 2025 Michael van der Westhuizen
  */
 
 #ifndef _GIC_REG_H
@@ -697,6 +697,9 @@ extern "C" {
 #define	ICC_SRE_EL1_DIB				0x0000000000000004
 #define	ICC_SRE_EL1_DFB				0x0000000000000002
 #define	ICC_SRE_EL1_SRE				0x0000000000000001
+
+#define	ICC_SRE_EL2_EN				(1U << 3)
+#define	ICC_SRE_EL2_SRE				(1U << 0)
 
 #define	ICC_IGRPEN0_EL1_Enable			0x0000000000000001
 

--- a/usr/src/uts/armv8/sys/machcpuvar.h
+++ b/usr/src/uts/armv8/sys/machcpuvar.h
@@ -25,7 +25,7 @@
  *
  * Copyright 2011 Joyent, Inc. All rights reserved.
  * Copyright 2017 Hayashi Naoyuki
- * Copyright 2023 Michael van der Westhuizen
+ * Copyright 2025 Michael van der Westhuizen
  */
 
 #ifndef _SYS_MACHCPUVAR_H
@@ -88,6 +88,7 @@ struct	cpu_startup_data {
 	uint64_t	ttbr0;
 	uint64_t	ttbr1;
 	uint64_t	sctlr;
+	uint64_t	vbar;
 };
 
 #ifdef	__cplusplus


### PR DESCRIPTION
Tweak the kernel startup code (in `dboot` and `locore`) to recognise different types of hypervisor support and set up EL2 appropriately. This fixes a few bugs that became visible in testing on Qemu SBSA-REF (the worst being a preprocessor sign-overflow bug).

These changes are aligned with what FreeBSD does to support `bhyve` on `aarch64`, which we'll want to pick up when it stabilises.

An additional change uses the correct timer interrupt when running at EL2 - this uses the Hypervisor timer interrupt rather than the physical timer interrupt. Prior to this change boot would hang after `cbe` was up.

We can now [boot illumos](https://gist.github.com/r1mikey/f82fbd1146c906d025b6ca3b20157d2d) on systems that support VHE (Virtualisation Host Extensions) using a command like this:
```
QEMU_SCRIPT_CPU="neoverse-n2" \
  QEMU_SCRIPT_MACHINE="virt,gic-version=3,virtualization=on" \
  QEMU_SCRIPT_NCPU=4 ./run.sh
```

Prior to this change the above command would [trap when entering](https://gist.github.com/r1mikey/dfa2094ba80e7fe64b9cc16c9ddb36e8) `unix`.