### PR TITLE
defcons: deferred-console-buf is a 64bit value

### DIFF
--- a/usr/src/uts/armv8/os/fakebop.c
+++ b/usr/src/uts/armv8/os/fakebop.c
@@ -81,6 +81,7 @@ static paddr_t do_bop_phys_alloc(bootops_t *, size_t, int);
 static void do_bsys_free(bootops_t *, caddr_t, size_t);
 static char *do_bsys_nextprop(bootops_t *, char *);
 static void bsetprops(char *, char *);
+static void bsetprop32(char *, uint32_t);
 static void bsetprop64(char *, uint64_t);
 static void bsetpropsi(char *, int);
 static void bsetprop(int, char *, int, void *, int);
@@ -1064,7 +1065,7 @@ defcons_init(size_t size)
 
 	p = do_bsys_alloc(NULL, NULL, size, MMU_PAGESIZE);
 	*p = 0;
-	bsetprop32("deferred-console-buf", (uint32_t)((uintptr_t)&p));
+	bsetprop64("deferred-console-buf", (uint64_t)((uintptr_t)&p));
 	return (p);
 }
 


### PR DESCRIPTION
Picking this out of my ACPI tree, as it's a generic fix and not ACPI-related.

When we reworked console initialisation and consconfig we picked up a lot of code from i86pc. This was one piece that I did not stare at for long enough, and missed that on i86pc the deferred console buffer (allocated from bootmem) will always be a 32bit address but can be a 64bit address on aarch64.

Fix up this oversight.