### PR TITLE
Add SMBIOS support

### DIFF
--- a/usr/src/cmd/devfsadm/aarch64/misc_link_aarch64.c
+++ b/usr/src/cmd/devfsadm/aarch64/misc_link_aarch64.c
@@ -34,6 +34,9 @@ static devfsadm_create_t misc_cbt[] = {
 	{ "pseudo", "ddi_pseudo", "devfdt",
 	    TYPE_EXACT | DRV_EXACT, ILEVEL_1, ln_minor_name,
 	},
+	{ "pseudo", "ddi_pseudo", "smbios",
+	    TYPE_EXACT | DRV_EXACT, ILEVEL_1, ln_minor_name,
+	},
 };
 
 DEVFSADM_CREATE_INIT_V0(misc_cbt);

--- a/usr/src/man/man4d/Makefile
+++ b/usr/src/man/man4d/Makefile
@@ -270,6 +270,7 @@ aarch64_MANFILES=	ahci.4d			\
 			si3124.4d		\
 			simple-bus.4d		\
 			skd.4d			\
+			smbios.4d		\
 			uath.4d			\
 			ural.4d			\
 			urtw.4d			\

--- a/usr/src/pkg/manifests/system-kernel.p5m
+++ b/usr/src/pkg/manifests/system-kernel.p5m
@@ -452,7 +452,7 @@ dir  path=usr/share/man/man2
 dir  path=usr/share/man/man3
 dir  path=usr/share/man/man4
 dir  path=usr/share/man/man4d
-$(i386_ONLY)file path=usr/share/man/man4d/smbios.4d
+file path=usr/share/man/man4d/smbios.4d
 dir  path=usr/share/man/man4fs
 dir  path=usr/share/man/man4m
 dir  path=usr/share/man/man4p
@@ -564,7 +564,7 @@ driver name=sgen perms="* 0600 root sys" \
     alias=scsa,08.bvhci
 driver name=signalfd perms="* 0666 root sys"
 driver name=simnet perms="* 0666 root sys" clone_perms="simnet 0666 root sys"
-$(i386_ONLY)driver name=smbios perms="smbios 0444 root sys"
+driver name=smbios perms="smbios 0444 root sys"
 driver name=softmac
 driver name=spdsock perms="spdsock 0666 root sys" \
     policy="read_priv_set=sys_ip_config write_priv_set=sys_ip_config"

