### PR TITLE
consconfig_dacf: deferred-console-buf is a 64bit value on aarch64

### DIFF
--- a/usr/src/uts/common/io/consconfig_dacf.c
+++ b/usr/src/uts/common/io/consconfig_dacf.c
@@ -2135,12 +2135,20 @@ flush_deferred_console_buf(void)
 {
 	int rval;
 	vnode_t *vp;
-	uint_t defcons_buf;
 	char *kc, *bc, *defcons_kern_buf;
+
+#if defined(__aarch64__)
+	uint64_t defcons_buf;
+
+	defcons_buf = ddi_prop_get_int64(DDI_DEV_T_ANY, ddi_root_node(),
+	    DDI_PROP_DONTPASS, "deferred-console-buf", 0);
+#else
+	uint_t defcons_buf;
 
 	/* defcons_buf is in low memory, so an int works here */
 	defcons_buf = ddi_prop_get_int(DDI_DEV_T_ANY, ddi_root_node(),
 	    DDI_PROP_DONTPASS, "deferred-console-buf", 0);
+#endif
 
 	if (defcons_buf == 0)
 		return;


### PR DESCRIPTION
This a follow-up to #186, and makes the only code that consumes `deferred-console-buf` aware of this value being 64bit on aarch64.

Built and booted, but since we don't yet have systems with a deferred console there's no more meaningful testing to be done.