### PR TITLE
MSI/MSI-X preparation

### DIFF
--- a/usr/src/uts/aarch64/sys/obpdefs.h
+++ b/usr/src/uts/aarch64/sys/obpdefs.h
@@ -93,6 +93,9 @@ typedef	phandle_t pnode_t;
 
 #define	OBP_MSI_CONTROLLER		"msi-controller"
 #define	OBP_MSI_CELLS			"#msi-cells"
+#define	OBP_MSI_PARENT			"msi-parent"
+#define	OBP_MSI_MAP			"msi-map"
+#define	OBP_MSI_MAP_MASK		"msi-map-mask"
 
 /*
  * From Bindings/interrupt-controller/msi.txt as found in the devicetree-source

--- a/usr/src/uts/armv8/io/gicthree.c
+++ b/usr/src/uts/armv8/io/gicthree.c
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2025 Michael van der Westhuizen
+ * Copyright 2026 Michael van der Westhuizen
  */
 
 /*
@@ -1283,7 +1283,7 @@ gicv3_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 	gc->gc_syspic.spo_addspl = gicv3_addspl;
 	gc->gc_syspic.spo_delspl = gicv3_delspl;
 
-	if (!syspic_register_syspic(gc, &gc->gc_syspic)) {
+	if (!syspic_register_syspic(gc, &gc->gc_syspic, dip)) {
 		dev_err(dip, CE_PANIC, "Failed to register GIC as the "
 		    "system programmable interrupt controller.");
 	}

--- a/usr/src/uts/armv8/io/gictwo.c
+++ b/usr/src/uts/armv8/io/gictwo.c
@@ -21,7 +21,7 @@
 
 /*
  * Copyright 2017 Hayashi Naoyuki
- * Copyright 2025 Michael van der Westhuizen
+ * Copyright 2026 Michael van der Westhuizen
  */
 
 /*
@@ -892,7 +892,7 @@ gicv2_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 	xconf->gc_syspic.spo_addspl = gicv2_addspl;
 	xconf->gc_syspic.spo_delspl = gicv2_delspl;
 
-	if (!syspic_register_syspic(xconf, &xconf->gc_syspic)) {
+	if (!syspic_register_syspic(xconf, &xconf->gc_syspic, dip)) {
 		dev_err(dip, CE_PANIC, "Failed to register GIC as the "
 		    "system programmable interrupt controller.");
 	}

--- a/usr/src/uts/armv8/os/syspic.c
+++ b/usr/src/uts/armv8/os/syspic.c
@@ -11,7 +11,7 @@
 
 /*
  * Copyright 2024 Richard Lowe
- * Copyright 2025 Michael van der Westhuizen
+ * Copyright 2026 Michael van der Westhuizen
  */
 
 #include <sys/types.h>
@@ -53,6 +53,7 @@ static syspic_ops_t spo_default_ops = {
 
 static spo_ctx_t spo_ctx = &spo_default_ops;
 static syspic_ops_t *spo_ops = &spo_default_ops;
+static dev_info_t *syspic_dip;
 
 static void
 stub_not_config(void)
@@ -141,7 +142,7 @@ syspic_init(void)
 }
 
 int
-syspic_register_syspic(spo_ctx_t ctx, syspic_ops_t *ops)
+syspic_register_syspic(spo_ctx_t ctx, syspic_ops_t *ops, dev_info_t *dip)
 {
 	VERIFY3U(spo_ctx, ==, &spo_default_ops);
 	VERIFY3U(spo_ops, ==, &spo_default_ops);
@@ -151,7 +152,16 @@ syspic_register_syspic(spo_ctx_t ctx, syspic_ops_t *ops)
 
 	spo_ctx = ctx;
 	spo_ops = ops;
+	VERIFY3P(dip, !=, NULL);
+	VERIFY3P(syspic_dip, ==, NULL);
+	syspic_dip = dip;
 	return (1);
+}
+
+dev_info_t *
+syspic_get_dip(void)
+{
+	return (syspic_dip);
 }
 
 void

--- a/usr/src/uts/armv8/rpi4/io/bcm2711_pcie/bcm2711_pcie.c
+++ b/usr/src/uts/armv8/rpi4/io/bcm2711_pcie/bcm2711_pcie.c
@@ -105,6 +105,7 @@
 #include <sys/pcie_impl.h>
 
 #include <sys/mach_intr.h>
+#include <sys/obpdefs.h>
 
 #include <pcierc.h>
 
@@ -1463,9 +1464,12 @@ bcm2711_pcie_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 	 * Defensively remove any reference to an MSI capability until we're
 	 * ready for that.
 	 */