--- a/usr/src/uts/aarch64/sys/bootinfo.h
+++ b/usr/src/uts/aarch64/sys/bootinfo.h
@@ -101,6 +101,7 @@ struct xboot_cpu_info {
 struct xboot_info {
 	uint64_t		bi_fdt;
 	uint64_t		bi_uefi_systab;
+	uint64_t		bi_smbios;
 	uint64_t		bi_cmdline;
 	uint64_t		bi_modules;
 	uint64_t		bi_phys_installed;

--- a/usr/src/uts/armv8/Makefile.files
+++ b/usr/src/uts/armv8/Makefile.files
@@ -83,6 +83,12 @@ CORE_OBJS +=			\
 CORE_OBJS += $(PCI_STRING_OBJS)
 
 #
+#	Add the SMBIOS subsystem object files directly to the list of objects
+#	built into unix itself; this is all common code except for smb_dev.c.
+#
+CORE_OBJS += $(SMBIOS_OBJS)
+
+#
 # These get compiled twice:
 # - once in the dboot (direct boot) identity mapped code
 # - once for use during early startup in unix

--- a/usr/src/uts/armv8/dboot/dboot_conf.c
+++ b/usr/src/uts/armv8/dboot/dboot_conf.c
@@ -347,6 +347,8 @@ dboot_configure(caddr_t modulep, struct xboot_info *xbi,
 	caddr_t			scratch_addr;
 	uint64_t		scratch_size;
 
+	extern uint64_t dboot_uefi_get_smbios3_address(void);
+
 	if (modulep == NULL || xbi == NULL ||
 	    pkernel == NULL || pkernel_size == NULL)
 		panic("dboot: bad call to dboot_configure\n");
@@ -666,6 +668,10 @@ dboot_configure(caddr_t modulep, struct xboot_info *xbi,
 	/*
 	 * Configuration from firmware tables
 	 */
+	if ((xbi->bi_smbios = dboot_uefi_get_smbios3_address()) == 0)
+		dboot_printf("NOTICE: No SMBIOS3 configuration "
+		    "table passed via UEFI\n");
+
 	if (xbi->bi_fdt != 0) {
 		if (dboot_configure_fdt() != 0) {
 			dboot_printf("dboot: failed to perform early "

--- a/usr/src/uts/armv8/dboot/dboot_conf_uefi.c
+++ b/usr/src/uts/armv8/dboot/dboot_conf_uefi.c
@@ -28,6 +28,7 @@
 extern void boot_psci_init(struct xboot_info *);
 
 static efi_guid_t acpi2 = EFI_ACPI_TABLE_GUID;
+static efi_guid_t smbios3 = SMBIOS3_TABLE_GUID;
 
 
 static const EFI_SYSTEM_TABLE64 *
@@ -70,6 +71,35 @@ same_guids(efi_guid_t *g1, efi_guid_t *g2)
 			return (false);
 
 	return (true);
+}
+
+uint64_t
+dboot_uefi_get_smbios3_address(void)
+{
+	efi_guid_t vguid;
+	const EFI_SYSTEM_TABLE64 *st;
+	const EFI_CONFIGURATION_TABLE64 *cf;
+	uint64_t saddr;
+	UINT32 i;
+
+	if ((st = get_uefi_systab()) == NULL)
+		return (0);
+
+	cf = (const EFI_CONFIGURATION_TABLE64 *)st->ConfigurationTable;
+	if (cf == NULL)
+		return (0);
+
+	saddr = 0;
+
+	for (i = 0; i < st->NumberOfTableEntries; ++i) {
+		memcpy(&vguid, &cf[i].VendorGuid, sizeof (vguid));
+		if (same_guids(&vguid, &smbios3)) {
+			saddr = (uint64_t)cf[i].VendorTable;
+			break;
+		}
+	}
+
+	return (saddr);
 }
 
 const void *

--- a/usr/src/uts/armv8/os/fakebop.c
+++ b/usr/src/uts/armv8/os/fakebop.c
@@ -1038,6 +1038,9 @@ build_firmware_properties_fdt(const void *fdtp)
 static void
 build_firmware_properties(struct xboot_info *xbp __maybe_unused)
 {
+	if (xbp->bi_smbios != 0)
+		bsetprop64("smbios-address", xbp->bi_smbios);
+
 #if defined(_USE_FDT)
 	if (xbp->bi_fdt != 0) {
 		const void *fdtp = (void *)xbp->bi_fdt;

--- a/usr/src/uts/armv8/os/smb_dev.c
+++ b/usr/src/uts/armv8/os/smb_dev.c
@@ -1,0 +1,148 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License, Version 1.0 only
+ * (the "License").  You may not use this file except in compliance
+ * with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright 2006 Sun Microsystems, Inc.  All rights reserved.
+ * Use is subject to license terms.
+ * Copyright (c) 2018, Joyent, Inc.
+ * Copyright 2025 Michael van der Westhuizen
+ */
+
+/*
+ * Platform-Specific SMBIOS Subroutines
+ *
+ * The routines in this file form part of <sys/smbios_impl.h> and combine with
+ * the usr/src/common/smbios code to form an in-kernel SMBIOS decoding service.
+ *
+ * The SMBIOS entry point is located using the pointer passed to unix by dboot,
+ * which gets this address from the UEFI System Table.
+ */
+
+#include <sys/smbios_impl.h>
+#include <sys/sysmacros.h>
+#include <sys/errno.h>
+#include <sys/smp_impldefs.h>
+
+smbios_hdl_t *ksmbios;
+int ksmbios_flags;
+
+smbios_hdl_t *
+smb_open_error(smbios_hdl_t *shp, int *errp, int err)
+{
+	if (shp != NULL)
+		smbios_close(shp);
+
+	if (errp != NULL)
+		*errp = err;
+
+	if (ksmbios == NULL)
+		cmn_err(CE_CONT, "?SMBIOS not loaded (%s)\n",
+		    smbios_errmsg(err));
+
+	return (NULL);
+}
+
+smbios_hdl_t *
+smbios_open(const char *file, int version, int flags, int *errp)
+{
+	smbios_hdl_t *shp = NULL;
+	smbios_entry_t *ep;
+	caddr_t stbuf, bios, smb3;
+	uint64_t startaddr, startoff = 0;
+	size_t bioslen;
+	uint_t smbe_stlen;
+	uint8_t smbe_major, smbe_minor;
+	int err;
+
+	if (file != NULL || (flags & ~SMB_O_MASK))
+		return (smb_open_error(shp, errp, ESMB_INVAL));
+
+	if ((startaddr = ddi_prop_get_int64(DDI_DEV_T_ANY, ddi_root_node(),
+	    DDI_PROP_DONTPASS, "smbios-address", 0)) == 0)
+		return (smb_open_error(shp, errp, ESMB_NOTFOUND));
+
+	bioslen = MMU_PAGESIZE;
+	startoff = startaddr & MMU_PAGEOFFSET;
+	startaddr &= MMU_PAGEMASK;
+
+	if ((bios = psm_map_phys(startaddr, bioslen, PROT_READ)) == NULL)
+		return (smb_open_error(shp, errp, ESMB_MAPDEV));
+
+	smb3 = bios + startoff;
+	if (strncmp(smb3, SMB3_ENTRY_EANCHOR, SMB3_ENTRY_EANCHORLEN) != 0) {
+		psm_unmap_phys(bios, bioslen);
+		return (smb_open_error(shp, errp, ESMB_NOTFOUND));
+	}
+
+	ep = smb_alloc(SMB_ENTRY_MAXLEN);
+	bcopy(smb3, ep, sizeof (smbios_entry_t));
+	ep->ep30.smbe_elen = MIN(ep->ep30.smbe_elen, SMB_ENTRY_MAXLEN);
+	bcopy(smb3, ep, ep->ep30.smbe_elen);
+
+	psm_unmap_phys(bios, bioslen);
+
+	smbe_major = ep->ep30.smbe_major;
+	smbe_minor = ep->ep30.smbe_minor;
+	smbe_stlen = ep->ep30.smbe_stlen;
+
+	bios = psm_map_phys(ep->ep30.smbe_staddr, smbe_stlen, PROT_READ);
+	if (bios == NULL) {
+		smb_free(ep, SMB_ENTRY_MAXLEN);
+		return (smb_open_error(shp, errp, ESMB_MAPDEV));
+	}
+
+	stbuf = smb_alloc(smbe_stlen);
+	bcopy(bios, stbuf, smbe_stlen);
+	psm_unmap_phys(bios, smbe_stlen);
+
+	shp = smbios_bufopen(ep, stbuf, smbe_stlen, version, flags, &err);
+	if (shp == NULL) {
+		smb_free(stbuf, smbe_stlen);
+		smb_free(ep, SMB_ENTRY_MAXLEN);
+		return (smb_open_error(shp, errp, err));
+	}
+
+	if (ksmbios == NULL) {
+		cmn_err(CE_CONT, "?SMBIOS v%u.%u loaded (%u bytes)\n",
+		    smbe_major, smbe_minor, smbe_stlen);
+		if (shp->sh_flags & SMB_FL_TRUNC)
+			cmn_err(CE_CONT, "?SMBIOS table is truncated\n");
+	}
+
+	shp->sh_flags |= SMB_FL_BUFALLOC;
+	smb_free(ep, SMB_ENTRY_MAXLEN);
+
+	return (shp);
+}
+
+smbios_hdl_t *
+smbios_fdopen(int fd __unused, int version __unused,
+    int flags __unused, int *errp)
+{
+	return (smb_open_error(NULL, errp, ENOTSUP));
+}
+
+int
+smbios_write(smbios_hdl_t *shp, int fd __unused)
+{
+	return (smb_set_errno(shp, ENOTSUP));
+}


### PR DESCRIPTION
We've had the `smbios` module for a long time, but we've been missing a few pieces to use it.

Now that we always boot via UEFI the first necessary piece is present: SMBIOS tables themselves. Pass the address of the SMBIOS3 table (SMBIOS2 does not support aarch64) to `unix` from `dboot`.

In cases where we don't have a `mfg-name` boot property passed from `loader(7)` (new FDT boards and all ACPI boards), prefer to set `mfg-name` from SMBIOS data (passed by `loader(7)`) when available.

Even with a loadable `smbios` module we'd need a link to the device node in `/dev` - add that via `devfsadm`.

There are two things preventing the `smbios` module loading. The first is missing symbols, and the second is that the module does not have a name-to-major entry. Fix up the driver stanza to add this entry and, while we're at it, add the manual page and package it.

Finally, add the necessary SMBIOS implementation functions and wire up SMBIOS initialisation at the same place in the boot sequence as `i86pc` does.

Testing on rpi4: https://gist.github.com/r1mikey/84a8bad8a12084c3a50cce6ebf271815
Testing on qemu-virt: https://gist.github.com/r1mikey/edbb1dd9c7c37acb0027c79a5305bd1b
Testing on Qemu SBSA-ref: https://gist.github.com/r1mikey/aa860ae0eb45a52f47a6d60adb272235

Will be rebased once https://github.com/richlowe/illumos-gate/pull/173 is merged.