### PR TITLE
Correct the ASID design and implementation

### DIFF
--- a/usr/src/uts/aarch64/asm/controlregs.h
+++ b/usr/src/uts/aarch64/asm/controlregs.h
@@ -21,13 +21,26 @@
 
 /*
  * Copyright 2017 Hayashi Naoyuki
- * Copyright 2024 Michael van der Westhuizen
+ * Copyright 2026 Michael van der Westhuizen
  */
 
 #ifndef	_ASM_CONTROLREGS_H
 #define	_ASM_CONTROLREGS_H
 
 #include <sys/types.h>
+
+/*
+ * TLBI operand construction macros.
+ *
+ * The TLBI instructions that take a VA operand expect:
+ *   Bits [63:48]  ASID
+ *   Bits [43:0]   VA[55:12] (page-aligned address, shifted right by 12)
+ *
+ * See ARM DDI 0487 (ARM ARM), TLBI SYS instruction encoding.
+ */
+#define	TLBI_VA(addr)			(((addr) >> 12) & ((1ul << 44) - 1))
+#define TLBI_ASID(asid)			((uint64_t)(asid) << 48)
+#define	TLBI_VA_ASID(addr, asid)	(TLBI_VA(addr) | TLBI_ASID(asid))
 
 #ifdef	__cplusplus
 extern "C" {
@@ -146,7 +159,37 @@ tlbi_mva(uint64_t addr)
 	 *	VAA (global/non-global, any level)
 	 */
 	__asm__ __volatile__("tlbi vaae1is, %0"
-	    ::"r"((addr >> 12) & ((1ul << 44) - 1)):"memory");
+	    ::"r"(TLBI_VA(addr)):"memory");
+}
+
+static __inline__ void
+tlbi_va_asid(uint64_t addr, uint64_t asid)
+{
+	/*
+	 * TLB Invalidate by VA, ASID, EL1, Inner Shareable, last-level
+	 */
+	uint64_t r = TLBI_VA_ASID(addr, asid);
+	__asm__ __volatile__("tlbi vale1is, %0" ::"r"(r):"memory");
+}
+
+static __inline__ void
+tlbi_va_asid_any(uint64_t addr, uint64_t asid)
+{
+	/*
+	 * TLB Invalidate by VA, ASID, EL1, Inner Shareable, any level
+	 */
+	uint64_t r = TLBI_VA_ASID(addr, asid);
+	__asm__ __volatile__("tlbi vae1is, %0" ::"r"(r):"memory");
+}
+
+static __inline__ void
+tlbi_asid(uint64_t asid)
+{
+	/*
+	 * TLB Invalidate by ASID, EL1, Inner Shareable
+	 */
+	uint64_t r = TLBI_ASID(asid);
+	__asm__ __volatile__("tlbi aside1is, %0" ::"r"(r):"memory");
 }
 
 static __inline__ uint64_t

--- a/usr/src/uts/aarch64/sys/controlregs.h
+++ b/usr/src/uts/aarch64/sys/controlregs.h
@@ -21,7 +21,7 @@
 
 /*
  * Copyright 2017 Hayashi Naoyuki
- * Copyright 2025 Michael van der Westhuizen
+ * Copyright 2026 Michael van der Westhuizen
  */
 
 #ifndef _SYS_CONTROLREGS_H
@@ -351,7 +351,7 @@
 
 
 #define	TTBR_ASID_SHIFT		48
-#define	TTBR_ASID_MASK		(0xffull << TTBR_ASID_SHIFT)
+#define	TTBR_ASID_MASK		(0xffffull << TTBR_ASID_SHIFT)
 #define	TTBR_ASID(x)		(((x) & TTBR_ASID_MASK) >> TTBR_ASID_SHIFT)
 /*
  * NB: This is read as if it included an implicit 0 1-bit, it does not need

--- a/usr/src/uts/armv8/dboot/dboot_standalloc.c
+++ b/usr/src/uts/armv8/dboot/dboot_standalloc.c
@@ -221,11 +221,20 @@ init_pt(void)
 	    (MAIR_ATTR_INC_ONC	<< (MAIR_NORMAL_MEMORY_UC * 8)) |
 	    (MAIR_ATTR_nGRE	<< (MAIR_UNORDERED * 8)));
 
+	/*
+	 * Enable 16-bit ASIDs if the hardware supports them.  This
+	 * dramatically reduces the frequency of ASID epoch rollovers
+	 * (65534 usable ASIDs vs 254 with 8-bit).
+	 * ID_AA64MMFR0_EL1.ASIDBits == 0x2 means 16-bit ASIDs.
+	 */
+	uint64_t mmfr0 = read_id_aa64mmfr0();
+
 	uint64_t tcr =
-	    ((uint64_t)MMFR0_PARANGE(read_id_aa64mmfr0()) << TCR_IPS_SHIFT) |
+	    ((uint64_t)MMFR0_PARANGE(mmfr0) << TCR_IPS_SHIFT) |
 	    TCR_TG1_4K | TCR_SH1_ISH | TCR_ORGN1_WBWA | TCR_IRGN1_WBWA |
 	    TCR_T1SZ_256T | TCR_TG0_4K | TCR_SH0_ISH | TCR_ORGN0_WBWA |
-	    TCR_IRGN0_WBWA | TCR_T0SZ_256T;
+	    TCR_IRGN0_WBWA | TCR_T0SZ_256T |
+	    (MMFR0_ASIDBITS(mmfr0) >= 0x2 ? TCR_AS : 0);
 
 	uint64_t sctlr = SCTLR_EL1_RES1 | SCTLR_EL1_UCI | SCTLR_EL1_UCT |
 	    SCTLR_EL1_DZE | SCTLR_EL1_I | SCTLR_EL1_C | SCTLR_EL1_M;

