### PR TITLE
cbe: don't flood the system with unnecessary IPIs

### DIFF
--- a/usr/src/uts/armv8/io/arm_gtmr.c
+++ b/usr/src/uts/armv8/io/arm_gtmr.c
@@ -70,8 +70,6 @@ static ddi_softint_hdl_impl_t cbe_clock_hdl =
 
 static hrtime_t cbe_timer_resolution;
 
-static int cbe_ticks = 0;	/* XXXARM: why do we need this? */
-
 /*
  * cbe_xcall_lock is used to protect the xcall globals since the cyclic
  * reprogramming API does not use cpu_lock.
@@ -248,34 +246,35 @@ cbe_hres_tick(void)
 	s = splr(ipltospl(XC_HI_PIL));
 	hres_tick();
 	splx(s);
-
-	cbe_ticks++;
 }
 
 /*
  * Cyclic backend interrupt handlers.
  *
- * `cbe_fire' is hooked up to the generic timer virtual or non-secure
- * interrupt as appropriate for the boot exception level. `cbe_fire_ipi' is
- * an IPI handler and `cbe_softclock' and `cbe_low_level' are soft interrupts.
+ * The Arm Generic Timer is a per-CPU PPI (Private Peripheral Interrupt):
+ * every CPU has its own independent timer hardware, programmed via CVAL
+ * and reprogrammed by the cyclic subsystem through cbe_reprogram().
+ * This is analogous to x86 APIC one-shot mode where each CPU owns its
+ * own local timer.
+ *
+ * `cbe_fire' is the per-CPU timer PPI handler -- it processes the local
+ * CPU's cyclic heap only.  Unlike the i86pc periodic-mode CBE, there is
+ * no IPI broadcast to other CPUs; each CPU's PPI fires independently.
+ *
+ * `cbe_fire_ipi' handles cross-calls sent by cbe_xcall() when the cyclic
+ * subsystem needs to manipulate a remote CPU's cyclic heap (e.g. adding
+ * or removing a cyclic).  It calls cyclic_fire() to process the updated
+ * heap after the cross-call function runs.
+ *
+ * `cbe_softclock' and `cbe_low_level' are soft interrupt handlers driven
+ * by the cyclic subsystem for CY_LOCK_LEVEL and CY_LOW_LEVEL cyclics.
  */
 
 static uint_t
 cbe_fire(caddr_t arg1 __unused, caddr_t arg2 __unused)
 {
-	cpu_t *cpu = CPU;
-	processorid_t me = cpu->cpu_id, i;
-
 	arch_timer_set_cval(CNT_CVAL_MAX);
-
-	cyclic_fire(cpu);
-
-	for (i = 0; i < NCPU; i++) {
-		if (CPU_IN_SET(cbe_enabled, i) && me != i) {
-			send_dirint(i, IRQ_IPI_CBE);
-		}
-	}
-
+	cyclic_fire(CPU);
 	return (DDI_INTR_CLAIMED);
 }
 

--- a/usr/src/uts/armv8/sys/clock.h
+++ b/usr/src/uts/armv8/sys/clock.h
@@ -48,7 +48,6 @@ extern void rtcsync(void);
 
 extern void unlock_hres_lock(void);
 extern void hres_tick(void);
-extern void (*hrtime_tick)(void);
 
 #define	ADJ_SHIFT 4		/* used in get_hrestime */
 


### PR DESCRIPTION
The Generic Timer interrupt is a private-peripheral interrupt (PPI), meaning that it is morally equivalent to the i86pc TIMER_ONESHOT mechanism.

Even though we very carefully arrange for PPIs to be enabled on all CPUs at CPU startup, the Generic Timer CBE was written as if the system behaves like a legacy i86pc TIMER_PERIODIC implementation, where there is one timer and one interrupt, which needs to be redistributed to other cores via IPI.

Assuming the default 100Hz (firing every 10ms, 100 times per second), we see the following set of interrupts due to CBE.

Raspberry Pi 4 (four cores):
* Per tick per CPU: 1 PPI + 3 IPIs received = 4 interrupts
* Per tick total: 4 PPIs + 4 x 3 = 12 IPIs = 16 interrupts
* Per second: 16 x 100 = 1,600 interrupts/sec

Ampere Altra Max (128 cores):
* Per tick per CPU: 1 PPI + 127 IPIs received = 128 interrupts
* Per tick total: 128 PPIs + 128 x 127 = 16,256 IPIs = 16,384 interrupts
* Per second: 16,384 x 100 = 1,638,400 interrupts/sec

With this change in place we no longer do redundant IPIs to CPUs, since other CPUs have their own PPI handler. This changes our numbers to:

Raspberry Pi 4 (four cores):
* Per tick per CPU: 1 PPI
* Per tick total: 4 PPIs
* Per second: 4 x 100 = 400 interrupts/sec (25% of previous)

Ampere Altra Max (128 cores):
* Per tick per CPU: 1 PPI
* Per tick total: 128 PPIs
* Per second: 128 x 100 = 12,800 interrupts/sec (0.78% of previous)

The CBE IPI is especially egregious on larger systems, as it's completely serialised (needs an IPI subsystem rewrite to be more like i86pc).

Testing: booted and ran on Altra Max, used the testsuite to create some load, no issues.
* libproc-tests: https://gist.github.com/r1mikey/5b412feff9557276abb33cf97121c2a9
* libsec-tests: https://gist.github.com/r1mikey/48e6ddc94274bd42186429d342ec0511
* nvme-tests: https://gist.github.com/r1mikey/5687a53a4c49ce2262b9923ae6e82b75
* i2c-tests: https://gist.github.com/r1mikey/d3f5b2ac064d3ec13d17e2b94d60516d
* crypto-tests: https://gist.github.com/r1mikey/16d5c2114140b035032a531d5c93ca43
* os-tests: https://gist.github.com/r1mikey/f8fe260bb0ebd1d9ca44af07bd4cc083
* elf-tests: https://gist.github.com/r1mikey/333375c1f814ba28ab760f136511b31d
* util-tests: https://gist.github.com/r1mikey/59e29596ffb555c4dee4c512c1e08a70
* libc-tests: https://gist.github.com/r1mikey/caf8e9e056ae58a8851cc973dd2b4386