-	(void) ddi_prop_undefine(DDI_DEV_T_NONE, dip, DDI_PROP_CANSLEEP, "msi-controller");
-	(void) ddi_prop_undefine(DDI_DEV_T_NONE, dip, DDI_PROP_CANSLEEP, "msi-parent");
-	(void) ddi_prop_undefine(DDI_DEV_T_NONE, dip, DDI_PROP_CANSLEEP, "msi-map");
+	(void) ddi_prop_undefine(DDI_DEV_T_NONE, dip,
+	    DDI_PROP_CANSLEEP, OBP_MSI_CONTROLLER);
+	(void) ddi_prop_undefine(DDI_DEV_T_NONE, dip,
+	    DDI_PROP_CANSLEEP, OBP_MSI_PARENT);
+	(void) ddi_prop_undefine(DDI_DEV_T_NONE, dip,
+	    DDI_PROP_CANSLEEP, OBP_MSI_MAP);
 
 	if ((ret = pcierc_attach(dip, cmd)) != DDI_SUCCESS) {
 		dev_err(dip, CE_WARN, "pcierc_attach failed: %d", ret);

--- a/usr/src/uts/armv8/sys/mach_intr.h
+++ b/usr/src/uts/armv8/sys/mach_intr.h
@@ -65,6 +65,22 @@ typedef struct ihdl_plat {
 
 	/* XXXARM: `void *ihdl_ctlr_private`? */
 	unit_intr_t	*ip_unitintr;	/* devicetree unit interrupt spec. */
+
+	/*
+	 * MSI controller fields.  Set by the MSI controller driver
+	 * during ENABLE; consumed by the nexus driver (pcierc) to
+	 * program the PCI MSI/MSI-X capability registers.
+	 *
+	 *	ip_msi_devid  - Device ID for the MSI controller (e.g. ITS
+	 *			DeviceID, derived from PCI RID via msi-map).
+	 *	ip_msi_addr   - Doorbell physical address (e.g. GITS_TRANSLATER
+	 *			or V2M_MSI_SETSPI_NS register PA).
+	 *	ip_msi_data   - Data value written by the device (e.g. EventID
+	 *			for ITS, SPI number for GICv2m).
+	 */
+	uint32_t	ip_msi_devid;	/* MSI: device ID for controller */
+	uint64_t	ip_msi_addr;	/* MSI: doorbell physical address */
+	uint32_t	ip_msi_data;	/* MSI: data value */
 } ihdl_plat_t;
 
 #endif /* _KERNEL */

--- a/usr/src/uts/armv8/sys/syspic_impl.h
+++ b/usr/src/uts/armv8/sys/syspic_impl.h
@@ -11,7 +11,7 @@
 
 /*
  * Copyright 2024 Richard Lowe
- * Copyright 2025 Michael van der Westhuizen
+ * Copyright 2026 Michael van der Westhuizen
  */
 
 #ifndef _SYSPIC_IMPL_H
@@ -154,7 +154,13 @@ extern int syspic_init(void);
  * Called by one (and only one) interrupt driver to register the driver
  * instance for the root of the interrupt hierarchy.
  */
-extern int syspic_register_syspic(spo_ctx_t ctx, syspic_ops_t *ops);
+extern int syspic_register_syspic(spo_ctx_t ctx, syspic_ops_t *ops,
+    dev_info_t *dip);
+
+/*
+ * Return the dev_info_t of the registered system PIC.
+ */
+extern dev_info_t *syspic_get_dip(void);
 
 #endif	/* _KERNEL */
 


### PR DESCRIPTION
_This is one of five PRs for initial MSI/MSI-X support, and is a pre-requisite for the MSI/MSI-X driver PRs (GICv2m, GICv3-ITS). This PR has no dependencies._

Three small preparatory changes for MSI/MSI-X support. These add no new functionality on their own but provide the constants, tracking, and handle fields that the GIC MSI drivers and DDI framework depend on.

### obpdefs: Add remaining MSI properties

Add `OBP_MSI_PARENT`, `OBP_MSI_MAP`, and `OBP_MSI_MAP_MASK` constants to the aarch64 obpdefs.h, completing the set of devicetree MSI property names alongside the existing `OBP_MSI_CONTROLLER` and `OBP_MSI_CELLS`.
Switch `bcm2711_pcie` from string literals to the new constants for its defensive `ddi_prop_undefine` calls.

### syspic: track system PIC dip

Add a `dev_info_t` parameter to `syspic_register_syspic` so that the syspic subsystem can track which device node is the registered system PIC. Add `syspic_get_dip` accessor to retrieve it.

MSI controller drivers (GICv2m, GICv3 ITS) call directly into their parent GIC via syspic interfaces (via `add_avint`/`rem_avintr`). Tracking the dip allows them to verify at attach time that their parent is the actual system PIC instance, rather than silently operating against the wrong controller.

### intr: Add ihdl_plat fields for MSI/MSI-X

Add `ip_msi_devid`, `ip_msi_addr`, and `ip_msi_data` to the platform-specific interrupt handle structure (`ihdl_plat_t`).

On aarch64, MSI delivery requires the PCI nexus to program the device's MSI/MSI-X capability registers with a doorbell address and data value provided by the MSI controller (GICv2m or GICv3 ITS). These fields carry that information from the controller's ENABLE handler back to the nexus driver without introducing a direct coupling between them.

### Testing

All base FDT testing on my [feature/msi-msix](https://github.com/r1mikey/illumos-gate/tree/feature/msi-msix) branch, all ACPI testing on my [r1mikey/armh-sbbr-msi-msix](https://github.com/r1mikey/illumos-gate/tree/r1mikey/armh-sbbr-msi-msix) branch.

* [QEMU virt FDT](https://gist.github.com/r1mikey/915102a57815af1fc81e226b95ad921a) (GICv2): vioblk on SPIs 80+81, clean boot
* [QEMU virt FDT](https://gist.github.com/r1mikey/8b6b98c66f7acd130e05bf49b364fe96) (GICv3): vioblk on LPIs 8192+8193, clean boot
* [RPi4 FDT](https://gist.github.com/r1mikey/4952a56c12bb10f770536132de934b89): intentionally still on the INTx path, no regression
* [QEMU virt ACPI](https://gist.github.com/r1mikey/d4e76c63e21bf1fc2b9f98357b1207d4) (GICv3): 6 LPIs across vioblk/vioif/xhci, clean boot
* Ampere [Altra Max ACPI](https://gist.github.com/r1mikey/38de5803a035bf402c724ccdcd3161e0) (GICv3): nvme*2, ixgbe*2, xhci, igb, [67 LPIs](https://gist.github.com/r1mikey/c676ee43f158b9bac98a89d66b01f8f3), INTx on pcieb