--- a/usr/src/uts/armv8/sys/machcpuvar.h
+++ b/usr/src/uts/armv8/sys/machcpuvar.h
@@ -42,8 +42,6 @@ extern "C" {
 
 struct	machcpu {
 	struct hat	*mcpu_current_hat;
-	uint32_t	mcpu_asid;
-	uint64_t	mcpu_asid_gen;
 	int		mcpu_pri;
 
 	volatile int	xc_pend;
@@ -73,8 +71,6 @@ struct	machcpu {
 #define	NINTR_THREADS	(LOCK_LEVEL)	/* number of interrupt threads */
 #endif
 
-#define	cpu_asid	cpu_m.mcpu_asid
-#define	cpu_asid_gen	cpu_m.mcpu_asid_gen
 #define	cpu_current_hat cpu_m.mcpu_current_hat
 #define	cpu_implementer	cpu_m.mcpu_implementer
 #define	cpu_partname	cpu_m.mcpu_partname

--- a/usr/src/uts/armv8/vm/aarch64_mmu.c
+++ b/usr/src/uts/armv8/vm/aarch64_mmu.c
@@ -210,6 +210,14 @@ hat_kern_setup(void)
 	    mmu_btop(TTBR_BADDR48(read_ttbr1())));
 
 	/*
+	 * Ensure all boot loader PTE stores are visible to the
+	 * hardware page table walker.  The boot loader likely
+	 * issued its own barriers, but architecturally there
+	 * is no guarantee.
+	 */
+	dsb(ish);
+
+	/*
 	 * The kernel HAT is now officially open for business.
 	 */
 	khat_running = 1;

--- a/usr/src/uts/armv8/vm/hat_aarch64.c
+++ b/usr/src/uts/armv8/vm/hat_aarch64.c
@@ -19,7 +19,6 @@
  * CDDL HEADER END
  */
 /*
- * Copyright 2017 Hayashi Naoyuki
  * Copyright (c) 1992, 2010, Oracle and/or its affiliates. All rights reserved.
  */
 /*
@@ -29,6 +28,8 @@
 /*
  * Copyright 2011 Nexenta Systems, Inc.  All rights reserved.
  * Copyright (c) 2014, 2015 by Delphix. All rights reserved.
+ * Copyright 2017 Hayashi Naoyuki
+ * Copyright 2026 Michael van der Westhuizen
  */
 
 #include <sys/machparam.h>
@@ -69,6 +70,55 @@
  * Basic parameters for hat operation.
  */
 struct hat_mmu_info mmu;
+
+/*
+ * Global ASID allocator.
+ *
+ * ASIDs are globally unique: the same ASID means the same address space
+ * on every CPU.  This enables ASID-specific TLB invalidation (vale1is)
+ * for user address spaces, which is far more efficient than the
+ * ASID-unaware vaae1is that would otherwise be required.
+ *
+ * The allocator uses a simple bitmap protected by a spin mutex.  When
+ * all ASIDs are exhausted, an epoch rollover occurs: the bitmap is
+ * cleared, currently-active (on-CPU) ASIDs are re-reserved (so that they
+ * survive the rollover with their live-in-hardware values), all TLBs are
+ * flushed, and allocation resumes.
+ *
+ * Since the ASID bitmap can be quite large, resulting in slow scans, we
+ * maintain a summary bitmap, with one bit per long in the primary bitmap,
+ * allowing us to cheaply skip longs with no bits free.  We may choose to
+ * have two summary bitmaps in the future to deal with the regressive case
+ * of needing a full scan, but for now our round-robin approach to allocation
+ * means we end up starting near some likely-free ASIDs more often than not.
+ */
+#define	ASID_RESERVED_FOR_PID0	0
+/* ASID_RESERVED_FOR_EFI is 1, defined in hat_aarch64.h */
+#define	ASID_FIRST_AVAILABLE	2
+
+#define	HAT_ASID_COOKIE(asid, epoch)	\
+	((int64_t)((uint32_t)(asid) |	\
+	((uint64_t)(uint32_t)(epoch) << 32)))
+#define	HAT_COOKIE_TO_ASID(c)		((uint16_t)(c))
+#define	HAT_COOKIE_TO_EPOCH(c)		((int32_t)((uint64_t)(c) >> 32))
+#define	HAT_COOKIE_NONE			HAT_ASID_COOKIE(0xffff, INT_MIN)
+#define	HAT_COOKIE_NEEDS_ASSIGN		HAT_ASID_COOKIE(0xffff, INT_MAX)
+
+static ulong_t		*asid_bitmap;
+static ulong_t		*asid_summary;	/* 1 bit per long in asid_bitmap */
+static uint32_t		asid_summary_len; /* summary bits (= main bitmap words) */
+static kmutex_t		asid_lock;
+static uint32_t		asid_next = ASID_FIRST_AVAILABLE;
+static volatile int32_t	asid_epoch;
+static uint32_t		asid_count;	/* usable ASIDs (excludes sentinel) */
+
+/*
+ * Forward declarations for ASID allocator functions.
+ */
+static void hat_asid_init(void);
+static void hat_asid_alloc(hat_t *hat);
+static void hat_asid_free(hat_t *hat);
+static void hat_asid_rollover(void);
 
 /*
  * forward declaration of internal utility routines
@@ -183,10 +233,7 @@ hat_alloc(struct as *as)
 	kas.a_hat->hat_next = hat;
 	mutex_exit(&hat_list_lock);
 
-	for (int cpuid = 0; cpuid < NCPU; cpuid++) {
-		hat->hat_asid_gen[cpuid] = -1;
-		hat->hat_asid[cpuid] = 0;
-	}
+	hat->hat_asid_cookie = HAT_COOKIE_NEEDS_ASSIGN;
 
 	return (hat);
 }
@@ -234,6 +281,11 @@ hat_free_end(hat_t *hat)
 		kas.a_hat->hat_prev = hat->hat_prev;
 	mutex_exit(&hat_list_lock);
 	hat->hat_next = hat->hat_prev = NULL;
+
+	/*
+	 * Release the hat's ASID back to the global bitmap.
+	 */
+	hat_asid_free(hat);
 
 	/*
 	 * Make a pass through the htables freeing them all up.
@@ -284,6 +336,315 @@ mmu_init(void)
 #define	HASH_MAX_LENGTH 4
 	while (mmu.hash_cnt * HASH_MAX_LENGTH < max_htables)
 		mmu.hash_cnt <<= 1;
+}
+
+/*
+ * Initialise the global ASID bitmap allocator.  Called from hat_init
+ * after kmem is available and mmu.max_asid has been set by mmu_init.
+ */
+static void
+hat_asid_init(void)
+{
+	uint32_t bitmap_words;
+	index_t i, nwords;
+
+	asid_count = mmu.max_asid;
+	asid_bitmap = kmem_zalloc(BT_SIZEOFMAP(asid_count), KM_SLEEP);
+
+	/*
+	 * Summary bitmap: one bit per long in asid_bitmap.
+	 *
+	 * A set bit means the corresponding main bitmap long has at least one
+	 * free ASID.  Scanning this first reduces worst-case search from
+	 * asid_count/64 longs to asid_summary_len + 1.
+	 */
+	bitmap_words = (asid_count + BT_NBIPUL - 1) >> BT_ULSHIFT;
+	asid_summary_len = bitmap_words;
+	asid_summary = kmem_alloc(BT_SIZEOFMAP(asid_summary_len), KM_SLEEP);
+
+	/* All ASIDs are initially free, so set all summary bits */
+	nwords = (asid_summary_len + BT_NBIPUL - 1) >> BT_ULSHIFT;
+	for (i = 0; i < nwords; i++)
+		asid_summary[i] = ~0UL;
+
+	mutex_init(&asid_lock, NULL, MUTEX_SPIN,
+	    (void *)ipltospl(DISP_LEVEL));
+
+	/*
+	 * Reserve ASIDs 0 (PID 0) and 1 (EFI runtime services)
+	 *
+	 * No summary bitmap update is needed, as there are still bits
+	 * available in the first long (ASID_FIRST_AVAILABLE).
+	 */
+	BT_SET(asid_bitmap, ASID_RESERVED_FOR_PID0);
+	BT_SET(asid_bitmap, ASID_RESERVED_FOR_EFI);
+
+	asid_next = ASID_FIRST_AVAILABLE;
+	asid_epoch = 0;
+}
+
+/*
+ * Update the summary bitmap after modifying a main bitmap word.
+ * If the main bitmap long at word index 'widx' has any free bits,
+ * set the corresponding summary bit; otherwise clear it.
+ */
+static inline void
+asid_summary_update(index_t widx)
+{
+	if (asid_bitmap[widx] != ~0UL) {
+		BT_SET(asid_summary, widx);
+	} else {
+		BT_CLEAR(asid_summary, widx);
+	}
+}
+
+/*
+ * Epoch rollover: all ASIDs are exhausted.  Clear the bitmap, re-mark
+ * ASIDs that are currently loaded in a CPU's TTBR0 (so they are not
+ * prematurely reassigned), flush all TLBs, and resume allocation.
+ *
+ * Must be called with asid_lock held.
+ */
+static void
+hat_asid_rollover(void)
+{
+	cpu_t *cp;
+	index_t i, nwords;
+
+	ASSERT(MUTEX_HELD(&asid_lock));
+
+	asid_epoch++;
+
+	/* Clear entire bitmap */
+	bzero(asid_bitmap, BT_SIZEOFMAP(asid_count));
+
+	/*
+	 * Set all summary bits: everything is free after clearing.
+	 * Then re-reserve and re-mark will selectively clear summary
+	 * bits for fully-occupied words.
+	 */
+	nwords = (asid_summary_len + BT_NBIPUL - 1) >> BT_ULSHIFT;
+	for (i = 0; i < nwords; i++)
+		asid_summary[i] = ~0UL;
+
+	/* Re-reserve permanent ASIDs */
+	BT_SET(asid_bitmap, ASID_RESERVED_FOR_PID0);
+	BT_SET(asid_bitmap, ASID_RESERVED_FOR_EFI);
+
+	/*
+	 * Re-mark ASIDs that are currently loaded in a CPU's TTBR0.
+	 *
+	 * Reading another CPU's cpu_current_hat without an IPI is safe
+	 * here: the worst case is a slightly stale read, which just means
+	 * we keep an ASID marked as used for one extra epoch (wasting
+	 * a slot, not a correctness issue).
+	 */
+	cp = cpu_list;
+	do {
+		hat_t *active_hat = cp->cpu_current_hat;
+
+		if (active_hat != NULL && active_hat != kas.a_hat) {
+			uint16_t asid =
+			    HAT_COOKIE_TO_ASID(active_hat->hat_asid_cookie);
+			if (asid < asid_count) {
+				BT_SET(asid_bitmap, asid);
+				membar_producer();
+				active_hat->hat_asid_cookie =
+				    HAT_ASID_COOKIE(asid, asid_epoch);
+			}
+		}
+
+		cp = cp->cpu_next;
+	} while (cp != cpu_list);
+
+	/*
+	 * Rebuild summary after re-marking: any word that is now fully
+	 * occupied gets its summary bit cleared.
+	 */
+	for (i = 0; i < (index_t)asid_summary_len; i++)
+		asid_summary_update(i);
+
+	/* Flush all TLBs across all CPUs */
+	dsb(ish);
+	tlbi_allis();
+	dsb(ish);
+	isb();
+
+	asid_next = ASID_FIRST_AVAILABLE;
+}
+
+/*
+ * Allocate a globally-unique ASID for the given hat and record it
+ * in hat_asid_cookie.  If all ASIDs are exhausted, trigger an epoch
+ * rollover and retry.
+ */
+static void
+hat_asid_alloc(hat_t *hat)
+{
+	uint32_t asid;
+
+	mutex_enter(&asid_lock);
+
+	/* Another thread may have allocated while we waited for the lock */
+	if (HAT_COOKIE_TO_EPOCH(hat->hat_asid_cookie) == asid_epoch) {
+		mutex_exit(&asid_lock);
+		return;
+	}
+
+	for (;;) {
+		index_t widx;
+		index_t nextword = asid_next >> BT_ULSHIFT;
+		index_t nextbit = asid_next & BT_ULMASK;
+
+		/*
+		 * Two-level scan: check the summary bitmap first to
+		 * skip fully-occupied main bitmap words entirely.
+		 * With 64K ASIDs the summary is 16 longs, so the
+		 * worst-case scan is 16 + 1 = 17 word inspections
+		 * (down from 1024 with the single-level word scan).
+		 *
+		 * Phase 1: partial word containing asid_next (bypass
+		 *          summary: we know which word to check).
+		 * Phase 2: summary-guided scan forward to end.
+		 * Phase 3: summary-guided wrap to start.
+		 */
+
+		/*
+		 * Phase 1: partial word containing asid_next.
+		 */
+		if (nextbit != 0) {
+			ulong_t word = asid_bitmap[nextword];
+
+			if (word != ~0UL) {
+				ulong_t mask = ~0UL << nextbit;
+				ulong_t avail = ~word & mask;
+				if (avail != 0) {
+					asid = (nextword << BT_ULSHIFT) +
+					    (uint32_t)__builtin_ctzl(avail);
+					if (asid < asid_count)
+						goto found;
+				}
+			}
+
+			nextword++;
+		}
+
+		/*
+		 * Phase 2: scan summary from nextword to end of
+		 * bitmap, then check the indicated main bitmap word.
+		 */
+		for (widx = nextword;
+		    widx < (index_t)asid_summary_len; widx++) {
+			if (!BT_TEST(asid_summary, widx))
+				continue;
+
+			if (asid_bitmap[widx] != ~0UL) {
+				index_t bit =
+				    (index_t)__builtin_ctzl(
+				    ~asid_bitmap[widx]);
+				asid = (widx << BT_ULSHIFT) +
+				    (uint32_t)bit;
+				if (asid < asid_count)
+					goto found;
+			}
+
+			/* Summary was stale; correct it */
+			BT_CLEAR(asid_summary, widx);
+		}
+
+		/*
+		 * Phase 3: wrap - scan summary from start to
+		 * the original nextword position.
+		 */
+		if (asid_next > ASID_FIRST_AVAILABLE) {
+			index_t limit = (asid_next >> BT_ULSHIFT) + 1;
+			if (limit > (index_t)asid_summary_len)
+				limit = (index_t)asid_summary_len;
+
+			for (widx = 0; widx < limit; widx++) {
+				if (!BT_TEST(asid_summary, widx))
+					continue;
+
+				if (asid_bitmap[widx] != ~0UL) {
+					index_t bit =
+					    (index_t)__builtin_ctzl(
+					    ~asid_bitmap[widx]);
+					asid = (widx << BT_ULSHIFT) +
+					    (uint32_t)bit;
+
+					if (asid >= ASID_FIRST_AVAILABLE &&
+					    asid < asid_count)
+						goto found;
+				}
+
+				BT_CLEAR(asid_summary, widx);
+			}
+		}
+
+		/*
+		 * All ASIDs exhausted, rollover
+		 *
+		 * On smaller systems this will happen when more than 255 HATs
+		 * are active.  On larger systems, 65534, so much less likely
+		 * to happen in practice.
+		 */
+		hat_asid_rollover();
+
+		/*
+		 * After rollover, the hat might already have a valid ASID
+		 * if it was active on a CPU.
+		 */
+		if (HAT_COOKIE_TO_EPOCH(hat->hat_asid_cookie) == asid_epoch) {
+			mutex_exit(&asid_lock);
+			return;
+		}
+	}
+
+found:
+	BT_SET(asid_bitmap, asid);
+	asid_summary_update(asid >> BT_ULSHIFT);
+	asid_next = asid + 1;
+	if (asid_next >= asid_count)
+		asid_next = ASID_FIRST_AVAILABLE;
+	membar_producer();
+	hat->hat_asid_cookie = HAT_ASID_COOKIE(asid, asid_epoch);
+
+	mutex_exit(&asid_lock);
+}
+
+/*
+ * Release the ASID held by the given hat back to the global bitmap
+ * and invalidate any remaining TLB entries tagged with that ASID.
+ */
+static void
+hat_asid_free(hat_t *hat)
+{
+	int32_t epoch;
+	uint16_t asid;
+
+	epoch = HAT_COOKIE_TO_EPOCH(hat->hat_asid_cookie);
+	if (epoch == (int32_t)INT_MIN || epoch == (int32_t)INT_MAX) {
+		/* Never assigned or permanent - nothing to free */
+		return;
+	}
+
+	asid = HAT_COOKIE_TO_ASID(hat->hat_asid_cookie);
+	membar_producer();
+	hat->hat_asid_cookie = HAT_COOKIE_NONE;
+
+	mutex_enter(&asid_lock);
+	if (epoch == asid_epoch && asid < asid_count) {
+		BT_CLEAR(asid_bitmap, asid);
+		/* Word now has a free bit - unconditionally set summary */
+		BT_SET(asid_summary, asid >> BT_ULSHIFT);
+	}
+	mutex_exit(&asid_lock);
+
+	/* Flush any remaining TLB entries for this ASID */
+	dsb(ish);
+	tlbi_asid((uint64_t)asid);
+	dsb(ish);
+	isb();
 }
 
 /*
@@ -345,6 +706,9 @@ hat_init()
 	 */
 	hrm_hashtab = kmem_zalloc(HRM_HASHSIZE * sizeof (struct hrmstat *),
 	    KM_SLEEP);
+
+	/* Initialise the ASID allocator */
+	hat_asid_init();
 }
 
 /*
@@ -388,55 +752,44 @@ hat_switch(hat_t *hat)
 			write_tcr(read_tcr() | TCR_EPD0);
 			isb();
 		} else {
-			processorid_t cpuid = cpu->cpu_id;
-			uint64_t cur_gen = cpu->cpu_asid_gen;
-			int req_tlbi = 0;
+			int64_t cookie = hat->hat_asid_cookie;
+			membar_consumer();
 
-			if (hat->hat_asid_gen[cpuid] != cur_gen) {
-				uint32_t cur_asid = cpu->cpu_asid + 1;
-				if (cur_asid > mmu.max_asid) {
-					cur_gen++;
-					cpu->cpu_asid_gen = cur_gen;
-					cur_asid = 1;
-					req_tlbi = 1;
-				}
-				cpu->cpu_asid = cur_asid;
-				hat->hat_asid_gen[cpuid] = cur_gen;
-				hat->hat_asid[cpuid] = cur_asid;
+			if (HAT_COOKIE_TO_EPOCH(cookie) != asid_epoch) {
+				hat_asid_alloc(hat);
+				cookie = hat->hat_asid_cookie;
+				membar_consumer();
 			}
 
+			uint16_t asid = HAT_COOKIE_TO_ASID(cookie);
+
 			/*
-			 * Disable TTBR0 walks before writing TTBR0.
-			 * This prevents speculative walks against the
-			 * stale page table base or, on ASID rollover,
-			 * against stale TLB entries from the recycled
-			 * ASID's previous owner.
+			 * Suppress TTBR0 walks before writing TTBR0.
 			 *
-			 * On rollover the sequence is:
-			 *   set EPD0 -> write TTBR0 -> TLBI -> clear EPD0
-			 * so walks are suppressed for the entire window
-			 * between ASID reuse and TLB flush completion.
-			 *
-			 * Without rollover we still disable walks for
-			 * the TTBR0 write to avoid speculative walks on
-			 * the old base with the new ASID (or vice versa).
+			 * This prevents speculative table walks from
+			 * creating TLB entries that mix the old ASID
+			 * (or page table base) with the new one during
+			 * the transition.  On a user-to-user switch
+			 * EPD0 is clear, so we must set it; on a
+			 * kernel-to-user switch it is already set.
 			 */
 			if (!(read_tcr() & TCR_EPD0)) {
 				write_tcr(read_tcr() | TCR_EPD0);
 				isb();
 			}
 
-			write_ttbr0(((uint64_t)hat->hat_asid[cpuid] <<
-			    TTBR_ASID_SHIFT) |
+			write_ttbr0(((uint64_t)asid << TTBR_ASID_SHIFT) |
 			    pfn_to_pa(hat->hat_htable->ht_pfn));
-			isb();
 
-			if (req_tlbi) {
-				tlbi_allis();
-				dsb(ish);
-				isb();
-			}
-
+			/*
+			 * Re-enable TTBR0 walks.  The ISB is a context
+			 * synchronization event that ensures the new
+			 * TCR, TTBR0, and ASID are all observed by
+			 * subsequent instruction fetches and data
+			 * accesses.  Without the ISB, speculative
+			 * instruction fetches could still see EPD0
+			 * set and suppress TTBR0 walks.
+			 */
 			write_tcr(read_tcr() & ~TCR_EPD0);
 			isb();
 		}
@@ -1309,12 +1662,47 @@ hat_tlb_inval_range(hat_t *hat, uintptr_t va, size_t len)
 		return;
 
 	dsb(ish);
-	if (va == DEMAP_ALL_ADDR) {
-			tlbi_allis();
+	if (hat == kas.a_hat || hat->hat_ism_pgcnt > 0) {
+		/*
+		 * Kernel hat: kernel PTEs are global (PTE_NG is not
+		 * set), so global TLB entries are not tagged with an
+		 * ASID.  ASID-specific TLBI (vale1is, aside1is) only
+		 * matches non-global entries and cannot invalidate
+		 * them; vaae1is/vmalle1is are the only correct choice.
+		 *
+		 * ISM hat: the hat participates in shared page tables
+		 * (ISM/DISM), so other hats may have TLB entries for
+		 * the same physical pages under different ASIDs.  We
+		 * must use ASID-unaware invalidation to catch them all.
+		 */
+		if (va == DEMAP_ALL_ADDR) {
+			tlbi_allis();		/* vmalle1is */
+		} else {
+			for (size_t i = 0; i < len; i += MMU_PAGESIZE)
+				tlbi_mva(va + i);	/* vaae1is */
+		}
 	} else {
-		for (size_t i = 0; i < len; i += MMU_PAGESIZE)
-			tlbi_mva(va + i);
+		/*
+		 * User hat without ISM: use ASID-specific invalidation
+		 * to avoid disturbing other address spaces' TLB entries.
+		 *
+		 * We use vae1is (any-level) rather than vale1is
+		 * (last-level only) to also invalidate walk-cache
+		 * entries for intermediate table descriptors.  This
+		 * is critical for unlink_ptp where a table descriptor
+		 * is removed: stale walk-cache entries on other CPUs
+		 * could follow freed page tables.
+		 */
+		uint16_t asid = HAT_COOKIE_TO_ASID(hat->hat_asid_cookie);
+		membar_consumer();
+		if (va == DEMAP_ALL_ADDR) {
+			tlbi_asid((uint64_t)asid);	/* aside1is */
+		} else {
+			for (size_t i = 0; i < len; i += MMU_PAGESIZE)
+				tlbi_va_asid_any(va + i, (uint64_t)asid);
+		}
 	}
+
 	dsb(ish);
 	isb();
 }
@@ -3175,8 +3563,8 @@ hat_page_fault(hat_t *hat, caddr_t vaddr)
 			}
 
 			PTE_SET(newpte, PTE_AF);
