### PR TITLE
FDT reduction: 4 of 6

### DIFF
--- a/usr/src/uts/aarch64/sys/obpdefs.h
+++ b/usr/src/uts/aarch64/sys/obpdefs.h
@@ -90,6 +90,12 @@ typedef	phandle_t pnode_t;
 #define	OBP_INTERRUPT_MAP_MASK		"interrupt-map-mask"
 
 /*
+ * DTSpec defaults
+ */
+#define	OBP_DEFAULT_ADDRESS_CELLS	2
+#define	OBP_DEFAULT_SIZE_CELLS		1
+
+/*
  * OBP status values defines
  */
 #define	OBP_ST_OKAY		"okay"


### PR DESCRIPTION
`get_dma_ranges` should not use prom

Rewrite the `get_dma_ranges` to use DDI interfaces rather than the prom. This further reduces our exposure to raw prom interfaces.

Tested on rpi4: https://gist.github.com/r1mikey/a65d7315d74d91e9a396d86c4d295e78

Will be rebased on https://github.com/richlowe/illumos-gate/pull/170 is merged.