### PR TITLE
xhci: Add pciexclass driver alias, enable on !i386

### DIFF
--- a/usr/src/pkg/manifests/driver-usb.p5m
+++ b/usr/src/pkg/manifests/driver-usb.p5m
@@ -269,7 +269,9 @@ driver name=usb_as perms="* 0600 root sys" alias=usbif,class1.2
 driver name=usb_ia alias=usb,ia
 driver name=usb_mid alias=usb,device
 driver name=usbprn perms="* 0666 root sys" alias=usbif,class7.1
-$(i386_ONLY)driver name=xhci perms="* 0644 root sys" alias=pciclass,0c0330
+driver name=xhci perms="* 0644 root sys" \
+    alias=pciclass,0c0330 \
+    alias=pciexclass,0c0330
 legacy pkg=SUNWusb desc="USBA (USB framework) and USB Device Drivers" \
     name="USB Device Drivers"
 license cr_Sun license=cr_Sun


### PR DESCRIPTION
Allows the xhci driver to attach on aarch64, which only generates pciexclass aliases.

Tested on [rpi4](https://gist.github.com/r1mikey/fc5351efa67ce6fb20c4e896be442708).