### PR TITLE
bcm2711_pcie: missing newline in CE_CONT message

### DIFF
--- a/usr/src/uts/armv8/rpi4/io/bcm2711_pcie/bcm2711_pcie.c
+++ b/usr/src/uts/armv8/rpi4/io/bcm2711_pcie/bcm2711_pcie.c
@@ -822,7 +822,7 @@ bcm2711_pcie_vl805_reset(bcm2711_pcie_softc_t *softc)
 		return;
 	}
 
-	dev_err(softc->bc_dip, CE_CONT, "?VL805 xHCI firmware loaded");
+	dev_err(softc->bc_dip, CE_CONT, "?VL805 xHCI firmware loaded\n");
 
 	/*
 	 * Allow the controller time to initialise after firmware load.


### PR DESCRIPTION
Simple cosmetic fix to clean up verbose boot output.