### PR TITLE
fakebop: Issue isb() after updating page tables.

### DIFF
--- a/usr/src/uts/armv8/os/fakebop.c
+++ b/usr/src/uts/armv8/os/fakebop.c
@@ -278,6 +278,7 @@ map_phys(bootops_t *bop, pte_t pte_attr, caddr_t vaddr, uint64_t paddr)
 	}
 	l4_ptbl[l4_idx] = paddr | pte_attr | PTE_PAGE;
 	dsb(ish);
+	isb();
 }
 
 void


### PR DESCRIPTION
I'm working on booting under Apple's HVF. Using `QEMU_SCRIPT_ACCEL=hvf QEMU_SCRIPT_CPU=host` I get an early exception:

```
Kernel Entrypoint: 0xfffffffffe053000
dump_exception
pc  = fffffffffe0633f8
esr = 96000047
far = ffff80000000a000
x0 = ffff80000000a000
x1 = 1000
x2 = 0
x3 = 0
x4 = 0
x5 = 1000
x6 = 16ce5f000
x7 = fff
x8 = ffff80000000a000
x9 = 0
x10  = 786c6d650a223536
x11  = 7865696370222073
x12  = 2234392c63373131
x13  = 222073786c6d650a
x14  = 6139317865696370
x15  = 1be6875a0
x16  = 20000000
x17  = 40
x18  = 1bd426e48
x19  = ffff80000000b000
x20  = ffff80000000b000
x21  = fffffffffe1626e0
x22  = ffff80000000a000
x23  = 8000401b1000
x24  = 1000
x25  = 400000000000708
x26  = 1ad01b000
x27  = 1
x28  = 1b90db000
x29  = fffffffffe1509f0
x30  = fffffffffe050c98
```

Digging out the addresses I get:

```
fffffffffe0633f8 is unix`memset+0x58, in /home/jperkin/git/arm64-gate/illumos-gate/proto/root_aarch64/platform/armv8/kernel/aarch64/unix [fffffffffe022000,fffffffffe1437f0)
fffffffffe050c98 is unix`do_bsys_alloc+0xc8, in /home/jperkin/git/arm64-gate/illumos-gate/proto/root_aarch64/platform/armv8/kernel/aarch64/unix [fffffffffe022000,fffffffffe1437f0)
```

`do_bsys_alloc()` calls `map_phys()` to configure the page tables and then `memset()` to clear it, but there's no `isb` in between. Earlier versions of this patch did a full `tlbi_mva()` sequence for the address but I also tried without and it appears enough. It's unclear to me what the correct fix here is, so happy to add that back in if deemed necessary.

I'm also wondering why the `dsb(ish)`s in `map_phys()` come *before* rather than *after* updating each page table level, and could they not be `ishst`s.  Mostly for my own education and trying to map to the example sequences shown in the ARMv8 ARM.

With this applied the boot gets much further before crashing in DDI, investigating that next.