### PR TITLE
fix native aarch64 build

### DIFF
--- a/usr/src/uts/aarch64/sys/machtypes.h
+++ b/usr/src/uts/aarch64/sys/machtypes.h
@@ -32,7 +32,7 @@
 extern "C" {
 #endif
 
-// x30(pc), sp, x19 - x29
+/* x30(pc), sp, x19 - x29 */
 #define	LABEL_REG_PC	0
 #define	LABEL_REG_SP	1
 #define	LABEL_REG_X19	2


### PR DESCRIPTION
I did a native aarch64 build on an rpi 4 and hit this:

```
dtrace: failed to compile script ../port/threads/plockstat.d: "/usr/include/sys/machtypes.h", line 35: syntax error near "/"
*** Error code 1
```

here is the `mail_msg`:

```
==== Nightly build started:   Sat Feb 28 14:20:52 UTC 2026 ====
==== Nightly build completed: Sat Feb 28 16:44:55 UTC 2026 ====

==== Total build time ====

real    2:24:02

==== Build environment ====

/usr/bin/uname
SunOS mafonen 5.11 arm64-gate-0-g20fd17e145 armv8 aarch64 RaspberryPi,4

/usr/bin/dmake
dmake: illumos make
number of concurrent jobs = 6

cw version 11.0
primary: /opt/gcc-14/bin/aarch64-unknown-solaris2.11-gcc
aarch64-unknown-solaris2.11-gcc (OmniOS 151057/14.3.0-il-1) 14.3.0
Copyright (C) 2024 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.



/usr/bin/openssl
OpenSSL 3.6.1 27 Jan 2026 (Library: OpenSSL 3.6.1 27 Jan 2026)

/usr/ccs/bin/ld
ld: Software Generation Utilities - Solaris Link Editors: 5.11-1.1790

Build project:  default
Build taskid:   183

==== Nightly argument issues ====


==== Make clobber ERRORS ====


==== Make tools clobber ERRORS ====


==== Build version ====

braich_native_build-0-g1ef77017a4

==== Bootstrap build errors ====


==== Tools build errors ====


==== Build errors (aarch64/DEBUG) ====


==== Build warnings (aarch64/DEBUG) ====


==== Elapsed build time (aarch64/DEBUG) ====

real  1:42:53.3
user  4:02:20.7
sys   1:47:20.1

==== Build noise differences (aarch64/DEBUG) ====


==== package build errors (aarch64/DEBUG) ====


==== Linting packages ====


==== Validating manifests against proto area ====


==== Check versioning and ABI information ====


==== Check ELF runtime attributes ====

opt/libc-tests/tests/strtox.32: .SUNW_dynsymsort: duplicate 0x00000000004017e0: __netf2, __eqtf2
opt/libc-tests/tests/strtox.64: .SUNW_dynsymsort: duplicate 0x00000000004017e0: __netf2, __eqtf2
usr/lib/libstandsaveargs.so: non-conforming mcs(1) comment	<no $(POST_PROCESS)?>

==== Diff ELF runtime attributes (since last build) ====


==== cstyle/hdrchk errors ====


==== Find core files ====


==== Check lists of files ====


==== Impact on file permissions ====


==== Nightly build status ====

Completed WITH WARNINGS
```