### PR TITLE
unix: Bump NCPU to 128

### DIFF
--- a/usr/src/uts/armv8/sys/machparam.h
+++ b/usr/src/uts/armv8/sys/machparam.h
@@ -42,8 +42,8 @@ extern "C" {
 #define	ADDRESS_C(c)	UINT64_C(c)
 #endif
 
-#define	NCPU		64
-#define	NCPU_LOG2	6
+#define	NCPU		128
+#define	NCPU_LOG2	7
 #define	NCPU_P2		(1 << NCPU_LOG2)
 
 #define	MMU_PAGE_SIZES	3


### PR DESCRIPTION
Support up to 128 CPUs for larger VMs and Altra Max.

Tested in my r1mikey/armh-sbbr branch:
* Qemu virt (FDT, GICv2): https://gist.github.com/r1mikey/d472aa885808b5a15e12e2954c46828d
* Qemu virt (FDT, GICv3): https://gist.github.com/r1mikey/42a44cdf7828d8950472a86242908c00
* Qemu virt (ACPI, GICv2): https://gist.github.com/r1mikey/aff27ef0afb1a5601af1ab2a97b0b13f
* Qemu virt (ACPI, GICv3): https://gist.github.com/r1mikey/e8d9f86ea79790658a9d4a72cc1f7e18
* Qemu sbsa-ref (ACPI, GICv3): https://gist.github.com/r1mikey/68ae974fa47fc0caee8e2d94ae7d26b4
* Raspberry Pi 4 (FDT, GICv2): https://gist.github.com/r1mikey/ef22c862dda726a770d79270244ddc78
* Ampere Altra Max (ACPI, GICv3): https://gist.github.com/r1mikey/42670cd138165b3a07f284e887feb164
