### PR TITLE
Support all boot archive formats

### DIFF
--- a/usr/src/cmd/boot/bootadm/bootadm.c
+++ b/usr/src/cmd/boot/bootadm/bootadm.c
@@ -3421,10 +3421,6 @@ use_mkisofs()
 		return (B_TRUE);
 	}
 
-	 /* XXXARM: For complicated reasons, aarch64 _must_ use hsfs right now */
-	if (is_flag_on(IS_AARCH64_TARGET))
-		return (B_TRUE);
-
 	/* If working on an alt-root, do not use HSFS unless asked via -F */
 	if (bam_alt_root)
 		return (B_FALSE);

--- a/usr/src/cmd/boot/scripts/create_ramdisk.ksh
+++ b/usr/src/cmd/boot/scripts/create_ramdisk.ksh
@@ -400,7 +400,7 @@ function create_cpio_archive
 	touch "$tarchive" \
 	    || fatal_error "Cannot create temporary archive $tarchive"
 
-	if [ $ISA != i386 ] ; then
+	if [ $ISA = sparc ] ; then
 		# compression does not work (yet?).
 		# The krtld does not support gzip but fiocompress
 		# does not seem to work either.

--- a/usr/src/common/fs/ufsops.c
+++ b/usr/src/common/fs/ufsops.c
@@ -73,6 +73,13 @@ static	void set_cache(int, void *, uint_t);
 static	void *get_cache(int);
 static	void free_cache();
 
+static int
+get_weakish_int(int *ip)
+{
+	return (ip == NULL ? 0 : *ip);
+}
+
+#define	_kmem_ready	get_weakish_int(&kmem_ready)
 
 /*
  *	There is only 1 open (mounted) device at any given time.
@@ -771,7 +778,7 @@ bufs_close(int fd)
 		 * Until kmem is ready, clear the inode cache when closing a
 		 * file.
 		 */
-		if (kmem_ready == 0)
+		if (_kmem_ready == 0)
 			free_cache();
 
 		return (0);

--- a/usr/src/uts/common/os/aio_subr.c
+++ b/usr/src/uts/common/os/aio_subr.c
@@ -1115,7 +1115,7 @@ aio_copyout_result(aio_req_t *reqp)
 		(void) suword32(&((aio_result32_t *)resultp)->aio_errno, error);
 	}
 #else
-	(void) suword32(&((aio_result_t *)resultp)->aio_return, retval);
+	(void) sulword(&((aio_result_t *)resultp)->aio_return, retval);
 	(void) suword32(&((aio_result_t *)resultp)->aio_errno, error);
 #endif
 }
@@ -1147,7 +1147,7 @@ aio_copyout_result_port(struct iovec *iov, struct buf *bp, void *resultp)
 		(void) suword32(&((aio_result32_t *)resultp)->aio_errno, errno);
 	}
 #else
-	(void) suword32(&((aio_result_t *)resultp)->aio_return, retval);
+	(void) sulword(&((aio_result_t *)resultp)->aio_return, retval);
 	(void) suword32(&((aio_result_t *)resultp)->aio_errno, errno);
 #endif
 }


### PR DESCRIPTION
This is a collection of small changes that make it possible to boot from a boot_archive in hsfs (existing support), ufs-nocompress, ufs and cpio formats.

The PR was tested with:
```
# construct an image, which gets the hsfs archive, boot it
svccfg -s system/boot-archive setprop config/format=cpio
bootadm update-archive -f -F cpio
shutdown -y -i6 -g0
# reboot, boot_archive is NOT updated during reboot
svccfg -s system/boot-archive setprop config/format=ufs-nocompress
bootadm update-archive -f -F ufs-nocompress
shutdown -y -i6 -g0
# reboot, boot_archive is NOT updated during reboot
svccfg -s system/boot-archive setprop config/format=ufs
bootadm update-archive -f -F ufs
shutdown -y -i6 -g0
# reboot, boot_archive is NOT updated during reboot
svccfg -s system/boot-archive setprop config/format=hsfs
bootadm update-archive -f -F hsfs
shutdown -y -i6 -g0
# reboot, boot_archive is NOT updated during reboot
```

Once this is in we could change the build_image.ksh script to call the create_ramdisk script for creating our initial boot_archive (and set SMF properties if we wish to keep an alternate format).