### PR TITLE
FDT reduction: 5 of 6

### DIFF
--- a/usr/src/uts/aarch64/sys/prom_plat.h
+++ b/usr/src/uts/aarch64/sys/prom_plat.h
@@ -42,8 +42,6 @@ struct prom_hwclock {
 	uint32_t id;
 };
 
-extern pnode_t prom_fdt_parentnode(pnode_t nodeid);
-extern pnode_t prom_fdt_findnode_by_phandle(phandle_t phandle);
 extern int prom_fdt_get_reg(pnode_t node, int index, uint64_t *base);
 extern int prom_fdt_get_clock_by_name(pnode_t node, const char *name,
     struct prom_hwclock *clock);


### PR DESCRIPTION
Now that `get_dma_ranges` uses DDI interfaces we have two more FDT functions that can become private. These are:
* prom_fdt_parentnode
* prom_fdt_findnode_by_phandle

Make these private, static and rename them to have shorter names.

Will be rebased once https://github.com/richlowe/illumos-gate/pull/171 is merged.