### PR TITLE
prop lookup takes DDI_DEV_T_ANY, not DDI_DEV_T_NONE

### DIFF
--- a/usr/src/uts/common/io/cardbus/cardbus.c
+++ b/usr/src/uts/common/io/cardbus/cardbus.c
@@ -1279,7 +1279,7 @@ cardbus_initchild(dev_info_t *rdip, dev_info_t *dip, dev_info_t *child,
 		(ppd->ppd.par_intr)->intrspec_func = (uint_t (*)()) 0;
 #endif
 
-		if (ddi_prop_exists(DDI_DEV_T_NONE, child, DDI_PROP_DONTPASS,
+		if (ddi_prop_exists(DDI_DEV_T_ANY, child, DDI_PROP_DONTPASS,
 		    "interrupts"))
 			ppd->ppd.par_nintr = 1;
 

--- a/usr/src/uts/common/io/cpqary3/cpqary3.c
+++ b/usr/src/uts/common/io/cpqary3/cpqary3.c
@@ -792,7 +792,7 @@ cpqary3_update_ctlrdetails(cpqary3_t *cpqary3p, uint32_t *cleanstatus)
 	 * Free the memory that regp points towards after the
 	 * ddi_prop_lookup_int_array() call
 	 */
-	if (ddi_prop_lookup_int_array(DDI_DEV_T_NONE, cpqary3p->dip,
+	if (ddi_prop_lookup_int_array(DDI_DEV_T_ANY, cpqary3p->dip,
 	    DDI_PROP_DONTPASS, "reg", &regp, &reglen) != DDI_PROP_SUCCESS)
 		return (CPQARY3_FAILURE);
 

--- a/usr/src/uts/common/io/sata/adapters/nv_sata/nv_sata.c
+++ b/usr/src/uts/common/io/sata/adapters/nv_sata/nv_sata.c
@@ -746,7 +746,7 @@ nv_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 		/*
 		 * save off the controller number
 		 */
-		(void) ddi_prop_lookup_int_array(DDI_DEV_T_NONE, dip,
+		(void) ddi_prop_lookup_int_array(DDI_DEV_T_ANY, dip,
 		    DDI_PROP_DONTPASS, "reg", (int **)&regs, &rlen);
 		nvc->nvc_ctlr_num = PCI_REG_FUNC_G(regs->pci_phys_hi);
 		ddi_prop_free(regs);

--- a/usr/src/uts/common/io/usb/usba/usba.c
+++ b/usr/src/uts/common/io/usb/usba/usba.c
@@ -312,7 +312,7 @@ usba_bus_ctl(
 
 		/* the dip should have an address and reg property */
 
-		if ((usb_addr = ddi_prop_get_int(DDI_DEV_T_NONE, child_dip,
+		if ((usb_addr = ddi_prop_get_int(DDI_DEV_T_ANY, child_dip,
 		    DDI_PROP_DONTPASS, "assigned-address", -1)) == -1) {
 			USB_DPRINTF_L2(DPRINT_MASK_USBA, hubdi_log_handle,
 			    "usba_bus_ctl:\n\t"

--- a/usr/src/uts/common/os/pcifm.c
+++ b/usr/src/uts/common/os/pcifm.c
@@ -1225,7 +1225,7 @@ pci_check_regs(dev_info_t *dip, void *arg)
 		 * is a valid config space address for this device - based
 		 * on pci_phys_hi of the config space entry in reg property.
 		 */
-		if (ddi_prop_lookup_int_array(DDI_DEV_T_NONE, dip,
+		if (ddi_prop_lookup_int_array(DDI_DEV_T_ANY, dip,
 		    DDI_PROP_DONTPASS, "reg", (int **)&drv_regp,
 		    &reglen) != DDI_SUCCESS) {
 			return (DDI_WALK_CONTINUE);
@@ -1252,7 +1252,7 @@ pci_check_regs(dev_info_t *dip, void *arg)
 		 * for any non-relocable mapping, otherwise check
 		 * assigned-addresses.
 		 */
-		if (ddi_prop_lookup_int_array(DDI_DEV_T_NONE, dip,
+		if (ddi_prop_lookup_int_array(DDI_DEV_T_ANY, dip,
 		    DDI_PROP_DONTPASS, "reg", (int **)&drv_regp,
 		    &reglen) != DDI_SUCCESS) {
 			return (DDI_WALK_CONTINUE);
@@ -1280,7 +1280,7 @@ pci_check_regs(dev_info_t *dip, void *arg)
 		}
 		ddi_prop_free(drv_regp);
 
-		if (ddi_prop_lookup_int_array(DDI_DEV_T_NONE, dip,
+		if (ddi_prop_lookup_int_array(DDI_DEV_T_ANY, dip,
 		    DDI_PROP_DONTPASS, "assigned-addresses",
 		    (int **)&drv_regp, &reglen) != DDI_SUCCESS) {
 			return (DDI_WALK_CONTINUE);

--- a/usr/src/uts/intel/io/pciex/pcieb_x86.c
+++ b/usr/src/uts/intel/io/pciex/pcieb_x86.c
@@ -146,7 +146,7 @@ void
 pcieb_plat_initchild(dev_info_t *child)
 {
 	struct ddi_parent_private_data *pdptr;
-	if (ddi_prop_exists(DDI_DEV_T_NONE, child, DDI_PROP_DONTPASS,
+	if (ddi_prop_exists(DDI_DEV_T_ANY, child, DDI_PROP_DONTPASS,
 	    "interrupts")) {
 		pdptr = kmem_zalloc((sizeof (struct ddi_parent_private_data) +
 		    sizeof (struct intrspec)), KM_SLEEP);


### PR DESCRIPTION
DDI_DEV_T_NONE is for creation, ANY is for lookup.

On i86pc there is no early bail-out for DDI_DEV_T_NONE, but armv8 is stricter, so fails calls that get this wrong.

In the particular case I'm looking at, https://github.com/richlowe/illumos-gate/commit/1b5cce3147 inadvertently used the wrong arg for usba (and a few other calls), so this PR is what's needed to get usba/hubd working on Arm.

This scares me a whole lot - we should probably have an ASSERT so that we can surface this when it happens.

Full test, showing hubd attaching, device insertion and presence, device removal at: https://gist.github.com/r1mikey/6e713c76028df9e20c2c96f07e286f73