### PR TITLE
os/softhostid.c: commonize the _SOFT_HOSTID code

### DIFF
--- a/usr/src/uts/armv8/Makefile.files
+++ b/usr/src/uts/armv8/Makefile.files
@@ -79,7 +79,8 @@ CORE_OBJS +=			\
 	earlybsa.o		\
 	cpuinfo.o		\
 	pci_cfgacc.o		\
-	pci_cfgacc_armv8.o
+	pci_cfgacc_armv8.o	\
+	softhostid.o
 
 #
 #	Add the SMBIOS subsystem object files directly to the list of objects

--- a/usr/src/uts/armv8/os/machdep.c
+++ b/usr/src/uts/armv8/os/machdep.c
@@ -785,6 +785,21 @@ abort_sequence_enter(char *msg)
 		audit_exitprom(1);
 }
 
+#if defined(_SOFT_HOSTID)
+/*
+ * Generate an ephemeral hostid for hostid(1), hw_serial, etc.
+ * This may then be preserved /etc/hostid and become the system hostid.
+ *
+ * No real effort is made to make this more than approximately unique, we
+ * return some bits of the hardware timer.
+ */
+int32_t
+mach_ephemeral_hostid(void)
+{
+	return (arch_timer_count() & 0x0cfffff);
+}
+#endif
+
 void
 progressbar_key_abort(ldi_ident_t li)
 {}

--- a/usr/src/uts/armv8/os/startup.c
+++ b/usr/src/uts/armv8/os/startup.c
@@ -23,6 +23,7 @@
  * Copyright 2025 Michael van der Westhuizen
  * Copyright 2017 Hayashi Naoyuki
  * Copyright (c) 2015 by Delphix. All rights reserved.
+ * Copyright 2012 DEY Storage Systems, Inc.  All rights reserved.
  * Copyright (c) 1992, 2010, Oracle and/or its affiliates. All rights reserved.
  */
 
@@ -104,8 +105,7 @@ extern void mach_init(void);
 extern void set_platform_defaults(void);
 extern time_t process_rtc_config_file(void);
 
-static int32_t set_soft_hostid(void);
-static char hostid_file[] = "/etc/hostid";
+extern int32_t soft_hostid(void);
 
 #define	TERABYTE		(1ul << 40)
 #define	PHYSMEM_MAX64		mmu_btop(64 * TERABYTE)
@@ -1083,135 +1083,6 @@ startup_kmem(void)
 	PRM_POINT("startup_kmem() done");
 }
 
