### PR TITLE
dboot: MIDR Architecture is [19:16] not [18:15].

### DIFF
--- a/usr/src/uts/armv8/dboot/dboot_srt0.S
+++ b/usr/src/uts/armv8/dboot/dboot_srt0.S
@@ -238,7 +238,7 @@
 	cmp	x1, #(MIDR_IMPL_ARM)
 	b.ne	.Lnot_cortex_a5x_0
 	/* examine the architecture, must be 0xf */
-	ubfx	x1, x0, #15, #4
+	ubfx	x1, x0, #16, #4
 	cmp	x1, #0xF
 	b.ne	.Lnot_cortex_a5x_0
 	/* examine the part */


### PR DESCRIPTION
While investigating other HVF issues I noticed that the architecture check does not match the manual and we are checking the wrong bits, presumably getting away with the high bit of PartNum happening to be set.