### PR TITLE
startup: Reserve sufficiant KVA for pcierc config space mappings

### DIFF
--- a/usr/src/uts/aarch64/sys/bootinfo.h
+++ b/usr/src/uts/aarch64/sys/bootinfo.h
@@ -118,6 +118,7 @@ struct xboot_info {
 	uint64_t		bi_cpuinfo;
 	xbi_bsvc_uart_type_t	bi_bsvc_uart_type;
 	uint32_t		bi_cpuinfo_cnt;
+	uint32_t		bi_pcierc_cnt;
 	uint32_t		bi_module_cnt;
 	uint32_t		bi_psci_version;
 	uint32_t		bi_psci_conduit_hvc;

--- a/usr/src/uts/armv8/dboot/dboot_conf_fdt.c
+++ b/usr/src/uts/armv8/dboot/dboot_conf_fdt.c
@@ -389,6 +389,29 @@ dboot_configure_fdt_cpuinfo(const void *fdtp, struct xboot_info *bi)
 	return (0);
 }
 
+static void
+dboot_count_pcierc_compat(const void *fdtp, struct xboot_info *bi,
+    const char *compat)
+{
+	int off = fdt_node_offset_by_compatible(fdtp, -1, compat);
+
+	while (off != -FDT_ERR_NOTFOUND) {
+		bi->bi_pcierc_cnt++;
+		off = fdt_node_offset_by_compatible(fdtp, off, compat);
+	}
+}
+
+static void
+dboot_count_pcierc(const void *fdtp, struct xboot_info *bi)
+{
+	static const char *ecam = "pci-host-ecam-generic";
+	static const char *rpi4 = "brcm,bcm2711-pcie";
+
+	bi->bi_pcierc_cnt = 0;
+	dboot_count_pcierc_compat(fdtp, bi, ecam);
+	dboot_count_pcierc_compat(fdtp, bi, rpi4);
+}
+
 int
 dboot_configure_fdt(void)
 {
@@ -463,5 +486,6 @@ dboot_configure_fdt(void)
 			    fdt32_to_cpu(*((const uint32_t *)pval));
 	}
 
+	dboot_count_pcierc(fdtp, bi);
 	return (dboot_configure_fdt_cpuinfo(fdtp, bi));
 }

--- a/usr/src/uts/armv8/dboot/dboot_machdep.c
+++ b/usr/src/uts/armv8/dboot/dboot_machdep.c
@@ -124,6 +124,7 @@ exitto(int (*entrypoint)(struct xboot_info *), struct xboot_info *bi)
 		dprintf("  %s: 0x%lx\n", "bi_hyp_stubs", bi->bi_hyp_stubs);
 		dprintf("  %s: 0x%x\n", "bi_bsvc_uart_type",
 		    bi->bi_bsvc_uart_type);
+		dprintf("  %s: 0x%x\n", "bi_pcierc_cnt", bi->bi_pcierc_cnt);
 		dprintf("  %s: 0x%x\n", "bi_module_cnt", bi->bi_module_cnt);
 		dprintf("  %s: 0x%x\n", "bi_psci_version", bi->bi_psci_version);
 		dprintf("  %s: 0x%x\n", "bi_psci_conduit_hvc",
@@ -150,6 +151,8 @@ exitto(int (*entrypoint)(struct xboot_info *), struct xboot_info *bi)
 		    bi->bi_framebuffer == 0 ? "Absent" : "Present");
 		dboot_printf("  %s: %luHz\n", "Timer Frequency",
 		    bi->bi_arch_timer_freq);
+		dboot_printf("  %s: %u\n", "PCIe Root Complexes",
+		    bi->bi_pcierc_cnt);
 		dboot_printf("  %s: %u.%u\n", "PSCI Version",
 		    bi->bi_psci_version >> 16, bi->bi_psci_version & 0xffff);
 		dboot_printf("  %s: %s\n", "PSCI Conduit",

--- a/usr/src/uts/armv8/os/fakebop.c
+++ b/usr/src/uts/armv8/os/fakebop.c
@@ -1046,6 +1046,9 @@ build_firmware_properties(struct xboot_info *xbp __maybe_unused)
 	if (xbp->bi_smbios != 0)
 		bsetprop64("smbios-address", xbp->bi_smbios);
 
+	if (xbp->bi_pcierc_cnt != 0)
+		bsetprop32("num-known-pcierc", xbp->bi_pcierc_cnt);
+
 #if defined(_USE_FDT)
 	if (xbp->bi_fdt != 0) {
 		const void *fdtp = (void *)xbp->bi_fdt;


### PR DESCRIPTION
At present we reserve 1GiB of VA for the device arena. When faced with a large number of PCIe root complexes that need their config space mapped we rapidly exhaust the available VA.

Discover the number of known PCIe root complexes from `dboot`, passing this number through to `unix` so that `toxic_size` can be adjusted to take larger machines into account.

In FDT systems this is accomplished by counting the number of known PCIe root complexes. In ACPI systems this is accomplished by counting the number of MMCFG records in the MCFG table.

Since it's possible to have unknown or dynamic root complexes show up (i.e. via DSDT-only nodes, or unrecognised complexes in FDT), also add an environment variable, settable both in the environment and on the command-line, indicating the number of additional complexes to provision space for. This should allow us to iterate on support for new devices without building a new kernel.

Each root complex results in 256MiB of additional VA being allocated in `toxic_size`, reflecting the needs of ECAM, which is a reasonable approximation.

Testing:
* Rpi4, FDT, showing that the BCRM complexes is detected and that additional space can be provisioned: https://gist.github.com/r1mikey/9654f3322080d1a3e597d86d56592b8d
* Qemu virt, FDT, showing that the ECAM complexes is detected and that additional space can be provisioned: https://gist.github.com/r1mikey/f38a5e94b218f73536a7526481e38f85
* Qemu virt, ACPI, showing that the ECAM complexes is detected and that additional space can be provisioned:  https://gist.github.com/r1mikey/8c1c004a391fd7adda778ee9ad4499a2
* Ampere Altra Max, ACPI, all 8 ECAM complexes are detected: https://gist.github.com/r1mikey/229afa6598895c658148d082ad3e582e

The Altra Max case, specifically, used to exhaust device arena VA during boot, and now works as expected.

Altra Max is the most extreme case I've seen so far, with 8 root complexes. Nvidia's Grace has 5 root complexes.