### PR TITLE
unix: Work around Linux/KVM cache quirks

### DIFF
--- a/usr/src/uts/armv8/os/startup.c
+++ b/usr/src/uts/armv8/os/startup.c
@@ -274,6 +274,7 @@ getl2cacheinfo(int *csz, int *lsz, int *assoc)
 
 	write_csselr_el1(1u << 1); /* CCSIDR_EL1 should reflect L2$ */
 	ccsidr = read_ccsidr_el1();
+	PRM_DEBUG(ccsidr);
 
 	/*
 	 * We need ID_AA64MMFR2.CCIDX prior to cpu features being detected
@@ -287,8 +288,19 @@ getl2cacheinfo(int *csz, int *lsz, int *assoc)
 		l2cache_assoc = bitx64(ccsidr, 23, 3) + 1;
 	}
 
+	PRM_DEBUG(num_sets);
+	PRM_DEBUG(l2cache_assoc);
+
 	l2cache_linesz = (1u << (4 + bitx64(ccsidr, 2, 0)));
+	PRM_DEBUG(l2cache_linesz);
 	l2cache_sz = l2cache_linesz * l2cache_assoc * num_sets;
+	PRM_DEBUG(l2cache_sz);
+
+	if (num_sets == 1 && l2cache_assoc == 1) {
+		PRM_POINT("NOTICE: working around KVM cache size "
+		    "discovery restrictions");
+		l2cache_assoc = 0;
+	}
 }
 
 void

--- a/usr/src/uts/armv8/vm/vm_machdep.c
+++ b/usr/src/uts/armv8/vm/vm_machdep.c
@@ -982,13 +982,14 @@ page_coloring_init(uint_t l2_sz, int l2_linesz, int l2_assoc)
 	ASSERT(mmu_page_sizes <= MMU_PAGE_SIZES);
 
 	ASSERT(ISP2(l2_linesz));
-	ASSERT(l2_sz > MMU_PAGESIZE);
 
 	/* l2_assoc is 0 for fully associative l2 cache */
-	if (l2_assoc)
+	if (l2_assoc) {
+		ASSERT3U(l2_sz, >, MMU_PAGESIZE);
 		l2_colors = MAX(1, l2_sz / (l2_assoc * MMU_PAGESIZE));
-	else
+	} else {
 		l2_colors = 1;
+	}
 
 	ASSERT(ISP2(l2_colors));
 


### PR DESCRIPTION
Plucked from my ACPI branch, but not ACPI-specific. I discovered this issue when running virtual machines under Linux/KVM on Ubuntu 25.04.

`getl2cacheinfo` falls foul of a Linux/KVM decision to only expose one cache set and one cache way to guests via CCSIDR_EL1. This results in invalid cache colours calculations in `page_coloring_init`.

When we see this condition, adjust the L2 cache association value to 0 to force a single cache colour (as if fully associative), since no more sensible value can be derived.