-			if (pte_update(ht, entry, oldpte, newpte) !=
-			    oldpte) {
+			if (pte_update(ht, entry, oldpte, newpte)
+			    != oldpte) {
 				hm_exit(pp);
 				htable_release(ht);
 				continue;

--- a/usr/src/uts/armv8/vm/hat_aarch64.c
+++ b/usr/src/uts/armv8/vm/hat_aarch64.c
@@ -388,10 +388,6 @@ hat_switch(hat_t *hat)
 			write_tcr(read_tcr() | TCR_EPD0);
 			isb();
 		} else {
-			if (old == kas.a_hat || old == NULL) {
-				write_tcr(read_tcr() & ~TCR_EPD0);
-			}
-
 			processorid_t cpuid = cpu->cpu_id;
 			uint64_t cur_gen = cpu->cpu_asid_gen;
 			int req_tlbi = 0;
@@ -408,15 +404,41 @@ hat_switch(hat_t *hat)
 				hat->hat_asid_gen[cpuid] = cur_gen;
 				hat->hat_asid[cpuid] = cur_asid;
 			}
+
+			/*
+			 * Disable TTBR0 walks before writing TTBR0.
+			 * This prevents speculative walks against the
+			 * stale page table base or, on ASID rollover,
+			 * against stale TLB entries from the recycled
+			 * ASID's previous owner.
+			 *
+			 * On rollover the sequence is:
+			 *   set EPD0 -> write TTBR0 -> TLBI -> clear EPD0
+			 * so walks are suppressed for the entire window
+			 * between ASID reuse and TLB flush completion.
+			 *
+			 * Without rollover we still disable walks for
+			 * the TTBR0 write to avoid speculative walks on
+			 * the old base with the new ASID (or vice versa).
+			 */
+			if (!(read_tcr() & TCR_EPD0)) {
+				write_tcr(read_tcr() | TCR_EPD0);
+				isb();
+			}
+
 			write_ttbr0(((uint64_t)hat->hat_asid[cpuid] <<
 			    TTBR_ASID_SHIFT) |
 			    pfn_to_pa(hat->hat_htable->ht_pfn));
 			isb();
+
 			if (req_tlbi) {
 				tlbi_allis();
 				dsb(ish);
 				isb();
 			}
+
+			write_tcr(read_tcr() & ~TCR_EPD0);
+			isb();
 		}
 		cpu->cpu_current_hat = hat;
 	}
