### PR TITLE
libsqlite: vxprintf: va_arg() integral types with their signedness specified

### DIFF
--- a/usr/src/lib/libsqlite/src/printf.c
+++ b/usr/src/lib/libsqlite/src/printf.c
@@ -337,8 +337,8 @@ static int vxprintf(
     */
     switch( xtype ){
       case etRADIX:
-        if( flag_long )  longvalue = va_arg(ap,long);
-        else             longvalue = va_arg(ap,int);
+        if( flag_long )  longvalue = va_arg(ap,unsigned long);
+        else             longvalue = va_arg(ap,unsigned int);
 #if 1
         /* For the format %#x, the value zero is printed "0" not "0x0".
         ** I think this is stupid. */


### PR DESCRIPTION
else a 64bit sqlite will sign-extend values with the 31bit set, which breaks idmap and presumably SMF in the cases where a property exists in this state, and does who knows what to smb.

@jclulow @citrus-it this is the idmap bug I've been chasing all week, idmap forms queries using `sqlite_mprintf` and using the `%u` format to format uids and gids.  This turns out -- because of the bug here -- to sign-extend them if they have the 31bit set, which ephemeral IDs always do.  This then causes them to fail in the future and for ephemeral IDs for a given SID to be constantly recreated.

Anyway, the more important thing is that this seems to me like it means 64bit sqlite2 is just not a thing we can rely on, so both arm64-gate and illumos-gate actually _need_ a sqlite3.  arm64-gate in general, illumos-gate for any hope of 2038.  What's the best way to communicate that? File a bug? get the 2038 IPD updated?

Also, should I fix this as here in the short term while I look at integrating sqlite3 per Bill's changes.