### PR TITLE
aarch64: yield does not

### DIFF
--- a/usr/src/uts/aarch64/sys/cpu.h
+++ b/usr/src/uts/aarch64/sys/cpu.h
@@ -34,7 +34,7 @@ extern "C" {
 #if defined(_KERNEL) && !defined(_ASM)
 
 #define	SMT_PAUSE()	\
-    __asm__ __volatile__("yield":::"memory")
+    __asm__ __volatile__("isb":::"memory")
 
 #endif
 

--- a/usr/src/uts/armv8/os/mp_startup.c
+++ b/usr/src/uts/armv8/os/mp_startup.c
@@ -97,7 +97,7 @@ mp_startup_wait(cpuset_t *sp, processorid_t cpuid)
 
 	for (tempset = *sp; !CPU_IN_SET(tempset, cpuid);
 	    tempset = *(volatile cpuset_t *)sp) {
-		__asm__ volatile("yield");
+		__asm__ volatile("isb");
 	}
 	CPUSET_ATOMIC_DEL(*(cpuset_t *)sp, cpuid);
 }
@@ -110,7 +110,7 @@ mp_startup_signal(cpuset_t *sp, processorid_t cpuid)
 	CPUSET_ATOMIC_ADD(*(cpuset_t *)sp, cpuid);
 	for (tempset = *sp; CPU_IN_SET(tempset, cpuid);
 	    tempset = *(volatile cpuset_t *)sp) {
-		__asm__ volatile("yield");
+		__asm__ volatile("isb");
 	}
 }
 


### PR DESCRIPTION
Somewhat strangely, yield does not actually yield in all but a few cases. Where it does work is in systems with CMT. Where it does not work is... basically all machines you can buy that contain an Arm CPU.

What's worse is that the yield instruction lives in NOP-space, and is therefore discarded by the CPU frontend on most modern Arm processors (this is definitely the case on Neoverse-V2), so it's misleading at best, and incorrect wherever it is used for things like spin-loop backoff.

Advice from Arm is to use an instruction sync barrier (isb) to introduce a short stall in processing. Terrible, but this is the state of the Art until future CPUs ship with the wfet instruction.

Tested in my r1mikey/armh-sbbr branch:
* Qemu virt (FDT, GICv2): https://gist.github.com/r1mikey/d472aa885808b5a15e12e2954c46828d
* Qemu virt (FDT, GICv3): https://gist.github.com/r1mikey/42a44cdf7828d8950472a86242908c00
* Qemu virt (ACPI, GICv2): https://gist.github.com/r1mikey/aff27ef0afb1a5601af1ab2a97b0b13f
* Qemu virt (ACPI, GICv3): https://gist.github.com/r1mikey/e8d9f86ea79790658a9d4a72cc1f7e18
* Qemu sbsa-ref (ACPI, GICv3): https://gist.github.com/r1mikey/68ae974fa47fc0caee8e2d94ae7d26b4
* Raspberry Pi 4 (FDT, GICv2): https://gist.github.com/r1mikey/ef22c862dda726a770d79270244ddc78
* Ampere Altra Max (ACPI, GICv3): https://gist.github.com/r1mikey/42670cd138165b3a07f284e887feb164