### PR TITLE
Clean up DTSpec compliance for address/size cells and fixed interrupt properties

### DIFF
--- a/usr/src/uts/armv8/os/ddi_impl.c
+++ b/usr/src/uts/armv8/os/ddi_impl.c
@@ -1513,12 +1513,29 @@ map_interrupt_parent(dev_info_t *dip, ddi_intr_handle_impl_t *hdlp)
 	if (ip != -1) {
 		ipdip = e_ddi_nodeid_to_dip(ip);
 	} else {
+		/*
+		 * If dip were somehow the root node AND had no
+		 * interrupt-parent, that VERIFY would fire since
+		 * ddi_get_parent(root) is NULL. This shouldn't normally
+		 * be hit (root should have interrupt-parent on FDT). If
+		 * reality kicks in and proves this wrong we'll have to
+		 * do something more intelligent.
+		 */
 		ipdip = ddi_get_parent(dip);
 		VERIFY3P(ipdip, !=, NULL);
 		ndi_hold_devi(ipdip);
 	}
 
-	priv->ip_unitintr = i_ddi_update_unitintr_unit(priv->ip_unitintr, dip);
+	/*
+	 * Update the unit interrupt descriptor to reflect the addressing
+	 * context at this node.  Skip for the root node - it has no parent
+	 * address space, and the unit address is not used for interrupt-map
+	 * matching beyond this point.
+	 */
+	if (dip != ddi_root_node()) {
+		priv->ip_unitintr =
+		    i_ddi_update_unitintr_unit(priv->ip_unitintr, dip);
+	}
 
 	return (ipdip);
 }
@@ -1673,17 +1690,30 @@ map_interrupt(dev_info_t *dip, ddi_intr_handle_impl_t *hdlp)
 	 * This outlives mapping and is used to communicate vector and sense
 	 * information to the interrupt controller.  It is cleaned up in
 	 * i_ddi_intr_ops().
+	 *
+	 * On first entry, dip is the device whose interrupt we are mapping.
+	 * Any interrupt-map on dip is for routing its children's interrupts,
+	 * not its own (DTSpec §2.4.3), so we must follow interrupt-parent
+	 * (or the device tree) rather than our own interrupt-map.  On
+	 * recursive calls (ip_unitintr already set), dip is a nexus we've
+	 * arrived at and its interrupt-map should be used.
 	 */
-	if (priv->ip_unitintr == NULL)
-		priv->ip_unitintr = i_ddi_unitintr(dip, hdlp->ih_inum);
-
 	dev_info_t *par = NULL;
 
