### PR TITLE
Implement UEFI RuntimeServices access

### DIFF
--- a/usr/src/pkg/manifests/system-kernel-platform.aarch64.inc
+++ b/usr/src/pkg/manifests/system-kernel-platform.aarch64.inc
@@ -26,7 +26,7 @@
 # Copyright 2019 Joyent, Inc.
 # Copyright 2020 Peter Tribble.
 # Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
-# Copyright 2025 Michael van der Westhuizen
+# Copyright 2026 Michael van der Westhuizen
 #
 
 file path=kernel/drv/$(ARCH)/devfdt
@@ -61,6 +61,7 @@ file path=platform/armv8/kernel/misc/$(ARCH)/pcie mode=0755
 file path=platform/armv8/kernel/misc/$(ARCH)/platmod mode=0755
 dir  path=platform/armv8/kernel/tod
 dir  path=platform/armv8/kernel/tod/$(ARCH)
+file path=platform/armv8/kernel/tod/$(ARCH)/efitod mode=0755
 file path=platform/armv8/kernel/tod/$(ARCH)/pl03one mode=0755
 file path=usr/lib/devfsadm/linkmod/SUNW_misc_link_aarch64.so
 file path=usr/share/man/man4d/devfdt.4d

--- a/usr/src/uts/aarch64/sys/bootinfo.h
+++ b/usr/src/uts/aarch64/sys/bootinfo.h
@@ -26,7 +26,7 @@
 
 /*
  * Copyright 2020 Joyent, Inc.
- * Copyright 2025 Michael van der Westhuizen
+ * Copyright 2026 Michael van der Westhuizen
  */
 
 #ifndef	_SYS_BOOTINFO_H
