### PR TITLE
bootdev: ship on arm, it's absolutely required but only rarely

### DIFF
--- a/usr/src/pkg/manifests/system-kernel.p5m
+++ b/usr/src/pkg/manifests/system-kernel.p5m
@@ -306,7 +306,7 @@ dir  path=kernel/misc group=sys
 dir  path=kernel/misc/$(ARCH64) group=sys
 $(i386_ONLY)file path=kernel/misc/$(ARCH64)/acpica group=sys mode=0755
 file path=kernel/misc/$(ARCH64)/bignum group=sys mode=0755
-$(i386_ONLY)file path=kernel/misc/$(ARCH64)/bootdev group=sys mode=0755
+file path=kernel/misc/$(ARCH64)/bootdev group=sys mode=0755
 file path=kernel/misc/$(ARCH64)/busra group=sys mode=0755
 $(not_aarch64)file path=kernel/misc/$(ARCH64)/cardbus group=sys mode=0755
 file path=kernel/misc/$(ARCH64)/cc group=sys mode=0755

--- a/usr/src/uts/armv8/Makefile.armv8
+++ b/usr/src/uts/armv8/Makefile.armv8
@@ -236,5 +236,6 @@ DACF_KMODS += consconfig_dacf
 #
 #	'Misc' Modules (/kernel/misc):
 #
+MISC_KMODS += bootdev
 MISC_KMODS += gfx_private
 MISC_KMODS += platmod

--- a/usr/src/uts/armv8/Makefile.files
+++ b/usr/src/uts/armv8/Makefile.files
@@ -169,6 +169,8 @@ GFX_PRIVATE_OBJS	+= gfx_private.o gfxp_segmap.o \
 
 EFIFB_OBJS		+= efifb.o
 
+BOOTDEV_OBJS		+= bootdev.o
+
 ASSYM_DEPS +=			\
 	aarch64_subr.o		\
 	copy.o			\

--- a/usr/src/uts/armv8/bootdev/Makefile
+++ b/usr/src/uts/armv8/bootdev/Makefile
@@ -1,0 +1,72 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+#
+# Copyright 2007 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+#
+#	This makefile drives the production of the bootdev driver
+#	kernel module.
+#
+
+#
+#	Path to the base of the uts directory tree (usually /usr/src/uts).
+#
+UTSBASE	= ../..
+
+#
+#	Define the module and object file sets.
+#
+MODULE		= bootdev
+OBJECTS		= $(BOOTDEV_OBJS:%=$(OBJS_DIR)/%)
+ROOTMODULE	= $(ROOT_MISC_DIR)/$(MODULE)
+
+#
+#	Include common rules.
+#
+include $(UTSBASE)/armv8/Makefile.armv8
+
+#
+#	Define targets
+#
+ALL_TARGET	= $(BINARY)
+INSTALL_TARGET	= $(BINARY) $(ROOTMODULE)
+
+#
+#	Default build targets.
+#
+.KEEP_STATE:
+
+def:		$(DEF_DEPS)
+
+all:		$(ALL_DEPS)
+
+clean:		$(CLEAN_DEPS)
+
+clobber:	$(CLOBBER_DEPS)
+
+install:	$(INSTALL_DEPS)
+
+#
+#	Include common targets.
+#
+include $(UTSBASE)/armv8/Makefile.targ

--- a/usr/src/uts/armv8/os/bootdev.c
+++ b/usr/src/uts/armv8/os/bootdev.c
@@ -1,0 +1,100 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License, Version 1.0 only
+ * (the "License").  You may not use this file except in compliance
+ * with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright 2008 Sun Microsystems, Inc.  All rights reserved.
+ * Use is subject to license terms.
+ */
+
+#include <sys/modctl.h>
+#include <sys/sunddi.h>
+
+/* internal global data */
+static struct modlmisc modlmisc = {
+	&mod_miscops, "bootdev misc module"
+};
+
+static struct modlinkage modlinkage = {
+	MODREV_1, (void *)&modlmisc, NULL
+};
+
+int
+_init()
+{
+	return (mod_install(&modlinkage));
+}
+
+int
+_fini()
+{
+	return (mod_remove(&modlinkage));
+}
+
+int
+_info(struct modinfo *modinfop)
+{
+	return (mod_info(&modlinkage, modinfop));
+}
+
+/*
+ * convert a prom device path to an equivalent path in /devices
+ * Does not deal with aliases.  Does deal with pathnames which
+ * are not fully qualified.  This routine is generalized
+ * to work across several flavors of OBP
+ */
+int
+i_promname_to_devname(char *prom_name, char *ret_buf)
+{
+	if (prom_name == NULL || ret_buf == NULL ||
+	    (strlen(prom_name) >= MAXPATHLEN)) {
+		return (EINVAL);
+	}
+	if (i_ddi_prompath_to_devfspath(prom_name, ret_buf) != DDI_SUCCESS)
+		return (EINVAL);
+
+	return (0);
+}
+
+/*
+ * If bootstring contains a device path, we need to convert to a format
+ * the prom will understand.  To do so, we convert the existing path to
+ * a prom-compatible path and return the value of new_path.  If the
+ * caller specifies new_path as NULL, we allocate an appropriately
+ * sized new_path on behalf of the caller.  If the caller invokes this
+ * function with new_path = NULL, they must do so from a context in
+ * which it is safe to perform a sleeping memory allocation.
+ *
+ * NOTE: It's not clear what this would do for ARM, so the implementation
+ *       simply returns a copy of the string passed in.
+ */
+char *
+i_convert_boot_device_name(char *cur_path, char *new_path, size_t *len)
+{
+	if (new_path != NULL) {
+		(void) snprintf(new_path, *len, "%s", cur_path);
+		return (new_path);
+	} else {
+		*len = strlen(cur_path) + 1;
+		new_path = kmem_alloc(*len, KM_SLEEP);
+		(void) snprintf(new_path, *len, "%s", cur_path);
+		return (new_path);
+	}
+}


### PR DESCRIPTION
The mechanism we require this through is a bit weird.

The short answer is that we define modstubs as being within this module, we thus commit to providing the module and providing concrete versions.  oops.

The long answer includes why this seems to only crash in a minority of cases, we never call these stubbed functions that I can find _except_ when we are rebooting, and even then perhaps only when rebooting after a forced boot archive rebuild.

Provide what intel does, in the same ways.

I've "tested this" by managing to trigger the problem circumstances with breakpoints in these functions, to see that they were called (`i_convert_boot_device_name` is, twice), and then continuing from them.  They're called so deep into rebooting it is hard to say really whether the only one that is called -- a **strdup(3C)** in sheep's clothing -- does the right thing.  It does work though.

I'm not sure if there is any benefit to **misc/bootdev** staying a module when nobody overrides anything it does on any basis whatever.