### PR TITLE
obpdefs: Add more constants and document default values

### DIFF
--- a/usr/src/uts/aarch64/sys/obpdefs.h
+++ b/usr/src/uts/aarch64/sys/obpdefs.h
@@ -91,8 +91,22 @@ typedef	phandle_t pnode_t;
 #define	OBP_INTERRUPT_MAP		"interrupt-map"
 #define	OBP_INTERRUPT_MAP_MASK		"interrupt-map-mask"
 
+#define	OBP_MSI_CONTROLLER		"msi-controller"
+#define	OBP_MSI_CELLS			"#msi-cells"
+
 /*
- * DTSpec defaults
+ * From Bindings/interrupt-controller/msi.txt as found in the devicetree-source
+ * repository at https://github.com/devicetree-org/devicetree-source.
+ *
+ * #msi-cells: The number of cells in an msi-specifier, required if not zero.
+ */
+#define	OBP_DEFAULT_MSI_CELLS		0
+
+/*
+ * DTSpec defaults (DTSpec 0.4, §2.3.5)
+ *
+ * If missing, a client program should assume a default value of 2 for
+ * #address-cells, and a value of 1 for #size-cells.
  */
 #define	OBP_DEFAULT_ADDRESS_CELLS	2
 #define	OBP_DEFAULT_SIZE_CELLS		1


### PR DESCRIPTION
Add constants and defaults for dtspec MSI bindings as well as documentation for our default values and where they come from.

Tested in my r1mikey/armh-sbbr branch:
* Qemu virt (FDT, GICv2): https://gist.github.com/r1mikey/d472aa885808b5a15e12e2954c46828d
* Qemu virt (FDT, GICv3): https://gist.github.com/r1mikey/42a44cdf7828d8950472a86242908c00
* Qemu virt (ACPI, GICv2): https://gist.github.com/r1mikey/aff27ef0afb1a5601af1ab2a97b0b13f
* Qemu virt (ACPI, GICv3): https://gist.github.com/r1mikey/e8d9f86ea79790658a9d4a72cc1f7e18
* Qemu sbsa-ref (ACPI, GICv3): https://gist.github.com/r1mikey/68ae974fa47fc0caee8e2d94ae7d26b4
* Raspberry Pi 4 (FDT, GICv2): https://gist.github.com/r1mikey/ef22c862dda726a770d79270244ddc78
* Ampere Altra Max (ACPI, GICv3): https://gist.github.com/r1mikey/42670cd138165b3a07f284e887feb164