### PR TITLE
os/trap.c: preserve t_onfault across faults

### DIFF
--- a/usr/src/uts/armv8/os/trap.c
+++ b/usr/src/uts/armv8/os/trap.c
@@ -911,7 +911,18 @@ out:
 					rp->r_pc = ct->t_ontrap->ot_trampoline;
 					goto cleanup;
 				}
+
+				/*
+				 * See if we can handle as pagefault. Save lofault and onfault
+				 * across this. Here we assume that an address less than
+				 * KERNELBASE is a user fault.  We can do this as copy.s
+				 * routines verify that the starting address is less than
+				 * KERNELBASE before starting and because we know that we
+				 * always have KERNELBASE mapped as invalid to serve as a
+				 * "barrier".
+				 */
 				lofault = ct->t_lofault;
+				onfault = ct->t_onfault;
 				ct->t_lofault = 0;
 
 				mstate = new_mstate(ct, LMS_KFAULT);
@@ -931,7 +942,12 @@ out:
 
 				new_mstate(ct, mstate);
 
+				/*
+				 * Restore lofault and onfault. If we resolved the fault, exit.
+				 * If we didn't and lofault wasn't set, die.
+				 */
 				ct->t_lofault = lofault;
+				ct->t_onfault = onfault;
 				if (res == 0)
 					goto cleanup;
 


### PR DESCRIPTION
This seems to have got lost at some point between:

   69c9224907 3181 t_onfault should be preserved across pagefaults

and now, but I'm not sure why.

@citrus-it @r1mikey I think this is a valid thing to be doing, and that the comment that comes with it applies here too, could you check you think I'm right?