### PR TITLE
FDT reduction: 6 of 6

### DIFF
--- a/usr/src/uts/aarch64/Makefile.files
+++ b/usr/src/uts/aarch64/Makefile.files
@@ -91,7 +91,12 @@ CORE_OBJS +=			\
 	prom_panic.o		\
 	prom_enter.o		\
 	prom_exit.o		\
-	prom_prop.o		\
+	prom_prop.o
+
+#
+#	When building unix for FDT, include these objects.
+#
+CORE_OBJS_FDT +=		\
 	fdt.o			\
 	fdt_ro.o		\
 	fdt_wip.o		\

--- a/usr/src/uts/armv8/Makefile.rules
+++ b/usr/src/uts/armv8/Makefile.rules
@@ -37,13 +37,6 @@ $(OBJS_DIR)/%.o:		$(UTSBASE)/armv8/promif/%.c
 	$(COMPILE.c) -o $@ $<
 	$(CTFCONVERT_O)
 
-#
-# Explicitly list objects that depend on raw libfdt so that we can
-# be aware of these dependencies and limit them as much as possible.
-#
-$(OBJS_DIR)/prom_emul_fdt.o := CPPFLAGS += -I$(SRC)/contrib/libfdt
-$(OBJS_DIR)/fakebop.o := CPPFLAGS += -I$(SRC)/contrib/libfdt
-
 $(OBJS_DIR)/%.o:		$(UTSBASE)/armv8/os/%.c
 	$(COMPILE.c) $(EARLY_CFLAGS) -o $@ $<
 	$(CTFCONVERT_O)

--- a/usr/src/uts/armv8/os/fakebop.c
+++ b/usr/src/uts/armv8/os/fakebop.c
@@ -63,8 +63,11 @@
 #include <sys/kobj_lex.h>
 #include <sys/ddipropdefs.h>	/* For DDI prop types */
 #include <netinet/inetutil.h>	/* for hexascii_to_octet */
-#include <libfdt.h>
 #include <sys/boot_console.h>
+#include <sys/sunddi.h>
+#if defined(_USE_FDT)
+#include <libfdt.h>
+#endif
 
 extern void bsvc_init(struct xboot_info *);
 
@@ -285,6 +288,7 @@ bop_relocate(void)
 		return;
 
 	if (xbootp->bi_fdt != 0) {
+#if defined(_USE_FDT)
 		size_t sz;
 
 		if (fdt_check_header((const void *)xbootp->bi_fdt) != 0)
@@ -306,6 +310,7 @@ bop_relocate(void)
 			panic("failed to relocate FDT to KVA\n");
 
 		prom_init("kernel", vaddr);
+#endif
 	}
 }
 
@@ -983,6 +988,7 @@ bop_panic(const char *fmt, ...)
 	for (;;) {}	/* XXXARM: spin forever, for now */
 }
 
+#if defined(_USE_FDT)
 static void
 build_firmware_properties_fdt(const void *fdtp)
 {
@@ -1024,13 +1030,15 @@ build_firmware_properties_fdt(const void *fdtp)
 		}
 	}
 }
+#endif
 
 /*
  * Populate properties from firmware values.
  */
 static void
-build_firmware_properties(struct xboot_info *xbp)
+build_firmware_properties(struct xboot_info *xbp __maybe_unused)
 {
+#if defined(_USE_FDT)
 	if (xbp->bi_fdt != 0) {
 		const void *fdtp = (void *)xbp->bi_fdt;
 
@@ -1038,6 +1046,7 @@ build_firmware_properties(struct xboot_info *xbp)
 			build_firmware_properties_fdt(fdtp);
 		}
 	}
+#endif
 }
 
 /*

--- a/usr/src/uts/armv8/unix/Makefile
+++ b/usr/src/uts/armv8/unix/Makefile
@@ -115,7 +115,18 @@ CLOBBERFILES	= $(CLEANFILES) $(UNIX_BIN)
 # Turn on doubleword alignment for 64 bit counter timer registers
 #
 CFLAGS += $(CCVERBOSE)
-$(OBJS_DIR)/platimpl.o := CPPFLAGS += -I$(SRC)/contrib/libfdt
+
+#
+# Enable any code conditionally compiled for FDT support.
+#
+CPPFLAGS += -D_USE_FDT
+
+#
+# Explicitly list objects that depend on raw libfdt so that we can
+# be aware of these dependencies and limit them as much as possible.
+#
+$(OBJS_DIR)/fakebop.o := CPPFLAGS += -I$(SRC)/contrib/libfdt
+$(OBJS_DIR)/prom_emul_fdt.o := CPPFLAGS += -I$(SRC)/contrib/libfdt
 
 #
 # For now, disable these lint checks; maintainers should endeavor


### PR DESCRIPTION
Make FDT optional at build-time

As we get closer to introducing ACPI we are getting to the point where FDT support is sufficiently contained that we can build without it.

Make it optional now and turn it on for the FDT kernel.

Will be rebased once https://github.com/richlowe/illumos-gate/pull/172 is merged.