### PR TITLE
cpuinfo: Propagate the CPU uid to unix when present

### DIFF
--- a/usr/src/uts/armv8/dboot/dboot_conf_acpi.c
+++ b/usr/src/uts/armv8/dboot/dboot_conf_acpi.c
@@ -140,6 +140,7 @@ fill_xcpuinfo(const ACPI_MADT_GENERIC_INTERRUPT *gicc,
 	xci->xci_ppver = CPUINFO_ENABLE_METHOD_PSCI;
 	xci->xci_parked_addr = 0;
 	xci->xci_cpuif = gicc->CpuInterfaceNumber;
+	xci->xci_uid = gicc->Uid;
 
 	return (0);
 }

--- a/usr/src/uts/armv8/dboot/dboot_conf_fdt.c
+++ b/usr/src/uts/armv8/dboot/dboot_conf_fdt.c
@@ -273,6 +273,9 @@ fill_xcpuinfo(const void *fdtp, int nodeoff, struct xboot_cpu_info *xci)
 			return (-1);
 	}
 
+	/* the Uid field is ACPI-specific */
+	xci->xci_uid = 0;
+
 	xci->xci_cpuif = 0;
 	if (!is_gicv3(fdtp)) {
 		/*

--- a/usr/src/uts/armv8/os/cpuinfo.c
+++ b/usr/src/uts/armv8/os/cpuinfo.c
@@ -103,6 +103,7 @@ fill_cpuinfo(const struct xboot_cpu_info *xci, struct cpuinfo *ci)
 	ci->ci_ppver = xci->xci_ppver;
 	ci->ci_parked_addr = xci->xci_parked_addr;
 	ci->ci_cpuif = xci->xci_cpuif;
+	ci->ci_uid = xci->xci_uid;
 	return (0);
 }
 


### PR DESCRIPTION
The CPU uid field is an ACPI-specific piece of data allowing us to tie a CPU as expressed in the MADT to an ACPI namespace node.

Consistently populate this field from dboot.

Tested in my r1mikey/armh-sbbr branch:
* Qemu virt (FDT, GICv2): https://gist.github.com/r1mikey/d472aa885808b5a15e12e2954c46828d
* Qemu virt (FDT, GICv3): https://gist.github.com/r1mikey/42a44cdf7828d8950472a86242908c00
* Qemu virt (ACPI, GICv2): https://gist.github.com/r1mikey/aff27ef0afb1a5601af1ab2a97b0b13f
* Qemu virt (ACPI, GICv3): https://gist.github.com/r1mikey/e8d9f86ea79790658a9d4a72cc1f7e18
* Qemu sbsa-ref (ACPI, GICv3): https://gist.github.com/r1mikey/68ae974fa47fc0caee8e2d94ae7d26b4
* Raspberry Pi 4 (FDT, GICv2): https://gist.github.com/r1mikey/ef22c862dda726a770d79270244ddc78
* Ampere Altra Max (ACPI, GICv3): https://gist.github.com/r1mikey/42670cd138165b3a07f284e887feb164