### PR TITLE
sys/mcontext.h: introduce and shuffle types to match the x86 version

### DIFF
--- a/usr/src/lib/libc/aarch64/genassym.cf
+++ b/usr/src/lib/libc/aarch64/genassym.cf
@@ -1,6 +1,9 @@
 include <sys/types.h>
 include <sys/time_impl.h>
 include <sys/trap.h>
+include <sys/regset.h>
+include <sys/fp.h>
+include <sys/mcontext.h>
 
 include <signal.h>
 

--- a/usr/src/pkg/manifests/system-header.p5m
+++ b/usr/src/pkg/manifests/system-header.p5m
@@ -1128,8 +1128,7 @@ $(i386_ONLY)file path=usr/include/sys/mc_amd.h
 $(i386_ONLY)file path=usr/include/sys/mc_intel.h
 $(i386_ONLY)file path=usr/include/sys/mca_amd.h
 $(i386_ONLY)file path=usr/include/sys/mca_x86.h
-# XXXARM: Why? What?
-$(not_aarch64)file path=usr/include/sys/mcontext.h
+file path=usr/include/sys/mcontext.h
 file path=usr/include/sys/md4.h
 file path=usr/include/sys/md5.h
 file path=usr/include/sys/md5_consts.h

--- a/usr/src/uts/aarch64/ml/genassym.cf
+++ b/usr/src/uts/aarch64/ml/genassym.cf
@@ -3,6 +3,8 @@ include <sys/pcb.h>
 include <sys/controlregs.h>
 include <sys/trap.h>
 include <sys/privregs.h>
+include <sys/mcontext.h>
+include <sys/fp.h>
 
 define	MODS_SIZE		sizeof(struct mod_stub_info)
 define	MODS_INSTFCN		offsetof(struct mod_stub_info, mods_func_adr)

--- a/usr/src/uts/aarch64/sys/Makefile
+++ b/usr/src/uts/aarch64/sys/Makefile
@@ -49,6 +49,7 @@ HDRS	=			\
 	machlock.h		\
 	machsig.h		\
 	machtypes.h		\
+	mcontext.h		\
 	mutex_impl.h		\
 	obpdefs.h		\
 	old_procfs.h		\

--- a/usr/src/uts/aarch64/sys/fp.h
+++ b/usr/src/uts/aarch64/sys/fp.h
@@ -134,16 +134,29 @@ extern "C" {
 /* [0] invalid operation cumulative exception since last cleared? */
 #define	FPSR_IOC	(1 << 0)
 
-#ifdef _KERNEL
-
 #define	FPCR_INIT	(FPCR_RM_RN << FPCR_RM_SHIFT)
+
+#ifndef _ASM
+typedef upad128_t fpreg_t;
+
+/*
+ * Kernel's FPU save area
+ */
+typedef struct {
+	fpreg_t			kfpu_regs[32];
+	uint32_t		kfpu_cr;
+	uint32_t		kfpu_sr;
+} kfpu_t;
+
+typedef struct fpu_ctx {
+	kfpu_t		fpu_regs;	/* kernel save area for FPU */
+} fpu_ctx_t;
 
 extern void fp_save(fpu_ctx_t *ctx);
 extern void fp_restore(fpu_ctx_t *ctx);
 extern void fp_init(void);
 extern int fp_fenflt(void);
-
-#endif	/* _KERNEL */
+#endif	/* _ASM */
 
 #ifdef __cplusplus
 }

--- a/usr/src/uts/aarch64/sys/mcontext.h
+++ b/usr/src/uts/aarch64/sys/mcontext.h
@@ -32,63 +32,63 @@
 /*	Copyright (c) 1984, 1986, 1987, 1988, 1989 AT&T		*/
 /*	All Rights Reserved	*/
 
-#ifndef	_SYS_REGSET_H
-#define	_SYS_REGSET_H
+#ifndef _SYS_MCONTEXT_H
+#define	_SYS_MCONTEXT_H
 
 #include <sys/feature_tests.h>
+#include <sys/fp.h>
 
 #if !defined(_ASM)
 #include <sys/types.h>
 #endif
