### PR TITLE
bop: Set the efi-systab boot property

### DIFF
--- a/usr/src/uts/armv8/os/fakebop.c
+++ b/usr/src/uts/armv8/os/fakebop.c
@@ -1039,6 +1039,10 @@ build_firmware_properties_fdt(const void *fdtp)
 static void
 build_firmware_properties(struct xboot_info *xbp __maybe_unused)
 {
+	if (xbp->bi_uefi_systab == 0)
+		prom_panic("illumos/aarch64 requires UEFI\n");
+	bsetprop64("efi-systab", xbp->bi_uefi_systab);
+
 	if (xbp->bi_smbios != 0)
 		bsetprop64("smbios-address", xbp->bi_smbios);
 


### PR DESCRIPTION
Use the same property name for `aarch64` as we do for `i86pc` machines.

Tested in my r1mikey/armh-sbbr branch:
* Qemu virt (FDT, GICv2): https://gist.github.com/r1mikey/d472aa885808b5a15e12e2954c46828d
* Qemu virt (FDT, GICv3): https://gist.github.com/r1mikey/42a44cdf7828d8950472a86242908c00
* Qemu virt (ACPI, GICv2): https://gist.github.com/r1mikey/aff27ef0afb1a5601af1ab2a97b0b13f
* Qemu virt (ACPI, GICv3): https://gist.github.com/r1mikey/e8d9f86ea79790658a9d4a72cc1f7e18
* Qemu sbsa-ref (ACPI, GICv3): https://gist.github.com/r1mikey/68ae974fa47fc0caee8e2d94ae7d26b4
* Raspberry Pi 4 (FDT, GICv2): https://gist.github.com/r1mikey/ef22c862dda726a770d79270244ddc78
* Ampere Altra Max (ACPI, GICv3): https://gist.github.com/r1mikey/42670cd138165b3a07f284e887feb164