### PR TITLE
unix: commonize -Bdisable-<module>=true from i86

### DIFF
--- a/usr/src/uts/armv8/os/ddi_impl.c
+++ b/usr/src/uts/armv8/os/ddi_impl.c
@@ -94,7 +94,6 @@ static kmutex_t		ctgmutex;
 #define	CTGLOCK()	mutex_enter(&ctgmutex)
 #define	CTGUNLOCK()	mutex_exit(&ctgmutex)
 
-
 uint8_t
 i_ddi_get8(ddi_acc_impl_t *hdlp, uint8_t *addr)
 {

--- a/usr/src/uts/i86pc/os/ddi_impl.c
+++ b/usr/src/uts/i86pc/os/ddi_impl.c
@@ -141,34 +141,6 @@ static kmutex_t		ctgmutex;
  */
 pfn_t	ddiphysmin = 2;
 
-static void
-check_driver_disable(void)
-{
-	int proplen = 128;
-	char *prop_name;
-	char *drv_name, *propval;
-	major_t major;
-
-	prop_name = kmem_alloc(proplen, KM_SLEEP);
-	for (major = 0; major < devcnt; major++) {
-		drv_name = ddi_major_to_name(major);
-		if (drv_name == NULL)
-			continue;
-		(void) snprintf(prop_name, proplen, "disable-%s", drv_name);
-		if (ddi_prop_lookup_string(DDI_DEV_T_ANY, ddi_root_node(),
-		    DDI_PROP_DONTPASS, prop_name, &propval) == DDI_SUCCESS) {
-			if (strcmp(propval, "true") == 0) {
-				devnamesp[major].dn_flags |= DN_DRIVER_REMOVED;
-				cmn_err(CE_NOTE, "driver %s disabled",
-				    drv_name);
-			}
-			ddi_prop_free(propval);
-		}
-	}
-	kmem_free(prop_name, proplen);
-}
-
-
 /*
  * Configure the hardware on the system.
  * Called before the rootfs is mounted
@@ -2629,11 +2601,6 @@ impl_setup_ddi(void)
 
 	/* Copy console font if provided by boot. */
 	get_console_font();
-
-	/*
-	 * Check for administratively disabled drivers.
-	 */
-	check_driver_disable();
 
 #if !defined(__xpv)
 	if (!post_fastreboot && BOP_GETPROPLEN(bootops, "efi-systab") < 0)


### PR DESCRIPTION
This is called prior to nearly any real module being loaded (pci_autoconfig on i86 slides past it, a victim of the search for a suitable place to insert this machine independently)

@jclulow @citrus-it @hadfl @r1mikey I think we've each talked about this before in some degree or other