@@ -111,6 +111,7 @@ struct xboot_info {
 	uint64_t		bi_fw_data;
 	uint64_t		bi_fw_mmio;
 	uint64_t		bi_fw_rsvd;
+	uint64_t		bi_uefi_memmap;
 	uint64_t		bi_bsvc_uart_mmio_base;
 	uint64_t		bi_arch_timer_freq;
 	uint64_t		bi_framebuffer;

--- a/usr/src/uts/armv8/Makefile.armv8
+++ b/usr/src/uts/armv8/Makefile.armv8
@@ -26,7 +26,7 @@
 # Copyright (c) 2013 Andrew Stormont.  All rights reserved.
 # Copyright 2017 Hayashi Naoyuki
 # Copyright 2019 Joyent, Inc.
-# Copyright 2025 Michael van der Westhuizen
+# Copyright 2026 Michael van der Westhuizen
 #
 #	This makefile contains the common definitions for the armv8 unix
 #	and all armv8 implementation architecture dependent modules.
@@ -228,6 +228,7 @@ DRV_KMODS += gicthree
 DRV_KMODS += gicv2m
 DRV_KMODS += gicv3_its
 DRV_KMODS += pl03one
+DRV_KMODS += efitod
 DRV_KMODS += efifb
 DRV_KMODS += pcieb
 

--- a/usr/src/uts/armv8/Makefile.files
+++ b/usr/src/uts/armv8/Makefile.files
@@ -166,6 +166,8 @@ GICV3_ITS_OBJS += gicv3_its.o
 
 PL03ONE_OBJS += pl03one.o
 
+EFITOD_OBJS += efitod.o
+
 GFX_PRIVATE_OBJS	+=		\
 			gfx_private.o	\
 			gfxp_bitmap.o	\

--- a/usr/src/uts/armv8/Makefile.files
+++ b/usr/src/uts/armv8/Makefile.files
@@ -21,7 +21,7 @@
 
 #
 # Copyright 2017 Hayashi Naoyuki
-# Copyright 2025 Michael van der Westhuizen
+# Copyright 2026 Michael van der Westhuizen
 #
 
 CORE_OBJS_FDT +=		\
@@ -30,6 +30,8 @@ CORE_OBJS_FDT +=		\
 CORE_OBJS +=			\
 	aarch64_subr.o		\
 	ddi_aarch64.o		\
+	efirt_machdep.o		\
+	efirt_call.o		\
 	kdi_asm.o		\
 	kdi_exceptions.o	\
 	kdi_util.o		\

--- a/usr/src/uts/armv8/dboot/dboot.h
+++ b/usr/src/uts/armv8/dboot/dboot.h
@@ -10,13 +10,14 @@
  */
 
 /*
- * Copyright 2025 Michael van der Westhuizen
+ * Copyright 2026 Michael van der Westhuizen
  */
 
 #ifndef _DBOOT_DBOOT_H
 #define	_DBOOT_DBOOT_H
 
 #include <sys/types.h>
+#include <sys/efi.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -28,15 +29,6 @@ extern int debug;
 #define	dprintf	if (debug) dboot_printf
 
 struct xboot_info;
-
-struct efi_map_header {
-	size_t		memory_size;
-	size_t		descriptor_size;
-	uint32_t	descriptor_version;
-};
-
-#define	efi_mmap_next(ptr, size) \
-	((EFI_MEMORY_DESCRIPTOR *)(((uint8_t *)(ptr)) + (size)))
 
 #define	RNDUP(x, y)	(((x) + ((y) - 1ul)) & ~((y) - 1ul))
 #define	RNDDN(x, y)	((x) & ~((y) - 1ul))

--- a/usr/src/uts/armv8/dboot/dboot_machdep.c
+++ b/usr/src/uts/armv8/dboot/dboot_machdep.c
@@ -20,7 +20,7 @@
  */
 /*
  * Copyright 2017 Hayashi Naoyuki
- * Copyright 2025 Michael van der Westhuizen
+ * Copyright 2026 Michael van der Westhuizen
  */
 
 #include <sys/types.h>
@@ -62,9 +62,11 @@ exitto(int (*entrypoint)(struct xboot_info *), struct xboot_info *bi)
 	boot_framebuffer_t *fb;
 	struct efi_fb *efifb;
 	extern fb_info_t fb_info;
+	extern struct efi_map_header *efi_map_header;
 
 	efifb = NULL;
 
+	bi->bi_uefi_memmap = (uint64_t)efi_map_header;
 	bi->bi_phys_installed = (uint64_t)pinstalledp;
 	bi->bi_phys_avail = (uint64_t)pfreelistp;
 	bi->bi_boot_scratch = (uint64_t)pscratchlistp;
@@ -116,6 +118,7 @@ exitto(int (*entrypoint)(struct xboot_info *), struct xboot_info *bi)
 		dprintf("  %s: 0x%lx\n", "bi_fw_data", bi->bi_fw_data);
 		dprintf("  %s: 0x%lx\n", "bi_fw_mmio", bi->bi_fw_mmio);
 		dprintf("  %s: 0x%lx\n", "bi_fw_rsvd", bi->bi_fw_rsvd);
+		dprintf("  %s: 0x%lx\n", "bi_uefi_memmap", bi->bi_uefi_memmap);
 		dprintf("  %s: 0x%lx\n", "bi_bsvc_uart_mmio_base",
 		    bi->bi_bsvc_uart_mmio_base);
 		dprintf("  %s: 0x%lx\n", "bi_arch_timer_freq",

--- a/usr/src/uts/armv8/dboot/dboot_machdep_efi.c
+++ b/usr/src/uts/armv8/dboot/dboot_machdep_efi.c
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2025 Michael van der Westhuizen
+ * Copyright 2026 Michael van der Westhuizen
  */
 
 #include <sys/types.h>
@@ -96,7 +96,6 @@ void
 init_physmem(void)
 {
 	struct efi_map_header	*mhdr;
-	size_t			efisz;
 	EFI_MEMORY_DESCRIPTOR	*map;
 	int			ndesc;
 	EFI_MEMORY_DESCRIPTOR	*p;
@@ -115,12 +114,11 @@ init_physmem(void)
 
 	ptot = stot = rtot = rttot = 0;
 	mhdr = efi_map_header;
-	efisz = (sizeof (struct efi_map_header) + 0xf) & ~0xf;
-	map = (EFI_MEMORY_DESCRIPTOR *)((uint8_t *)mhdr + efisz);
+	map = efi_mmap_start(mhdr);
 	if (mhdr->descriptor_size == 0)
 		panic("init_physmem: invalid memory descriptor size\n");
 
-	ndesc = mhdr->memory_size / mhdr->descriptor_size;
+	ndesc = efi_mmap_ndesc(mhdr);
 
 	for (i = 0, p = map; i < ndesc;
 	    i++, p = efi_mmap_next(p, mhdr->descriptor_size)) {

--- a/usr/src/uts/armv8/efitod/Makefile
+++ b/usr/src/uts/armv8/efitod/Makefile
@@ -1,0 +1,64 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2026 Michael van der Westhuizen
+#
+
+#
+#	Path to the base of the uts directory tree (usually /usr/src/uts).
+#
+UTSBASE	= ../..
+
+#
+#	Define the module and object file sets.
+#
+MODULE		= efitod
+OBJECTS		= $(EFITOD_OBJS:%=$(OBJS_DIR)/%)
+ROOTMODULE	= $(ROOT_PSM_TOD_DIR)/$(MODULE)
+
+#
+#	Include common rules.
+#
+include $(UTSBASE)/armv8/Makefile.armv8
+
+#
+#       Define targets
+#
+ALL_TARGET	= $(BINARY)
+INSTALL_TARGET	= $(BINARY) $(ROOTMODULE)
+
+#
+#	Overrides
+#
+ALL_BUILDS	= $(ALL_BUILDSONLY64)
+DEF_BUILDS	= $(DEF_BUILDSONLY64)
+
+#
+#	Default build targets.
+#
+.KEEP_STATE:
+
+all:		$(ALL_DEPS)
+
+def:		$(DEF_DEPS)
+
+clean:		$(CLEAN_DEPS)
+
+clobber:	$(CLOBBER_DEPS)
+
+install:	$(INSTALL_DEPS)
+
+
+#
+#	Include common targets.
+#
+include $(UTSBASE)/armv8/Makefile.targ

--- a/usr/src/uts/armv8/io/efitod.c
+++ b/usr/src/uts/armv8/io/efitod.c
@@ -1,0 +1,198 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2026 Michael van der Westhuizen
+ */
+
+/*
+ * UEFI Runtime Services Time-of-Day Driver.
+ *
+ * Implements the illumos tod_ops interface using UEFI Runtime Services
+ * GetTime and SetTime calls.  This driver is suitable for any platform
+ * where the hardware RTC is accessible through UEFI firmware interfaces.
+ *
+ * The driver assumes the firmware RTC stores UTC.  If EFI_TIME
+ * includes a timezone offset, it is ignored - the conversion between
+ * UTC and local time is handled by the kernel via ggmtl. This is
+ * a common expectation across platforms.
+ *
+ * To use this driver, set the following in /etc/system (or arrange
+ * for the platform code to set tod_module_name):
+ *
+ *   set tod_module_name="efitod"
+ */
+
+#include <sys/types.h>
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/clock.h>
+#include <sys/time.h>
+#include <sys/cmn_err.h>
+#include <sys/stat.h>
+#include <sys/sunddi.h>
+#include <sys/sysmacros.h>
+#include <sys/efi.h>
+#include <sys/efirt.h>
+#include <sys/machsystm.h>
+
+/*
+ * Convert an EFI_TIME (broken-down UTC) to a todinfo_t.
+ *
+ * todinfo_t.tod_year is years since 1900 (matching struct tm).
+ * EFI_TIME.Year is the absolute year (e.g. 2026).
+ * todinfo_t.tod_dow is not used by tod_to_utc(), so we leave it 0.
+ *
+ * Nanoseconds are ignored, and are integrated into the timestruc_t
+ * by the caller.
+ */
+static todinfo_t
+efitod_to_todinfo(EFI_TIME *etime)
+{
+	todinfo_t tod;
+
+	tod.tod_year = etime->Year - 1900;
+	tod.tod_month = etime->Month;
+	tod.tod_day = etime->Day;
+	tod.tod_hour = etime->Hour;
+	tod.tod_min = etime->Minute;
+	tod.tod_sec = etime->Second;
+	tod.tod_dow = 0;
+
+	return (tod);
+}
+
+/*
+ * Convert a todinfo_t to an EFI_TIME.
+ *
+ * We always store UTC with an unspecified timezone, matching the
+ * convention used by most UEFI firmware implementations.
+ *
+ * Nanoseconds are ignored, and are integrated from the timestruc_t
+ * by the caller.
+ */
+static void
+todinfo_to_efitime(todinfo_t *tod, EFI_TIME *etime)
+{
+	bzero(etime, sizeof (*etime));
+
+	etime->Year = tod->tod_year + 1900;
+	etime->Month = tod->tod_month;
+	etime->Day = tod->tod_day;
+	etime->Hour = tod->tod_hour;
+	etime->Minute = tod->tod_min;
+	etime->Second = tod->tod_sec;
+	etime->TimeZone = EFI_UNSPECIFIED_TIMEZONE;
+	etime->Daylight = 0;
+}
+
+/*
+ * Read the current time from the firmware RTC.
+ *
+ * Must be called with tod_lock held.
+ */
+static timestruc_t
+efitod_get(void)
+{
+	EFI_TIME	etime;
+	todinfo_t	tod;
+	timestruc_t	ts;
+	uint64_t	status;
+
+	ASSERT(MUTEX_HELD(&tod_lock));
+
+	status = efi_get_time(&etime, NULL);
+	if (status != EFI_SUCCESS) {
+		ts.tv_sec = 0;
+		ts.tv_nsec = 0;
+		tod_status_set(TOD_GET_FAILED);
+		return (ts);
+	}
+
+	tod_status_clear(TOD_GET_FAILED);
+
+	tod = efitod_to_todinfo(&etime);
+	ts.tv_sec = tod_to_utc(tod) + ggmtl();
+	ts.tv_nsec = etime.Nanosecond;
+
+	return (ts);
+}
+
+/*
+ * Write the specified time to the firmware RTC.
+ *
+ * Must be called with tod_lock held.
+ */
+static void
+efitod_set(timestruc_t ts)
+{
+	EFI_TIME	etime;
+	todinfo_t	tod;
+
+	ASSERT(MUTEX_HELD(&tod_lock));
+
+	tod = utc_to_tod(ts.tv_sec - ggmtl());
+	todinfo_to_efitime(&tod, &etime);
+	etime.Nanosecond = ts.tv_nsec;
+
+	(void) efi_set_time(&etime);
+}
+
+static struct modlmisc modlmisc = {
+	.misc_modops	= &mod_miscops,
+	.misc_linkinfo	= "EFI Runtime Services TOD"
+};
+
+static struct modlinkage modlinkage = {
+	.ml_rev		= MODREV_1,
+	.ml_linkage	= {&modlmisc, NULL}
+};
+
+int
+_init(void)
+{
+	extern tod_ops_t tod_ops;
+
+	if (strcmp(tod_module_name, "efitod") == 0) {
+		/*
+		 * Only install our ops if EFI runtime services
+		 * are actually available.  If not, fall through
+		 * to mod_install() without replacing the default
+		 * (non-functional) tod_ops - the kernel will use
+		 * hrestime as a fallback.
+		 */
+		if (efirt_is_active()) {
+			tod_ops.tod_get = efitod_get;
+			tod_ops.tod_set = efitod_set;
+			tod_ops.tod_set_watchdog_timer = NULL;
+			tod_ops.tod_clear_watchdog_timer = NULL;
+			tod_ops.tod_set_power_alarm = NULL;
+			tod_ops.tod_clear_power_alarm = NULL;
+		} else {
+			cmn_err(CE_WARN,
+			    "!efitod: EFI runtime services not available");
+		}
+	}
+
+	return (mod_install(&modlinkage));
+}
+
+int
+_fini(void)
+{
+	return (EBUSY);
+}
+
+int
+_info(struct modinfo *modinfop)
+{
+	return (mod_info(&modlinkage, modinfop));
+}

--- a/usr/src/uts/armv8/ml/efirt_call.S
+++ b/usr/src/uts/armv8/ml/efirt_call.S
@@ -1,0 +1,86 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2026 Michael van der Westhuizen
+ */
+
+	.file	"efirt_call.S"
+
+/*
+ * Assembly trampoline for UEFI runtime service calls.
+ *
+ * Switches to a dedicated EFI stack before calling firmware, and
+ * switches back to the kernel stack on return.  This isolates the
+ * kernel thread stack from firmware stack consumption.
+ *
+ * If the firmware faults, the on_trap/longjmp mechanism (set up by
+ * the C caller) restores SP from the setjmp buffer that was saved
+ * on the kernel stack before this function was called.  The UEFI
+ * stack is simply abandoned - no explicit cleanup is needed here.
+ */
+
+#include <sys/asm_linkage.h>
+
+/*
+ * uint64_t efirt_call_asm(uint64_t func, uint64_t a0, uint64_t a1,
+ *     uint64_t a2, uint64_t a3, uint64_t a4, uint64_t stack_top)
+ *
+ * Arguments:
+ * - x0  function pointer (EFI runtime service)
+ * - x1  arg0
+ * - x2  arg1
+ * - x3  arg2
+ * - x4  arg3
+ * - x5  arg4
+ * - x6  top of the dedicated EFI stack (grows downward)
+ *
+ * Returns:
+ *   x0  EFI_STATUS from the firmware call
+ */
+	ENTRY(efirt_call_asm)
+
+	/* Save frame pointer and return address on the kernel stack */
+	stp	x29, x30, [sp, #-16]!
+	mov	x29, sp
+
+	/* Switch to the dedicated EFI stack */
+	mov	sp, x6
+
+	/* Save the kernel SP on the EFI stack */
+	stp	x29, xzr, [sp, #-16]!
+
+	/*
+	 * Shuffle arguments: move the function pointer to x8 (a
+	 * scratch register under AAPCS64) and shift the five
+	 * arguments down into x0-x4.
+	 */
+	mov	x8, x0
+	mov	x0, x1
+	mov	x1, x2
+	mov	x2, x3
+	mov	x3, x4
+	mov	x4, x5
+
+	/* Call the firmware runtime service */
+	blr	x8
+
+	/* Recover kernel SP from the EFI stack */
+	ldp	x29, xzr, [sp], #16
+
+	/* Switch back to the kernel stack and restore the frame */
+	mov	sp, x29
+	ldp	x29, x30, [sp], #16
+
+	/* x0 holds the EFI_STATUS return value */
+	ret
+
+	SET_SIZE(efirt_call_asm)

--- a/usr/src/uts/armv8/os/efirt_machdep.c
+++ b/usr/src/uts/armv8/os/efirt_machdep.c
@@ -69,6 +69,7 @@
 #include <sys/kfpu.h>
 #include <sys/bootconf.h>
 #include <sys/efi.h>
+#include <sys/efirt.h>
 #include <sys/ontrap.h>
 #include <sys/machsystm.h>
 #include <sys/machparam.h>
@@ -812,4 +813,47 @@ boolean_t
 efirt_is_active(void)
 {
 	return (efirt_active);
+}
+
+/*
+ * EFI Runtime Service Wrappers
+ *
+ * Each wrapper follows the same pattern:
+ * 1. Check efirt_is_active - bail if RT services never initialised.
+ * 2. Check efirt_is_supported - bail if firmware advertised this
+ *    service as unsupported, or a previous call returned EFI_UNSUPPORTED.
+ * 3. Call firmware via efirt_call_rt.
+ * 4. If firmware returns EFI_UNSUPPORTED, clear the supported bit so
+ *    subsequent calls return immediately without entering firmware.
+ */
+
+/*
+ * Reset or shut down the system (UEFI Specification 2.10, Section 8.5.1).
+ *
+ * ResetSystem does not return on success - the machine reboots or
+ * powers off.  If we return from this function, the reset failed.
+ *
+ * The data_size/data arguments allow passing a reset reason string
+ * to firmware (optional, may be NULL/0).
+ */
+void
+efi_reset_system(EFI_RESET_TYPE type, uint64_t status,
+    uint64_t data_size, void *data)
+{
+	if (!efirt_is_active()) {
+		return;
+	}
+
+	if (!efirt_is_supported(EFI_RT_SUPPORTED_RESET_SYSTEM)) {
+		return;
+	}
+
+	(void) efirt_call_rt(efirt_reset_system,
+	    (uint64_t)type, status, data_size, (uint64_t)data, 0);
+
+	/*
+	 * If we get here, the reset failed.  Clear the supported bit
+	 * so we don't try this path again.
+	 */
+	efirt_clear_supported(EFI_RT_SUPPORTED_RESET_SYSTEM);
 }

--- a/usr/src/uts/armv8/os/efirt_machdep.c
+++ b/usr/src/uts/armv8/os/efirt_machdep.c
@@ -1,0 +1,815 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2026 Michael van der Westhuizen
+ */
+
+/*
+ * UEFI Runtime Services support for AArch64.
+ *
+ * This file implements the machine-dependent parts of UEFI Runtime
+ * Services support:
+ * - Building a 1:1 identity-mapped page table for EFI RT regions
+ *   using hand-crafted page tables - necessary to not fall foul
+ *   of as initialisation order and hat datastructure lifecycles
+ * - Low-level enter/leave routines that switch TTBR0 to the EFI
+ *   page table and save/restore FPU state.
+ * - A fault-protected call wrapper that runs firmware on a
+ *   dedicated stack via on_trap and an assembly trampoline
+ * - Extracting RT function pointers from the EFI system table
+ * - Easily callable function wrappers that protect callers from
+ *   all of this complexity.
+ *
+ * Key design decisions:
+ * * We identity-map RT regions (VA == PA) following the FreeBSD
+ *   model. We still call SetVirtualAddressMap with the
+ *   identity-mapped setup to ensure that we don't fall foul of
+ *   well known firmware bugs.
+ * * TTBR0 is switched directly (not via hat_switch()) to avoid
+ *   side effects on cpu_current_hat.
+ * * ASID 1 is permanently reserved for the UEFI page table to
+ *   avoid unwanted interactions with user address spaces.
+ * * A sleep mutex serializes all RT calls (UEFI RT is not
+ *   reentrant - it is in some cases, but the rules are complex
+ *   and it's simpler to just serialise calls).
+ * * kernel_fpu_begin/end bracket RT calls because while the UEFI
+ *   calling convention does not explicitly permit FP/SIMD register
+ *   use there are implementations in the wild that use FP/SIMD.
+ * * Firmware runs on a dedicated stack (DEFAULTSTKSZ = 20 KB)
+ *   to avoid kernel stack overflow or corruption from greedy or
+ *   buggy firmware.
+ * * on_trap(OT_DATA_ACCESS) provides fault recovery for both
+ *   data aborts and instruction aborts from EL1 (the trap
+ *   handler dispatches both through the same on_trap check).
+ *   Per-call recovery: a fault returns EFI_DEVICE_ERROR to the
+ *   caller.  The faulting RT service is disabled, but other calls
+ *   remain available.
+ *
+ * The EFI page table is constructed manually (not via the hat/as
+ * layer) to avoid dependencies on htable lifecycle - the hat layer
+ * may reap htable pages under memory pressure, but UEFI page tables
+ * must be permanently pinned.  Page table pages are allocated via
+ * kmem_zalloc and are never freed.
+ */
+
+#include <sys/types.h>
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/cmn_err.h>
+#include <sys/mutex.h>
+#include <sys/kfpu.h>
+#include <sys/bootconf.h>
+#include <sys/efi.h>
+#include <sys/ontrap.h>
+#include <sys/machsystm.h>
+#include <sys/machparam.h>
+#include <sys/controlregs.h>
+#include <asm/controlregs.h>
+#include <asm/atomic.h>
+#include <vm/as.h>
+#include <vm/hat.h>
+#include <vm/hat_aarch64.h>
+#include <vm/hat_pte.h>
+#include <vm/kpm.h>
+
+/*
+ * Convert a physical address to a KPM virtual address, preserving
+ * the intra-page offset.  hat_kpm_pfn2va returns the VA for the
+ * page boundary; we add back the offset within the page.
+ */
+static caddr_t
+efirt_pa_to_va(uint64_t pa)
+{
+	return ((caddr_t)hat_kpm_pfn2va(mmu_btop(pa)) +
+	    (pa & MMU_PAGEOFFSET));
+}
+
+/*
+ * EFI Runtime Services state.
+ *
+ * These variables are set up at initialisation time.
+ */
+static pte_t		*efirt_pt;
+static uint64_t		efirt_ttbr0;
+static kmutex_t		efirt_lock;
+static boolean_t	efirt_active = B_FALSE;
+
+/*
+ * Saved CPU state across an EFI RT call. Protected by efirt_lock.
+ */
+static uint64_t		efirt_saved_ttbr0;
+static uint64_t		efirt_saved_tcr;
+
+/*
+ * Kernel FPU state for EFI RT calls.
+ */
+static struct kfpu_state	*efirt_kfpu;
+
+/*
+ * Dedicated stack for EFI runtime service calls.  Firmware runs on
+ * this stack to avoid consuming the kernel thread's stack.  Sized at
+ * DEFAULTSTKSZ (20 KB), which exceeds the UEFI specification's
+ * typical requirements. Protected by efirt_lock.
+ */
+static caddr_t		efirt_stack;
+static caddr_t		efirt_stack_top;
+
+/*
+ * Bitmask of runtime services that firmware advertises as functional
+ * after ExitBootServices.  Initialised from EFI_RT_PROPERTIES_TABLE
+ * if present, otherwise all bits are set (assume all available).
+ *
+ * Bits are cleared dynamically when a service returns EFI_UNSUPPORTED or
+ * faults when called.
+ */
+static uint32_t		efirt_supported = EFI_RT_SUPPORTED_ALL;
+
+/*
+ * Assembly trampoline: switches to the UEFI dedicated stack, shuffles
+ * arguments, calls the firmware function, and switches back.
+ *
+ * Implemented in armv8/ml/efirt_call.S.
+ */
+extern uint64_t efirt_call_asm(uint64_t func, uint64_t a0, uint64_t a1,
+    uint64_t a2, uint64_t a3, uint64_t a4, uint64_t stack_top);
+
+/*
+ * UEFI Runtime Services function pointers (physical addresses).
+ *
+ * These are extracted from the EFI_RUNTIME_SERVICES64 table.
+ */
+uint64_t	efirt_get_time;
+uint64_t	efirt_set_time;
+uint64_t	efirt_get_wakeup_time;
+uint64_t	efirt_set_wakeup_time;
+uint64_t	efirt_get_variable;
+uint64_t	efirt_get_next_variable_name;
+uint64_t	efirt_set_variable;
+uint64_t	efirt_get_next_high_mono_count;
+uint64_t	efirt_reset_system;
+uint64_t	efirt_update_capsule;
+uint64_t	efirt_query_capsule_caps;
+uint64_t	efirt_query_variable_info;
+
+/*
+ * Translate EFI memory descriptor attributes to AArch64 PTE bits.
+ *
+ * All EFI PTEs get:
+ *   PTE_PAGE      - L0 page descriptor
+ *   PTE_AF        - access flag pre-set (no fault on first touch)
+ *   PTE_SH_INNER  - inner shareable
+ *   PTE_NG        - non-global (tagged with ASID 1)
+ *   PTE_UXN       - never user-executable
+ *   PTE_AP_KRWUNA - kernel read/write, user no-access
+ *
+ * Code regions omit PTE_PXN so firmware can execute at EL1.
+ * Data and MMIO regions set PTE_PXN.
+ */
+static pte_t
+efirt_efi_to_pte_attr(uint32_t type, uint64_t attr)
+{
+	pte_t pte = PTE_PAGE | PTE_AF | PTE_SH_INNER | PTE_NG |
+	    PTE_UXN | PTE_AP_KRWUNA;
+
+	/* Caching attributes */
+	if (type == EfiMemoryMappedIO ||
+	    type == EfiMemoryMappedIOPortSpace) {
+		pte |= PTE_ATTR_DEVICE;
+	} else if (attr & EFI_MEMORY_WB) {
+		pte |= PTE_ATTR_NORMEM;
+	} else if (attr & EFI_MEMORY_WT) {
+		pte |= PTE_ATTR_NORMEM_WT;
+	} else if (attr & EFI_MEMORY_WC) {
+		pte |= PTE_ATTR_NORMEM_UC;
+	} else {
+		pte |= PTE_ATTR_DEVICE;
+	}
+
+	/* Code regions: no PXN so firmware can execute at EL1 */
+	if (type != EfiRuntimeServicesCode) {
+		pte |= PTE_PXN;
+	}
+
+	return (pte);
+}
+
+/*
+ * Allocate a zeroed page-table page.
+ *
+ * These are never freed - the UEFI page table must be permanently pinned.
+ */
+static pte_t *
+efirt_alloc_ptpage(void)
+{
+	return ((pte_t *)kmem_zalloc(MMU_PAGESIZE, KM_SLEEP));
+}
+
+/*
+ * Install a single page mapping in the UEFI page table.
+ *
+ * Allocates intermediate tables as needed.
+ *
+ * Level numbering follows the illumos convention.
+ */
+static void
+efirt_map_page(pte_t *root, uint64_t pa, pte_t pte_attr)
+{
+	int level;
+	pte_t *table = root;
+
+	for (level = mmu.max_level; level > 0; level--) {
+		uint_t idx = LEVEL_INDEX(pa, level);
+
+		if (!PTE_ISVALID(table[idx])) {
+			pte_t *next = efirt_alloc_ptpage();
+			table[idx] = MAKEPTP(hat_getpfnum(
+			    kas.a_hat, (caddr_t)next), level, 1);
+			table = next;
+		} else {
+			table = (pte_t *)pfn_to_kseg(
+			    PTE2PFN(table[idx], level));
+		}
+	}
+
+	/* Leaf page entry */
+	table[LEVEL_INDEX(pa, 0)] = (pa & PTE_PFN_MASK) | pte_attr;
+}
+
+/*
+ * Walk the EFI configuration table to find EFI_RT_PROPERTIES_TABLE.
+ *
+ * If found, return the RuntimeServicesSupported bitmask.
+ * If not found, return EFI_RT_SUPPORTED_ALL (assume all available).
+ */
+static uint32_t
+efirt_get_rt_supported(EFI_SYSTEM_TABLE64 *systab)
+{
+	uint64_t		cfg_pa;
+	uint64_t		count;
+	EFI_CONFIGURATION_TABLE64	*cfg;
+	static const efi_guid_t	rt_prop_guid =
+	    EFI_RT_PROPERTIES_TABLE_GUID;
+
+	count = systab->NumberOfTableEntries;
+	cfg_pa = systab->ConfigurationTable;
+
+	if (count == 0 || cfg_pa == 0) {
+		return (EFI_RT_SUPPORTED_ALL);
+	}
+
+	cfg = (EFI_CONFIGURATION_TABLE64 *)efirt_pa_to_va(cfg_pa);
+
+	for (uint64_t i = 0; i < count; i++) {
+		if (bcmp(&cfg[i].VendorGuid, &rt_prop_guid,
+		    sizeof (efi_guid_t)) == 0) {
+			EFI_RT_PROPERTIES_TABLE	*prop;
+
+			prop = (EFI_RT_PROPERTIES_TABLE *)
+			    efirt_pa_to_va(cfg[i].VendorTable);
+
+			if (prop->Version >=
+			    EFI_RT_PROPERTIES_TABLE_VERSION) {
+				return (prop->RuntimeServicesSupported &
+				    EFI_RT_SUPPORTED_ALL);
+			}
+
+			/*
+			 * Version mismatch - table is present but we
+			 * don't understand it.  Assume all available.
+			 */
+			cmn_err(CE_NOTE,
+			    "!EFI RT: RT properties table version %u "
+			    "not supported (expected >= %u)",
+			    prop->Version,
+			    EFI_RT_PROPERTIES_TABLE_VERSION);
+			return (EFI_RT_SUPPORTED_ALL);
+		}
+	}
+
+	/* Table not found - assume all services available */
+	cmn_err(CE_NOTE, "!EFI RT: RT properties table not found");
+	return (EFI_RT_SUPPORTED_ALL);
+}
+
+/*
+ * Clear one or more bits in the runtime services supported mask.
+ *
+ * Called by service wrappers when firmware returns EFI_UNSUPPORTED,
+ * so that subsequent calls return EFI_UNSUPPORTED immediately without
+ * entering firmware.  Safe to call without the RT lock - the only
+ * transition is from set to clear, never back, so a race just means
+ * one extra firmware round-trip.
+ */
+static void
+efirt_clear_supported(uint32_t mask)
+{
+	atomic_and_32(&efirt_supported, ~mask);
+}
+
+/*
+ * Check whether a set of runtime services are supported.
+ *
+ * Returns B_TRUE if all bits in the mask are set in efirt_supported.
+ * Can be called without holding the RT lock (benign race at worst:
+ * one extra call that returns EFI_UNSUPPORTED before the bit is cleared).
+ */
+static boolean_t
+efirt_is_supported(uint32_t mask)
+{
+	return ((efirt_supported & mask) == mask);
+}
+
+/*
+ * Call SetVirtualAddressMap with an identity mapping (VA == PA).
+ *
+ * Although we use a 1:1 identity map and could operate purely in
+ * physical mode, calling SetVirtualAddressMap is necessary to work
+ * around well-known firmware bugs - notably on Ampere eMAG platforms,
+ * where firmware assumes the OS will always call SVAM and behaves
+ * incorrectly if it is not called.
+ *
+ * This function is called once during efirt_init, after the UEFI
+ * page table, dedicated stack, and FPU state are ready, but before
+ * RT function pointers are extracted.  This ordering is important:
+ * firmware may relocate its internal pointers during SVAM, so the
+ * RT function pointer table must be read only after SVAM returns.
+ *
+ * Because efirt_active is not yet B_TRUE, we cannot use efirt_call_rt
+ * (which asserts efirt_active).  Instead we inline the enter/call/leave
+ * sequence.  This is safe because we are on a single CPU during early
+ * boot with no contention.
+ */
+static void
+efirt_set_virtual_address_map(struct efi_map_header *mhdr,
+    EFI_RUNTIME_SERVICES64 *rt)
+{
+	EFI_MEMORY_DESCRIPTOR	*src, *dst;
+	caddr_t			map_copy;
+	on_trap_data_t		otd;
+	uint64_t		svam_func;
+	uint64_t		status;
+	size_t			map_size;
+	int			ndesc;
+
+	ASSERT(!efirt_active);
+
+	if (!(efirt_supported & EFI_RT_SUPPORTED_SET_VIRTUAL_ADDRESS_MAP)) {
+		return;
+	}
+
+	svam_func = rt->SetVirtualAddressMap;
+	if (svam_func == 0) {
+		efirt_clear_supported(EFI_RT_SUPPORTED_SET_VIRTUAL_ADDRESS_MAP);
+		return;
+	}
+
+	/*
+	 * Allocate a writable copy of the memory map.  Firmware reads
+	 * VirtualStart from each descriptor to relocate its internal
+	 * pointers.  The copy is a kernel VA (TTBR1 range) which
+	 * firmware can access because TTBR1 remains active during
+	 * EFI calls.
+	 */
+	map_size = mhdr->memory_size;
+	ndesc = efi_mmap_ndesc(mhdr);
+	map_copy = kmem_alloc(map_size, KM_SLEEP);
+
+	src = efi_mmap_start(mhdr);
+	dst = (EFI_MEMORY_DESCRIPTOR *)map_copy;
+	for (int i = 0; i < ndesc; i++) {
+		bcopy(src, dst, mhdr->descriptor_size);
+
+		if (dst->Attribute & EFI_MEMORY_RUNTIME) {
+			dst->VirtualStart = dst->PhysicalStart;
+		} else {
+			dst->VirtualStart = 0;
+		}
+
+		src = efi_mmap_next(src, mhdr->descriptor_size);
+		dst = efi_mmap_next(dst, mhdr->descriptor_size);
+	}
+
+	/*
+	 * Inline the EFI enter sequence.  No lock needed - single
+	 * CPU during early boot.
+	 */
+	kpreempt_disable();
+	kernel_fpu_begin(efirt_kfpu, 0);
+
+	efirt_saved_tcr = read_tcr();
+	efirt_saved_ttbr0 = read_ttbr0();
+	write_ttbr0(efirt_ttbr0);
+	write_tcr(efirt_saved_tcr & ~(TCR_EPD0));
+	isb();
+
+	if (on_trap(&otd, OT_DATA_ACCESS) != 0) {
+		no_trap();
+		status = EFI_DEVICE_ERROR;
+		goto leave;
+	}
+
+	status = efirt_call_asm(svam_func,
+	    (uint64_t)map_size,
+	    (uint64_t)mhdr->descriptor_size,
+	    (uint64_t)mhdr->descriptor_version,
+	    (uint64_t)(uintptr_t)map_copy,
+	    0,
+	    (uint64_t)(uintptr_t)efirt_stack_top);
+
+	no_trap();
+
+leave:
+	write_tcr(efirt_saved_tcr);
+	write_ttbr0(efirt_saved_ttbr0);
+	isb();
+
+	kernel_fpu_end(efirt_kfpu, 0);
+	kpreempt_enable();
+
+	kmem_free(map_copy, map_size);
+
+	if (status != EFI_SUCCESS) {
+		cmn_err(CE_WARN,
+		    "!EFI RT: SetVirtualAddressMap failed: 0x%lx "
+		    "(continuing with physical addresses)", status);
+		efirt_clear_supported(EFI_RT_SUPPORTED_SET_VIRTUAL_ADDRESS_MAP);
+	}
+}
+
+/*
+ * Initialize EFI Runtime Services support.
+ *
+ * Called from startup_efi, after startup_vm has made kmem,
+ * the hat layer, and the ASID allocator available.  Boot scratch
+ * memory (which holds the raw EFI memory map) is still intact -
+ * release_bootstrap runs much later from main.c.
+ */
+void
+efirt_init(void)
+{
+	uint64_t			systab_pa = 0;
+	uint64_t			memmap_pa = 0;
+	struct efi_map_header		*mhdr;
+	EFI_MEMORY_DESCRIPTOR		*desc;
+	EFI_SYSTEM_TABLE64		*systab;
+	EFI_RUNTIME_SERVICES64		*rt;
+	int				ndesc;
+	int				nrt = 0;
+
+	/*
+	 * Read boot properties set by fakebop.c.
+	 */
+	if (do_bsys_getproplen(NULL, "efi-systab") > 0)
+		(void) do_bsys_getprop(NULL, "efi-systab", &systab_pa);
+	if (do_bsys_getproplen(NULL, "efi-memmap") > 0)
+		(void) do_bsys_getprop(NULL, "efi-memmap", &memmap_pa);
+
+	if (systab_pa == 0 || memmap_pa == 0) {
+		cmn_err(CE_NOTE,
+		    "!EFI RT: system table or memory map not available");
+		return;
+	}
+
+	/*
+	 * Validate the EFI system table and runtime services table
+	 * before committing to any resource allocation.  These are
+	 * accessed in-place via KPM from boot scratch memory.
+	 */
+	systab = (EFI_SYSTEM_TABLE64 *)efirt_pa_to_va(systab_pa);
+
+	if (systab->Hdr.Signature != EFI_SYSTEM_TABLE_SIGNATURE) {
+		cmn_err(CE_WARN,
+		    "!EFI RT: invalid system table signature");
+		return;
+	}
+
+	if (systab->RuntimeServices == 0) {
+		cmn_err(CE_WARN,
+		    "!EFI RT: no runtime services table pointer");
+		return;
+	}
+
+	rt = (EFI_RUNTIME_SERVICES64 *)
+	    efirt_pa_to_va(systab->RuntimeServices);
+
+	if (rt->Hdr.Signature != EFI_RUNTIME_SERVICES_SIGNATURE) {
+		cmn_err(CE_WARN,
+		    "!EFI RT: invalid runtime services signature");
+		return;
+	}
+
+	/*
+	 * Check whether firmware advertises restricted RT service
+	 * availability via the EFI_RT_PROPERTIES_TABLE.  If the table
+	 * is not present we assume all services are available.
+	 */
+	efirt_supported = efirt_get_rt_supported(systab);
+
+	/*
+	 * Access the raw EFI memory map in-place via KPM.  The map
+	 * lives in boot scratch memory (EfiLoaderData) which is still
+	 * intact - release_bootstrap runs much later from main.c.
+	 *
+	 * We do not copy the map; it is only needed during init.
+	 */
+	mhdr = (struct efi_map_header *)efirt_pa_to_va(memmap_pa);
+
+	/*
+	 * Allocate the top-level page table and identity-map all
+	 * EFI_MEMORY_RUNTIME regions.  Page table pages are allocated
+	 * via kmem_zalloc and never freed, as runtime services are
+	 * required all the way up to reboot.
+	 */
+	efirt_pt = efirt_alloc_ptpage();
+
+	ndesc = efi_mmap_ndesc(mhdr);
+	desc = efi_mmap_start(mhdr);
+
+	for (int i = 0;
+	    i < ndesc;
+	    i++, desc = efi_mmap_next(desc, mhdr->descriptor_size)) {
+		uint64_t	pa;
+		uint64_t	npages;
+		pte_t		pte_attr;
+
+		if (!(desc->Attribute & EFI_MEMORY_RUNTIME)) {
+			continue;
+		}
+
+		pa = desc->PhysicalStart;
+		npages = desc->NumberOfPages;
+		pte_attr = efirt_efi_to_pte_attr(desc->Type, desc->Attribute);
+
+		for (uint64_t p = 0; p < npages; p++) {
+			efirt_map_page(efirt_pt, pa + p * MMU_PAGESIZE,
+			    pte_attr);
+		}
+
+		nrt++;
+	}
+
+	/*
+	 * Ensure all page table stores are visible to the translation
+	 * table walker before we switch TTBR0 for the first time.  The
+	 * walker is coherent with the data cache on AArch64, so no cache
+	 * maintenance is needed, but a DSB is required to guarantee that
+	 * the stores have completed before the TTBR0 write in the SVAM
+	 * call below.
+	 */
+	dsb(ish);
+
+	/*
+	 * Precompute the TTBR0 value for EFI context switches.
+	 * ASID 1 is permanently reserved in the ASID bitmap allocator.
+	 */
+	efirt_ttbr0 = ((uint64_t)ASID_RESERVED_FOR_EFI << TTBR_ASID_SHIFT) |
+	    pfn_to_pa(hat_getpfnum(kas.a_hat, (caddr_t)efirt_pt));
+
+	/*
+	 * Initialize the RT call serialization lock, FPU state, and
+	 * the dedicated firmware call stack.
+	 */
+	mutex_init(&efirt_lock, NULL, MUTEX_DEFAULT, NULL);
+
+	efirt_kfpu = kernel_fpu_alloc(KM_SLEEP);
+
+	efirt_stack = kmem_zalloc(DEFAULTSTKSZ, KM_SLEEP);
+	efirt_stack_top = efirt_stack + DEFAULTSTKSZ;
+
+	/*
+	 * Call SetVirtualAddressMap with our identity mapping before
+	 * extracting function pointers.  SVAM may cause firmware to
+	 * relocate its internal state and update the RT function
+	 * pointer table entries.  By calling SVAM first, the function
+	 * pointer extraction below picks up the post-SVAM values.
+	 *
+	 * If SVAM fails, we continue - the identity-mapped physical
+	 * addresses are still valid.
+	 */
+	efirt_set_virtual_address_map(mhdr, rt);
+
+	/*
+	 * Extract RT function pointers from the (already validated)
+	 * runtime services table.  Function pointers for services not
+	 * advertised in the RT properties table are zeroed out - callers
+	 * should check efi_rt_is_supported before calling efi_call_rt.
+	 */
+	efirt_get_time = (efirt_supported & EFI_RT_SUPPORTED_GET_TIME) ?
+	    rt->GetTime : 0;
+	efirt_set_time = (efirt_supported & EFI_RT_SUPPORTED_SET_TIME) ?
+	    rt->SetTime : 0;
+	efirt_get_wakeup_time =
+	    (efirt_supported & EFI_RT_SUPPORTED_GET_WAKEUP_TIME) ?
+	    rt->GetWakeupTime : 0;
+	efirt_set_wakeup_time =
+	    (efirt_supported & EFI_RT_SUPPORTED_SET_WAKEUP_TIME) ?
+	    rt->SetWakeupTime : 0;
+	efirt_get_variable =
+	    (efirt_supported & EFI_RT_SUPPORTED_GET_VARIABLE) ?
+	    rt->GetVariable : 0;
+	efirt_get_next_variable_name =
+	    (efirt_supported & EFI_RT_SUPPORTED_GET_NEXT_VARIABLE_NAME) ?
+	    rt->GetNextVariableName : 0;
+	efirt_set_variable =
+	    (efirt_supported & EFI_RT_SUPPORTED_SET_VARIABLE) ?
+	    rt->SetVariable : 0;
+	efirt_get_next_high_mono_count =
+	    (efirt_supported & EFI_RT_SUPPORTED_GET_NEXT_HIGH_MONO_COUNT) ?
+	    rt->GetNextHighMonotonicCount : 0;
+	efirt_reset_system =
+	    (efirt_supported & EFI_RT_SUPPORTED_RESET_SYSTEM) ?
+	    rt->ResetSystem : 0;
+	efirt_update_capsule =
+	    (efirt_supported & EFI_RT_SUPPORTED_UPDATE_CAPSULE) ?
+	    rt->UpdateCapsule : 0;
+	efirt_query_capsule_caps =
+	    (efirt_supported & EFI_RT_SUPPORTED_QUERY_CAPSULE_CAPS) ?
+	    rt->QueryCapsuleCapabilities : 0;
+	efirt_query_variable_info =
+	    (efirt_supported & EFI_RT_SUPPORTED_QUERY_VARIABLE_INFO) ?
+	    rt->QueryVariableInfo : 0;
+
+	/*
+	 * Refine the supported services to remove services that have NULL
+	 * pointers in the RuntimeServices structure (but may be otherwise
+	 * considered available due to a default or buggy supported services
+	 * bitmap).
+	 */
+
+	if (efirt_get_time == 0) {
+		efirt_clear_supported(EFI_RT_SUPPORTED_GET_TIME);
+	}
+
+	if (efirt_set_time == 0) {
+		efirt_clear_supported(EFI_RT_SUPPORTED_SET_TIME);
+	}
+
+	if (efirt_get_wakeup_time == 0) {
+		efirt_clear_supported(EFI_RT_SUPPORTED_GET_WAKEUP_TIME);
+	}
+
+	if (efirt_set_wakeup_time == 0) {
+		efirt_clear_supported(EFI_RT_SUPPORTED_SET_WAKEUP_TIME);
+	}
+
+	if (efirt_get_variable == 0) {
+		efirt_clear_supported(EFI_RT_SUPPORTED_GET_VARIABLE);
+	}
+
+	if (efirt_get_next_variable_name == 0) {
+		efirt_clear_supported(EFI_RT_SUPPORTED_GET_NEXT_VARIABLE_NAME);
+	}
+
+	if (efirt_set_variable == 0) {
+		efirt_clear_supported(EFI_RT_SUPPORTED_SET_VARIABLE);
+	}
+
+	if (efirt_get_next_high_mono_count == 0) {
+		efirt_clear_supported(
+		    EFI_RT_SUPPORTED_GET_NEXT_HIGH_MONO_COUNT);
+	}
+
+	if (efirt_reset_system == 0) {
+		efirt_clear_supported(EFI_RT_SUPPORTED_RESET_SYSTEM);
+	}
+
+	if (efirt_update_capsule == 0) {
+		efirt_clear_supported(EFI_RT_SUPPORTED_UPDATE_CAPSULE);
+	}
+
+	if (efirt_query_capsule_caps == 0) {
+		efirt_clear_supported(EFI_RT_SUPPORTED_QUERY_CAPSULE_CAPS);
+	}
+
+	if (efirt_query_variable_info == 0) {
+		efirt_clear_supported(EFI_RT_SUPPORTED_QUERY_VARIABLE_INFO);
+	}
+
+	efirt_active = B_TRUE;
+
+	cmn_err(CE_CONT,
+	    "!EFI RT: %d regions mapped, services supported: 0x%x\n",
+	    nrt, efirt_supported);
+}
+
+/*
+ * Enter EFI runtime services context.
+ *
+ * Must be called with efirt_lock held.  Disables preemption, saves
+ * FPU state, and switches TTBR0 to the UEFI 1:1 identity map.
+ *
+ * The previous TTBR0 and TCR values are saved in file-scope statics
+ * (safe because the mutex serializes all RT calls).
+ */
+static void
+efirt_arch_enter(void)
+{
+	ASSERT(MUTEX_HELD(&efirt_lock));
+
+	kpreempt_disable();
+	kernel_fpu_begin(efirt_kfpu, 0);
+
+	/*
+	 * Save TCR and TTBR0, then install the EFI page table.
+	 * Order matters: install TTBR0 first (while walks may still
+	 * be disabled via TCR_EPD0), then clear EPD0 to enable walks.
+	 * This avoids a window where walks are enabled against a
+	 * stale TTBR0.
+	 */
+	efirt_saved_tcr = read_tcr();
+	efirt_saved_ttbr0 = read_ttbr0();
+	write_ttbr0(efirt_ttbr0);
+	write_tcr(efirt_saved_tcr & ~(TCR_EPD0));
+	isb();
+}
+
+/*
+ * Leave EFI runtime services context.
+ *
+ * Restores TCR and TTBR0, restores FPU state and re-enables preemption.
+ */
+static void
+efirt_arch_leave(void)
+{
+	ASSERT(MUTEX_HELD(&efirt_lock));
+
+	/*
+	 * Restore TCR first (may re-set EPD0, disabling walks), then
+	 * restore the previous TTBR0.  This avoids a window where
+	 * walks are enabled against the UEFI page table after we've
+	 * logically left UEFI context.
+	 */
+	write_tcr(efirt_saved_tcr);
+	write_ttbr0(efirt_saved_ttbr0);
+	isb();
+
+	kernel_fpu_end(efirt_kfpu, 0);
+	kpreempt_enable();
+}
+
+/*
+ * Call an EFI runtime service with fault protection.
+ *
+ * Acquires the RT lock, enters UEFI context (TTBR0 switch, FPU save),
+ * sets up on_trap fault recovery, calls the firmware function on a
+ * dedicated stack via the assembly wrapper, then unwinds everything.
+ *
+ * Returns the UEFI status from firmware, or EFI_DEVICE_ERROR on fault.
+ * Per-call recovery: a fault does not permanently disable RT services,
+ * that is a decision made by individual runtime services call wrappers.
+ */
+uint64_t
+efirt_call_rt(uint64_t func, uint64_t a0, uint64_t a1, uint64_t a2,
+    uint64_t a3, uint64_t a4)
+{
+	on_trap_data_t	otd;
+	uint64_t	status;
+
+	ASSERT(efirt_active);
+
+	mutex_enter(&efirt_lock);
+	efirt_arch_enter();
+
+	if (on_trap(&otd, OT_DATA_ACCESS) != 0) {
+		/*
+		 * A data abort or instruction abort occurred during the
+		 * firmware call.  on_trap's longjmp has already restored
+		 * SP to the kernel stack (from the setjmp buffer saved
+		 * before we switched to the UEFI stack), so the dedicated
+		 * UEFI stack is cleanly abandoned.
+		 */
+		no_trap();
+		efirt_arch_leave();
+		mutex_exit(&efirt_lock);
+		cmn_err(CE_WARN,
+		    "!EFI RT: firmware fault during runtime service call");
+		return (EFI_DEVICE_ERROR);
+	}
+
+	status = efirt_call_asm(func, a0, a1, a2, a3, a4,
+	    (uint64_t)(uintptr_t)efirt_stack_top);
+
+	no_trap();
+	efirt_arch_leave();
+	mutex_exit(&efirt_lock);
+
+	return (status);
+}
+
+/*
+ * Return B_TRUE if EFI Runtime Services are available.
+ */
+boolean_t
+efirt_is_active(void)
+{
+	return (efirt_active);
+}

--- a/usr/src/uts/armv8/os/efirt_machdep.c
+++ b/usr/src/uts/armv8/os/efirt_machdep.c
@@ -857,3 +857,59 @@ efi_reset_system(EFI_RESET_TYPE type, uint64_t status,
 	 */
 	efirt_clear_supported(EFI_RT_SUPPORTED_RESET_SYSTEM);
 }
+
+/*
+ * Get the current time and date from the platform RTC
+ * (UEFI Specification 2.10, Section 8.3).
+ *
+ * caps may be NULL if the caller does not need clock capabilities.
+ */
+uint64_t
+efi_get_time(EFI_TIME *time, EFI_TIME_CAPABILITIES *caps)
+{
+	uint64_t status;
+
+	if (!efirt_is_active()) {
+		return (EFI_UNSUPPORTED);
+	}
+
+	if (!efirt_is_supported(EFI_RT_SUPPORTED_GET_TIME)) {
+		return (EFI_UNSUPPORTED);
+	}
+
+	status = efirt_call_rt(efirt_get_time,
+	    (uint64_t)time, (uint64_t)caps, 0, 0, 0);
+
+	if (status == EFI_UNSUPPORTED) {
+		efirt_clear_supported(EFI_RT_SUPPORTED_GET_TIME);
+	}
+
+	return (status);
+}
+
+/*
+ * Set the current time and date on the platform RTC
+ * (UEFI Specification 2.10, Section 8.3).
+ */
+uint64_t
+efi_set_time(EFI_TIME *time)
+{
+	uint64_t status;
+
+	if (!efirt_is_active()) {
+		return (EFI_UNSUPPORTED);
+	}
+
+	if (!efirt_is_supported(EFI_RT_SUPPORTED_SET_TIME)) {
+		return (EFI_UNSUPPORTED);
+	}
+
+	status = efirt_call_rt(efirt_set_time,
+	    (uint64_t)time, 0, 0, 0, 0);
+
+	if (status == EFI_UNSUPPORTED) {
+		efirt_clear_supported(EFI_RT_SUPPORTED_SET_TIME);
+	}
+
+	return (status);
+}

--- a/usr/src/uts/armv8/os/fakebop.c
+++ b/usr/src/uts/armv8/os/fakebop.c
@@ -29,7 +29,7 @@
  * Copyright 2017 Hayashi Naoyuki
  * Copyright 2020 Joyent, Inc.
  * Copyright 2024 Oxide Computer Company
- * Copyright 2025 Michael van der Westhuizen
+ * Copyright 2026 Michael van der Westhuizen
  */
 
 /*
@@ -1006,6 +1006,9 @@ build_firmware_properties(struct xboot_info *xbp __maybe_unused)
 	if (xbp->bi_uefi_systab == 0)
 		prom_panic("illumos/aarch64 requires UEFI\n");
 	bsetprop64("efi-systab", xbp->bi_uefi_systab);
+
+	if (xbp->bi_uefi_memmap != 0)
+		bsetprop64("efi-memmap", xbp->bi_uefi_memmap);
 
 	if (xbp->bi_smbios != 0)
 		bsetprop64("smbios-address", xbp->bi_smbios);

--- a/usr/src/uts/armv8/os/machdep.c
+++ b/usr/src/uts/armv8/os/machdep.c
@@ -60,6 +60,7 @@
 #include <sys/reboot.h>
 #include <sys/kdi_machimpl.h>
 #include <sys/bootsvcs.h>
+#include <sys/efirt.h>
 
 #include <c2/audit.h>
 
@@ -625,9 +626,21 @@ mdboot(int cmd, int fcn, char *mdep, boolean_t invoke_cb)
 		halt((char *)NULL);
 	} else if (fcn == AD_POWEROFF) {
 		stop_other_cpus();
+
+		if (!panicstr) {
+			efi_reset_system(EfiResetShutdown,
+			    EFI_SUCCESS, 0, NULL);
+		}
+
 		prom_power_off();
 	} else {
 		stop_other_cpus();
+
+		if (!panicstr) {
+			efi_reset_system(EfiResetCold,
+			    EFI_SUCCESS, 0, NULL);
+		}
+
 		prom_reboot("");
 	}
 	/* MAYBE REACHED */

--- a/usr/src/uts/armv8/os/platmod.c
+++ b/usr/src/uts/armv8/os/platmod.c
@@ -10,10 +10,13 @@
  */
 
 /*
- * Copyright 2025 Michael van der Westhuizen
+ * Copyright 2026 Michael van der Westhuizen
  */
 
 #include <sys/systm.h>
+#include <sys/machclock.h>
+#include <sys/efi.h>
+#include <sys/efirt.h>
 
 /*
  * All platmod functions are weak and are only present when required.
@@ -32,4 +35,15 @@ char *platform_module_list[] = {
 void
 plat_tod_fault(enum tod_fault_type tod_bad __unused)
 {
+}
+
+void
+set_platform_defaults(void)
+{
+	EFI_TIME t;
+	EFI_TIME_CAPABILITIES tc;
+
+	if (efi_get_time(&t, &tc) == EFI_SUCCESS) {
+		tod_module_name = "efitod";
+	}
 }

--- a/usr/src/uts/armv8/os/startup.c
+++ b/usr/src/uts/armv8/os/startup.c
@@ -20,7 +20,7 @@
  */
 
 /*
- * Copyright 2025 Michael van der Westhuizen
+ * Copyright 2026 Michael van der Westhuizen
  * Copyright 2017 Hayashi Naoyuki
  * Copyright (c) 2015 by Delphix. All rights reserved.
  * Copyright 2012 DEY Storage Systems, Inc.  All rights reserved.
@@ -264,6 +264,7 @@ perform_allocations(void)
 static void startup_init(void);
 static void startup_memlist(void);
 static void startup_kmem(void);
+static void startup_efi(void);
 static void startup_modules(void);
 static void startup_vm(void);
 static void startup_end(void);
@@ -386,6 +387,7 @@ startup(void)
 	startup_memlist();
 	startup_kmem();
 	startup_vm();
+	startup_efi();
 	startup_modules();
 	startup_end();
 }
@@ -1477,6 +1479,22 @@ startup_vm(void)
 	segdev_init();
 
 	PRM_POINT("startup_vm() done");
+}
+
+/*
+ * Initialize EFI Runtime Services.
+ *
+ * This must happen after startup_vm (kmem, hat, and the ASID
+ * allocator are all available) and before release_bootstrap
+ * (called from main.c) reclaims boot scratch memory, which holds
+ * the raw EFI memory map passed from the boot loader.
+ */
+static void
+startup_efi(void)
+{
+	PRM_POINT("startup_efi() starting...");
+	efirt_init();
+	PRM_POINT("startup_efi() done");
 }
 
 void

--- a/usr/src/uts/armv8/sys/efirt.h
+++ b/usr/src/uts/armv8/sys/efirt.h
@@ -36,7 +36,49 @@ typedef enum {
 	EfiResetPlatformSpecific
 } EFI_RESET_TYPE;
 
+/*
+ * EFI time representation (UEFI Specification 2.10, Section 8.3).
+ *
+ * Packed to match the UEFI wire format (16 bytes).  The Pad1 and Pad2
+ * fields are required by the specification and must be zero.
+ */
+typedef struct {
+	uint16_t	Year;		/* 1900-9999 */
+	uint8_t		Month;		/* 1-12 */
+	uint8_t		Day;		/* 1-31 */
+	uint8_t		Hour;		/* 0-23 */
+	uint8_t		Minute;		/* 0-59 */
+	uint8_t		Second;		/* 0-59 */
+	uint8_t		Pad1;
+	uint32_t	Nanosecond;	/* 0-999999999 */
+	int16_t		TimeZone;	/* -1440 to 1440, or 2047 */
+	uint8_t		Daylight;
+	uint8_t		Pad2;
+} __packed EFI_TIME;
+
+/* Daylight Savings Time field bits */
+#define	EFI_TIME_ADJUST_DAYLIGHT	0x01
+#define	EFI_TIME_IN_DAYLIGHT		0x02
+
+/* Unspecified timezone sentinel */
+#define	EFI_UNSPECIFIED_TIMEZONE	0x07FF
+
+/*
+ * EFI time capabilities (UEFI Specification 2.10, Section 8.3).
+ *
+ * Returned by GetTime() to describe the hardware clock's properties.
+ * SetsToZero is a UEFI BOOLEAN (uint8_t), not an illumos boolean_t,
+ * to match the specification's structure layout.
+ */
+typedef struct {
+	uint32_t	Resolution;	/* counts per second */
+	uint32_t	Accuracy;	/* error rate in ppm */
+	uint8_t		SetsToZero;	/* TRUE = time resets on hw reset */
+} EFI_TIME_CAPABILITIES;
+
 extern void efi_reset_system(EFI_RESET_TYPE, uint64_t, uint64_t, void *);
+extern uint64_t efi_get_time(EFI_TIME *, EFI_TIME_CAPABILITIES *);
+extern uint64_t efi_set_time(EFI_TIME *);
 
 #ifdef __cplusplus
 }

--- a/usr/src/uts/armv8/sys/efirt.h
+++ b/usr/src/uts/armv8/sys/efirt.h
@@ -1,0 +1,45 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2026 Michael van der Westhuizen
+ */
+
+#ifndef _SYS_EFIRT_H
+#define	_SYS_EFIRT_H
+
+/*
+ * UEFI Runtime Services types and declarations.
+ */
+
+#include <sys/efi.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * EFI reset types (UEFI Specification 2.10, Section 8.5.1).
+ */
+typedef enum {
+	EfiResetCold,
+	EfiResetWarm,
+	EfiResetShutdown,
+	EfiResetPlatformSpecific
+} EFI_RESET_TYPE;
+
+extern void efi_reset_system(EFI_RESET_TYPE, uint64_t, uint64_t, void *);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _SYS_EFIRT_H */

--- a/usr/src/uts/armv8/sys/machsystm.h
+++ b/usr/src/uts/armv8/sys/machsystm.h
@@ -26,6 +26,9 @@
  * Copyright (c) 2010, Intel Corporation.
  * All rights reserved.
  */
+/*
+ * Copyright 2026 Michael van der Westhuizen
+ */
 
 #ifndef _SYS_MACHSYSTM_H
 #define	_SYS_MACHSYSTM_H
@@ -88,6 +91,15 @@ extern void *mach_cpucontext_xalloc(struct cpu *, int);
 extern void mach_cpucontext_xfree(struct cpu *, void *, int, int);
 extern void kcpc_hw_fini(cpu_t *cp);
 extern void siron(void);
+
+/*
+ * UEFI Runtime Services (efirt_machdep.c/efirt_call.S)
+ */
+extern void efirt_init(void);
+extern boolean_t efirt_is_active(void);
+extern uint64_t efirt_call_rt(uint64_t, uint64_t, uint64_t, uint64_t,
+    uint64_t, uint64_t);
+
 #endif /* _KERNEL */
 
 #ifdef __cplusplus

--- a/usr/src/uts/common/sys/efi.h
+++ b/usr/src/uts/common/sys/efi.h
@@ -80,6 +80,10 @@ extern "C" {
 	{ 0x880aaca3, 0x4adc, 0x4a04, 0x90, 0x79, \
 	{ 0xb7, 0x47, 0x34, 0x8, 0x25, 0xe5 } }
 
+#define	EFI_RT_PROPERTIES_TABLE_GUID	\
+	{ 0xeb66918a, 0x7eef, 0x402a, 0x84, 0x2e, \
+	{ 0x93, 0x1d, 0x21, 0xc3, 0x8a, 0xe9 } }
+
 typedef struct uuid efi_guid_t __aligned(8);
 
 /* Memory data */
@@ -160,9 +164,47 @@ typedef struct {
 #define	EFI_REV_MAJOR(x)	(((x) >> 16) & 0xffff)
 #define	EFI_REV_MINOR(x)	((x) & 0xffff)
 #define	EFI_SYSTEM_TABLE_SIGNATURE	0x5453595320494249
+#define	EFI_RUNTIME_SERVICES_SIGNATURE	0x56524553544e5552
+
+/*
+ * EFI status codes (UEFI Specification 2.10, Appendix D).
+ * The high bit indicates an error status.
+ */
+#define	EFI_ERROR_BIT		0x8000000000000000ull
+#define	EFI_SUCCESS		0
+#define	EFI_UNSUPPORTED		(EFI_ERROR_BIT | 3)
+#define	EFI_DEVICE_ERROR	(EFI_ERROR_BIT | 7)
 
 typedef uint32_t	efiptr32_t;
 typedef uint64_t	efiptr64_t;
+
+typedef struct {
+	uint16_t	Version;
+	uint16_t	Length;
+	uint32_t	RuntimeServicesSupported;
+} __packed EFI_RT_PROPERTIES_TABLE;
+
+#define	EFI_RT_PROPERTIES_TABLE_VERSION	0x1
+
+/*
+ * RuntimeServicesSupported bitmask values.
+ */
+#define	EFI_RT_SUPPORTED_GET_TIME			0x0001
+#define	EFI_RT_SUPPORTED_SET_TIME			0x0002
+#define	EFI_RT_SUPPORTED_GET_WAKEUP_TIME		0x0004
+#define	EFI_RT_SUPPORTED_SET_WAKEUP_TIME		0x0008
+#define	EFI_RT_SUPPORTED_GET_VARIABLE			0x0010
+#define	EFI_RT_SUPPORTED_GET_NEXT_VARIABLE_NAME		0x0020
+#define	EFI_RT_SUPPORTED_SET_VARIABLE			0x0040
+#define	EFI_RT_SUPPORTED_SET_VIRTUAL_ADDRESS_MAP	0x0080
+#define	EFI_RT_SUPPORTED_CONVERT_POINTER		0x0100
+#define	EFI_RT_SUPPORTED_GET_NEXT_HIGH_MONO_COUNT	0x0200
+#define	EFI_RT_SUPPORTED_RESET_SYSTEM			0x0400
+#define	EFI_RT_SUPPORTED_UPDATE_CAPSULE			0x0800
+#define	EFI_RT_SUPPORTED_QUERY_CAPSULE_CAPS		0x1000
+#define	EFI_RT_SUPPORTED_QUERY_VARIABLE_INFO		0x2000
+
+#define	EFI_RT_SUPPORTED_ALL				0x3FFF
 
 typedef struct _EFI_CONFIGURATION_TABLE32 {
 	efi_guid_t	VendorGuid;

--- a/usr/src/uts/common/sys/efi.h
+++ b/usr/src/uts/common/sys/efi.h
@@ -220,6 +220,49 @@ typedef struct _EFI_SYSTEM_TABLE64 {
 } __packed EFI_SYSTEM_TABLE64;
 
 /*
+ * EFI Runtime Services Tables.
+ *
+ * The 32/64-bit variants use opaque pointers (efiptr32_t/efiptr64_t) for
+ * safe access to firmware tables from contexts where native pointer size
+ * may not match.
+ */
+typedef struct _EFI_RUNTIME_SERVICES32 {
+	EFI_TABLE_HEADER	Hdr;
+	efiptr32_t		GetTime;
+	efiptr32_t		SetTime;
+	efiptr32_t		GetWakeupTime;
+	efiptr32_t		SetWakeupTime;
+	efiptr32_t		SetVirtualAddressMap;
+	efiptr32_t		ConvertPointer;
+	efiptr32_t		GetVariable;
+	efiptr32_t		GetNextVariableName;
+	efiptr32_t		SetVariable;
+	efiptr32_t		GetNextHighMonotonicCount;
+	efiptr32_t		ResetSystem;
+	efiptr32_t		UpdateCapsule;
+	efiptr32_t		QueryCapsuleCapabilities;
+	efiptr32_t		QueryVariableInfo;
+} __packed EFI_RUNTIME_SERVICES32;
+
+typedef struct _EFI_RUNTIME_SERVICES64 {
+	EFI_TABLE_HEADER	Hdr;
+	efiptr64_t		GetTime;
+	efiptr64_t		SetTime;
+	efiptr64_t		GetWakeupTime;
+	efiptr64_t		SetWakeupTime;
+	efiptr64_t		SetVirtualAddressMap;
+	efiptr64_t		ConvertPointer;
+	efiptr64_t		GetVariable;
+	efiptr64_t		GetNextVariableName;
+	efiptr64_t		SetVariable;
+	efiptr64_t		GetNextHighMonotonicCount;
+	efiptr64_t		ResetSystem;
+	efiptr64_t		UpdateCapsule;
+	efiptr64_t		QueryCapsuleCapabilities;
+	efiptr64_t		QueryVariableInfo;
+} __packed EFI_RUNTIME_SERVICES64;
+
+/*
  * EFI memory map header, as passed by loader via dboot.  This header
  * structure is a FreeBSD/illumos loader(7) convention, not defined in
  * the UEFI specification; it describes the data returned by

--- a/usr/src/uts/common/sys/efi.h
+++ b/usr/src/uts/common/sys/efi.h
@@ -11,6 +11,7 @@
 
 /*
  * Copyright 2016 Toomas Soome <tsoome@me.com>
+ * Copyright 2026 Michael van der Westhuizen
  */
 
 #ifndef _SYS_EFI_H
@@ -217,6 +218,32 @@ typedef struct _EFI_SYSTEM_TABLE64 {
 	uint64_t		NumberOfTableEntries;
 	efiptr64_t		ConfigurationTable;
 } __packed EFI_SYSTEM_TABLE64;
+
+/*
+ * EFI memory map header, as passed by loader via dboot.  This header
+ * structure is a FreeBSD/illumos loader(7) convention, not defined in
+ * the UEFI specification; it describes the data returned by
+ * EFI_BOOT_SERVICES.GetMemoryMap.
+ *
+ * Immediately followed in memory by an array of EFI_MEMORY_DESCRIPTOR
+ * entries (UEFI spec §7.2), each descriptor_size bytes long.  Use
+ * efi_mmap_next to iterate, as descriptor_size may exceed
+ * sizeof (EFI_MEMORY_DESCRIPTOR) in future UEFI revisions.
+ */
+struct efi_map_header {
+	size_t		memory_size;
+	size_t		descriptor_size;
+	uint32_t	descriptor_version;
+};
+
+#define	EFI_MAP_HEADER_SIZE		\
+	(((sizeof (struct efi_map_header)) + 0xf) & ~0xf)
+#define	efi_mmap_next(ptr, size)	\
+	((EFI_MEMORY_DESCRIPTOR *)(((uint8_t *)(ptr)) + (size)))
+#define	efi_mmap_start(hdr)		\
+	((EFI_MEMORY_DESCRIPTOR *)((uint8_t *)(hdr) + EFI_MAP_HEADER_SIZE))
+#define	efi_mmap_ndesc(hdr)		\
+	((hdr)->memory_size / (hdr)->descriptor_size)
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR adds the ability to call [UEFI runtime services](https://uefi.org/specs/UEFI/2.10/08_Services_Runtime_Services.html) from the kernel on aarch64. Three firmware calls are included:
* ResetSystem (for reboot/poweroff)
* GetTime/SetTime (via a new TOD driver)

### What it does

After ExitBootServices (done at the tail end of `loader(7)`), UEFI firmware retains a set of runtime services that the OS can call for things like reading/writing the hardware clock, resetting the machine and accessing NVRAM variables. This PR builds the infrastructure to make those calls safely from the illumos kernel, then wires up the two most immediately useful facilities.

`ResetSystem` replaces raw PSCI calls for reboot and poweroff, matching what Linux does. The `efitod` driver provides a proper time-of-day backend that reads and writes the platform RTC through firmware calls, replacing the previous no-op fallback when the `GetTime` firmware call is available.

### How it works

The core facility is `efirt_machdep.c`. At boot, `efirt_init`:
1. Reads the UEFI memory map (passed from `loader(7)` through `dboot` to `unix`) and the EFI system table pointer
2. Builds a dedicated set of identity-mapped page tables covering all `EFI_MEMORY_RUNTIME` regions. These tables are hand-built with `kmem_zalloc`, not through `hat`. They are permanently pinned (and will not be reaped under memory pressure) and installed/removed around firmware calls.
3. Calls `SetVirtualAddressMap` with the identity mapping. This is technically redundant since we are already using physical addresses, but it is needed to work around well-known firmware bugs. FreeBSD does the same thing, while Linux uses a quirks table to do this when necessary
4. Extracts function pointers from the Runtime Services table, filtered by the `EFI_RT_PROPERTIES_TABLE` if present (so firmware can advertise which services it actually supports). Some cross-checking is performed against the service function pointers to seed the initial set of supported services

Each runtime call goes through `efirt_call_rt`, which:
* Grabs a sleep mutex (UEFI Runtime Services allow limited reentrancy between certain service groups per the spec, but the tracking rules are complicated enough that we just serialise everything to ensure correctness)
* Disables preemption, saves FPU state (the UEFI calling convention does not explicitly disallow FP/SIMD use, so we have to assume firmware may clobber those registers)
* Swaps TTBR0 to the EFI page table using a permanently reserved ASID (ASID 1)
* Sets up `on_trap(OT_DATA_ACCESS)` for fault recovery
* Calls firmware on a dedicated 20KB stack via an assembly trampoline (`efirt_call.S`), keeping firmware stack consumption off the kernel thread stack
* Unwinds everything on return

If firmware faults, `on_trap`'s `longjmp` recovers back to the kernel stack, the call returns `EFI_DEVICE_ERROR`, and Runtime Services remain available for subsequent calls. No permanent disable on fault.

### Where it hooks in

**Boot path**: The EFI memory map structs are moved from dboot-private headers to `sys/efi.h` so the kernel can see them. `dboot_machdep.c` and `fakebop.c` pass the memory map PA through as a boot property. `startup.c` calls `efirt_init` from `startup_efi`, after the VM subsystem and ASID allocator are up but before boot scratch memory is released.

**Reset**: `mdboot` in `machdep.c` tries UEFI `ResetSystem` (cold reset for reboot, shutdown for poweroff) before falling back to PSCI. This matches the Linux/FreeBSD approach. Warm reboot is not used; cold is the safe default, and warm would only be needed for capsule update support later.

**TOD**: `efitod.c` is a standard illumos `tod_ops` module. It converts between `EFI_TIME` (broken-down UTC with year/month/day) and the kernel's `todinfo_t`/`timestruc_t`. Platform code (`platmod.c`/`sbbr.c`) probes for EFI Runtime Services availability at boot and sets `tod_module_name = "efitod"` when `GetTime` is supported and returns success from a trial call.

### Testing

* Ampere Altra Max (AMI UEFI firmware, ACPI): `ResetSystem` cold reboot and shutdown both work. `efitod` reads and writes the hardware RTC correctly.
* QEMU virt (EDK2/ACPI): `ResetSystem` cold reboot and shutdown both work. `efitod` reads correctly.
* QEMU virt (U-Boot/FDT): `ResetSystem` works (cold reboot and shutdown). Time services via existing PL031 driver (U-Boot does not provide `GetTime`/`SetTime` after `ExitBootServices`).
* rpi4 (U-Boot/FDT): `ResetSystem` works. No time services (expected).

Console output:
* Altra Max [power off](https://gist.github.com/r1mikey/ba86b10e34ad2886e2bd8ee0ecfaafe3) (initiated via the power button)
* Altra Max [reboot](https://gist.github.com/r1mikey/f0b379fb84d8b39edb33b042a9644c31)
* Qemu virt (EDK2) [reboot](https://gist.github.com/r1mikey/fe7177f131de123451830fea8f3e283a)
* Qemu virt (EDK2) [power off](https://gist.github.com/r1mikey/65e74122ea619b088b033b803ea4c959)

Other consoles not captured.