### PR TITLE
aarch64 DMA framework fixes

### DIFF
--- a/usr/src/uts/armv8/io/rootnex.c
+++ b/usr/src/uts/armv8/io/rootnex.c
@@ -3554,10 +3554,10 @@ rootnex_codedma_cache_sync(ddi_dma_handle_t handle,
 			    MIN(cur + map_size, end));
 			if (cache_flags == DDI_DMA_SYNC_FORDEV)
 				rootnex_codedma_cache_clean(vaddr + (off - cur),
-				    vaddr + op_end);
+				    vaddr + (op_end - cur));
 			else
 				rootnex_codedma_cache_flush(vaddr + (off - cur),
-				    vaddr + op_end);
+				    vaddr + (op_end - cur));
 			off = op_end;
 		}
 		cur += map_size;

--- a/usr/src/uts/armv8/io/rootnex.c
+++ b/usr/src/uts/armv8/io/rootnex.c
@@ -1441,12 +1441,29 @@ rootnex_coredma_bindhdl(dev_info_t *dip, dev_info_t *rdip,
 	attr = &hp->dmai_attr;
 
 	ddi_dma_attr_t cpu_attr;
-	e = i_ddi_convert_dma_attr(&cpu_attr, rdip, attr);
+	int64_t bus_offset = 0;
+	e = i_ddi_convert_dma_attr(&cpu_attr, rdip, attr, &bus_offset);
 	if (e != DDI_SUCCESS)
 		return (e);
+#if defined(DDI_MAP_DEBUG)
+	ddi_map_debug("rootnex_coredma_bindhdl: for %s%d, bus_offset=0x%"
+	    PRIx64 "\n", ddi_driver_name(rdip), ddi_get_instance(rdip),
+	    bus_offset);
+#endif
 
-	sinfo->si_cpu_addr_offset = cpu_attr.dma_attr_addr_lo -
-	    attr->dma_attr_addr_lo;
+	/*
+	 * The bus-to-CPU offset from dma-ranges captures the translation
+	 * between CPU physical addresses and bus addresses.  DMA cookies
+	 * must contain bus addresses (what the device sees), not CPU
+	 * physical addresses.  ROOTNEX_PADDR_TO_RBASE uses this offset
+	 * to perform that conversion.  The offset is signed (negative
+	 * when cpu_addr < bus_addr, e.g. BCM2711 where CPU 0x0 maps to
+	 * PCI 0x4_00000000 gives offset = -0x4_00000000).  Stored as
+	 * uint64_t, the two's complement representation ensures that
+	 * unsigned subtraction in ROOTNEX_PADDR_TO_RBASE produces the
+	 * correct bus address.
+	 */
+	sinfo->si_cpu_addr_offset = bus_offset;
 
 	/* convert the sleep flags */
 	if (dmareq->dmar_fp == DDI_DMA_SLEEP) {

--- a/usr/src/uts/armv8/os/ddi_impl.c
+++ b/usr/src/uts/armv8/os/ddi_impl.c
@@ -3369,18 +3369,49 @@ i_ddi_convert_dma_attr(
 	if (dma_range_num > 0) {
 		int i;
 		for (i = 0; i < dma_range_num; i++) {
-			if (dma_ranges[i].bus_addr <= dst->dma_attr_addr_lo &&
-			    dst->dma_attr_addr_hi <=
-			    dma_ranges[i].bus_addr + dma_ranges[i].size - 1) {
-				dst->dma_attr_addr_lo +=
-				    (dma_ranges[i].cpu_addr -
-				    dma_ranges[i].bus_addr);
-				dst->dma_attr_addr_hi +=
-				    (dma_ranges[i].cpu_addr -
-				    dma_ranges[i].bus_addr);
+			uint64_t win_lo, win_hi;
+			int64_t offset;
+
+			/* Skip degenerate zero-size windows */
+			if (dma_ranges[i].size == 0)
+				continue;
+
+			win_lo = dma_ranges[i].bus_addr;
+			win_hi = dma_ranges[i].bus_addr +
+			    dma_ranges[i].size - 1;
+
+			/*
+			 * Intersect the device's DMA capabilities with the
+			 * bus translation window.  The device's addr_lo/hi
+			 * describe what it can reach; dma-ranges describes
+			 * what the bus can translate.  We clamp to the
+			 * overlap rather than requiring full containment,
+			 * since a device that can DMA to 0..UINT64_MAX is
+			 * fine with a 3GB window - it just needs to know
+			 * the constraint.
+			 */
+			if (dst->dma_attr_addr_lo <= win_hi &&
+			    dst->dma_attr_addr_hi >= win_lo) {
+				offset = dma_ranges[i].cpu_addr -
+				    dma_ranges[i].bus_addr;
+
+				dst->dma_attr_addr_lo =
+				    MAX(dst->dma_attr_addr_lo, win_lo);
+				dst->dma_attr_addr_hi =
+				    MIN(dst->dma_attr_addr_hi, win_hi);
+
+				/*
+				 * When cpu_addr < bus_addr, offset is
+				 * negative.  The clamped lo >= win_lo
+				 * (== bus_addr) guarantees lo + offset
+				 * >= cpu_addr, so no underflow.
+				 */
+				dst->dma_attr_addr_lo += offset;
+				dst->dma_attr_addr_hi += offset;
 				break;
 			}
 		}
+
 		if (i == dma_range_num) {
 			cmn_err(CE_WARN,
 			    "%s: ddi_dma_attr_t is invalid range", __func__);

--- a/usr/src/uts/armv8/os/ddi_impl.c
+++ b/usr/src/uts/armv8/os/ddi_impl.c
@@ -3356,9 +3356,13 @@ err_exit:
 
 int
 i_ddi_convert_dma_attr(
-    ddi_dma_attr_t *dst, dev_info_t *dip, const ddi_dma_attr_t *src)
+    ddi_dma_attr_t *dst, dev_info_t *dip, const ddi_dma_attr_t *src,
+    int64_t *bus_offsetp)
 {
 	*dst = *src;
+
+	if (bus_offsetp != NULL)
+		*bus_offsetp = 0;
 
 	int dma_range_num = 0;
 	struct dma_range *dma_ranges = NULL;
@@ -3408,6 +3412,8 @@ i_ddi_convert_dma_attr(
 				 */
 				dst->dma_attr_addr_lo += offset;
 				dst->dma_attr_addr_hi += offset;
+				if (bus_offsetp != NULL)
+					*bus_offsetp = offset;
 				break;
 			}
 		}
@@ -3493,7 +3499,7 @@ i_ddi_mem_alloc(dev_info_t *dip, ddi_dma_attr_t *oattr,
 
 	ddi_dma_attr_t data;
 	ddi_dma_attr_t *attr = &data;
-	if (i_ddi_convert_dma_attr(attr, dip, oattr) != DDI_SUCCESS) {
+	if (i_ddi_convert_dma_attr(attr, dip, oattr, NULL) != DDI_SUCCESS) {
 		return (DDI_FAILURE);
 	}
 

--- a/usr/src/uts/armv8/rpi4/os/bcm2835_mbox.c
+++ b/usr/src/uts/armv8/rpi4/os/bcm2835_mbox.c
@@ -126,7 +126,7 @@ bcm2835_mbox_init(void)
 	dma_attr.dma_attr_count_max = dma_attr.dma_attr_addr_hi -
 	    dma_attr.dma_attr_addr_lo;
 
-	rv = i_ddi_convert_dma_attr(&dma_mem_attr, dip, &dma_attr);
+	rv = i_ddi_convert_dma_attr(&dma_mem_attr, dip, &dma_attr, NULL);
 	if (rv != DDI_SUCCESS) {
 		cmn_err(CE_PANIC, "i_ddi_convert_dma_attr failed (%d)!", rv);
 	}

--- a/usr/src/uts/armv8/sys/ddi_subrdefs.h
+++ b/usr/src/uts/armv8/sys/ddi_subrdefs.h
@@ -43,7 +43,7 @@ extern "C" {
 extern void impl_bus_add_probe(void (*)(int));
 extern void impl_bus_delete_probe(void (*)(int));
 extern int i_ddi_convert_dma_attr(ddi_dma_attr_t *, dev_info_t *,
-    const ddi_dma_attr_t *);
+    const ddi_dma_attr_t *, int64_t *);
 extern int i_ddi_update_dma_attr(dev_info_t *, ddi_dma_attr_t *);
 extern uint32_t i_ddi_get_intr_pri(dev_info_t *dip, uint_t inumber);
 


### PR DESCRIPTION
Three fixes for the aarch64 DMA path, discovered while bringing up PCIe on the Raspberry Pi 4. The first two are required for any platform where `dma-ranges` describes a non-identity bus-to-CPU address mapping; the third affects any multi-cookie scatter-gather DMA sync.

## dma_attr: intersect, rather than requiring containment

`i_ddi_convert_dma_attr()` rejected DMA attribute ranges that extended beyond the bus translation window. A driver declaring `addr_hi = 0xFFFFFFFF` would fail on a platform whose `dma-ranges` window ends at `0xBFFFFFFF`. The framework should intersect the driver's declared capability with the reachable window, not require strict containment. Existing contained/exact-match cases produce identical results.

## dma: fix cookie bus address translation for non-identity dma-ranges

DMA cookies must contain bus addresses (what the device sees), not CPU physical addresses. The `si_cpu_addr_offset` derivation from clamped attribute values always produced zero when `addr_lo = 0`, so `ROOTNEX_PADDR_TO_RBASE()` returned raw CPU physical addresses. On BCM2711 PCIe, where the inbound window maps PCI `0x4_00000000` → CPU `0x0`, this meant the VL805 USB controller received addresses outside its RC's inbound window and all DMA silently failed. Fixed by having `i_ddi_convert_dma_attr()` return the matched `dma-ranges` offset directly.

## rootnex: tighten up DMA cache sync

`rootnex_coredma_cache_sync()` computed flush ranges using a global byte offset (`op_end`) but a per-cookie virtual address. For cookie `N>0`, `vaddr + op_end` overshoots by the cumulative size of all preceding cookies — flushing past the end of the current mapping. Harmless for single-cookie allocations (the common case on x86 and most aarch64 DMA), but any multi-cookie scatter-gather sync would over-flush, potentially writing back dirty cachelines belonging to adjacent allocations.

## Testing
* [Raspberry Pi 4 (FDT)](https://gist.github.com/r1mikey/5226b3e1e447dab1b2b465273115516e)
* [QEMU virt (FDT)](https://gist.github.com/r1mikey/452b16c5a8e69d7fcc4c4ae3135d165d)
* [QEMU virt (UEFI/ACPI)](https://gist.github.com/r1mikey/5148e251037fa9b1bba5eb6ae01007fe)
* [Ampere Altra Max (UEFI/ACPI)](https://gist.github.com/r1mikey/569579a018fc9046c029889bad8a40ae)