-	if (ddi_prop_exists(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
+	if (priv->ip_unitintr == NULL) {
+		priv->ip_unitintr = i_ddi_unitintr(dip, hdlp->ih_inum);
+		par = map_interrupt_parent(dip, hdlp);
+	} else if (ddi_prop_exists(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
 	    OBP_INTERRUPT_MAP)) {
 		par = map_interrupt_map(dip, hdlp);
 	} else {
 		par = map_interrupt_parent(dip, hdlp);
+	}
+
+	if (par == NULL) {
+		dev_err(dip, CE_PANIC, "could not resolve interrupt "
+		    "controller");
+		return (NULL);	/* Unreachable */
 	}
 
 	if (i_ddi_attach_node_hierarchy(par) != DDI_SUCCESS) {

--- a/usr/src/uts/armv8/os/ddi_impl.c
+++ b/usr/src/uts/armv8/os/ddi_impl.c
@@ -1297,8 +1297,22 @@ i_ddi_unitaddr(dev_info_t *dip, uint_t *out, size_t out_cells)
 	int *reg;
 	uint_t reg_cells;
 
-	int addr_cells = ddi_prop_get_int(DDI_DEV_T_ANY, dip, 0,
-	    OBP_ADDRESS_CELLS, OBP_DEFAULT_ADDRESS_CELLS);
+	/*
+	 * A device's reg property is encoded using the parent's
+	 * #address-cells (DTSpec §2.3.5: the property describes how
+	 * children are addressed).  Read from the parent with
+	 * DDI_PROP_DONTPASS since these properties are not inherited.
+	 */
+	dev_info_t *pdip = ddi_get_parent(dip);
+	int addr_cells;
+
+	if (pdip == NULL) {
+		addr_cells = OBP_DEFAULT_ADDRESS_CELLS;
+	} else {
+		addr_cells = ddi_prop_get_int(DDI_DEV_T_ANY, pdip,
+		    DDI_PROP_DONTPASS, OBP_ADDRESS_CELLS,
+		    OBP_DEFAULT_ADDRESS_CELLS);
+	}
 
 	if (addr_cells == 0)
 		return (0);
@@ -1403,8 +1417,21 @@ static unit_intr_t *
 i_ddi_unitintr(dev_info_t *dip, uint_t inum)
 {
 	unit_intr_t *ui;
-	int addr_cells = ddi_prop_get_int(DDI_DEV_T_ANY, dip, 0,
-	    OBP_ADDRESS_CELLS, OBP_DEFAULT_ADDRESS_CELLS);
+
+	/*
+	 * A device's unit address uses the parent's #address-cells
+	 * (DTSpec §2.3.5).
+	 */
+	dev_info_t *pdip = ddi_get_parent(dip);
+	int addr_cells;
+
+	if (pdip == NULL) {
+		addr_cells = OBP_DEFAULT_ADDRESS_CELLS;
+	} else {
+		addr_cells = ddi_prop_get_int(DDI_DEV_T_ANY, pdip,
+		    DDI_PROP_DONTPASS, OBP_ADDRESS_CELLS,
+		    OBP_DEFAULT_ADDRESS_CELLS);
+	}
 
 	int *intrs = NULL;
 	int intr_cells = i_ddi_get_interrupt(dip, inum, &intrs);

--- a/usr/src/uts/armv8/os/ddi_impl.c
+++ b/usr/src/uts/armv8/os/ddi_impl.c
@@ -1099,15 +1099,20 @@ i_ddi_remove_softint(ddi_softint_hdl_impl_t *hdlp)
 
 
 /*
- * Return the device node that claims ownership of this interrupt domain
- * following "interrupt-parent" as necessary.  It is returned held.
+ * Find the interrupt domain that governs pdip's children, starting the
+ * walk from pdip.  Returns the first node with #interrupt-cells, held.
  *
- * In practical terms, this is the node with the "#interrupt-cells" which
- * applies to `pdip`.  This may be `pdip` itself.
+ * #interrupt-cells on a node describes the interrupt specifier format
+ * for that node's children/interrupt domain members (DTSpec §2.4).
+ * If pdip itself has #interrupt-cells, it is returned immediately.
  *
- * As I read the 1275 PCI bindings, I believe we don't need to handle
- * "interrupt-map" here, because we should always have an "#interrupt-cells"
- * on that same node.
+ * Callers interpreting a device's own interrupts property must pass
+ * ddi_get_parent(dip), not dip itself, because a device's interrupts
+ * are encoded per the parent's interrupt domain, not the device's own
+ * child-facing #interrupt-cells.
+ *
+ * Follows interrupt-parent when present, otherwise walks up the device
+ * tree.  Returns NULL only if no node with #interrupt-cells is found.
  */
 static dev_info_t *
 i_ddi_interrupt_domain(dev_info_t *pdip)

--- a/usr/src/uts/armv8/os/ddi_impl.c
+++ b/usr/src/uts/armv8/os/ddi_impl.c
@@ -1161,7 +1161,21 @@ i_ddi_get_interrupt(dev_info_t *dip, uint_t inumber, int **ret)
 
 	if (ddi_prop_lookup_int_array(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
 	    OBP_INTERRUPTS, &ip, &ip_sz) == DDI_SUCCESS) {
-		dev_info_t *id = i_ddi_interrupt_domain(dip);
+		/*
+		 * A device's interrupts property is encoded per the parent's
+		 * interrupt domain's #interrupt-cells, not the device's own.
+		 * The device's own #interrupt-cells (if any) describes its
+		 * children's interrupt specifier format.
+		 */
+		dev_info_t *pdip = ddi_get_parent(dip);
+		dev_info_t *id;
+
+		if (pdip == NULL) {
+			ddi_prop_free(ip);
+			return (0);
+		}
+
+		id = i_ddi_interrupt_domain(pdip);
 
 		VERIFY3P(id, !=, NULL);
 
@@ -1365,17 +1379,33 @@ i_ddi_free_unitintr(unit_intr_t *ui)
 }
 
 /*
- * Update ui to have the address of dip, the interrupt portion is unchanged
+ * Update ui to have the address of dip, the interrupt portion is unchanged.
+ *
+ * Both the interrupt domain and #address-cells are found via the parent,
+ * not dip itself: dip's own #interrupt-cells and #address-cells (if any)
+ * describe its children's format, not its own (DTSpec §2.3.5, §2.4).
  */
 static unit_intr_t *
 i_ddi_update_unitintr_unit(unit_intr_t *ui, dev_info_t *dip)
 {
-	dev_info_t *idom = i_ddi_interrupt_domain(dip);
+	dev_info_t *pdip = ddi_get_parent(dip);
+	dev_info_t *idom;
+
+	if (pdip == NULL) {
+		dev_err(dip, CE_PANIC, "no parent for interrupt domain "
+		    "lookup");
+		return (NULL);	/* Unreachable */
+	}
+
+	idom = i_ddi_interrupt_domain(pdip);
+
+	VERIFY3P(idom, !=, NULL);
 
 	int new_intr_cells = ddi_prop_get_int(DDI_DEV_T_ANY, idom,
 	    DDI_PROP_DONTPASS, OBP_INTERRUPT_CELLS, 1);
-	int new_addr_cells = ddi_prop_get_int(DDI_DEV_T_ANY, dip, 0,
-	    OBP_ADDRESS_CELLS, OBP_DEFAULT_ADDRESS_CELLS);
+	int new_addr_cells = ddi_prop_get_int(DDI_DEV_T_ANY, pdip,
+	    DDI_PROP_DONTPASS, OBP_ADDRESS_CELLS,
+	    OBP_DEFAULT_ADDRESS_CELLS);
 
 	ndi_rele_devi(idom);
 
@@ -1769,7 +1799,19 @@ i_ddi_get_intx_nintrs(dev_info_t *dip)
 
 	if (ddi_prop_lookup_int_array(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
 	    OBP_INTERRUPTS, &ip, &intrlen) == DDI_SUCCESS) {
-		dev_info_t *intrd = i_ddi_interrupt_domain(dip);
+		/*
+		 * The interrupts property is encoded per the parent's
+		 * interrupt domain's #interrupt-cells.
+		 */
+		dev_info_t *pdip = ddi_get_parent(dip);
+		dev_info_t *intrd;
+
+		if (pdip == NULL) {
+			ddi_prop_free(ip);
+			return (0);
+		}
+
+		intrd = i_ddi_interrupt_domain(pdip);
 
 		VERIFY3P(intrd, !=, NULL);
 

--- a/usr/src/uts/armv8/os/ddi_impl.c
+++ b/usr/src/uts/armv8/os/ddi_impl.c
@@ -1553,13 +1553,13 @@ map_interrupt_map(dev_info_t *dip, ddi_intr_handle_impl_t *hdlp)
 	ASSERT(RW_WRITE_HELD(&hdlp->ih_rwlock));
 
 	/*
-	 * By definition, if we have an interrupt-map we're the interrupt
-	 * domain
+	 * By definition, if we have an interrupt-map we should also have
+	 * #interrupt-cells (describing our children's interrupt specifier
+	 * format).
 	 */
 #ifdef DEBUG
-	dev_info_t *idom = i_ddi_interrupt_domain(dip);
-	ASSERT3P(idom, ==, dip);
-	ndi_rele_devi(idom);
+	ASSERT(ddi_prop_exists(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
+	    OBP_INTERRUPT_CELLS));
 #endif
 
 	ihdl_plat_t *priv = (ihdl_plat_t *)hdlp->ih_private;
@@ -1616,9 +1616,12 @@ map_interrupt_map(dev_info_t *dip, ddi_intr_handle_impl_t *hdlp)
 		VERIFY3P(parent, !=, NULL);
 
 #ifdef DEBUG
-		dev_info_t *idom = i_ddi_interrupt_domain(parent);
-		ASSERT3P(idom, ==, parent);
-		ndi_rele_devi(idom);
+		/*
+		 * The target of an interrupt-map entry should have
+		 * #interrupt-cells (it is an interrupt domain).
+		 */
+		ASSERT(ddi_prop_exists(DDI_DEV_T_ANY, parent,
+		    DDI_PROP_DONTPASS, OBP_INTERRUPT_CELLS));
 #endif
 
 		int par_addr_cells = ddi_prop_get_int(DDI_DEV_T_ANY,

--- a/usr/src/uts/armv8/os/ddi_impl.c
+++ b/usr/src/uts/armv8/os/ddi_impl.c
@@ -1924,9 +1924,9 @@ impl_xlate_regs(dev_info_t *child, uint32_t *in, size_t in_len,
 	}
 
 	int parent_addr_cells = ddi_prop_get_int(DDI_DEV_T_ANY, parent,
-	    0, OBP_ADDRESS_CELLS, OBP_DEFAULT_ADDRESS_CELLS);
+	    DDI_PROP_DONTPASS, OBP_ADDRESS_CELLS, OBP_DEFAULT_ADDRESS_CELLS);
 	int parent_size_cells = ddi_prop_get_int(DDI_DEV_T_ANY, parent,
-	    0, OBP_SIZE_CELLS, OBP_DEFAULT_SIZE_CELLS);
+	    DDI_PROP_DONTPASS, OBP_SIZE_CELLS, OBP_DEFAULT_SIZE_CELLS);
 
 	if (parent_size_cells < 1 || parent_size_cells > 2) {
 		dev_err(child, CE_WARN, "regspec: unsupported size cells %d",
@@ -2053,11 +2053,11 @@ impl_xlate_ranges(dev_info_t *child, uint32_t *in, size_t in_len,
 		ddi_prop_free(devtype);
 	}
 
-	pac = ddi_prop_get_int(DDI_DEV_T_ANY, pdip, 0,
+	pac = ddi_prop_get_int(DDI_DEV_T_ANY, pdip, DDI_PROP_DONTPASS,
 	    OBP_ADDRESS_CELLS, OBP_DEFAULT_ADDRESS_CELLS);
-	cac = ddi_prop_get_int(DDI_DEV_T_ANY, child, 0,
+	cac = ddi_prop_get_int(DDI_DEV_T_ANY, child, DDI_PROP_DONTPASS,
 	    OBP_ADDRESS_CELLS, OBP_DEFAULT_ADDRESS_CELLS);
-	csc = ddi_prop_get_int(DDI_DEV_T_ANY, child, 0,
+	csc = ddi_prop_get_int(DDI_DEV_T_ANY, child, DDI_PROP_DONTPASS,
 	    OBP_SIZE_CELLS, OBP_DEFAULT_SIZE_CELLS);
 
 	if (csc < 1 || csc > 2) {
@@ -3225,14 +3225,22 @@ get_dma_ranges(dev_info_t *dip, struct dma_range **range, int *nrange)
 		int bus_address_cells;
 		int bus_size_cells;
 		int parent_address_cells;
+		dev_info_t *pdip = ddi_get_parent(dip);
 
-		bus_address_cells = ddi_prop_get_int(DDI_DEV_T_ANY, dip, 0,
+		bus_address_cells = ddi_prop_get_int(DDI_DEV_T_ANY, dip,
+		    DDI_PROP_DONTPASS,
 		    OBP_ADDRESS_CELLS, OBP_DEFAULT_ADDRESS_CELLS);
-		bus_size_cells = ddi_prop_get_int(DDI_DEV_T_ANY, dip, 0,
+		bus_size_cells = ddi_prop_get_int(DDI_DEV_T_ANY, dip,
+		    DDI_PROP_DONTPASS,
 		    OBP_SIZE_CELLS, OBP_DEFAULT_SIZE_CELLS);
-		parent_address_cells = ddi_prop_get_int(DDI_DEV_T_ANY,
-		    ddi_get_parent(dip), 0,
-		    OBP_ADDRESS_CELLS, OBP_DEFAULT_ADDRESS_CELLS);
+
+		if (pdip == NULL) {
+			parent_address_cells = OBP_DEFAULT_ADDRESS_CELLS;
+		} else {
+			parent_address_cells = ddi_prop_get_int(DDI_DEV_T_ANY,
+			    pdip, DDI_PROP_DONTPASS,
+			    OBP_ADDRESS_CELLS, OBP_DEFAULT_ADDRESS_CELLS);
+		}
 
 		if ((rng_len % (bus_address_cells + bus_size_cells +
 		    parent_address_cells)) != 0) {

--- a/usr/src/uts/armv8/promif/prom_emul_fdt.c
+++ b/usr/src/uts/armv8/promif/prom_emul_fdt.c
@@ -479,17 +479,36 @@ get_prop_int(pnode_t node, const char *name, int def)
 	return (value);
 }
 
+/*
+ * Look up a single-int property on exactly this node, with no ancestor walk.
+ *
+ * Per DTSpec §2.3.5, #address-cells and #size-cells are NOT inherited from
+ * ancestors in the devicetree and shall be explicitly defined.  Use this
+ * function (not get_prop_int) when looking up cell-count properties.
+ */
+static int
+get_prop_int_local(pnode_t node, const char *name, int def)
+{
+	int len = promif_getproplen(node, name);
+	if (len == sizeof (int)) {
+		int prop;
+		promif_getprop(node, name, (caddr_t)&prop);
+		return (ntohl(prop));
+	}
+	return (def);
+}
+
 static int
 get_address_cells(pnode_t node)
 {
-	return (get_prop_int(get_parent(node), OBP_ADDRESS_CELLS,
+	return (get_prop_int_local(get_parent(node), OBP_ADDRESS_CELLS,
 	    OBP_DEFAULT_ADDRESS_CELLS));
 }
 
 static int
 get_size_cells(pnode_t node)
 {
-	return (get_prop_int(get_parent(node), OBP_SIZE_CELLS,
+	return (get_prop_int_local(get_parent(node), OBP_SIZE_CELLS,
 	    OBP_DEFAULT_SIZE_CELLS));
 }
 
@@ -657,11 +676,11 @@ prom_fdt_get_reg_address(pnode_t node, int index, uint64_t *reg)
 			continue;
 		}
 
-		int address_cells = get_prop_int(parent, OBP_ADDRESS_CELLS,
-		    OBP_DEFAULT_ADDRESS_CELLS);
-		int size_cells = get_prop_int(parent, OBP_SIZE_CELLS,
-		    OBP_DEFAULT_SIZE_CELLS);
-		int parent_address_cells = get_prop_int(
+		int address_cells = get_prop_int_local(parent,
+		    OBP_ADDRESS_CELLS, OBP_DEFAULT_ADDRESS_CELLS);
+		int size_cells = get_prop_int_local(parent,
+		    OBP_SIZE_CELLS, OBP_DEFAULT_SIZE_CELLS);
+		int parent_address_cells = get_prop_int_local(
 		    get_parent(parent), OBP_ADDRESS_CELLS,
 		    OBP_DEFAULT_ADDRESS_CELLS);
 

--- a/usr/src/uts/armv8/promif/prom_emul_fdt.c
+++ b/usr/src/uts/armv8/promif/prom_emul_fdt.c
@@ -482,13 +482,15 @@ get_prop_int(pnode_t node, const char *name, int def)
 static int
 get_address_cells(pnode_t node)
 {
-	return (get_prop_int(get_parent(node), OBP_ADDRESS_CELLS, 2));
+	return (get_prop_int(get_parent(node), OBP_ADDRESS_CELLS,
+	    OBP_DEFAULT_ADDRESS_CELLS));
 }
 
 static int
 get_size_cells(pnode_t node)
 {
-	return (get_prop_int(get_parent(node), OBP_SIZE_CELLS, 2));
+	return (get_prop_int(get_parent(node), OBP_SIZE_CELLS,
+	    OBP_DEFAULT_SIZE_CELLS));
 }
 
 static int
@@ -655,10 +657,13 @@ prom_fdt_get_reg_address(pnode_t node, int index, uint64_t *reg)
 			continue;
 		}
 
-		int address_cells = get_prop_int(parent, OBP_ADDRESS_CELLS, 2);
-		int size_cells = get_prop_int(parent, OBP_SIZE_CELLS, 2);
+		int address_cells = get_prop_int(parent, OBP_ADDRESS_CELLS,
+		    OBP_DEFAULT_ADDRESS_CELLS);
+		int size_cells = get_prop_int(parent, OBP_SIZE_CELLS,
+		    OBP_DEFAULT_SIZE_CELLS);
 		int parent_address_cells = get_prop_int(
-		    get_parent(parent), OBP_ADDRESS_CELLS, 2);
+		    get_parent(parent), OBP_ADDRESS_CELLS,
+		    OBP_DEFAULT_ADDRESS_CELLS);
 
 		if ((len % CELLS_1275_TO_BYTES(address_cells +
 		    parent_address_cells + size_cells)) != 0) {

--- a/usr/src/uts/common/io/viommionex/viommionex.c
+++ b/usr/src/uts/common/io/viommionex/viommionex.c
@@ -348,10 +348,36 @@ viommionex_bus_unconfig(dev_info_t *parent, uint_t flags,
 static int
 viommionex_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 {
+	int addr_cells;
+	int size_cells;
+	dev_info_t *pdip;
+
 	if (ddi_prop_update_int(DDI_DEV_T_NONE, dip,
 	    VIRTIO_MMIO_PROPERTY_NAME, 1) != DDI_PROP_SUCCESS) {
 		dev_err(dip, CE_WARN, "?failed to set the '%s' property",
 		    VIRTIO_MMIO_PROPERTY_NAME);
+		return (DDI_FAILURE);
+	}
+
+	pdip = ddi_get_parent(dip);
+	VERIFY3P(pdip, !=, NULL);
+
+	addr_cells = ddi_prop_get_int(DDI_DEV_T_ANY, pdip,
+	    DDI_PROP_DONTPASS, OBP_ADDRESS_CELLS, OBP_DEFAULT_ADDRESS_CELLS);
+	ASSERT(addr_cells >= 1);
+	size_cells = ddi_prop_get_int(DDI_DEV_T_ANY, pdip,
+	    DDI_PROP_DONTPASS, OBP_SIZE_CELLS, OBP_DEFAULT_SIZE_CELLS);
+	ASSERT(size_cells >= 1);
+
+	if (ndi_prop_update_int(DDI_DEV_T_NONE, dip,
+	    OBP_ADDRESS_CELLS, addr_cells) != NDI_SUCCESS) {
+		dev_err(dip, CE_WARN, "failed to set %s", OBP_ADDRESS_CELLS);
+		return (DDI_FAILURE);
+	}
+
+	if (ndi_prop_update_int(DDI_DEV_T_NONE, dip,
+	    OBP_SIZE_CELLS, size_cells) != NDI_SUCCESS) {
+		dev_err(dip, CE_WARN, "failed to set %s", OBP_SIZE_CELLS);
 		return (DDI_FAILURE);
 	}
 


### PR DESCRIPTION
This series of patches addresses a few issues in device tree handling for `#address-cells`, `#size-cells` and interrupt-related property lookup.

Generally, there's some confusion in the tree about where to start a search and how far to look upwards.

In the case of `#address-cells` and `#size-cells`, we haven't always been starting at the parent, and we've been walking up the tree. DTSpec §2.3.5 says, "The `#address-cells` and `#size-cells` properties are not inherited from ancestors in the devicetree.  They shall be explicitly defined.". We've been walking up the tree to find the closest value, which is wrong - as it turns out, the only violation of the "shall" rule is our own `viommionex` (which we should rid ourselves of now that we have PCI).

In a few places we haven't been respecting the default `#address-cells` and `#size-cells` values (per DTSpec), and this series corrects that.

When a node has `#address-cells` and `#size-cells`, those properties apply to decoding addresses for the node's children, not the node itself (the node itself has reg/ranges/dma-ranges decoded using it's parent's `#address-cells` and `#size-cells`).

Similarly, we've been mistakenly using `interrupt-map` and `#interrupt-cells` from the resource dip, not the parent when interpreting `interrupts` on a node and when determining the interrupt domain for a node. This has, so far, been benign, but my work on the rpi4 PCIe controller exposed this bug, where `interrupts` uses three cell GIC identifiers, but `#interrupt-cells` is set to 1 (for the legacy interrupt mapping on `interrupt-map`, so calculating the number of FIXED interrupts gives a bad value (6/1=6 instead of 6/3=2).

Generally, add NULL checks and fallback to DTSpec defaults where appropriate.

Testing: Booted on:
* [qemu virt, gicv2](https://gist.github.com/r1mikey/1c3bc9a502c2ce6ef315b57b571807e9)
* [qemu virt, gicv3](https://gist.github.com/r1mikey/fe8bff00016389713ea349a579f945c6)
* [rpi4](https://gist.github.com/r1mikey/84c22a6f0838e9224e09e1cbcb64821f)
* [Altra Max (ACPI tree)](https://gist.github.com/r1mikey/abeff643071344b82531ac176d54ee79)
* [rpi4 w/PCIe root complex](https://gist.github.com/r1mikey/cb2a4cf4d269cc80641a9f003c2c8af1) - this was the case that was getting tripped up before, and this now probes correctly.