### PR TITLE
dboot: Support /cpus FDT lacking enable-method.

### DIFF
--- a/usr/src/uts/armv8/dboot/dboot_conf_fdt.c
+++ b/usr/src/uts/armv8/dboot/dboot_conf_fdt.c
@@ -145,8 +145,16 @@ get_enable_method(const void *fdtp, int nodeoff)
 	int		plen;
 
 	plen = 0;
-	if ((prop = fdt_getprop(fdtp, nodeoff, "enable-method", &plen)) == NULL)
+	/*
+	 * When booting on a single CPU host (e.g. qemu) there may not be a
+	 * per-CPU enable-method, so go looking in the root.
+	 */
+	if ((prop = fdt_getprop(fdtp, nodeoff, "enable-method", &plen)) ==
+	    NULL) {
+		if (fdt_path_offset(fdtp, "/psci") >= 0)
+			return (CPUINFO_ENABLE_METHOD_PSCI);
 		return (CPUNODE_BAD_ENABLE_METHOD);
+	}
 	if (plen == 0)
 		return (CPUNODE_BAD_ENABLE_METHOD);
 


### PR DESCRIPTION
I'm working on booting under Apple's HVF. While debugging other problems I tried booting with a single CPU configured, but this fails much earlier in dboot:

```
dboot: error filling boot CPU info                                                                                                
dboot: failed to perform early configuration via FDT
dboot: configuration failed
```

Comparing the DTS between the two configurations it appears that qemu removes `enable-method` in the single CPU case:

```diff
 		cpu@0 {
-			phandle = <0x8002>;
+			phandle = <0x8001>;
 			reg = <0x00>;
-			enable-method = "psci";
 			compatible = "arm,armv8";
 			device_type = "cpu";
 		};
```

This patch falls back to looking for the top-level `/psci`, and with it the boot gets as far as the multi CPU case under HVF, and all the way to login under TCG.