### PR TITLE
ddi: property lookup should use ANY, not NONE

### DIFF
--- a/usr/src/uts/armv8/io/pciex/pcieb_armv8.c
+++ b/usr/src/uts/armv8/io/pciex/pcieb_armv8.c
@@ -112,7 +112,7 @@ void
 pcieb_plat_initchild(dev_info_t *child)
 {
 	struct ddi_parent_private_data *pdptr;
-	if (ddi_prop_exists(DDI_DEV_T_NONE, child, DDI_PROP_DONTPASS,
+	if (ddi_prop_exists(DDI_DEV_T_ANY, child, DDI_PROP_DONTPASS,
 	    OBP_INTERRUPTS)) {
 		pdptr = kmem_zalloc((sizeof (struct ddi_parent_private_data) +
 		    sizeof (struct intrspec)), KM_SLEEP);

--- a/usr/src/uts/common/io/cpqary3/cpqary3_util.c
+++ b/usr/src/uts/common/io/cpqary3/cpqary3_util.c
@@ -45,7 +45,7 @@ cpqary3_read_conf_file(dev_info_t *dip, cpqary3_t *cpqary3p)
 	 *
 	 * eg. :
 	 *
-	 * retvalue = ddi_prop_get_int(DDI_DEV_T_NONE, dip, DDI_PROP_DONTPASS,
+	 * retvalue = ddi_prop_get_int(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
 	 *	"cpqary3_online_debug", -1);
 	 */
 

--- a/usr/src/uts/common/io/gld.c
+++ b/usr/src/uts/common/io/gld.c
@@ -556,7 +556,7 @@ gld_register(dev_info_t *devinfo, char *devname, gld_mac_info_t *macinfo)
 	}
 
 	/* see gld_rsrv() */
-	if (ddi_prop_get_int(DDI_DEV_T_NONE, devinfo, 0, "fast_recv", 0))
+	if (ddi_prop_get_int(DDI_DEV_T_ANY, devinfo, 0, "fast_recv", 0))
 		macinfo->gldm_options |= GLDOPT_FAST_RECV;
 
 	mutex_enter(&gld_device_list.gld_devlock);
@@ -583,7 +583,7 @@ gld_register(dev_info_t *devinfo, char *devname, gld_mac_info_t *macinfo)
 		mutex_init(&glddev->gld_devlock, NULL, MUTEX_DRIVER, NULL);
 
 		/* allow increase of number of supported multicast addrs */
-		glddev->gld_multisize = ddi_prop_get_int(DDI_DEV_T_NONE,
+		glddev->gld_multisize = ddi_prop_get_int(DDI_DEV_T_ANY,
 		    devinfo, 0, "multisize", GLD_MAX_MULTICAST);
 
 		/*
@@ -592,7 +592,7 @@ gld_register(dev_info_t *devinfo, char *devname, gld_mac_info_t *macinfo)
 		 * -1 - don't create style 1 nodes
 		 * -2 - don't create style 2 nodes
 		 */
-		glddev->gld_styles = ddi_prop_get_int(DDI_DEV_T_NONE, devinfo,
+		glddev->gld_styles = ddi_prop_get_int(DDI_DEV_T_ANY, devinfo,
 		    0, "gld-provider-styles", 0);
 
 		/* Stuff that's needed before any PPA gets attached */

--- a/usr/src/uts/common/io/gldutil.c
+++ b/usr/src/uts/common/io/gldutil.c
@@ -1242,7 +1242,7 @@ gld_init_tr(gld_mac_info_t *macinfo)
 
 	/* Default is RDE enabled for this medium */
 	((gld_mac_pvt_t *)macinfo->gldm_mac_pvt)->rde_enabled =
-	    ddi_prop_get_int(DDI_DEV_T_NONE, macinfo->gldm_devinfo, 0,
+	    ddi_prop_get_int(DDI_DEV_T_ANY, macinfo->gldm_devinfo, 0,
 	    "gld_rde_enable", 1);
 
 	/*
@@ -1255,13 +1255,13 @@ gld_init_tr(gld_mac_info_t *macinfo)
 	 * the RDE algorithms.
 	 */
 	((gld_mac_pvt_t *)macinfo->gldm_mac_pvt)->rde_str_indicator_ste =
-	    ddi_prop_get_int(DDI_DEV_T_NONE, macinfo->gldm_devinfo, 0,
+	    ddi_prop_get_int(DDI_DEV_T_ANY, macinfo->gldm_devinfo, 0,
 	    "gld_rde_str_indicator_ste",
 	    ((gld_mac_pvt_t *)macinfo->gldm_mac_pvt)->rde_enabled);
 
 	/* Default 10 second route timeout on lack of activity */
 	{
-	int t = ddi_prop_get_int(DDI_DEV_T_NONE, macinfo->gldm_devinfo, 0,
+	int t = ddi_prop_get_int(DDI_DEV_T_ANY, macinfo->gldm_devinfo, 0,
 	    "gld_rde_timeout", 10);
 	if (t < 1)
 		t = 1;		/* Let's be reasonable */

--- a/usr/src/uts/common/io/hxge/hxge_main.c
+++ b/usr/src/uts/common/io/hxge/hxge_main.c
@@ -4498,7 +4498,7 @@ hxge_create_msi_property(p_hxge_t hxgep)
 
 	HXGE_DEBUG_MSG((hxgep, MOD_CTL,
 	    "==>hxge_create_msi_property(10G): exists 0x%x (nmsi %d)",
-	    ddi_prop_exists(DDI_DEV_T_NONE, hxgep->dip,
+	    ddi_prop_exists(DDI_DEV_T_ANY, hxgep->dip,
 	    DDI_PROP_CANSLEEP, "#msix-request"), nmsi));
 
 	HXGE_DEBUG_MSG((hxgep, MOD_CTL, "<==hxge_create_msi_property"));

--- a/usr/src/uts/common/io/ib/adapters/hermon/hermon_fm.c
+++ b/usr/src/uts/common/io/ib/adapters/hermon/hermon_fm.c
@@ -348,7 +348,7 @@ hermon_fm_init(hermon_state_t *state)
 	 * Check the "fm_disable" property. If it's defined,
 	 * use the Solaris FMA default action for Hermon.
 	 */
-	if (ddi_prop_get_int(DDI_DEV_T_NONE, state->hs_dip, DDI_PROP_DONTPASS,
+	if (ddi_prop_get_int(DDI_DEV_T_ANY, state->hs_dip, DDI_PROP_DONTPASS,
 	    "fm_disable", 0) != 0) {
 		state->hs_fm_disable = 1;
 	}

--- a/usr/src/uts/common/io/llc1.c
+++ b/usr/src/uts/common/io/llc1.c
@@ -276,7 +276,7 @@ llc1_attach(dev_info_t *devinfo, ddi_attach_cmd_t cmd)
 		ddi_remove_minor_node(devinfo, NULL);
 		return (DDI_FAILURE);
 	}
-	llc1_device_list.llc1_multisize = ddi_prop_get_int(DDI_DEV_T_NONE,
+	llc1_device_list.llc1_multisize = ddi_prop_get_int(DDI_DEV_T_ANY,
 	    devinfo, 0, "multisize", 0);
 	if (llc1_device_list.llc1_multisize == 0)
 		llc1_device_list.llc1_multisize = LLC1_MAX_MULTICAST;

--- a/usr/src/uts/common/io/nxge/nxge_main.c
+++ b/usr/src/uts/common/io/nxge/nxge_main.c
@@ -6969,7 +6969,7 @@ nxge_create_msi_property(p_nxge_t nxgep)
 		}
 		NXGE_DEBUG_MSG((nxgep, MOD_CTL,
 		    "==>nxge_create_msi_property(10G): exists 0x%x (nmsi %d)",
-		    ddi_prop_exists(DDI_DEV_T_NONE, nxgep->dip,
+		    ddi_prop_exists(DDI_DEV_T_ANY, nxgep->dip,
 		    DDI_PROP_CANSLEEP, "#msix-request"), nmsi));
 		break;
 
@@ -6989,7 +6989,7 @@ nxge_create_msi_property(p_nxge_t nxgep)
 		}
 		NXGE_DEBUG_MSG((nxgep, MOD_CTL,
 		    "==>nxge_create_msi_property(1G): exists 0x%x (nmsi %d)",
-		    ddi_prop_exists(DDI_DEV_T_NONE, nxgep->dip,
+		    ddi_prop_exists(DDI_DEV_T_ANY, nxgep->dip,
 		    DDI_PROP_CANSLEEP, "#msix-request"), nmsi));
 		break;
 	}

--- a/usr/src/uts/common/io/nxge/nxge_virtual.c
+++ b/usr/src/uts/common/io/nxge/nxge_virtual.c
@@ -456,7 +456,7 @@ nxge_update_rxdma_grp_properties(p_nxge_t nxgep, config_token_t token,
 		num_grps = 0;
 		for (port = 0; port < num_ports; port++) {
 			custom_start_grp[port] =
-			    ddi_prop_get_int(DDI_DEV_T_NONE, s_dip[port],
+			    ddi_prop_get_int(DDI_DEV_T_ANY, s_dip[port],
 			    DDI_PROP_DONTPASS, start_prop, -1);
 			if ((custom_start_grp[port] == -1) ||
 			    (custom_start_grp[port] >=
@@ -465,7 +465,7 @@ nxge_update_rxdma_grp_properties(p_nxge_t nxgep, config_token_t token,
 				break;
 			}
 			custom_num_grp[port] = ddi_prop_get_int(
-			    DDI_DEV_T_NONE,
+			    DDI_DEV_T_ANY,
 			    s_dip[port],
 			    DDI_PROP_DONTPASS,
 			    num_prop, -1);

--- a/usr/src/uts/common/io/pcic.c
+++ b/usr/src/uts/common/io/pcic.c
@@ -1272,7 +1272,7 @@ pcic_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 
 		smi = 0xff;	/* no more override */
 
-		if (ddi_prop_get_int(DDI_DEV_T_NONE, dip,
+		if (ddi_prop_get_int(DDI_DEV_T_ANY, dip,
 		    DDI_PROP_DONTPASS, "need-mult-irq",
 		    0xffff) != 0xffff)
 			pcic->pc_flags |= PCF_MULT_IRQ;
@@ -1335,7 +1335,7 @@ pcic_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 
 	cv_init(&pcic->pm_cv, NULL, CV_DRIVER, NULL);
 
-	if (!ddi_prop_get_int(DDI_DEV_T_NONE, dip, DDI_PROP_DONTPASS,
+	if (!ddi_prop_get_int(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
 	    "disable-audio", 0))
 		pcic->pc_flags |= PCF_AUDIO;
 

--- a/usr/src/uts/common/io/scsi/conf/scsi_confsubr.c
+++ b/usr/src/uts/common/io/scsi/conf/scsi_confsubr.c
@@ -1557,19 +1557,19 @@ create_inquiry_props(struct scsi_device *sd)
 	 * than the standard SCSI INQUIRY data.
 	 */
 	if (inq->inq_ansi != 1) {
-		if (ddi_prop_exists(DDI_DEV_T_NONE, sd->sd_dev,
+		if (ddi_prop_exists(DDI_DEV_T_ANY, sd->sd_dev,
 		    DDI_PROP_TYPE_STRING, INQUIRY_VENDOR_ID) == 0)
 			(void) scsi_device_prop_update_inqstring(sd,
 			    INQUIRY_VENDOR_ID,
 			    inq->inq_vid, sizeof (inq->inq_vid));
 
-		if (ddi_prop_exists(DDI_DEV_T_NONE, sd->sd_dev,
+		if (ddi_prop_exists(DDI_DEV_T_ANY, sd->sd_dev,
 		    DDI_PROP_TYPE_STRING, INQUIRY_PRODUCT_ID) == 0)
 			(void) scsi_device_prop_update_inqstring(sd,
 			    INQUIRY_PRODUCT_ID,
 			    inq->inq_pid, sizeof (inq->inq_pid));
 
-		if (ddi_prop_exists(DDI_DEV_T_NONE, sd->sd_dev,
+		if (ddi_prop_exists(DDI_DEV_T_ANY, sd->sd_dev,
 		    DDI_PROP_TYPE_STRING, INQUIRY_REVISION_ID) == 0)
 			(void) scsi_device_prop_update_inqstring(sd,
 			    INQUIRY_REVISION_ID,

--- a/usr/src/uts/common/io/scsi/impl/smp_transport.c
+++ b/usr/src/uts/common/io/scsi/impl/smp_transport.c
@@ -126,7 +126,7 @@ smp_probe(struct smp_device *smp_sd)
 			(void) snprintf(&component[ilen], clen - ilen,
 			    ".%05d.%03d", BE_16(srmir->srmir_component_id),
 			    srmir->srmir_component_revision_level);
-			if (ddi_prop_exists(DDI_DEV_T_NONE, smp_sd->smp_sd_dev,
+			if (ddi_prop_exists(DDI_DEV_T_ANY, smp_sd->smp_sd_dev,
 			    DDI_PROP_DONTPASS | DDI_PROP_NOTPROM,
 			    "component") == 0)
 				(void) ndi_prop_update_string(DDI_DEV_T_NONE,
@@ -135,26 +135,26 @@ smp_probe(struct smp_device *smp_sd)
 		}
 	}
 	/* First one to define the property wins */
-	if (ddi_prop_exists(DDI_DEV_T_NONE, smp_sd->smp_sd_dev,
+	if (ddi_prop_exists(DDI_DEV_T_ANY, smp_sd->smp_sd_dev,
 	    DDI_PROP_DONTPASS | DDI_PROP_NOTPROM, INQUIRY_REVISION_ID) == 0)
 		(void) smp_device_prop_update_inqstring(smp_sd,
 		    INQUIRY_REVISION_ID, srmir->srmir_product_revision_level,
 		    sizeof (srmir->srmir_product_revision_level));
 
-	if (ddi_prop_exists(DDI_DEV_T_NONE, smp_sd->smp_sd_dev,
+	if (ddi_prop_exists(DDI_DEV_T_ANY, smp_sd->smp_sd_dev,
 	    DDI_PROP_DONTPASS | DDI_PROP_NOTPROM, INQUIRY_PRODUCT_ID) == 0)
 		(void) smp_device_prop_update_inqstring(smp_sd,
 		    INQUIRY_PRODUCT_ID, srmir->srmir_product_identification,
 		    sizeof (srmir->srmir_product_identification));
 
-	if (ddi_prop_exists(DDI_DEV_T_NONE, smp_sd->smp_sd_dev,
+	if (ddi_prop_exists(DDI_DEV_T_ANY, smp_sd->smp_sd_dev,
 	    DDI_PROP_DONTPASS | DDI_PROP_NOTPROM, INQUIRY_VENDOR_ID) == 0)
 		(void) smp_device_prop_update_inqstring(smp_sd,
 		    INQUIRY_VENDOR_ID, srmir->srmir_vendor_identification,
 		    sizeof (srmir->srmir_vendor_identification));
 
 	/* NOTE: SMP_PROP_REPORT_MANUFACTURER is deleted after devid created */
-	if (ddi_prop_exists(DDI_DEV_T_NONE, smp_sd->smp_sd_dev,
+	if (ddi_prop_exists(DDI_DEV_T_ANY, smp_sd->smp_sd_dev,
 	    DDI_PROP_DONTPASS | DDI_PROP_NOTPROM,
 	    SMP_PROP_REPORT_MANUFACTURER) == 0)
 		(void) ndi_prop_update_byte_array(DDI_DEV_T_NONE,

--- a/usr/src/uts/common/io/scsi/targets/ses.c
+++ b/usr/src/uts/common/io/scsi/targets/ses.c
@@ -1721,7 +1721,7 @@ ses_register_dev_id(ses_softc_t *ssc, dev_info_t *dip)
 	 * This is from page 0x80, which may or may not be present.
 	 */
 	if ((len80 > 4) &&
-	    (!ddi_prop_exists(DDI_DEV_T_NONE, dip,
+	    (!ddi_prop_exists(DDI_DEV_T_ANY, dip,
 	    DDI_PROP_NOTPROM | DDI_PROP_DONTPASS, INQUIRY_SERIAL_NO))) {
 		char *sn;
 

--- a/usr/src/uts/common/os/ddifm.c
+++ b/usr/src/uts/common/os/ddifm.c
@@ -751,7 +751,7 @@ ddi_fm_init(dev_info_t *dip, int *fmcap, ddi_iblock_cookie_t *ibcp)
 	 */
 	if (DDI_FM_EREPORT_CAP(*fmcap) && DDI_FM_EREPORT_CAP(pcap)) {
 		fmhdl->fh_errorq = ereport_errorq;
-		if (ddi_prop_get_int(DDI_DEV_T_NONE, dip, DDI_PROP_DONTPASS,
+		if (ddi_prop_get_int(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
 		    "fm-ereport-capable", 0) == 0)
 			(void) ddi_prop_create(DDI_DEV_T_NONE, dip,
 			    DDI_PROP_CANSLEEP, "fm-ereport-capable", NULL, 0);
@@ -764,7 +764,7 @@ ddi_fm_init(dev_info_t *dip, int *fmcap, ddi_iblock_cookie_t *ibcp)
 	 */
 
 	if (DDI_FM_ERRCB_CAP(*fmcap) && DDI_FM_ERRCB_CAP(pcap)) {
-		if (ddi_prop_get_int(DDI_DEV_T_NONE, dip, DDI_PROP_DONTPASS,
+		if (ddi_prop_get_int(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
 		    "fm-errcb-capable", 0) == 0)
 			(void) ddi_prop_create(DDI_DEV_T_NONE, dip,
 			    DDI_PROP_CANSLEEP, "fm-errcb-capable", NULL, 0);
@@ -780,7 +780,7 @@ ddi_fm_init(dev_info_t *dip, int *fmcap, ddi_iblock_cookie_t *ibcp)
 		i_ndi_fmc_create(&fmhdl->fh_dma_cache, 2, ibc);
 
 		/* Set-up dma chk capability prop */
-		if (ddi_prop_get_int(DDI_DEV_T_NONE, dip, DDI_PROP_DONTPASS,
+		if (ddi_prop_get_int(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
 		    "fm-dmachk-capable", 0) == 0)
 			(void) ddi_prop_create(DDI_DEV_T_NONE, dip,
 			    DDI_PROP_CANSLEEP, "fm-dmachk-capable", NULL, 0);
@@ -791,7 +791,7 @@ ddi_fm_init(dev_info_t *dip, int *fmcap, ddi_iblock_cookie_t *ibcp)
 	if (DDI_FM_ACC_ERR_CAP(*fmcap) && DDI_FM_ACC_ERR_CAP(pcap)) {
 		i_ndi_fmc_create(&fmhdl->fh_acc_cache, 2, ibc);
 		/* Set-up dma chk capability prop */
-		if (ddi_prop_get_int(DDI_DEV_T_NONE, dip, DDI_PROP_DONTPASS,
+		if (ddi_prop_get_int(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
 		    "fm-accchk-capable", 0) == 0)
 			(void) ddi_prop_create(DDI_DEV_T_NONE, dip,
 			    DDI_PROP_CANSLEEP, "fm-accchk-capable", NULL, 0);

--- a/usr/src/uts/common/os/devcfg.c
+++ b/usr/src/uts/common/os/devcfg.c
@@ -2882,7 +2882,7 @@ ddi_compatible_driver_major(dev_info_t *dip, char **formp)
 	 * virtualized environment.  Prevent its use.  This is only used by
 	 * Xen and (previously) by sun4v LDOMs.  See pcie_init_dom().
 	 */
-	if (ddi_prop_exists(DDI_DEV_T_NONE, dip, DDI_PROP_DONTPASS,
+	if (ddi_prop_exists(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
 	    "ddi-assigned")) {
 		major = ddi_name_to_major("nulldriver");
 		return (major);

--- a/usr/src/uts/common/os/sunddi.c
+++ b/usr/src/uts/common/os/sunddi.c
@@ -3540,6 +3540,10 @@ ddi_prop_lookup_common(dev_t match_dev, dev_info_t *dip,
 	uint_t		ourflags;
 	prop_handle_t	ph;
 
+#if defined(__aarch64__)
+	ASSERT(match_dev != DDI_DEV_T_NONE);
+#endif
+
 	if ((match_dev == DDI_DEV_T_NONE) ||
 	    (name == NULL) || (strlen(name) == 0))
 		return (DDI_PROP_INVAL_ARG);

--- a/usr/src/uts/common/pcmcia/nexus/pcmcia.c
+++ b/usr/src/uts/common/pcmcia/nexus/pcmcia.c
@@ -548,7 +548,7 @@ pcmcia_ctlops(dev_info_t *dip, dev_info_t *rdip,
 			    ddi_driver_name(dip),
 			    ddi_get_name_addr(dip),
 			    CS_GET_SOCKET_NUMBER(
-			    ddi_prop_get_int(DDI_DEV_T_NONE, rdip,
+			    ddi_prop_get_int(DDI_DEV_T_ANY, rdip,
 			    DDI_PROP_DONTPASS,
 			    PCM_DEV_SOCKET, -1)));
 
@@ -3173,7 +3173,7 @@ pcmcia_init_devinfo(dev_info_t *pdip, struct pcm_device_info *info)
 	unit = CS_MAKE_SOCKET_NUMBER(info->pd_socket, info->pd_function);
 
 	dip = pcm_find_devinfo(pdip, info, unit);
-	if ((dip != NULL) && (ddi_prop_get_int(DDI_DEV_T_NONE, dip,
+	if ((dip != NULL) && (ddi_prop_get_int(DDI_DEV_T_ANY, dip,
 	    DDI_PROP_DONTPASS, PCM_DEV_SOCKET, -1) != -1)) {
 		/* it already exist but isn't a .conf file */
 

--- a/usr/src/uts/common/pcmcia/sys/cs_priv.h
+++ b/usr/src/uts/common/pcmcia/sys/cs_priv.h
@@ -249,7 +249,7 @@ typedef struct cisregister_t {
  *	the passed dip.  If the property can't be found, then the default
  *	value of cs_globals.max_socket_num is returned.
  */
-#define	DIP2SOCKET_NUM(dip)		ddi_prop_get_int(DDI_DEV_T_NONE, dip,\
+#define	DIP2SOCKET_NUM(dip)		ddi_prop_get_int(DDI_DEV_T_ANY, dip,\
 						DDI_PROP_NOTPROM, \
 						PCM_DEV_SOCKET,		\
 						cs_globals.max_socket_num)

--- a/usr/src/uts/intel/io/dnet/dnet_mii.c
+++ b/usr/src/uts/intel/io/dnet/dnet_mii.c
@@ -172,11 +172,11 @@ mii_init_phy(mii_handle_t mac, int phy)
 
 	/* Override speed and duplex mode from conf-file if present */
 	phydata->fix_duplex =
-	    ddi_prop_get_int(DDI_DEV_T_NONE,
+	    ddi_prop_get_int(DDI_DEV_T_ANY,
 	    mac->mii_dip, DDI_PROP_DONTPASS, "full-duplex", 0);
 
 	phydata->fix_speed =
-	    ddi_prop_get_int(DDI_DEV_T_NONE,
+	    ddi_prop_get_int(DDI_DEV_T_ANY,
 	    mac->mii_dip, DDI_PROP_DONTPASS, "speed", 0);
 
 	status = mac->mii_read(dip, phy, MII_STATUS);
@@ -277,7 +277,7 @@ mii_init_phy(mii_handle_t mac, int phy)
 	/* Do all post-reset hacks and user settings */
 	(void) mii_sync(mac, phy);
 
-	if (ddi_prop_get_int(DDI_DEV_T_NONE, mac->mii_dip, DDI_PROP_DONTPASS,
+	if (ddi_prop_get_int(DDI_DEV_T_ANY, mac->mii_dip, DDI_PROP_DONTPASS,
 	    "dump-phy", 0))
 		(void) mii_dump_phy(mac, phy);
 

--- a/usr/src/uts/intel/io/pci/pci_pci.c
+++ b/usr/src/uts/intel/io/pci/pci_pci.c
@@ -704,7 +704,7 @@ ppb_initchild(dev_info_t *child)
 	}
 
 	/* transfer select properties from PROM to kernel */
-	if (ddi_prop_get_int(DDI_DEV_T_NONE, child, DDI_PROP_DONTPASS,
+	if (ddi_prop_get_int(DDI_DEV_T_ANY, child, DDI_PROP_DONTPASS,
 	    "interrupts", -1) != -1) {
 		pdptr = kmem_zalloc((sizeof (struct ddi_parent_private_data) +
 		    sizeof (struct intrspec)), KM_SLEEP);

--- a/usr/src/uts/sparc/io/pciex/pcieb_sparc.c
+++ b/usr/src/uts/sparc/io/pciex/pcieb_sparc.c
@@ -172,7 +172,7 @@ pcieb_plat_initchild(dev_info_t *child)
 	 * XXX set ppd to 1 to disable iommu BDF protection on SPARC.
 	 * It relies on unused parent private data for PCI devices.
 	 */
-	if (ddi_prop_exists(DDI_DEV_T_NONE, child, DDI_PROP_DONTPASS,
+	if (ddi_prop_exists(DDI_DEV_T_ANY, child, DDI_PROP_DONTPASS,
 	    "dvma-share"))
 		ppd = 1;
 

--- a/usr/src/uts/sun4/io/px/px.c
+++ b/usr/src/uts/sun4/io/px/px.c
@@ -620,7 +620,7 @@ px_pwr_setup(dev_info_t *dip)
 	 * indicate support LDI (Layered Driver Interface)
 	 * Create the property, if it is not already there
 	 */
-	if (!ddi_prop_exists(DDI_DEV_T_NONE, dip, DDI_PROP_DONTPASS,
+	if (!ddi_prop_exists(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
 	    DDI_KERNEL_IOCTL)) {
 		if (ddi_prop_create(DDI_DEV_T_NONE, dip, DDI_PROP_CANSLEEP,
 		    DDI_KERNEL_IOCTL, NULL, 0) != DDI_PROP_SUCCESS) {

--- a/usr/src/uts/sun4/io/px/px_util.c
+++ b/usr/src/uts/sun4/io/px/px_util.c
@@ -433,7 +433,7 @@ px_init_child(px_t *px_p, dev_info_t *child)
 	 * XXX set ppd to 1 to disable iommu BDF protection
 	 * It relies on unused parent private data for PCI devices.
 	 */
-	if (ddi_prop_exists(DDI_DEV_T_NONE, child, DDI_PROP_DONTPASS,
+	if (ddi_prop_exists(DDI_DEV_T_ANY, child, DDI_PROP_DONTPASS,
 	    "dvma-share"))
 		ppd = 1;
 

--- a/usr/src/uts/sun4v/io/px/px_lib4v.c
+++ b/usr/src/uts/sun4v/io/px/px_lib4v.c
@@ -2185,7 +2185,7 @@ px_lib_do_count_waiting_dev(dev_info_t *dip, void *arg)
 
 	while (cdip != NULL) {
 		/* check if this is an assigned device */
-		if (ddi_prop_exists(DDI_DEV_T_NONE, cdip, DDI_PROP_DONTPASS,
+		if (ddi_prop_exists(DDI_DEV_T_ANY, cdip, DDI_PROP_DONTPASS,
 		    "ddi-assigned")) {
 			DBG(DBG_ATTACH, dip, "px_lib_do_count_waiting_dev: "
 			    "Found an assigned dev %p, under bridge %p",


### PR DESCRIPTION
This is a very easy interface to get wrong, and aarch64 is a bit stricter, which results in hard-to-debug behaviour.

Audit all ddi_prop_lookup, ddi_prop_exists and ddi_prop_get callsites for correct argument passing and add an assertion so that future errors happen early and in obvious, easy to track, ways.

The assertion is scoped to only aarch64 for now - this code has been running "fine" for years, and we don't want to blow up people's debug builds on other platforms.  The assertion really should be made to apply to all platforms in the future though, as it improves the visibility of subtle bugs.

When I just added the assert I immediately got failures during boot, which was a little surprising. This audit catches all ddi_prop_exists, ddi_prop_lookup and ddi_prop_get_int/ddi_prop_get_int64 calls.

Tested:
* [rpi4](https://gist.github.com/r1mikey/369574d5e94b84c4eaf268a680148139)
* [Altra Max](https://gist.github.com/r1mikey/5c366cf86cae93c14c3862f6d47a448c)
* [Qemu virt/edk2](https://gist.github.com/r1mikey/e0f88e182c84e702d8905ecee0e0fec9)
* [Qemu virt/FDT](https://gist.github.com/r1mikey/a549cc998ddad70a4418adc28c2a2df6)
