### PR TITLE
cpuid: read mmfr3 now we have a newer binutils which supports it by name

### DIFF
--- a/usr/src/uts/aarch64/os/cpuid.c
+++ b/usr/src/uts/aarch64/os/cpuid.c
@@ -1071,11 +1071,7 @@ cpuid_gather_arm_features(void *features)
 	cpuid_regs.mmfr0 = read_id_aa64mmfr0();
 	cpuid_regs.mmfr1 = read_id_aa64mmfr1();
 	cpuid_regs.mmfr2 = read_id_aa64mmfr2();
-#if 0				/* XXXARM: binutils doesn't support this */
 	cpuid_regs.mmfr3 = read_id_aa64mmfr3();
-#else
-	cpuid_regs.mmfr3 = 0;
-#endif
 
 	/* These are initialized later based on FEAT_SVE, and FEAT_SME */
 	cpuid_regs.zfr0 = 0;


### PR DESCRIPTION
I'd appreciate people booting this in case anything traps (though it absolutely shouldn't) @hadfl @r1mikey