### PR TITLE
ddi_impl: fix interrupt-map parent #address-cells default

### DIFF
--- a/usr/src/uts/armv8/os/ddi_impl.c
+++ b/usr/src/uts/armv8/os/ddi_impl.c
@@ -1629,9 +1629,30 @@ map_interrupt_map(dev_info_t *dip, ddi_intr_handle_impl_t *hdlp)
 		    DDI_PROP_DONTPASS, OBP_INTERRUPT_CELLS));
 #endif
 
+		/*
+		 * The parent unit address component of each interrupt-map
+		 * entry uses the parent's #address-cells.  For interrupt
+		 * controllers that are not buses (the common case), the
+		 * DTSpec says #address-cells should be 0 or absent -- there
+		 * is no parent unit address in the table at all.
+		 *
+		 * The IEEE 1275 bus default of 2 is wrong here; it would
+		 * over-count the stride by 2 cells per entry, causing the
+		 * parent interrupt specifier to be misread.
+		 *
+		 * Default to 0 when the parent is an interrupt-controller
+		 * and has no explicit #address-cells.
+		 */
+		int par_addr_default;
+		if (ddi_prop_exists(DDI_DEV_T_ANY, parent,
+		    DDI_PROP_DONTPASS, OBP_INTERRUPT_CONTROLLER)) {
+			par_addr_default = 0;
+		} else {
+			par_addr_default = OBP_DEFAULT_ADDRESS_CELLS;
+		}
 		int par_addr_cells = ddi_prop_get_int(DDI_DEV_T_ANY,
 		    parent, DDI_PROP_DONTPASS,
-		    OBP_ADDRESS_CELLS, OBP_DEFAULT_ADDRESS_CELLS);
+		    OBP_ADDRESS_CELLS, par_addr_default);
 		int par_intr_cells = ddi_prop_get_int(DDI_DEV_T_ANY,
 		    parent, DDI_PROP_DONTPASS, OBP_INTERRUPT_CELLS,
 		    1);


### PR DESCRIPTION
`map_interrupt_map()` uses `OBP_DEFAULT_ADDRESS_CELLS` (`2`) as the fallback when the `interrupt-map` parent node has no `#address-cells` property.  This is the correct IEEE 1275 bus default, but is wrong for interrupt controllers that are not buses.

DTSpec 2.4 specifies that the parent unit address component of an `interrupt-map` entry uses the parent's `#address-cells`.  Interrupt controllers that do not manage an address space (the common case: GICv2 without v2m children, GICv3 without ITS children, etc.) have _zero parent address cells in the interrupt-map_, and legitimately omit `#address-cells` from their node.

With the default of 2, the per-entry stride through the `interrupt-map` is over-counted by 2 cells.  On the first match the code copies 2 phantom address cells plus 3 interrupt cells from the table; the actual 3-cell interrupt specifier lands in the address slots, and the interrupt cells presented to the GIC are garbage read from the next entry.

For the BCM2711 PCIe `interrupt-map` (INTA to SPI 143), this results in the GIC receiving `type=4/vector=0/sense=0` instead of `type=0(SPI)/vector=143/sense=4(level-high)` --  the xHCI handler is registered on the wrong IRQ and `INTx` interrupts are never serviced.

Fix: when the parent has the `interrupt-controller` property and no explicit `#address-cells`, default to `0` rather than `2`.  If the node does set `#address-cells` (e.g. a GIC with v2m children), the explicit value is respected.  This matches Linux's `of_irq_parse_raw()` behaviour.

Other callers using `OBP_DEFAULT_ADDRESS_CELLS` were audited, and operate on bus address properties where the default of 2 is correct.

Should be merged after https://github.com/richlowe/illumos-gate/pull/225.

## Testing
* [Raspberry Pi 4 (FDT)](https://gist.github.com/r1mikey/5226b3e1e447dab1b2b465273115516e)
* [QEMU virt (FDT)](https://gist.github.com/r1mikey/452b16c5a8e69d7fcc4c4ae3135d165d)
* [QEMU virt (UEFI/ACPI)](https://gist.github.com/r1mikey/5148e251037fa9b1bba5eb6ae01007fe)
* [Ampere Altra Max (UEFI/ACPI)](https://gist.github.com/r1mikey/569579a018fc9046c029889bad8a40ae)