### PR TITLE
Don't scan low memory for smbios tables

### DIFF
--- a/usr/src/boot/libsa/smbios.c
+++ b/usr/src/boot/libsa/smbios.c
@@ -424,6 +424,15 @@ smbios_probe(const caddr_t addr)
 		return;
 	smbios.probed = 1;
 
+#if defined(__aarch64__)
+	/*
+	 * On aarch64 systems we can't blindly poke around in low memory to
+	 * locate firmware tables.
+	 */
+	if (addr == NULL)
+		return;
+#endif
+
 	/* Search signatures and validate checksums. */
 	if (smbios_sigsearch(paddr, SMBIOS_LENGTH) == NULL)
 		return;


### PR DESCRIPTION
On Arm systems there may not be any low memory in the x86 SMBIOS discovery range, and even if there was it's highly unlikely that you'd find anything useful there. Avoid scanning this memory to avoid crashing when the firmware has not provided SMBIOS tables.

To correct this in firmware, specifically for U-Boot, ensure that at least the following configuration variables are present:

```
CONFIG_GENERATE_SMBIOS_TABLE=y
CONFIG_SMBIOS=y
```

Testing on FreeBSD-CURRENT with:
```
sudo bhyve -c 16 -D -m 32G \
  -s 0,hostbridge \
  -s 1,virtio-blk,${PWD}/illumos-disk.img \
  -s 2,virtio-net,tap0 \
  -o bootrom=/usr/local/share/u-boot/u-boot-bhyve-arm64/u-boot.bin \
  -o console=stdio \
  xxillumos
```

We get past the loader crash and end up with dboot not liking this system (still under investigation).

```
Booting...
NOTICE: No SMBIOS3 configuration table passed via UEFI
dboot: failed to perform early configuration via FDT
dboot: configuration failed
```

Addresses the crash in https://github.com/richlowe/arm64-gate/issues/60