### PR TITLE
aarch64 PCIe root complex fixes

### DIFF
--- a/usr/src/uts/aarch64/io/pci/pci_common.c
+++ b/usr/src/uts/aarch64/io/pci/pci_common.c
@@ -706,6 +706,101 @@ SUPPORTED_TYPES_OUT:
 }
 
 /*
+ * Configure a device for a certain type of interrupt.
+ *
+ * When hdlp->ih_type is DDI_INTR_TYPE_FIXED:
+ *  - ensures PCI_MSI_ENABLE_BIT is off in PCI_CAP_ID_MSI
+ *  - ensures PCI_MSIX_ENABLE_BIT is off in PCI_CAP_ID_MSI_X
+ *
+ * When hdlp->ih_type is DDI_INTR_TYPE_MSI
+ *  - ensures PCI_MSI_ENABLE_BIT is set in PCI_CAP_ID_MSI
+ *  - ensures PCI_MSIX_ENABLE_BIT is off in PCI_CAP_ID_MSI_X
+ *
+ * When hdlp->ih_type is DDI_INTR_TYPE_MSIX
+ *  - ensures PCI_MSI_ENABLE_BIT is off in PCI_CAP_ID_MSI
+ *  - ensures PCI_MSIX_ENABLE_BIT is set in PCI_CAP_ID_MSI_X
+ */
+static int
+pci_conf_intr_type(dev_info_t *pdip __unused, dev_info_t *rdip,
+    ddi_intr_handle_impl_t *hdlp)
+{
+	ddi_acc_handle_t	handle;
+	ushort_t		cap_ctrl;
+	uint16_t		cap_base;
+	int			ret;
+
+	ASSERT(RW_WRITE_HELD(&hdlp->ih_rwlock));
+
+	if ((ret = pci_config_setup(rdip, &handle)) != DDI_SUCCESS)
+		return (ret);
+
+	if (PCI_CAP_LOCATE(handle, PCI_CAP_ID_MSI, &cap_base) == DDI_SUCCESS) {
+		cap_ctrl = PCI_CAP_GET16(handle, 0, cap_base, PCI_MSI_CTRL);
+		if (cap_ctrl == PCI_CAP_EINVAL16) {
+			ret = DDI_FAILURE;
+			goto out;
+		}
+
+		if ((cap_ctrl & PCI_MSI_ENABLE_BIT) &&
+		    hdlp->ih_type != DDI_INTR_TYPE_MSI) {
+			DDI_INTR_NEXDBG((CE_CONT,
+			    "?pci_conf_intr_type: %s%d: "
+			    "clearing MSI enable\n",
+			    ddi_driver_name(rdip),
+			    ddi_get_instance(rdip)));
+			cap_ctrl &= ~PCI_MSI_ENABLE_BIT;
+			PCI_CAP_PUT16(handle, 0, cap_base,
+			    PCI_MSI_CTRL, cap_ctrl);
+		} else if (!(cap_ctrl & PCI_MSI_ENABLE_BIT) &&
+		    hdlp->ih_type == DDI_INTR_TYPE_MSI) {
+			DDI_INTR_NEXDBG((CE_CONT,
+			    "?pci_conf_intr_type: %s%d: "
+			    "setting MSI enable\n",
+			    ddi_driver_name(rdip),
+			    ddi_get_instance(rdip)));
+			cap_ctrl |= PCI_MSI_ENABLE_BIT;
+			PCI_CAP_PUT16(handle, 0, cap_base,
+			    PCI_MSI_CTRL, cap_ctrl);
+		}
+	}
+
+	if (PCI_CAP_LOCATE(handle, PCI_CAP_ID_MSI_X, &cap_base)
+	    == DDI_SUCCESS) {
+		cap_ctrl = PCI_CAP_GET16(handle, 0, cap_base, PCI_MSIX_CTRL);
+		if (cap_ctrl == PCI_CAP_EINVAL16) {
+			ret = DDI_FAILURE;
+			goto out;
+		}
+
+		if ((cap_ctrl & PCI_MSIX_ENABLE_BIT) &&
+		    hdlp->ih_type != DDI_INTR_TYPE_MSIX) {
+			DDI_INTR_NEXDBG((CE_CONT,
+			    "?pci_conf_intr_type: %s%d: "
+			    "clearing MSIX enable\n",
+			    ddi_driver_name(rdip),
+			    ddi_get_instance(rdip)));
+			cap_ctrl &= ~PCI_MSIX_ENABLE_BIT;
+			PCI_CAP_PUT16(handle, 0, cap_base,
+			    PCI_MSIX_CTRL, cap_ctrl);
+		} else if (!(cap_ctrl & PCI_MSIX_ENABLE_BIT) &&
+		    hdlp->ih_type == DDI_INTR_TYPE_MSIX) {
+			DDI_INTR_NEXDBG((CE_CONT,
+			    "?pci_conf_intr_type: %s%d: "
+			    "setting MSIX enable\n",
+			    ddi_driver_name(rdip),
+			    ddi_get_instance(rdip)));
+			cap_ctrl |= PCI_MSIX_ENABLE_BIT;
+			PCI_CAP_PUT16(handle, 0, cap_base,
+			    PCI_MSIX_CTRL, cap_ctrl);
+		}
+	}
+
+out:
+	pci_config_teardown(&handle);
+	return (ret);
+}
+
+/*
  * Allocate a vector for FIXED type interrupt.
  */
 void