-/*
- * On platforms that do not have a hardware serial number, attempt
- * to set one based on the contents of /etc/hostid.  If this file does
- * not exist, assume that we are to generate a new hostid and set
- * it in the kernel, for subsequent saving by a userland process
- * once the system is up and the root filesystem is mounted r/w.
- *
- * In order to gracefully support upgrade on OpenSolaris, if
- * /etc/hostid does not exist, we will attempt to get a serial number
- * using the legacy method (/kernel/misc/sysinit).
- *
- * In an attempt to make the hostid less prone to abuse
- * (for license circumvention, etc), we store it in /etc/hostid
- * in rot47 format.
- */
-static int atoi(char *);
-
-static int32_t
-set_soft_hostid(void)
-{
-	struct _buf *file;
-	char tokbuf[MAXNAMELEN];
-	token_t token;
-	int done = 0;
-	u_longlong_t tmp;
-	int i;
-	int32_t hostid = (int32_t)HW_INVALID_HOSTID;
-	unsigned char *c;
-	hrtime_t tsc;
-
-	/*
-	 * If /etc/hostid file not found, we'd like to get a pseudo
-	 * random number to use at the hostid.  A nice way to do this
-	 * is to read the real time clock.  To remain xen-compatible,
-	 * we can't poke the real hardware, so we use tsc_read() to
-	 * read the real time clock.  However, there is an ominous
-	 * warning in tsc_read that says it can return zero, so we
-	 * deal with that possibility by falling back to using the
-	 * (hopefully random enough) value in tenmicrodata.
-	 */
-
-	if ((file = kobj_open_file(hostid_file)) == (struct _buf *)-1) {
-		/*
-		 * hostid file not found - try to load sysinit module
-		 * and see if it has a nonzero hostid value...use that
-		 * instead of generating a new hostid here if so.
-		 */
-		if ((i = modload("misc", "sysinit")) != -1) {
-			if (strlen(hw_serial) > 0)
-				hostid = (int32_t)atoi(hw_serial);
-			(void) modunload(i);
-		}
-		if (hostid == HW_INVALID_HOSTID) {
-			tsc = arch_timer_count();
-			hostid = (int32_t)tsc & 0x0CFFFFF;
-		}
-	} else {
-		/* hostid file found */
-		while (!done) {
-			token = kobj_lex(file, tokbuf, sizeof (tokbuf));
-
-			switch (token) {
-			case POUND:
-				/*
-				 * skip comments
-				 */
-				kobj_find_eol(file);
-				break;
-			case STRING:
-				/*
-				 * un-rot47 - obviously this
-				 * nonsense is ascii-specific
-				 */
-				for (c = (unsigned char *)tokbuf;
-				    *c != '\0'; c++) {
-					*c += 47;
-					if (*c > '~')
-						*c -= 94;
-					else if (*c < '!')
-						*c += 94;
-				}
-				/*
-				 * now we should have a real number
-				 */
-
-				if (kobj_getvalue(tokbuf, &tmp) != 0)
-					kobj_file_err(CE_WARN, file,
-					    "Bad value %s for hostid",
-					    tokbuf);
-				else
-					hostid = (int32_t)tmp;
-
-				break;
-			case EOF:
-				done = 1;
-				/* FALLTHROUGH */
-			case NEWLINE:
-				kobj_newline(file);
-				break;
-			default:
-				break;
-
-			}
-		}
-		if (hostid == HW_INVALID_HOSTID) /* didn't find a hostid */
-			kobj_file_err(CE_WARN, file,
-			    "hostid missing or corrupt");
-
-		kobj_close_file(file);
-	}
-	/*
-	 * hostid is now the value read from /etc/hostid, or the
-	 * new hostid we generated in this routine or HW_INVALID_HOSTID if not
-	 * set.
-	 */
-	return (hostid);
-}
-
-static int
-atoi(char *p)
-{
-	int i = 0;
-
-	while (*p != '\0')
-		i = 10 * i + (*p++ - '0');
-
-	return (i);
-}
-
 static void
 startup_modules(void)
 {
@@ -1292,23 +1163,6 @@ startup_modules(void)
 	dispinit();
 
 	/*
-	 * This is needed here to initialize hw_serial[] for cluster booting.
-	 */
-	if ((h = set_soft_hostid()) == HW_INVALID_HOSTID) {
-		cmn_err(CE_WARN, "Unable to set hostid");
-	} else {
-		for (v = h, cnt = 0; cnt < 10; cnt++) {
-			d[cnt] = (char)(v % 10);
-			v /= 10;
-			if (v == 0)
-				break;
-		}
-		for (cp = hw_serial; cnt >= 0; cnt--)
-			*cp++ = d[cnt] + '0';
-		*cp = 0;
-	}
-
-	/*
 	 * Create a kernel device tree. First, create rootnex and
 	 * then invoke bus specific code to probe devices.
 	 */
@@ -1346,12 +1200,22 @@ startup_modules(void)
 		}
 	}
 
-	/*
-	 * Set up the CPU module subsystem for the boot cpu in the native
-	 * case, and all physical cpu resource in the xpv dom0 case.
-	 * Modifies the device tree, so this must be done after
-	 * setup_ddi().
-	 */
+#if defined(_SOFT_HOSTID)
+	if ((h = soft_hostid()) == HW_INVALID_HOSTID) {
+		cmn_err(CE_WARN, "Unable to set hostid");
+	} else {
+		for (v = h, cnt = 0; cnt < 10; cnt++) {
+			d[cnt] = (char)(v % 10);
+			v /= 10;
+			if (v == 0)
+				break;
+		}
+		for (cp = hw_serial; cnt >= 0; cnt--)
+			*cp++ = d[cnt] + '0';
+		*cp = 0;
+	}
+#endif
+
 	/*
 	 * Fake a prom tree such that /dev/openprom continues to work
 	 */

