### PR TITLE
kobj_isa: aarch64: Rework instruction cache flushing

### DIFF
--- a/usr/src/uts/aarch64/krtld/kobj_isa.c
+++ b/usr/src/uts/aarch64/krtld/kobj_isa.c
@@ -81,8 +81,8 @@ void
 kobj_sync_instruction_memory(caddr_t addr, size_t len)
 {
 	uint64_t ctr = read_ctr_el0();
-	uint64_t inst_line_size = CTR_IMINLINE_SIZE(ctr);
-	uint64_t data_line_size = CTR_DMINLINE_SIZE(ctr);
+	uint64_t inst_line_size = 4ul << (ctr & 0xful);
+	uint64_t data_line_size = 4ul << ((ctr & 0xf0000ul) >> 16);
 
 	for (uintptr_t v = P2ALIGN((uintptr_t)addr, data_line_size);
 	    v < (uintptr_t)addr + len; v += data_line_size) {


### PR DESCRIPTION
Avoid the CTR_ macros from sys/controlregs.h, as those are backed by bitx64, which lives in genunix and may not be resolved by the time this code is executed. Even if bitx64 has been resolved, this code could (and does) blow up on systems with a sufficiently large instruction prefetch buffer, such as Altra Max.

Tested in my r1mikey/armh-sbbr branch:
* Qemu virt (FDT, GICv2): https://gist.github.com/r1mikey/d472aa885808b5a15e12e2954c46828d
* Qemu virt (FDT, GICv3): https://gist.github.com/r1mikey/42a44cdf7828d8950472a86242908c00
* Qemu virt (ACPI, GICv2): https://gist.github.com/r1mikey/aff27ef0afb1a5601af1ab2a97b0b13f
* Qemu virt (ACPI, GICv3): https://gist.github.com/r1mikey/e8d9f86ea79790658a9d4a72cc1f7e18
* Qemu sbsa-ref (ACPI, GICv3): https://gist.github.com/r1mikey/68ae974fa47fc0caee8e2d94ae7d26b4
* Raspberry Pi 4 (FDT, GICv2): https://gist.github.com/r1mikey/ef22c862dda726a770d79270244ddc78
* Ampere Altra Max (ACPI, GICv3): https://gist.github.com/r1mikey/42670cd138165b3a07f284e887feb164