@@ -721,6 +816,9 @@ pci_alloc_intr_fixed(dev_info_t *pdip, dev_info_t *rdip,
 	pci_rval = pci_intx_get_cap(rdip, &pci_status);
 	if ((pci_rval == DDI_SUCCESS) && (pci_status != 0))
 		hdlp->ih_cap |= pci_status;
+
+	if (pci_conf_intr_type(pdip, rdip, hdlp) != DDI_SUCCESS)
+		dev_err(rdip, CE_WARN, "failed to configure interrupt type");
 }
 
 #if XXXARM

--- a/usr/src/uts/aarch64/io/pciex/pcierc/pci_boot.c
+++ b/usr/src/uts/aarch64/io/pciex/pcierc/pci_boot.c
@@ -1208,7 +1208,8 @@ find_resource(dev_info_t *rcdip, pci_prd_rsrc_t rsrc)
 		int busrng[2];
 
 		dip_bus_range(rcdip, busrng);
-		pci_memlist_insert(&mlp, busrng[0], busrng[1] - busrng[0]);
+		pci_memlist_insert(&mlp, busrng[0],
+		    (busrng[1] - busrng[0] + 1));
 		return (mlp);
 	}
 

--- a/usr/src/uts/aarch64/io/pciex/pcierc/pcierc.c
+++ b/usr/src/uts/aarch64/io/pciex/pcierc/pcierc.c
@@ -918,7 +918,10 @@ pcierc_initchild(dev_info_t *child)
 	bus_p = PCIE_DIP2BUS(child);
 	if (bus_p != NULL) {
 		pcie_init_dom(child);
-		(void) pcie_initchild(child);
+		if (pcie_initchild(child) != DDI_SUCCESS) {
+			pcie_fini_dom(child);
+			return (DDI_FAILURE);
+		}
 	}
 
 	return (DDI_SUCCESS);


### PR DESCRIPTION
Three fixes for the aarch64 PCIe root complex library and PCI common code, found during RPi4 PCIe bringup. The first two are latent bugs in `pcierc` that were masked on platforms with large bus ranges; the third ensures interrupt type configuration is consistent when switching between `FIXED` and `MSI` modes.

## pcierc: check for pcie_initchild failures

`pcierc` ignored the return value from `pcie_initchild()`. The equivalent code in `pcieb` (the bridge driver) already checks this. Align the root complex with the bridge.

## pcierc: pci_boot: fix off-by-one in memlist insertion

`find_resource()` for `PCI_PRD_R_BUS` passes (`start`, `end - start`) to `pci_memlist_insert()`, but the bus range is inclusive so the correct length is `end - start + 1`. On systems with 256 buses this is invisible — the missing high bus is never used in practice. On RPi4 with `bus-range <0, 1>` only one bus is inserted instead of two, so device enumeration on bus 1 reads uninitialised data.

## pci: ensure the right kind of interrupt is configured

`pci_conf_intr_type()` explicitly disables MSI and MSI-X when configuring FIXED (legacy INTx) interrupts, and conversely ensures only the intended MSI variant is enabled when configuring MSI or MSI-X. Without this, a device whose firmware or prior OS left MSI enabled could silently swallow INTx assertions. The implementation is deliberately over-cautious — the MSI enable path could rely on downstream logic to set the enable bit, but clearing/setting both sides here is defensive and cheap.

Should be merged after https://github.com/richlowe/illumos-gate/pull/225 and https://github.com/richlowe/illumos-gate/pull/226.

## Testing
* [Raspberry Pi 4 (FDT)](https://gist.github.com/r1mikey/5226b3e1e447dab1b2b465273115516e)
* [QEMU virt (FDT)](https://gist.github.com/r1mikey/452b16c5a8e69d7fcc4c4ae3135d165d)
* [QEMU virt (UEFI/ACPI)](https://gist.github.com/r1mikey/5148e251037fa9b1bba5eb6ae01007fe)
* [Ampere Altra Max (UEFI/ACPI)](https://gist.github.com/r1mikey/569579a018fc9046c029889bad8a40ae)