--- a/usr/src/uts/common/os/softhostid.c
+++ b/usr/src/uts/common/os/softhostid.c
@@ -1,0 +1,247 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright 2012 DEY Storage Systems, Inc.  All rights reserved.
+ * Copyright (c) 1992, 2010, Oracle and/or its affiliates. All rights reserved.
+ */
+
+#include <sys/kobj.h>
+#include <sys/kobj_lex.h>
+#include <sys/smbios.h>
+#include <sys/sunddi.h>
+#include <sys/sysmacros.h>
+#include <sys/systeminfo.h>
+#include <sys/types.h>
+
+extern int32_t mach_ephemeral_hostid(void);
+
+static char hostid_file[] = "/etc/hostid";
+
+/*
+ * On platforms that do not have a hardware serial number, attempt
+ * to set one based on the contents of /etc/hostid.  If this file does
+ * not exist, assume that we are to generate a new hostid and set
+ * it in the kernel, for subsequent saving by a userland process
+ * once the system is up and the root filesystem is mounted r/w.
+ *
+ * In order to gracefully support upgrade on OpenSolaris, if
+ * /etc/hostid does not exist, we will attempt to get a serial number
+ * using the legacy method (/kernel/misc/sysinit).
+ *
+ * If that isn't present, we attempt to use an SMBIOS UUID, which is
+ * a hardware serial number.  Note that we don't automatically trust
+ * all SMBIOS UUIDs (some older platforms are defective and ship duplicate
+ * UUIDs in violation of the standard), we check against a blacklist.
+ *
+ * In an attempt to make the hostid less prone to abuse
+ * (for license circumvention, etc), we store it in /etc/hostid
+ * in rot47 format.
+ */
+static int atoi(char *);
+
+/*
+ * Set this to non-zero in /etc/system if you think your SMBIOS returns a
+ * UUID that is not unique. (Also report it so that the smbios_uuid_blacklist
+ * array can be updated.)
+ */
+int smbios_broken_uuid = 0;
+
+/*
+ * List of known bad UUIDs.  This is just the lower 32-bit values, since
+ * that's what we use for the host id.  If your hostid falls here, you need
+ * to contact your hardware OEM for a fix for your BIOS.
+ */
+
+#define	UUID_BLACKLIST_BYTES	16
+
+static uint8_t
+smbios_uuid_blacklist[][UUID_BLACKLIST_BYTES] = {
+
+	{	/* Reported bad UUID (Google search) */
+		0x00, 0x02, 0x00, 0x03, 0x00, 0x04, 0x00, 0x05,
+		0x00, 0x06, 0x00, 0x07, 0x00, 0x08, 0x00, 0x09,
+	},
+	{	/* Known bad DELL UUID */
+		0x4C, 0x4C, 0x45, 0x44, 0x00, 0x00, 0x20, 0x10,
+		0x80, 0x20, 0x80, 0xC0, 0x4F, 0x20, 0x20, 0x20,
+	},
+	{	/* Uninitialized flash */
+		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff
+	},
+	{	/* All zeros */
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+	},
+};
+
+static int32_t
+uuid_to_hostid(const uint8_t *uuid)
+{
+	/*
+	 * Although the UUIDs are 128-bits, they may not distribute entropy
+	 * evenly.  We would like to use SHA or MD5, but those are located
+	 * in loadable modules and not available this early in boot.  As we
+	 * don't need the values to be cryptographically strong, we just
+	 * generate 32-bit vaue by xor'ing the various sequences together,
+	 * which ensures that the entire UUID contributes to the hostid.
+	 */
+	uint32_t	id = 0;
+
+	/* first check against the blacklist */
+	for (int i = 0; i < ARRAY_SIZE(smbios_uuid_blacklist); i++) {
+		if (bcmp(smbios_uuid_blacklist[i], uuid,
+		    UUID_BLACKLIST_BYTES) == 0) {
+			cmn_err(CE_NOTE, "?Broken SMBIOS UUID. "
+			    "Contact system firmware vendor for repair.");
+			return ((int32_t)HW_INVALID_HOSTID);
+		}
+	}
+
+	for (int i = 0; i < UUID_BLACKLIST_BYTES; i++)
+		id ^= ((uuid[i]) << (8 * (i % sizeof (id))));
+
+	/* Make sure return value is positive */
+	return (id & 0x7fffffff);
+}
+
+/*
+ * Initialize the system hostid in software, for systems without a Sun-like
+ * IDPROM.
+ */
+int32_t
+soft_hostid(void)
+{
+	struct _buf *file;
+	char tokbuf[MAXNAMELEN];
+	token_t token;
+	int done = 0;
+	u_longlong_t tmp;
+	int i;
+	int32_t hostid = (int32_t)HW_INVALID_HOSTID;
+	unsigned char *c;
+	smbios_system_t smsys;
+
+	if ((file = kobj_open_file(hostid_file)) == (struct _buf *)-1) {
+		/*
+		 * hostid file not found - try to load sysinit module
+		 * and see if it has a nonzero hostid value.
+		 */
+		if ((i = modload("misc", "sysinit")) != -1) {
+			if (strlen(hw_serial) > 0)
+				hostid = (int32_t)atoi(hw_serial);
+			(void) modunload(i);
+		}
+
+		/*
+		 * Use a value derived from the SMBIOS UUID. But not if it is
+		 * blacklisted.
+		 */
+		if ((hostid == HW_INVALID_HOSTID) &&
+		    (smbios_broken_uuid == 0) &&
+		    (ksmbios != NULL) &&
+		    (smbios_info_system(ksmbios, &smsys) != SMB_ERR) &&
+		    (smsys.smbs_uuidlen >= 16)) {
+			hostid = uuid_to_hostid(smsys.smbs_uuid);
+		}
+
+		/*
+		 * Generate a "random" hostid using the clock.  These
+		 * hostids will change on each boot if the value is not
+		 * saved to a persistent /etc/hostid file.
+		 */
+		if (hostid == HW_INVALID_HOSTID) {
+			hostid = mach_ephemeral_hostid();
+		}
+	} else {
+		/* hostid file found */
+		while (!done) {
+			token = kobj_lex(file, tokbuf, sizeof (tokbuf));
+
+			switch (token) {
+			case POUND:
+				/*
+				 * skip comments
+				 */
+				kobj_find_eol(file);
+				break;
+			case STRING:
+				/*
+				 * un-rot47 - obviously this
+				 * nonsense is ascii-specific
+				 */
+				for (c = (unsigned char *)tokbuf;
+				    *c != '\0'; c++) {
+					*c += 47;
+					if (*c > '~')
+						*c -= 94;
+					else if (*c < '!')
+						*c += 94;
+				}
+				/*
+				 * now we should have a real number
+				 */
+
+				if (kobj_getvalue(tokbuf, &tmp) != 0)
+					kobj_file_err(CE_WARN, file,
+					    "Bad value %s for hostid",
+					    tokbuf);
+				else
+					hostid = (int32_t)tmp;
+
+				break;
+			case EOF:
+				done = 1;
+				/* FALLTHROUGH */
+			case NEWLINE:
+				kobj_newline(file);
+				break;
+			default:
+				break;
+
+			}
+		}
+		if (hostid == HW_INVALID_HOSTID) /* didn't find a hostid */
+			kobj_file_err(CE_WARN, file,
+			    "hostid missing or corrupt");
+
+		kobj_close_file(file);
+	}
+
+	/*
+	 * hostid is now the value read from /etc/hostid, or the
+	 * new hostid we generated in this routine or HW_INVALID_HOSTID if not
+	 * set.
+	 */
+	return (hostid);
+}
+
+static int
+atoi(char *p)
+{
+	int i = 0;
+
+	while (*p != '\0')
+		i = 10 * i + (*p++ - '0');
+
+	return (i);
+}

