### PR TITLE
bcm2711_pcie: attach the driver automatically

### DIFF
--- a/usr/src/pkg/manifests/system-kernel-platform-raspberry-pi-4.p5m
+++ b/usr/src/pkg/manifests/system-kernel-platform-raspberry-pi-4.p5m
@@ -38,5 +38,6 @@ file path=usr/share/man/man4d/bcm2711_pcie.4d
 file path=usr/share/man/man4d/bcm2711_sensors.4d
 driver name=bcm2711_emmctwo perms="* 0666 root sys" alias=brcm,bcm2711-emmc2
 driver name=bcm2711_genet perms="* 0666 root sys" alias=brcm,bcm2711-genet-v5
+driver name=bcm2711_pcie alias=brcm,bcm2711-pcie
 driver name=bcm2711_sensors perms="* 0666 root sys"
 license lic_CDDL license=lic_CDDL


### PR DESCRIPTION
This driver is now functional, allow it to attach without user intervention.

Tested on [rpi4](https://gist.github.com/r1mikey/fc5351efa67ce6fb20c4e896be442708).