### PR TITLE
boot: Fix the root node's compatible property

### DIFF
--- a/usr/src/boot/efi/libfdtutil/bi.c
+++ b/usr/src/boot/efi/libfdtutil/bi.c
@@ -165,14 +165,13 @@ bi_implarch_fdt(const void *fdtp)
 	    fdtp, 0, "compatible", &plen)) == NULL || plen < 1)
 		return;	/* impossible, but ok... */
 	/*
-	 * New compat, comma, old compat, NUL.
+	 * New compat + NUL + old compat (already terminated appropriately)
 	 */
-	clen = strlen(compat) + 1 + plen + 1;
+	clen = strlen(compat) + 1 + plen;
 	if ((compatible = malloc(clen)) == NULL)
 		return;
 	memset(compatible, 0, clen);
 	strcpy(compatible, compat);
-	strcat(compatible, ",");
 	memcpy(compatible + strlen(compat) + 1, prop->data, plen);
 	(void) fdt_setprop((void *)fdtp, 0, "compatible", compatible, clen);
 	free(compatible);


### PR DESCRIPTION
- it should be a char[], each element being \0 terminated
- the pre-existing string is already terminated, so don't do it again

We rely on the memset having 0'd the string, and just skip a byte to leave a terminator

@hadfl