-#include <sys/mcontext.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+/*
+ * A gregset_t is defined as an array type for compatibility with the reference
+ * source. This is important due to differences in the way the C language
+ * treats arrays and structures as parameters.
+ */
+#define	_NGREG	36
+
+#ifndef _ASM
+typedef long	greg_t;
+typedef greg_t	gregset_t[_NGREG];
+
+/*
+ * Floating point definitions.
+ */
+typedef struct fpu {
 #if !defined(_XPG4_2) || defined(__EXTENSIONS__)
-#define	REG_X0		0
-#define	REG_X1		1
-#define	REG_X2		2
-#define	REG_X3		3
-#define	REG_X4		4
-#define	REG_X5		5
-#define	REG_X6		6
-#define	REG_X7		7
-#define	REG_X8		8
-#define	REG_X9		9
-#define	REG_X10		10
-#define	REG_X11		11
-#define	REG_X12		12
-#define	REG_X13		13
-#define	REG_X14		14
-#define	REG_X15		15
-#define	REG_X16		16
-#define	REG_X17		17
-#define	REG_X18		18
-#define	REG_X19		19
-#define	REG_X20		20
-#define	REG_X21		21
-#define	REG_X22		22
-#define	REG_X23		23
-#define	REG_X24		24
-#define	REG_X25		25
-#define	REG_X26		26
-#define	REG_X27		27
-#define	REG_X28		28
-#define	REG_X29		29
-#define	REG_FP		REG_X29
-#define	REG_X30		30
-#define	REG_LR		REG_X30
-#define	REG_SP		31
-#define	REG_PC		32
-#define	REG_SPSR	33
-#define	REG_TP		34
+	fpreg_t			d_fpregs[32];
+	uint32_t		fp_cr;
+	uint32_t		fp_sr;
+#else
+	fpreg_t			__d_fpregs[32];
+	uint32_t		__fp_cr;
+	uint32_t		__fp_sr;
+#endif
+} fpregset_t;
 
-#endif	/* !defined(_XPG4_2) || defined(__EXTENSIONS__) */
+/*
+ * Structure mcontext defines the complete hardware machine state.
+ */
+typedef struct {
+#if !defined(_XPG4_2) || defined(__EXTENSIONS__)
+	gregset_t	gregs;	/* general register set */
+	fpregset_t	fpregs;	/* floating point register set */
+#else
+	gregset_t	__gregs;	/* general register set */
+	fpregset_t	__fpregs;	/* floating point register set */
+#endif
+} mcontext_t;
 
-#ifdef	__cplusplus
+#endif	/* _ASM */
+
+#ifdef __cplusplus
 }
 #endif
 
-#endif	/* _SYS_REGSET_H */
+#endif /* _SYS_MCONTEXT_H */

--- a/usr/src/uts/aarch64/sys/pcb.h
+++ b/usr/src/uts/aarch64/sys/pcb.h
@@ -28,17 +28,15 @@
 #define	_SYS_PCB_H
 
 #include <sys/cpu.h>
+#include <sys/fp.h>
 #include <sys/regset.h>
+#include <sys/mcontext.h>
 
 #ifdef	__cplusplus
 extern "C" {
 #endif
 
-#ifndef _ASM
-typedef struct fpu_ctx {
-	kfpu_t		fpu_regs;	/* kernel save area for FPU */
-} fpu_ctx_t;
-
+#if !defined(_ASM)
 typedef struct pcb {
 	fpu_ctx_t	pcb_fpu;
 	uint_t		pcb_flags;	/* state flags; cleared on fork */

--- a/usr/src/uts/aarch64/sys/procfs_isa.h
+++ b/usr/src/uts/aarch64/sys/procfs_isa.h
@@ -35,6 +35,8 @@
  */
 
 #include <sys/regset.h>
+#include <sys/mcontext.h>
+#include <sys/fp.h>
 
 #ifdef	__cplusplus
 extern "C" {

--- a/usr/src/uts/aarch64/sys/ucontext.h
+++ b/usr/src/uts/aarch64/sys/ucontext.h
@@ -37,7 +37,8 @@
 #include <sys/feature_tests.h>
 
 #include <sys/types.h>
-#include <sys/regset.h>
+#include <sys/mcontext.h>
+#include <sys/fp.h>
 #if !defined(_XPG4_2) || defined(__EXTENSIONS__)
 #include <sys/signal.h>
 #endif


### PR DESCRIPTION
This is an attempt to mimic Gordon's 21227944c2bcc086121a5428f3f9d2496ba646f5 on the aarch64 side, to keep things smoothly compatible.

While looking at that, I noticed that some FP stuff seems like it went into the wrong places, and tried to fix that too.

I'm hoping I've achieved either.  @hadfl @citrus-it