@@ -3153,7 +3175,12 @@ hat_page_fault(hat_t *hat, caddr_t vaddr)
 			}
 
 			PTE_SET(newpte, PTE_AF);
-			pte_update(ht, entry, oldpte, newpte);
+			if (pte_update(ht, entry, oldpte, newpte) !=
+			    oldpte) {
+				hm_exit(pp);
+				htable_release(ht);
+				continue;
+			}
 
 			hm_exit(pp);
 		}

--- a/usr/src/uts/armv8/vm/hat_aarch64.h
+++ b/usr/src/uts/armv8/vm/hat_aarch64.h
@@ -62,21 +62,22 @@ extern "C" {
  * The hat struct exists for each address space.
  */
 struct hat {
-	kmutex_t	hat_mutex;
-	struct as	*hat_as;
-	uint_t		hat_stats;
-	pgcnt_t		hat_pages_mapped[MMU_PAGE_LEVELS];
-	pgcnt_t		hat_ism_pgcnt;
-	uint16_t	hat_flags;
-	htable_t	*hat_htable;	/* top level htable */
-	struct hat	*hat_next;
-	struct hat	*hat_prev;
-	htable_t	**hat_ht_hash;	/* htable hash buckets */
-	htable_t	*hat_ht_cached;	/* cached free htables */
-	uint64_t	hat_asid_gen[NCPU];
-	uint32_t	hat_asid[NCPU];
+	kmutex_t		hat_mutex;
+	struct as		*hat_as;
+	uint_t			hat_stats;
+	pgcnt_t			hat_pages_mapped[MMU_PAGE_LEVELS];
+	pgcnt_t			hat_ism_pgcnt;
+	uint16_t		hat_flags;
+	htable_t		*hat_htable;	/* top level htable */
+	struct hat		*hat_next;
+	struct hat		*hat_prev;
+	htable_t		**hat_ht_hash;	/* htable hash buckets */
+	htable_t		*hat_ht_cached;	/* cached free htables */
+	volatile int64_t	hat_asid_cookie;
 };
 typedef struct hat hat_t;
+
+#define	ASID_RESERVED_FOR_EFI	1
 
 #define	PGCNT_INC(hat, level)	\
 	atomic_inc_ulong(&(hat)->hat_pages_mapped[level]);

--- a/usr/src/uts/armv8/vm/htable.c
+++ b/usr/src/uts/armv8/vm/htable.c
@@ -1348,7 +1348,7 @@ htable_scan(htable_t *ht, uintptr_t *vap, uintptr_t eaddr)
 {
 	uint_t e;
 	pte_t found_pte = (pte_t)0;
-	caddr_t pte_ptr;
+	volatile caddr_t pte_ptr;
 	caddr_t end_pte_ptr;
 	int l = ht->ht_level;
 	uintptr_t va = *vap & LEVEL_MASK(l);
@@ -1680,10 +1680,7 @@ pte_set(htable_t *ht, uint_t entry, pte_t new, void *ptr)
 		 */
 		if (prev == n) {
 			old = new;
-			dsb(ish);
-			tlbi_mva(addr);
-			dsb(ish);
-			isb();
+			hat_tlb_inval(hat, addr);
 			goto done;
 		}
 
@@ -1710,8 +1707,22 @@ pte_set(htable_t *ht, uint_t entry, pte_t new, void *ptr)
 	 * Segmap is the only place where remaps happen on the same pfn and for
 	 * that we want to preserve the stale REF/MOD bits.
 	 */
-	if (old & PTE_AF)
+	if (old & PTE_AF) {
 		hat_tlb_inval(hat, addr);
+	} else if (PTE_ISVALID(n)) {
+		/*
+		 * New mapping installed (old PTE was invalid or this is a
+		 * remap to the same PFN with AF clear).  The hardware page
+		 * table walker may not observe the new PTE without a DSB,
+		 * as eret alone is only a context synchronization event
+		 * and does not order prior stores with respect to the
+		 * walker.  Without this barrier the walker can raise a
+		 * translation fault even though the PTE is present,
+		 * causing an infinite fault loop because the pagefault
+		 * slow-path reinstalls the same PTE without setting AF.
+		 */
+		dsb(ish);
+	}
 
 done:
 	return (old);
@@ -1730,6 +1741,15 @@ pte_cas(htable_t *ht, uint_t entry, pte_t old, pte_t new)
 	pte_t	*ptep;
 	ptep = PT_INDEX_PTR(hat_kpm_pfn2va(ht->ht_pfn), entry);
 	pte = CAS_PTE(ptep, old, new);
+	if (pte == old && PTE_ISVALID(new)) {
+		/*
+		 * Successfully linked a new intermediate page table.
+		 * Ensure the store is visible to the hardware walker
+		 * before any subsequent mapping in the child table
+		 * can be accessed.
+		 */
+		dsb(ish);
+	}
 	return (pte);
 }
 
@@ -1773,6 +1793,14 @@ pte_inval(
 		}
 		found = CAS_PTE(ptep, oldpte, 0);
 	} while (found != oldpte);
