### PR TITLE
bcm2711_pcie: fix undefine of MSI properties

### DIFF
--- a/usr/src/uts/armv8/rpi4/io/bcm2711_pcie/bcm2711_pcie.c
+++ b/usr/src/uts/armv8/rpi4/io/bcm2711_pcie/bcm2711_pcie.c
@@ -1463,8 +1463,9 @@ bcm2711_pcie_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 	 * Defensively remove any reference to an MSI capability until we're
 	 * ready for that.
 	 */
-	(void) ndi_prop_remove(DDI_DEV_T_NONE, dip, "msi-controller");
-	(void) ndi_prop_remove(DDI_DEV_T_NONE, dip, "msi-parent");
+	(void) ddi_prop_undefine(DDI_DEV_T_NONE, dip, DDI_PROP_CANSLEEP, "msi-controller");
+	(void) ddi_prop_undefine(DDI_DEV_T_NONE, dip, DDI_PROP_CANSLEEP, "msi-parent");
+	(void) ddi_prop_undefine(DDI_DEV_T_NONE, dip, DDI_PROP_CANSLEEP, "msi-map");
 
 	if ((ret = pcierc_attach(dip, cmd)) != DDI_SUCCESS) {
 		dev_err(dip, CE_WARN, "pcierc_attach failed: %d", ret);


### PR DESCRIPTION
As it turns out, ndi_prop_remove can't remove prom properties, since we consult the prom layer directly.  Use `ddi_prop_undefine`, which correctly masks these properties.  While here, also mask the remaining MSI property, `msi-map`.

Fixes bcm2711_pcie when used with the in-progress MSI stack.