### PR TITLE
xHCI fixes for portability

### DIFF
--- a/usr/src/uts/common/io/usb/hcd/xhci/xhci.c
+++ b/usr/src/uts/common/io/usb/hcd/xhci/xhci.c
@@ -913,6 +913,7 @@ uint64_t
 xhci_get64(xhci_t *xhcip, xhci_reg_type_t rtt, uintptr_t off)
 {
 	uintptr_t addr, roff;
+	uint32_t lo, hi;
 
 	switch (rtt) {
 	case XHCI_R_CAP:
@@ -932,8 +933,9 @@ xhci_get64(xhci_t *xhcip, xhci_reg_type_t rtt, uintptr_t off)
 	}
 	ASSERT(roff != PCI_EINVAL32);
 	addr = roff + off + (uintptr_t)xhcip->xhci_regs_base;
-
-	return (ddi_get64(xhcip->xhci_regs_handle, (void *)addr));
+	lo = ddi_get32(xhcip->xhci_regs_handle, (uint32_t *)addr);
+	hi = ddi_get32(xhcip->xhci_regs_handle, (uint32_t *)(addr + 4));
+	return ((uint64_t)lo | ((uint64_t)hi << 32));
 }
 
 void
@@ -1041,7 +1043,10 @@ xhci_put64(xhci_t *xhcip, xhci_reg_type_t rtt, uintptr_t off, uint64_t val)
 	ASSERT(roff != PCI_EINVAL32);
 	addr = roff + off + (uintptr_t)xhcip->xhci_regs_base;
 
-	ddi_put64(xhcip->xhci_regs_handle, (void *)addr, val);
+	ddi_put32(xhcip->xhci_regs_handle, (uint32_t *)addr,
+	    (uint32_t)(val & 0xFFFFFFFF));
+	ddi_put32(xhcip->xhci_regs_handle, (uint32_t *)(addr + 4),
+	    (uint32_t)(val >> 32));
 }
 
 int

--- a/usr/src/uts/common/io/usb/hcd/xhci/xhci_event.c
+++ b/usr/src/uts/common/io/usb/hcd/xhci/xhci_event.c
@@ -95,6 +95,15 @@ xhci_event_init(xhci_t *xhcip)
 	xev->xev_segs[0].xes_addr = LE_64(xhci_dma_pa(&xev->xev_ring.xr_dma));
 	xev->xev_segs[0].xes_size = LE_16(xev->xev_ring.xr_ntrb);
 
+	XHCI_DMA_SYNC(xev->xev_dma, DDI_DMA_SYNC_FORDEV);
+	if (xhci_check_dma_handle(xhcip, &xev->xev_dma) != DDI_FM_OK) {
+		xhci_error(xhcip, "encountered fatal FM error syncing "
+		    "event ring segment table: resetting device");
+		xhci_event_fini(xhcip);
+		ddi_fm_service_impact(xhcip->xhci_dip, DDI_SERVICE_LOST);
+		return (EIO);
+	}
+
 	reg = xhci_get32(xhcip, XHCI_R_RUN, XHCI_ERSTSZ(0));
 	reg &= ~XHCI_ERSTS_MASK;
 	reg |= XHCI_ERSTS_SET(XHCI_EVENT_NSEGS);

--- a/usr/src/uts/common/io/usb/hcd/xhci/xhci_intr.c
+++ b/usr/src/uts/common/io/usb/hcd/xhci/xhci_intr.c
@@ -144,6 +144,17 @@ xhci_intr(caddr_t arg1, caddr_t arg2)
 	}
 
 	/*
+	 * W1C: clear EINT (and PCD) to deassert INTx pin
+	 */
+	xhci_put32(xhcip, XHCI_R_OPER, XHCI_USBSTS, status);
+	if (xhci_check_regs_acc(xhcip) != DDI_FM_OK) {
+		xhci_error(xhcip, "failed to write USB status register: "
+		    "encountered fatal FM error, resetting device");
+		xhci_fm_runtime_reset(xhcip);
+		return (DDI_INTR_CLAIMED);
+	}
+
+	/*
 	 * Before we read the interrupt management register, check to see if we
 	 * have a fatal bit set. At which point, it's time to reset the world
 	 * anyway.


### PR DESCRIPTION
Three fixes for the common xHCI driver (`uts/common/io/usb/hcd/xhci/`), all in `uts/common` and applicable to every platform. Found during aarch64 PCIe bringup on RPi4, but two of the three are latent bugs on x86 that happen to be masked by hardware behaviour.

## xhci: always split qword writes

The xHCI spec (§5.1) requires that 64-bit register writes use two 32-bit writes (low dword first) when the system cannot guarantee qword access reaches the controller intact. The controller's AC64 capability only describes the xHC itself and says nothing about the bus path. On BCM2711 PCIe the bridge silently drops the high 32 bits of any 64-bit MMIO write, so `DCBAAP` and `ERSTBA` were programmed with garbage (the low dword duplicated into both halves). Unconditionally splitting matches Linux, FreeBSD, OpenBSD, and NetBSD — all four always use 32-bit pairs.

## xhci: deassert INTx pin in interrupt processing

The interrupt handler reads `USBSTS` but never writes it back. `USBSTS` is W1C - writing back the read value clears `EINT` (Event Interrupt), which deasserts the INTx pin. Under MSI/MSI-X this is redundant (the PCI write clears EINT automatically), so the omission is harmless on x86 where MSI is the norm. Under INTx the pin stays asserted and the host re-enters the ISR immediately on EOI, producing an interrupt storm. The unconditional W1C writeback matches Linux, FreeBSD, and OpenBSD.

## xhci: sync ERST for device consumption

`xhci_event_init()` populates the `ERST` (Event Ring Segment Table) in memory and then programs `ERSTBA`, but never calls `ddi_dma_sync()` in-between. Every other xHCI buffer that is exposed to the controller is synced before use - this was the only one missed. Per the DDI contract, `ddi_dma_sync()` is required even for `DDI_DMA_CONSISTENT` mappings. On x86 hardware cache coherency makes this invisible, on Arm the controller reads stale zeros from RAM and discards all events, resulting in a hang and panic.

Should be merged after https://github.com/richlowe/illumos-gate/pull/225, https://github.com/richlowe/illumos-gate/pull/226 and https://github.com/richlowe/illumos-gate/pull/227.

## Testing
* [Raspberry Pi 4 (FDT)](https://gist.github.com/r1mikey/5226b3e1e447dab1b2b465273115516e)
* [QEMU virt (FDT)](https://gist.github.com/r1mikey/452b16c5a8e69d7fcc4c4ae3135d165d)
* [QEMU virt (UEFI/ACPI)](https://gist.github.com/r1mikey/5148e251037fa9b1bba5eb6ae01007fe)
* [Ampere Altra Max (UEFI/ACPI)](https://gist.github.com/r1mikey/569579a018fc9046c029889bad8a40ae)
* [i86pc](https://gist.github.com/r1mikey/672598b4d465a8c0882cd8f6bf8cea0c) (no regressions - commits 1 and 2 are behaviour-preserving on coherent platforms; commit 3 adds a redundant but contractually correct sync) - SSH access via axf0 (USB), [xhci_portsc](https://gist.github.com/r1mikey/5ef54e0ac950af2340467b1bc1ab7c83) looks right.