### PR TITLE
pcie: Don't panic when encountering VGA, quieten debugging

### DIFF
--- a/usr/src/uts/aarch64/io/pciex/pcierc/pci_boot.c
+++ b/usr/src/uts/aarch64/io/pciex/pcierc/pci_boot.c
@@ -697,10 +697,10 @@ set_ppb_res(dev_info_t *rcdip, dev_info_t *dip, uchar_t bus, uchar_t dev,
 	}
 
 	if (base > limit) {
-		cmn_err(CE_NOTE, MSGHDR "DISABLE %4s range",
+		dcmn_err(CE_NOTE, MSGHDR "DISABLE %4s range",
 		    ddi_node_name(dip), bus, dev, func, tag);
 	} else {
-		cmn_err(CE_NOTE,
+		dcmn_err(CE_NOTE,
 		    MSGHDR "PROGRAM %4s range 0x%lx ~ 0x%lx",
 		    ddi_node_name(dip), bus, dev, func, tag, base, limit);
 	}
@@ -956,7 +956,7 @@ fix_ppb_res(dev_info_t *rcdip, struct pci_bus_resource *pci_bus_res,
 			if (addr != 0) {
 				add_ranges_prop(pci_bus_res, secbus, B_TRUE);
 
-				cmn_err(CE_NOTE,
+				dcmn_err(CE_NOTE,
 				    MSGHDR "PROGRAM  I/O range 0x%lx ~ 0x%lx "
 				    "(subtractive bridge)",
 				    ddi_node_name(dip), bus, dev, func,
@@ -972,7 +972,7 @@ fix_ppb_res(dev_info_t *rcdip, struct pci_bus_resource *pci_bus_res,
 			if (addr != 0) {
 				add_ranges_prop(pci_bus_res, secbus, B_TRUE);
 
-				cmn_err(CE_NOTE,
+				dcmn_err(CE_NOTE,
 				    MSGHDR "PROGRAM  MEM range 0x%lx ~ 0x%lx "
 				    "(subtractive bridge)",
 				    ddi_node_name(dip), bus, dev, func,
@@ -1706,7 +1706,7 @@ add_bar_reg_props(dev_info_t *rcdip, struct pci_bus_resource *pci_bus_res,
 			} else {
 				uint32_t nbase;
 
-				cmn_err(CE_NOTE, MSGHDR "BAR%u  "
+				dcmn_err(CE_NOTE, MSGHDR "BAR%u  "
 				    "I/O REPROG 0x%x ~ 0x%x",
 				    ddi_node_name(rcdip), bus, dev, func,
 				    bar, base, len);
@@ -1874,7 +1874,7 @@ add_bar_reg_props(dev_info_t *rcdip, struct pci_bus_resource *pci_bus_res,
 			} else {
 				uint64_t nbase, nbase_hi = 0;
 
-				cmn_err(CE_NOTE, MSGHDR "BAR%u "
+				dcmn_err(CE_NOTE, MSGHDR "BAR%u "
 				    "%s%s REPROG 0x%lx ~ 0x%lx",
 				    ddi_node_name(rcdip), bus, dev, func, bar,
 				    pf ? "PMEM" : "MEM",

--- a/usr/src/uts/aarch64/io/pciex/pcierc/pci_boot.c
+++ b/usr/src/uts/aarch64/io/pciex/pcierc/pci_boot.c
@@ -2084,14 +2084,14 @@ add_reg_props(dev_info_t *rcdip, dev_info_t *dip,
 	/* add the three hard-decode, aliased address spaces for VGA */
 	if ((baseclass == PCI_CLASS_DISPLAY && subclass == PCI_DISPLAY_VGA) ||
 	    (baseclass == PCI_CLASS_NONE && subclass == PCI_NONE_VGA)) {
-		dev_err(dip, CE_PANIC, "ARM PCI does not support legacy VGA");
+		dev_err(dip, CE_NOTE, "ARM PCI does not support legacy VGA");
 	}
 
 	/* add the hard-decode, aliased address spaces for 8514 */
 	if ((baseclass == PCI_CLASS_DISPLAY) &&
 	    (subclass == PCI_DISPLAY_VGA) &&
 	    (progclass & PCI_DISPLAY_IF_8514)) {
-		dev_err(dip, CE_PANIC, "ARM PCI does not support legacy VGA");
+		dev_err(dip, CE_NOTE, "ARM PCI does not support legacy VGA");
 	}
 
 done:
@@ -2226,7 +2226,7 @@ add_ppb_props(dev_info_t *rcdip, dev_info_t *dip,
 
 	if (pci_cfgacc_get16(rcdip, PCI_GETBDF(bus, dev, func),
 	    PCI_BCNF_BCNTRL) & PCI_BCNF_BCNTRL_VGA_ENABLE) {
-		dev_err(dip, CE_PANIC, "ARM PCI does not support legacy VGA");
+		dev_err(dip, CE_NOTE, "ARM PCI does not support legacy VGA");
 	}
 
 	add_bus_range_prop(pci_bus_res, secbus);


### PR DESCRIPTION
One small fix to convert a few debugging messages from cmn_err to dcmn_err.

The other commit converts CE_PANIC on encountering a legacy VGA device to notes so that we can boot on systems with PCIe graphics adapters (such as Altra Max, where the BMC exposes a VGA device to the host).

Tested in my r1mikey/armh-sbbr branch:
* Qemu virt (FDT, GICv2): https://gist.github.com/r1mikey/d472aa885808b5a15e12e2954c46828d
* Qemu virt (FDT, GICv3): https://gist.github.com/r1mikey/42a44cdf7828d8950472a86242908c00
* Qemu virt (ACPI, GICv2): https://gist.github.com/r1mikey/aff27ef0afb1a5601af1ab2a97b0b13f
* Qemu virt (ACPI, GICv3): https://gist.github.com/r1mikey/e8d9f86ea79790658a9d4a72cc1f7e18
* Qemu sbsa-ref (ACPI, GICv3): https://gist.github.com/r1mikey/68ae974fa47fc0caee8e2d94ae7d26b4
* Raspberry Pi 4 (FDT, GICv2): https://gist.github.com/r1mikey/ef22c862dda726a770d79270244ddc78
* Ampere Altra Max (ACPI, GICv3): https://gist.github.com/r1mikey/42670cd138165b3a07f284e887feb164