+
+	/*
+	 * When tlb is B_TRUE, invalidate the TLB entry and issue
+	 * the necessary barriers (DSB + TLBI + DSB + ISB).  When
+	 * tlb is B_FALSE (batched unload path), the caller is
+	 * responsible for issuing hat_tlb_inval_range() covering
+	 * this address before the unload is considered complete.
+	 */
 	if (tlb && (oldpte & PTE_AF))
 		hat_tlb_inval(ht->ht_hat, htable_e2va(ht, entry));
 
@@ -1800,28 +1828,76 @@ pte_update(
 	ptep = PT_INDEX_PTR(hat_kpm_pfn2va(ht->ht_pfn), entry);
 
 	/*
-	 * ARM ARM D5.10.1: Break-Before-Make is required when changing
-	 * the output address (PFN) of a valid PTE.  A direct valid-to-valid
-	 * CAS with a different PFN allows concurrent speculative walks to
-	 * see a transiently inconsistent mapping.
+	 * ARM requires break-before-make when changing a valid PTE's
+	 * output address: the old entry must be invalidated and the
+	 * TLB flushed before installing the new entry, otherwise the
+	 * TLB may hold conflicting entries for the same VA and the
+	 * result is CONSTRAINED UNPREDICTABLE (wrong translations).
 	 *
-	 * Attribute-only changes (same PFN) are safe as a direct CAS.
+	 * Attribute-only changes (same output address) may be done
+	 * in place per ARM ARM D5.10.1.
 	 */
-	if (PTE_ISVALID(expect) && PTE_ISVALID(new) &&
-	    PTE2PFN(expect, ht->ht_level) != PTE2PFN(new, ht->ht_level)) {
-		/* Break: CAS valid -> 0 */
+	if (PTE_ISVALID(expect) &&
+	     PTE2PFN(expect, ht->ht_level) != PTE2PFN(new, ht->ht_level)) {
+		/* Break: atomically invalidate the old entry */
 		found = CAS_PTE(ptep, expect, 0);
-		if (found != expect)
+		if (found != expect) {
 			return (found);
+		}
+
+		/*
+		 * Flush TLB for the old mapping.  hat_tlb_inval
+		 * issues DSB ISH + TLBI + DSB ISH + ISB, ensuring
+		 * completion before the new entry is installed.
+		 */
 		hat_tlb_inval(ht->ht_hat, htable_e2va(ht, entry));
-		/* Make: store the new PTE */
-		*ptep = new;
+
+		/*
+		 * Make: install the new entry.  No CAS needed as
+		 * we hold the slot (PTE is 0) and hat-level locking
+		 * prevents concurrent mappers to the same entry.
+		 */
+		*(volatile pte_t *)ptep = new;
+		/*
+		 * Ensure the new PTE is visible to the hardware page
+		 * table walker before we return.  No TLBI was issued
+		 * (the slot was zeroed and flushed above), so a DSB
+		 * is needed to order this store for the walker.
+		 */
+		dsb(ish);
 		return (expect);
 	}
 
 	found = CAS_PTE(ptep, expect, new);
 	if (found == expect) {
-		hat_tlb_inval(ht->ht_hat, htable_e2va(ht, entry));
+		/*
+		 * Determine whether the change only adds permissions.
+		 *
+		 * ARM ARM D5.10.2: setting the Access flag does not
+		 * require TLB maintenance.  ARM ARM D5.10.1: relaxation
+		 * of permissions (RO->RW, XN->X) does not create a TLB
+		 * conflict; the stale restrictive entry is safe until
+		 * naturally evicted or the next TLBI.
+		 *
+		 * For such changes a standalone DSB ensures the walker
+		 * sees the updated PTE and avoids a cross-CPU TLBI
+		 * broadcast.  Restrictive changes (clearing AF, adding
+		 * AP_RO/UXN/PXN) or non-permission changes require a
+		 * full TLB invalidate.
+		 */
+		pte_t diff = expect ^ new;
+		pte_t newly_restricted =
+		    ((new & ~expect) & (PTE_AP_RO | PTE_UXN | PTE_PXN)) |
+		    ((~new & expect) & PTE_AF);
+		pte_t non_perm = diff &
+		    ~(PTE_AF | PTE_AP_RO | PTE_UXN | PTE_PXN);
+
+		if (newly_restricted == 0 && non_perm == 0) {
+			dsb(ish);
+		} else {
+			hat_tlb_inval(ht->ht_hat,
+			    htable_e2va(ht, entry));
+		}
 	}
 	return (found);
 }
@@ -1852,6 +1928,15 @@ pte_copy(htable_t *src, htable_t *dest, uint_t entry, uint_t count)
 	 */
 	size = count << PTE_BITS;
 	bcopy(src_va, dst_va, size);
+
+	/*
+	 * Ensure the copied PTEs are visible to the hardware page
+	 * table walker before the destination table is linked into
+	 * the page table tree.  Without this barrier, a concurrent
+	 * walker could follow a table descriptor pointing here and
+	 * read stale (pre-copy) entries.
+	 */
+	dsb(ish);
 }
 
 /*
@@ -1872,6 +1957,15 @@ pte_zero(htable_t *dest, uint_t entry, uint_t count)
 
 	size = count << PTE_BITS;
 	bzero(dst_va, size);
+
+	/*
+	 * Ensure the zeroed PTEs are visible to the hardware page
+	 * table walker before this page is linked as a page table.
+	 * Without this barrier, a walker following a newly-installed
+	 * table descriptor could read stale (non-zero) entries from
+	 * a recycled page.
+	 */
+	dsb(ish);
 }
 
 /*

--- a/usr/src/uts/armv8/vm/htable.c
+++ b/usr/src/uts/armv8/vm/htable.c
@@ -1798,6 +1798,27 @@ pte_update(
 	ASSERT(ht->ht_level <= mmu.max_page_level);
 
 	ptep = PT_INDEX_PTR(hat_kpm_pfn2va(ht->ht_pfn), entry);
+
+	/*
+	 * ARM ARM D5.10.1: Break-Before-Make is required when changing
+	 * the output address (PFN) of a valid PTE.  A direct valid-to-valid
+	 * CAS with a different PFN allows concurrent speculative walks to
+	 * see a transiently inconsistent mapping.
+	 *
+	 * Attribute-only changes (same PFN) are safe as a direct CAS.
+	 */
+	if (PTE_ISVALID(expect) && PTE_ISVALID(new) &&
+	    PTE2PFN(expect, ht->ht_level) != PTE2PFN(new, ht->ht_level)) {
+		/* Break: CAS valid -> 0 */
+		found = CAS_PTE(ptep, expect, 0);
+		if (found != expect)
+			return (found);
+		hat_tlb_inval(ht->ht_hat, htable_e2va(ht, entry));
+		/* Make: store the new PTE */
+		*ptep = new;
+		return (expect);
+	}
+
 	found = CAS_PTE(ptep, expect, new);
 	if (found == expect) {
 		hat_tlb_inval(ht->ht_hat, htable_e2va(ht, entry));


### PR DESCRIPTION
This series fixes correctness bugs in the `hat_switch` page table transition sequence and replaces the per-CPU ASID allocator with a global allocator modelled on FreeBSD's approach.

## `hat_switch` ordering fixes

**TTBR0 ordering and break-before-make**: Three fixes for memory corruption caused by stale or incorrect page table walks:
1. `hat_switch` was clearing `TCR_EPD0` (enabling `TTBR0` walks) before writing the new page table base into `TTBR0`. This opened a window where the MMU could speculatively walk using the stale `TTBR0`.
2. `pte_update` did not implement break-before-make per ARM ARM D5.10.1. When the output address changes between two valid PTEs, a direct `CAS` allows concurrent speculative walks to see a transiently inconsistent mapping. The update is now `CAS`-to-zero (break), `TLBI`+`DSB`, then store the new PTE (make). Attribute-only changes (same PFN) remain a direct `CAS`+`TLBI`.
3. `hat_pagesetattr` ignored `pte_update`'s `CAS` return value when setting `PTE_AF`, silently losing concurrent updates.

**EPD0 suppression across ASID transitions**: Addresses remaining speculative walk windows in user-to-user transitions (`EPD0` never set, so the MMU walks the old page table with the new ASID or vice versa) and during ASID rollover (stale TLB entries from the recycled ASID survive until the `TLBI` completes). The `hat_switch` sequence now unconditionally sets `EPD0` before writing `TTBR0`, completes any rollover `TLBI` while walks are suppressed, and only clears `EPD0` after everything is consistent.

## TLB invalidation-by-ASID helpers

Adds `tlbi_va_asid`, `tlbi_va_asid_any`, and `tlbi_asid` inline helpers for ASID-qualified TLB invalidation (`TLBI` `VALE1IS`, `VAE1IS`, `ASIDE1IS`). Also widens `TTBR_ASID_MASK` from 8 bits to 16 bits to support hardware with larger ASID spaces (Ampere Altra Max provides 64K ASIDs, as does qemu's virt machine).

## ASID redesign

The existing ASID implementation assumed TLB maintenance is a local concern, but aarch64 `TLBI` instructions (as we use them) are broadcast across all TLBs in the inner shareable domain. The per-CPU allocation made it easy for the same ASID to be used for different processes on different CPUs - a correctness bug masked by the existing TLB invalidation strategy of flushing all entries for a given VA range regardless of ASID.

The new implementation provides a global ASID allocator with generation-based rollover:
* ASID 0 is reserved for PID 0 (kernel), ASID 1 reserved for future UEFI runtime services use (`TTBR0`-space)
* Remaining ASIDs are allocated from a global bitmap in a round-robin fashion
* On exhaustion, the generation counter is bumped, allocations are cleared, and in-use (on-CPU) ASIDs are reinstated before restarting allocation
* A two-level summary bitmap accelerates free-slot scanning (worst case on Altra Max: 1024 words -> 17; RPi4: 4 -> 2) - a three-level design is possible, but would regress rpi4 to 3 scans
* Kernel VA and ISM invalidations continue to use the global flush strategy

## Testing

**NOTE**: we can never hit rollover in the default system configuration:
```sh
root@braich:~# mdb -ke 'maxuprc/D'
maxuprc:
maxuprc:        24581
root@braich:~# mdb -ke 'max_nprocs/D'
max_nprocs:
max_nprocs:     24586
root@braich:~#
```

Extensively tested alongside the FPU rework in my SBBR tree - this would exercise scanning, alloc and free, but **not** rollover.

To aggravate rollover I use this stressor: https://gist.github.com/r1mikey/44aed08467e42544155fc88a3b24d773

On current hardware, one cannot blindly bump limits and successfully start an extraordinary number of processes due to swap space size limits:

```
root@braich:~# echo 'set maxuprc = 70000' >> /etc/system
root@braich:~# echo 'set max_nprocs = 80000' >> /etc/system
root@braich:~# sudo shutdown -y -i6 -g0
...
root@braich:~# ./rollover
Spawning 66000 processes to exhaust ASID space...
  10000 spawned
fork failed at 16292: Resource temporarily unavailable
16292 processes alive. Attach mdb now.
Press enter to kill all children.
May 29 11:22:09 braich tmpfs: WARNING: /etc/svc/volatile: File system full, swap space limit exceeded

May 29 11:22:58 braich last message repeated 1552 times
```

So we have to fudge it:
```
root@braich:~# mdb -ke 'asid_epoch/D'
asid_epoch:
asid_epoch:     0
root@braich:~# mdb -ke 'asid_next/D'
asid_next:
asid_next:      17377
root@braich:~# mdb -kwe 'asid_count/W 0x100'
asid_count:     0xffff          =       0x100
root@braich:~# mdb -ke 'asid_next/D'
asid_next:
asid_next:      7
root@braich:~# ./rollover 260
Spawning 260 processes to exhaust ASID space...
260 processes alive. Attach mdb now.
Press enter to kill all children.
^Z[1] + Stopped                  ./rollover 260
root@braich:~# mdb -ke 'asid_next/D'
asid_next:
asid_next:      33
root@braich:~# mdb -ke 'asid_epoch/D'
asid_epoch:
asid_epoch:     2
root@braich:~# fg
./rollover 260

All children reaped.
root@braich:~#
```

One more time, to see the bump:
```
root@braich:~# mdb -ke 'asid_epoch/D'
asid_epoch:
asid_epoch:     3
root@braich:~# ./rollover 260
Spawning 260 processes to exhaust ASID space...
260 processes alive. Attach mdb now.
Press enter to kill all children.
^Z[1] + Stopped                  ./rollover 260
root@braich:~# mdb -ke 'asid_epoch/D'
asid_epoch:
asid_epoch:     5
root@braich:~# fg
./rollover 260

All children reaped.
root@braich:~#
```

**NOTE**: all of our supported machines (qemu virt, rpi4, Altra Max) have 64k ASID support, so the only reasonable way to test rollover is the synthetic test above.