### PR TITLE
autovect hash collision fixes

### DIFF
--- a/usr/src/cmd/mdb/aarch64/modules/unix/unix.c
+++ b/usr/src/cmd/mdb/aarch64/modules/unix/unix.c
@@ -113,7 +113,8 @@ gic_print_vec(uintptr_t state_addr, const void *aw_buff, void *arg)
 		return (WALK_ERR);
 	}
 
-	uintptr_t av_addr = (uintptr_t)avec_tbl[state.si_vector].avh_link;
+	uintptr_t av_addr =
+	    (uintptr_t)avec_tbl[state.si_vector % MAX_VECT].avh_link;
 
 	while (av_addr != 0x0) {
 		if (mdb_vread(&av, sizeof (struct autovec), av_addr) == -1) {
@@ -123,6 +124,16 @@ gic_print_vec(uintptr_t state_addr, const void *aw_buff, void *arg)
 		}
 
 		if (av.av_vector == NULL) {
+			av_addr = (uintptr_t)av.av_link;
+			continue;
+		}
+
+		/*
+		 * On aarch64, multiple vectors can hash to the same
+		 * autovect bucket.  Only print entries that match
+		 * the vector we're looking for.
+		 */
+		if (av.av_vecnum != state.si_vector) {
 			av_addr = (uintptr_t)av.av_link;
 			continue;
 		}

--- a/usr/src/uts/common/io/avintr.c
+++ b/usr/src/uts/common/io/avintr.c
@@ -260,6 +260,40 @@ add_avintr(void *intr_id, int lvl, avfunc xxintr, char *name, int vect,
 	 */
 	hi_pri = vecp->avh_hi_pri;
 	if (vecp->avh_link && (hi_pri != 0)) {
+#if defined(__aarch64__)
+		/*
+		 * On aarch64, MAX_VECT < the INTID space (LPIs can be
+		 * >=8192), so multiple vectors hash to the same bucket.
+		 * We must only check for IPL conflicts among entries
+		 * with the same vector, not all entries in the bucket.
+		 */
+		struct autovec *p;
+		ushort_t vec_hi = 0, vec_lo = MAXIPL;
+		boolean_t found = B_FALSE;
+
+		for (p = vecp->avh_link; p != NULL; p = p->av_link) {
+			if (p->av_vector == NULL || p->av_prilevel == 0)
+				continue;
+			if (!av_vector_match(p, vect))
+				continue;
+			found = B_TRUE;
+			if (p->av_prilevel > vec_hi)
+				vec_hi = p->av_prilevel;
+			if (p->av_prilevel < vec_lo)
+				vec_lo = p->av_prilevel;
+		}
+
+		if (found) {
+			if (((vec_hi > LOCK_LEVEL) && (lvl < LOCK_LEVEL)) ||
+			    ((vec_hi < LOCK_LEVEL) && (lvl > LOCK_LEVEL))) {
+				cmn_err(CE_WARN, multilevel2, name, lvl, vect,
+				    vec_hi);
+				return (0);
+			}
+			if ((vec_lo != lvl) || (vec_hi != lvl))
+				cmn_err(CE_NOTE, multilevel, vect);
+		}
+#else
 		if (((hi_pri > LOCK_LEVEL) && (lvl < LOCK_LEVEL)) ||
 		    ((hi_pri < LOCK_LEVEL) && (lvl > LOCK_LEVEL))) {
 			cmn_err(CE_WARN, multilevel2, name, lvl, vect,
@@ -268,6 +302,7 @@ add_avintr(void *intr_id, int lvl, avfunc xxintr, char *name, int vect,
 		}
 		if ((vecp->avh_lo_pri != lvl) || (hi_pri != lvl))
 			cmn_err(CE_NOTE, multilevel, vect);
+#endif
 	}
 
 	insert_av(intr_id, vecp, vect, f, arg1, arg2, ticksp, lvl, dip);


### PR DESCRIPTION
_This is one of five PRs for initial MSI/MSI-X support, and is a pre-requisite for the final PR (DDI/PCI framework). This PR has no dependencies._

Two fixes for autovect hash table handling, where the INTID space (LPIs start at 8192) exceeds `MAX_VECT` (256) and multiple unrelated vectors share the same hash bucket.

### mdb: deal with autovec hash table collisions

The `::interrupts` dcmd in the aarch64 mdb unix module indexes `autovect[]` directly by `si_vector`. Without the modulo, `si_vector` values >= `MAX_VECT` produce an out-of-bounds read.

Fix the index to use `si_vector % MAX_VECT`, matching the kernel's own hashing, and filter the resulting chain by `av_vecnum` so only handlers for the requested vector are printed.

### avintr: fix vector detection on hash collision

`add_avintr` checks for IPL conflicts between handlers sharing the same interrupt vector. The module was designed for systems where the vector number is the direct index into `autovect[]`, so `avh_hi_pri` and `avh_lo_pri` accurately reflect the priority range for that vector.

With hashing, multiple unrelated vectors share the same bucket, and the priority range spans all of them. This causes false-positive multilevel interrupt warnings and can reject a legitimate `add_avintr` call when an unrelated vector in the same bucket happens to straddle `LOCK_LEVEL`.

Fix by walking the bucket chain on aarch64 and computing the priority range only from entries whose `av_vecnum` matches the vector being added. The existing code path is unchanged on other architectures.

### Testing

All base FDT testing on my [feature/msi-msix](https://github.com/r1mikey/illumos-gate/tree/feature/msi-msix) branch, all ACPI testing on my [r1mikey/armh-sbbr-msi-msix](https://github.com/r1mikey/illumos-gate/tree/r1mikey/armh-sbbr-msi-msix) branch.

* [QEMU virt FDT](https://gist.github.com/r1mikey/915102a57815af1fc81e226b95ad921a) (GICv2): vioblk on SPIs 80+81, clean boot
* [QEMU virt FDT](https://gist.github.com/r1mikey/8b6b98c66f7acd130e05bf49b364fe96) (GICv3): vioblk on LPIs 8192+8193, clean boot
* [RPi4 FDT](https://gist.github.com/r1mikey/4952a56c12bb10f770536132de934b89): intentionally still on the INTx path, no regression
* [QEMU virt ACPI](https://gist.github.com/r1mikey/d4e76c63e21bf1fc2b9f98357b1207d4) (GICv3): 6 LPIs across vioblk/vioif/xhci, clean boot
* Ampere [Altra Max ACPI](https://gist.github.com/r1mikey/38de5803a035bf402c724ccdcd3161e0) (GICv3): nvme*2, ixgbe*2, xhci, igb, [67 LPIs](https://gist.github.com/r1mikey/c676ee43f158b9bac98a89d66b01f8f3), INTx on pcieb