### PR TITLE
remove USRSTACK32 through tidying

### DIFF
--- a/usr/src/uts/aarch64/sys/vmparam.h
+++ b/usr/src/uts/aarch64/sys/vmparam.h
@@ -51,8 +51,9 @@ extern "C" {
  * USRSTACK is the top (end) of the user stack.
  */
 #define	USRSTACK	USERLIMIT
-/* XXXARM: I feel like we should booby-trap these in case they're referenced */
-#define	USRSTACK32	USERLIMIT32
+
+/* NB: aarch64 has no 32bit processes and thus no USRSTACK32 */
+
 /* This is used for LP64 SF1_SUNW_ADDR32 processes */
 #define	USRSTACK64_32	USERLIMIT32
 

--- a/usr/src/uts/aarch64/sys/vmparam.h
+++ b/usr/src/uts/aarch64/sys/vmparam.h
@@ -53,6 +53,7 @@ extern "C" {
 #define	USRSTACK	USERLIMIT
 /* XXXARM: I feel like we should booby-trap these in case they're referenced */
 #define	USRSTACK32	USERLIMIT32
+/* This is used for LP64 SF1_SUNW_ADDR32 processes */
 #define	USRSTACK64_32	USERLIMIT32
 
 /*

--- a/usr/src/uts/armv8/sys/machparam.h
+++ b/usr/src/uts/armv8/sys/machparam.h
@@ -134,6 +134,11 @@ extern "C" {
  * Define upper limit on user address space
  */
 #define	USERLIMIT	(ADDRESS_C(1) << (VA_BITS - 1))
+
+/*
+ * This limit, traditionally for ILP32 processes, may also be applied to LP64
+ * processes with the SF1_SUNW_ADDR32 flag set.
+ */
 #define	USERLIMIT32	((ADDRESS_C(1) << 32) - 0x1000)
 
 /*

--- a/usr/src/uts/armv8/sys/vm_machparam.h
+++ b/usr/src/uts/armv8/sys/vm_machparam.h
@@ -52,6 +52,9 @@ extern "C" {
 #define	MAXSSIZ		(USRSTACK - 64*1024)
 #define	DFLSSIZ		(8*1024*1024)
 
+/* The default maximum stack size in an ILP32 process (aarch64 has none) */
+#define	MAXSSIZ32	0
+
 /*
  * The following are limits beyond which the hard or soft limits for stack
  * and data cannot be increased. These may be viewed as fundamental

--- a/usr/src/uts/common/os/exec.c
+++ b/usr/src/uts/common/os/exec.c
@@ -2032,12 +2032,15 @@ exec_args(execa_t *uap, uarg_t *args, intpdata_t *intp, void **auxvpp)
 			usrstack = (char *)USRSTACK64_32;
 		else
 			usrstack = (char *)USRSTACK;
-	} else {
+	}
+#ifdef _MULTI_DATAMODEL
+	else {
 		args->to_ptrsize = sizeof (int32_t);
 		args->ncargs = NCARGS32;
 		args->stk_align = STACK_ALIGN32;
 		usrstack = (char *)USRSTACK32;
 	}
+#endif	/* _MULTI_DATAMODEL */
 
 	ASSERT(P2PHASE((uintptr_t)usrstack, args->stk_align) == 0);
 

--- a/usr/src/uts/common/os/rctl_proc.c
+++ b/usr/src/uts/common/os/rctl_proc.c
@@ -307,24 +307,10 @@ rctlproc_init(void)
 	    RCENTITY_PROCESS, RCTL_GLOBAL_LOWERABLE | RCTL_GLOBAL_DENY_ALWAYS |
 	    RCTL_GLOBAL_SIGNAL_NEVER | RCTL_GLOBAL_BYTES,
 	    ULONG_MAX, UINT32_MAX, &rctl_default_ops);
-#ifdef _LP64
-#ifdef __sparc
 	rctlproc_legacy[RLIMIT_STACK] = rctl_register("process.max-stack-size",
 	    RCENTITY_PROCESS, RCTL_GLOBAL_LOWERABLE | RCTL_GLOBAL_DENY_ALWAYS |
 	    RCTL_GLOBAL_SIGNAL_NEVER | RCTL_GLOBAL_BYTES,
-	    LONG_MAX, INT32_MAX, &proc_stack_ops);
-#else	/* __sparc */
-	rctlproc_legacy[RLIMIT_STACK] = rctl_register("process.max-stack-size",
-	    RCENTITY_PROCESS, RCTL_GLOBAL_LOWERABLE | RCTL_GLOBAL_DENY_ALWAYS |
-	    RCTL_GLOBAL_SIGNAL_NEVER | RCTL_GLOBAL_BYTES,
-	    MAXSSIZ, USRSTACK32 - PAGESIZE, &proc_stack_ops);
-#endif	/* __sparc */
-#else 	/* _LP64 */
-	rctlproc_legacy[RLIMIT_STACK] = rctl_register("process.max-stack-size",
-	    RCENTITY_PROCESS, RCTL_GLOBAL_LOWERABLE | RCTL_GLOBAL_DENY_ALWAYS |
-	    RCTL_GLOBAL_SIGNAL_NEVER | RCTL_GLOBAL_BYTES,
-	    USRSTACK - PAGESIZE, USRSTACK - PAGESIZE, &proc_stack_ops);
-#endif
+	    MAXSSIZ, MAXSSIZ32, &proc_stack_ops);
 	rctlproc_legacy[RLIMIT_CORE] = rctl_register("process.max-core-size",
 	    RCENTITY_PROCESS, RCTL_GLOBAL_LOWERABLE | RCTL_GLOBAL_DENY_ALWAYS |
 	    RCTL_GLOBAL_SIGNAL_NEVER | RCTL_GLOBAL_BYTES,

--- a/usr/src/uts/common/sys/exec.h
+++ b/usr/src/uts/common/sys/exec.h
@@ -95,7 +95,7 @@ typedef struct uarg {
 	uint_t	stk_prot;
 	uint_t	dat_prot;
 	int	traceinval;
-	int	addr32;
+	boolean_t addr32;		/* LP64 process with SF1_SUNW_ADDR32 */
 	model_t	to_model;
 	model_t	from_model;
 	size_t	to_ptrsize;

--- a/usr/src/uts/i86pc/sys/vm_machparam.h
+++ b/usr/src/uts/i86pc/sys/vm_machparam.h
@@ -48,7 +48,7 @@ extern "C" {
  * the page directory entry which also maps the initial text and data,
  * and makes the default slightly bigger than the 8MB on SPARC.
  */
-#ifdef __amd64
+
 /*
  * On amd64, the stack grows down from just below KERNELBASE (see the
  * definition of USERLIMIT in i86pc/sys/machparam.h). Theoretically,
@@ -63,10 +63,10 @@ extern "C" {
  * For 32bit processes, the stack is below the text segment.
  */
 #define	MAXSSIZ		(32ULL * 1024ULL * 1024ULL * 1024ULL * 1024ULL)
-#else
-#define	MAXSSIZ		(USRSTACK - 1024*1024)
-#endif /* __amd64 */
 #define	DFLSSIZ		(8*1024*1024 + ((USRSTACK) & 0x3FFFFF))
+
+/* The default maximum stack size in an ILP32 process */
+#define	MAXSSIZ32	USRSTACK32 - PAGESIZE
 
 /*
  * Size of the kernel segkmem system pte table.  This virtual

--- a/usr/src/uts/intel/sys/vmparam.h
+++ b/usr/src/uts/intel/sys/vmparam.h
@@ -49,15 +49,10 @@ extern "C" {
 /*
  * USRSTACK is the top (end) of the user stack.
  */
-#if defined(__amd64)
 #define	USRSTACK	USERLIMIT
 #define	USRSTACK32	0x8048000
+/* This is used for LP64 SF1_SUNW_ADDR32 processes */
 #define	USRSTACK64_32	USERLIMIT32
-#elif defined(__i386)
-#define	USRSTACK	0x8048000
-#define	USRSTACK32	USRSTACK
-#define	USRSTACK64_32	USRSTACK
-#endif
 
 /*
  * Implementation architecture independent sections of the kernel use

--- a/usr/src/uts/sparc/sys/vmparam.h
+++ b/usr/src/uts/sparc/sys/vmparam.h
@@ -51,6 +51,7 @@ extern "C" {
  */
 #define	USRSTACK	USERLIMIT
 #define	USRSTACK32	USERLIMIT32
+/* This is used for LP64 SF1_SUNW_ADDR32 processes */
 #define	USRSTACK64_32	USERLIMIT32
 
 /*

--- a/usr/src/uts/sun4/sys/vm_machparam.h
+++ b/usr/src/uts/sun4/sys/vm_machparam.h
@@ -48,8 +48,11 @@ extern "C" {
  * resources so that in normal use a single mmu region map entry (smeg)
  * can be used to map both the stack and shared libraries
  */
-#define	MAXSSIZ		(0x7ffff000)	/* max stack size limit */
+#define	MAXSSIZ		LONG_MAX	/* max stack size limit */
 #define	DFLSSIZ		(8*1024*1024)	/* initial stack size limit */
+
+/* The default maximum stack size in an ILP32 process*/
+#define	MAXSSIZ32	INT32_MAX
 
 /*
  * Minimum allowable virtual address space to be used


### PR DESCRIPTION
This set of changes removes `USRSTACK32`, simplifies the rlimit/rctl initialization, and leaves a paper trail about `USRSTACK64_32`

@hadfl @citrus-it @r1mikey