--- a/usr/src/uts/i86pc/Makefile.files
+++ b/usr/src/uts/i86pc/Makefile.files
@@ -118,6 +118,7 @@ CORE_OBJS +=			\
 	prom_panic.o		\
 	prom_reboot.o		\
 	pwrnow.o		\
+	softhostid.o		\
 	speedstep.o		\
 	ssp.o			\
 	startup.o		\

--- a/usr/src/uts/i86pc/os/machdep.c
+++ b/usr/src/uts/i86pc/os/machdep.c
@@ -1499,3 +1499,18 @@ do_hotinlines(struct module *mp)
 #endif	/* __xpv */
 	}
 }
+
+#if defined(_SOFT_HOSTID)
+/*
+ * Generate an ephemeral hostid for hostid(1), hw_serial, etc.
+ * This may then be preserved /etc/hostid and become the system hostid.
+ *
+ * No real effort is made to make this more than approximately unique, we
+ * return some bits of the hardware timer.
+ */
+int32_t
+mach_ephemeral_hostid(void)
+{
+	return (tsc_read() & 0x0cfffff);
+}
+#endif /* _SOFT_HOSTID */

--- a/usr/src/uts/i86xpv/Makefile.files
+++ b/usr/src/uts/i86xpv/Makefile.files
@@ -98,8 +98,9 @@ CORE_OBJS +=			\
 	ppage.o			\
 	prom_reboot.o		\
 	prom_panic.o		\
-	startup.o		\
+	softhostid.o		\
 	ssp.o			\
+	startup.o		\
 	xpv_timestamp.o		\
 	todpc_subr.o		\
 	trap.o			\


### PR DESCRIPTION
shares the soft hostid with i86pc and i86xpv, fixes the blacklist so we actually check all the entries while here.

I'd like to upstream at least the blacklist fix, after this goes into arm64-gate.

I haven't further conditionalized the smbios bit in the now-shared file on the basis that all the platforms I know of -- except stlouis -- would use it, so it really is as common as all that.

I haven't, though I would have liked to, just removed us doing this as probably more harm than good.

I also haven't fixed up the code that does the derivation here, because while I'm not certain it does a good enough job, I'm not sure the effort to do a good enough job is warranted.

I talked to @jclulow about whether someone might in future want to do this better via the TPM, and decided that if they did they were better placed to make that easier than I am.

I haven't changed the last-effort generation to use any convenient hardware random number instruction, although that would obviously be better than what we do now.  Things are structured so that would be easy to do if someone cared.

I haven't tested the i86 side at the moment.

@citrus-it @jclulow @r1mikey does this seem reasonable?