### PR TITLE
ranges: Don't crash when parent private data is NULL

### DIFF
--- a/usr/src/uts/aarch64/os/ddi_arch.c
+++ b/usr/src/uts/aarch64/os/ddi_arch.c
@@ -220,6 +220,13 @@ i_ddi_apply_range(dev_info_t *dp, dev_info_t *rdip, struct regspec *rp)
 	static char *out_of_range =
 	    "Out of range register specification from device node <%s>\n";
 
+	if (DEVI_PD(dp) == NULL) {
+#ifdef	DDI_MAP_DEBUG
+		ddi_map_debug("    No range.\n");
+#endif	/* DDI_MAP_DEBUG */
+		return (0);
+	}
+
 	nrange = i_ddi_pd_getnrng(dp);
 	if (nrange == 0)  {
 #ifdef	DDI_MAP_DEBUG


### PR DESCRIPTION
Avoid a crash in resolving ranges when no parent private data exists.

When that condition occurs, act as if no ranges were present.

Tested in my r1mikey/armh-sbbr branch:
* Qemu virt (FDT, GICv2): https://gist.github.com/r1mikey/d472aa885808b5a15e12e2954c46828d
* Qemu virt (FDT, GICv3): https://gist.github.com/r1mikey/42a44cdf7828d8950472a86242908c00
* Qemu virt (ACPI, GICv2): https://gist.github.com/r1mikey/aff27ef0afb1a5601af1ab2a97b0b13f
* Qemu virt (ACPI, GICv3): https://gist.github.com/r1mikey/e8d9f86ea79790658a9d4a72cc1f7e18
* Qemu sbsa-ref (ACPI, GICv3): https://gist.github.com/r1mikey/68ae974fa47fc0caee8e2d94ae7d26b4
* Raspberry Pi 4 (FDT, GICv2): https://gist.github.com/r1mikey/ef22c862dda726a770d79270244ddc78
* Ampere Altra Max (ACPI, GICv3): https://gist.github.com/r1mikey/42670cd138165b3a07f284e887feb164
