### PR TITLE
GICv3 MSI/MSI-X support

### DIFF
--- a/usr/src/pkg/manifests/system-kernel-platform.aarch64.inc
+++ b/usr/src/pkg/manifests/system-kernel-platform.aarch64.inc
@@ -48,6 +48,7 @@ file path=platform/armv8/kernel/drv/$(ARCH)/efifb
 file path=platform/armv8/kernel/drv/$(ARCH)/gicthree
 file path=platform/armv8/kernel/drv/$(ARCH)/gictwo
 file path=platform/armv8/kernel/drv/$(ARCH)/gicv2m
+file path=platform/armv8/kernel/drv/$(ARCH)/gicv3_its
 file path=platform/armv8/kernel/drv/$(ARCH)/ns16550a
 file path=platform/armv8/kernel/drv/$(ARCH)/rootnex
 file path=platform/armv8/kernel/drv/$(ARCH)/simple-bus
@@ -74,6 +75,7 @@ driver name=gictwo \
     alias=arm,cortex-a15-gic \
     alias=arm,gic-400
 driver name=gicv2m alias=arm,gic-v2m-frame
+driver name=gicv3_its alias=arm,gic-v3-its
 driver name=ns16550a perms="* 0666 root sys" perms="*,cu 0600 uucp uucp" \
     alias=arm,pl011
 driver name=rootnex

--- a/usr/src/uts/armv8/Makefile.armv8
+++ b/usr/src/uts/armv8/Makefile.armv8
@@ -226,6 +226,7 @@ DRV_KMODS += ns16550a
 DRV_KMODS += gictwo
 DRV_KMODS += gicthree
 DRV_KMODS += gicv2m
+DRV_KMODS += gicv3_its
 DRV_KMODS += pl03one
 DRV_KMODS += efifb
 DRV_KMODS += pcieb

--- a/usr/src/uts/armv8/Makefile.files
+++ b/usr/src/uts/armv8/Makefile.files
@@ -160,6 +160,7 @@ ARM_GTMR_OBJS += arm_gtmr.o
 GICTWO_OBJS += gictwo.o
 GICV2M_OBJS += gicv2m.o
 GICTHREE_OBJS += gicthree.o
+GICV3_ITS_OBJS += gicv3_its.o
 
 PL03ONE_OBJS += pl03one.o
 

--- a/usr/src/uts/armv8/gicv3_its/Makefile
+++ b/usr/src/uts/armv8/gicv3_its/Makefile
@@ -1,0 +1,63 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2026 Michael van der Westhuizen
+#
+
+#
+#	Path to the base of the uts directory tree (usually /usr/src/uts).
+#
+UTSBASE	= ../..
+
+#
+#	Define the module and object file sets.
+#
+MODULE		= gicv3_its
+OBJECTS		= $(GICV3_ITS_OBJS:%=$(OBJS_DIR)/%)
+ROOTMODULE	= $(ROOT_PSM_DRV_DIR)/$(MODULE)
+
+#
+#	Include common rules.
+#
+include $(UTSBASE)/armv8/Makefile.armv8
+
+#
+#       Define targets
+#
+ALL_TARGET	= $(BINARY)
+INSTALL_TARGET	= $(BINARY) $(ROOTMODULE)
+
+#
+# depends on drv/gicthree
+#
+LDFLAGS         += -Ndrv/gicthree
+
+#
+#	Default build targets.
+#
+.KEEP_STATE:
+
+all:		$(ALL_DEPS)
+
+def:		$(DEF_DEPS)
+
+clean:		$(CLEAN_DEPS)
+
+clobber:	$(CLOBBER_DEPS)
+
+install:	$(INSTALL_DEPS)
+
+
+#
+#	Include common targets.
+#
+include $(UTSBASE)/armv8/Makefile.targ

--- a/usr/src/uts/armv8/io/gicthree.c
+++ b/usr/src/uts/armv8/io/gicthree.c
@@ -61,6 +61,17 @@
  * separate the running priority drop and deactivation of the interrupt.
  * Taking this approach alleviates the strict ordering requirement imposed
  * by the running priority drop, enabling full support for threaded IRQs.
+ *
+ * Lock ordering
+ * =============
+ *   gc_dist_lock (GICD_LOCK, spinlock + interrupts-disabled)
+ *     Protects all GICD register access for SPIs.
+ *
+ *   gc_lpi_prop_lock (mutex)
+ *     Protects the LPI property table (gc_lpi_prop) reads and writes.
+ *
+ *   ih_rwlock --> syspic_intrs_lock --> gc_dist_lock --> av_lock
+ *   gc_lpi_prop_lock is independent (no nesting with other locks).
  */
 
 #include <sys/types.h>
@@ -75,6 +86,10 @@
 #include <sys/sysmacros.h>
 #include <sys/archsystm.h>
 #include <sys/mach_intr.h>
+#include <sys/gic_v3.h>
+#include <sys/vmem.h>
+#include <vm/hat.h>
+#include <vm/hat_pte.h>
 
 /*
  * A redistributor region is a block of redistributor MMIO space. One finds
@@ -115,6 +130,10 @@ typedef struct {
 	caddr_t			gr_vlpi_base;
 	uint64_t		gr_typer;
 	uint64_t		gr_sgir;
+	caddr_t			gr_pend;	/* PENDBASER table VA */
+	uint64_t		gr_pend_pa;	/* PENDBASER table PA */
+	ddi_dma_handle_t	gr_pend_dmah;
+	ddi_acc_handle_t	gr_pend_acch;
 } gicv3_redistributor_t;
 
 typedef struct gicv3_conf {
@@ -152,6 +171,23 @@ typedef struct gicv3_conf {
 	 * only those CPUs we can target.
 	 */
 	cpuset_t		gc_cpuset;
+
+	/*
+	 * LPI support.  Populated unconditionally during attach if the
+	 * hardware supports LPIs (GICD_TYPER.LPIS).
+	 */
+	dev_info_t		*gc_dip;
+	uint32_t		gc_lpi_idbits;	/* GICD_TYPER IDbits value */
+	uint32_t		gc_lpi_max_intid; /* (1 << idbits) - 1 */
+	uint32_t		gc_lpi_count;	/* max_intid - 8191 */
+	vmem_t			*gc_lpi_arena;	/* LPI INTID allocator */
+	uint8_t			*gc_lpi_prop;	/* PROPBASER table VA */
+	uint64_t		gc_lpi_prop_pa;	/* PROPBASER table PA */
+	size_t			gc_lpi_prop_sz;	/* PROPBASER table bytes */
+	size_t			gc_lpi_pend_sz;	/* per-redist PENDBASER sz */
+	kmutex_t		gc_lpi_prop_lock; /* protects gc_lpi_prop */
+	ddi_dma_handle_t	gc_lpi_prop_dmah;
+	ddi_acc_handle_t	gc_lpi_prop_acch;
 
 	/*
 	 * System programmable interrupt controller registration control
@@ -247,6 +283,18 @@ gicr_rd_rmw4(gicv3_redistributor_t *r,
     uint32_t reg, uint32_t clrbits, uint32_t setbits)
 {
 	return (reg_rmw4(r->gr_hdlp, r->gr_rd_base, reg, clrbits, setbits));
+}
+
+static inline uint64_t
+gicr_rd_read8(gicv3_redistributor_t *r, uint32_t reg)
+{
+	return (ddi_get64(r->gr_hdlp, (uint64_t *)(r->gr_rd_base + reg)));
+}
+
+static inline void
+gicr_rd_write8(gicv3_redistributor_t *r, uint32_t reg, uint64_t val)
+{
+	ddi_put64(r->gr_hdlp, (uint64_t *)(r->gr_rd_base + reg), val);
 }
 
 /*
@@ -375,7 +423,7 @@ gicv3_config_irq_spi(gicv3_conf_t *gc, uint32_t irq, uint32_t v)
 		    GICD_ICFGR_REGVAL(irq, v)) {
 			cmn_err(CE_WARN, "gicthree: vector %d already "
 			    "configured differently", irq);
-			return;
+			goto unlock;
 		}
 
 	} else {
@@ -384,6 +432,8 @@ gicv3_config_irq_spi(gicv3_conf_t *gc, uint32_t irq, uint32_t v)
 		    GICD_ICFGR_REGVAL(irq, GICD_ICFGR_INT_CONFIG_MASK),
 		    GICD_ICFGR_REGVAL(irq, v));
 	}
+
+unlock:
 	GICD_UNLOCK(gc);
 }
 
@@ -533,6 +583,8 @@ gicv3_addspl(spo_ctx_t ctx, intr_intid_t intid, intr_ipl_t ipl,
 		    gicv3_addspl_percpu, (uint32_t)intid, (uint32_t)ipl);
 	} else if (GIC_INTID_IS_SPI(intid)) {
 		gicv3_addspl_spi(gc, (uint32_t)intid, (uint32_t)ipl);
+	} else if (GIC_INTID_IS_LPI(intid)) {
+		/* LPIs: config via PROPBASER table, not the distributor */
 	}
 
 	if (state != NULL) {
@@ -624,6 +676,8 @@ gicv3_delspl(spo_ctx_t ctx, intr_intid_t intid, intr_ipl_t ipl __unused,
 			    gicv3_delspl_percpu, (uint32_t)intid, 0);
 		} else if (GIC_INTID_IS_SPI(intid)) {
 			gicv3_delspl_spi(gc, (uint32_t)intid);
+		} else if (GIC_INTID_IS_LPI(intid)) {
+			/* LPIs: managed by ITS, not the distributor */
 		}
 
 		mutex_exit(&syspic_intrs_lock);
@@ -985,6 +1039,239 @@ gicv3_enable_system_register_access(void)
 }
 
 /*
+ * Allocate a physically contiguous, zeroed buffer and return both its
+ * virtual address and physical address.  The DMA and acc handles are
+ * returned for bookkeeping; the GIC never detaches so they are never freed.
+ *
+ * Exported for use by the ITS, which also never detaches, but does
+ * free these allocations during LPI lifecycle management.
+ */
+int
+gicv3_contig_alloc(dev_info_t *dip, size_t size, size_t align,
+    caddr_t *vap, uint64_t *pap, ddi_dma_handle_t *dma_hdlp,
+    ddi_acc_handle_t *acc_hdlp)
+{
+	ddi_dma_attr_t dma_attr = {
+		.dma_attr_version = DMA_ATTR_V0,
+		.dma_attr_addr_lo = 0,
+		.dma_attr_addr_hi = 0xFFFFFFFFFFFFFFFFull,
+		.dma_attr_count_max = 0xFFFFFFFFFFFFFFFFull,
+		.dma_attr_align = align,
+		.dma_attr_burstsizes = 0,
+		.dma_attr_minxfer = 1,
+		.dma_attr_maxxfer = 0xFFFFFFFFFFFFFFFFull,
+		.dma_attr_seg = 0xFFFFFFFFFFFFFFFFull,
+		.dma_attr_sgllen = 1,	/* guarantees physical contiguity */
+		.dma_attr_granular = 1,
+		.dma_attr_flags = 0,
+	};
+	ddi_device_acc_attr_t acc_attr = {
+		.devacc_attr_version = DDI_DEVICE_ATTR_V0,
+		.devacc_attr_endian_flags = DDI_NEVERSWAP_ACC,
+		.devacc_attr_dataorder = DDI_STRICTORDER_ACC,
+	};
+	size_t real_size;
+	uint_t ncookies;
+	ddi_dma_cookie_t cookie;
+	int ret;
+
+	if ((ret = ddi_dma_alloc_handle(dip, &dma_attr, DDI_DMA_SLEEP,
+	    NULL, dma_hdlp)) != DDI_SUCCESS) {
+		return (ret);
+	}
+
+	if ((ret = ddi_dma_mem_alloc(*dma_hdlp, size, &acc_attr,
+	    DDI_DMA_CONSISTENT, DDI_DMA_SLEEP, NULL,
+	    vap, &real_size, acc_hdlp)) != DDI_SUCCESS) {
+		ddi_dma_free_handle(dma_hdlp);
+		return (ret);
+	}
+
+	bzero(*vap, real_size);
+
+	ret = ddi_dma_addr_bind_handle(*dma_hdlp, NULL, *vap, real_size,
+	    DDI_DMA_RDWR | DDI_DMA_CONSISTENT, DDI_DMA_SLEEP, NULL,
+	    &cookie, &ncookies);
+	if (ret != DDI_DMA_MAPPED || ncookies != 1) {
+		ddi_dma_mem_free(acc_hdlp);
+		ddi_dma_free_handle(dma_hdlp);
+		return (DDI_FAILURE);
+	}
+
+	*pap = cookie.dmac_laddress;
+	return (DDI_SUCCESS);
+}
+
+void
+gicv3_contig_free(ddi_dma_handle_t *dma_hdlp, ddi_acc_handle_t *acc_hdlp)
+{
+	(void) ddi_dma_unbind_handle(*dma_hdlp);
+	ddi_dma_mem_free(acc_hdlp);
+	ddi_dma_free_handle(dma_hdlp);
+}
+
+/*
+ * Allocate LPI property and pending tables, and create the vmem arena
+ * for LPI INTID allocation.
+ *
+ * Called during GICv3 attach, after redistributors have been assigned.
+ * If the hardware does not support LPIs (GICD_TYPER.LPIS == 0), this
+ * is a no-op.
+ */
+static int
+gicv3_init_lpis(gicv3_conf_t *gc)
+{
+	uint32_t idbits;
+	uint32_t i;
+
+	/* Check if LPIs are supported */
+	if ((gc->gc_gicd_typer & GICD_TYPER_LPIS) == 0)
+		return (DDI_SUCCESS);
+
+	idbits = GICD_TYPER_IDBITS(gc->gc_gicd_typer);
+	gc->gc_lpi_idbits = idbits;
+	gc->gc_lpi_max_intid = (1U << idbits) - 1;
+	gc->gc_lpi_count = gc->gc_lpi_max_intid - GIC_INTID_LPI_MIN + 1;
+
+	/*
+	 * PROPBASER table: one byte per LPI INTID (8192 to max_intid).
+	 * Must be page-aligned and physically contiguous.
+	 */
+	gc->gc_lpi_prop_sz = gc->gc_lpi_max_intid + 1 - GIC_INTID_LPI_MIN;
+
+	if (gicv3_contig_alloc(gc->gc_dip, gc->gc_lpi_prop_sz,
+	    PAGESIZE, (caddr_t *)&gc->gc_lpi_prop, &gc->gc_lpi_prop_pa,
+	    &gc->gc_lpi_prop_dmah, &gc->gc_lpi_prop_acch) != DDI_SUCCESS) {
+		dev_err(gc->gc_dip, CE_WARN,
+		    "failed to allocate LPI property table (%lu bytes)",
+		    (unsigned long)gc->gc_lpi_prop_sz);
+		return (DDI_FAILURE);
+	}
+
+	/*
+	 * All LPI configs start as disabled at lowest priority.
+	 * The bzero in gicv3_contig_alloc handles this (prio=0, enable=0).
+	 */
+	mutex_init(&gc->gc_lpi_prop_lock, NULL, MUTEX_DEFAULT, NULL);
+
+	/*
+	 * PENDBASER tables: one bit per INTID, per redistributor.
+	 * Must be 64KB-aligned and physically contiguous.
+	 */
+	gc->gc_lpi_pend_sz = (gc->gc_lpi_max_intid + 1) / 8;
+
+	for (i = 0; i < gc->gc_num_redist; i++) {
+		gicv3_redistributor_t *r = &gc->gc_redist[i];
+
+		if (gicv3_contig_alloc(gc->gc_dip, gc->gc_lpi_pend_sz,
+		    GICV3_ITS_PEND_ALIGN, (caddr_t *)&r->gr_pend,
+		    &r->gr_pend_pa, &r->gr_pend_dmah, &r->gr_pend_acch)
+		    != DDI_SUCCESS) {
+			dev_err(gc->gc_dip, CE_WARN,
+			    "failed to allocate PENDBASER for redist %u", i);
+			goto fail_pend;
+		}
+	}
+
+	/* Create vmem arena for LPI INTID allocation */
+	gc->gc_lpi_arena = vmem_create("lpi_intid",
+	    (void *)(uintptr_t)GIC_INTID_LPI_MIN,
+	    gc->gc_lpi_count, 1, NULL, NULL, NULL, 0, VM_SLEEP);
+
+	return (DDI_SUCCESS);
+
+fail_pend:
+	while (i-- > 0) {
+		gicv3_redistributor_t *r = &gc->gc_redist[i];
+		ddi_dma_mem_free(&r->gr_pend_acch);
+		ddi_dma_free_handle(&r->gr_pend_dmah);
+	}
+	ddi_dma_mem_free(&gc->gc_lpi_prop_acch);
+	ddi_dma_free_handle(&gc->gc_lpi_prop_dmah);
+	return (DDI_FAILURE);
+}
+
+/*
+ * Program LPI tables on a single redistributor and enable LPIs.
+ *
+ * GICR_PROPBASER and GICR_PENDBASER must be written before
+ * GICR_CTLR.EnableLPIs is set.  Once EnableLPIs is set, both
+ * registers become read-only until the redistributor is reset.
+ *
+ * We request inner-shareable, read/write-allocate write-back cacheable.
+ * The hardware may modify the shareability; if it clears it to
+ * non-shareable we retry with non-cacheable.
+ */
+static void
+gicv3_enable_redist_lpis(gicv3_conf_t *gc, gicv3_redistributor_t *r)
+{
+	uint64_t val, readback;
+
+	/* Skip if LPIs are not supported */
+	if (gc->gc_lpi_count == 0) {
+		return;
+	}
+
+	/* Skip if already enabled (one-shot register) */
+	if (gicr_rd_read4(r, GICR_CTLR) & GICR_CTLR_EnableLPIs) {
+		return;
+	}
+
+	/*
+	 * Program GICR_PROPBASER: shared table across all redistributors.
+	 */
+	val = (gc->gc_lpi_prop_pa & GICR_PROPBASER_Physical_Address) |
+	    GICR_PROPBASER_OC(GIC_CACHE_RaWaWb) |
+	    GICR_PROPBASER_SHARE(GIC_SHARE_IS) |
+	    GICR_PROPBASER_IC(GIC_CACHE_RaWaWb) |
+	    (uint64_t)(gc->gc_lpi_idbits - 1);
+	gicr_rd_write8(r, GICR_PROPBASER, val);
+
+	/* Read back - hardware may modify shareability */
+	readback = gicr_rd_read8(r, GICR_PROPBASER);
+	if ((readback & GICR_PROPBASER_Shareability) ==
+	    GICR_PROPBASER_SHARE(GIC_SHARE_NS)) {
+		/* Hardware rejected shareability; use non-cacheable */
+		val = (gc->gc_lpi_prop_pa &
+		    GICR_PROPBASER_Physical_Address) |
+		    GICR_PROPBASER_OC(GIC_CACHE_nC) |
+		    GICR_PROPBASER_SHARE(GIC_SHARE_NS) |
+		    GICR_PROPBASER_IC(GIC_CACHE_nC) |
+		    (uint64_t)(gc->gc_lpi_idbits - 1);
+		gicr_rd_write8(r, GICR_PROPBASER, val);
+	}
+
+	/*
+	 * Program GICR_PENDBASER: per-redistributor table.
+	 * PTZ=1 indicates the table is zeroed (we zeroed at allocation).
+	 */
+	val = (r->gr_pend_pa & GICR_PENDBASER_Physical_Address) |
+	    GICR_PENDBASER_PTZ |
+	    GICR_PENDBASER_OC(GIC_CACHE_RaWaWb) |
+	    GICR_PENDBASER_SHARE(GIC_SHARE_IS) |
+	    GICR_PENDBASER_IC(GIC_CACHE_RaWaWb);
+	gicr_rd_write8(r, GICR_PENDBASER, val);
+
+	readback = gicr_rd_read8(r, GICR_PENDBASER);
+	if ((readback & GICR_PENDBASER_Shareability) ==
+	    GICR_PENDBASER_SHARE(GIC_SHARE_NS)) {
+		val = (r->gr_pend_pa &
+		    GICR_PENDBASER_Physical_Address) |
+		    GICR_PENDBASER_PTZ |
+		    GICR_PENDBASER_OC(GIC_CACHE_nC) |
+		    GICR_PENDBASER_SHARE(GIC_SHARE_NS) |
+		    GICR_PENDBASER_IC(GIC_CACHE_nC);
+		gicr_rd_write8(r, GICR_PENDBASER, val);
+	}
+
+	/*
+	 * Enable LPIs.  This is a one-shot - once set, PROPBASER and
+	 * PENDBASER become read-only until reset.
+	 */
+	(void) gicr_rd_rmw4(r, GICR_CTLR, 0, GICR_CTLR_EnableLPIs);
+}
+
+/*
  * Public function used for initializing CPUs.
  *
  * The boot processor is initialized from the tail of the main gicv3_init
@@ -1038,6 +1325,11 @@ gicv3_cpu_init_raw(gicv3_conf_t *gc, cpu_t *cp)
 	gicv3_init_gicr(&gc->gc_redist[cp->cpu_id], 0, 0);
 
 	/*
+	 * Program LPI tables and enable LPIs on this redistributor.
+	 */
+	gicv3_enable_redist_lpis(gc, &gc->gc_redist[cp->cpu_id]);
+
+	/*
 	 * Finally, tell the world we're ready.
 	 */
 	CPUSET_ADD(gc->gc_cpuset, cp->cpu_id);
@@ -1060,6 +1352,8 @@ static int
 gicv3_init(dev_info_t *dip, gicv3_conf_t *gc)
 {
 	uint32_t	n;
+
+	gc->gc_dip = dip;
 
 	/*
 	 * Global initialization involves the distributor, so lock it.
@@ -1160,6 +1454,16 @@ gicv3_init(dev_info_t *dip, gicv3_conf_t *gc)
 	 * No CPUs have been configured yet.
 	 */
 	CPUSET_ZERO(gc->gc_cpuset);
+
+	/*
+	 * Initialize LPI tables.  This must happen before the first
+	 * call to gicv3_cpu_init_raw, which enables LPIs on the boot
+	 * processor's redistributor.
+	 */
+	if (gicv3_init_lpis(gc) != DDI_SUCCESS) {
+		dev_err(dip, CE_WARN, "failed to initialize LPI tables");
+		return (DDI_FAILURE);
+	}
 
 	/*
 	 * Initialize the boot processor.
@@ -1333,6 +1637,38 @@ gicv3_bus_ctl(dev_info_t *dip, dev_info_t *rdip, ddi_ctl_enum_t ctlop,
 }
 
 /*
+ * Return the pending state of an SGI, PPI, or SPI from the GICv3 hardware.
+ *
+ * SGIs and PPIs (INTIDs 0-31) are per-CPU: their pending state lives in
+ * GICR_ISPENDR0 on the current CPU's redistributor.  SPIs (INTIDs 32-1019)
+ * are shared: their pending state lives in GICD_ISPENDRn on the distributor.
+ *
+ * This is inherently racy: the pending bit can change at any instant.
+ * The result is a best-effort snapshot for diagnostic use.
+ */
+static boolean_t
+gicv3_irq_ispending(gicv3_conf_t *gc, uint32_t irq)
+{
+	uint32_t val;
+
+	ASSERT(GIC_INTID_IS_SGI(irq) || GIC_INTID_IS_PPI(irq) ||
+	    GIC_INTID_IS_SPI(irq));
+
+	if (GIC_INTID_IS_PERCPU(irq)) {
+		gicv3_redistributor_t *r;
+
+		VERIFY3U(CPU->cpu_id, <, gc->gc_num_redist);
+		r = &gc->gc_redist[CPU->cpu_id];
+
+		val = gicr_sgi_read4(r, GICR_ISPENDR0);
+		return ((val & GICD_IPENDR_REGBIT(irq)) != 0);
+	}
+
+	val = gicd_read4(gc, GICD_ISPENDRn(GICD_IPENDR_REGNUM(irq)));
+	return ((val & GICD_IPENDR_REGBIT(irq)) != 0);
+}
+
+/*
  * Field interrupt operation requests to program this interrupt controller.
  *
  * We only handle the subset of requests that are routed toward an interrupt
@@ -1429,6 +1765,26 @@ gicv3_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 		break;
 	}
 
+	case DDI_INTROP_GETPENDING: {
+		gicv3_conf_t *gc =
+		    ddi_get_soft_state(gicv3_soft_state,
+		    ddi_get_instance(dip));
+		uint32_t irq = hdlp->ih_vector;
+
+		VERIFY3P(gc, !=, NULL);
+		*(int *)result = gicv3_irq_ispending(gc, irq) ? 1 : 0;
+		break;
+	}
+
+	case DDI_INTROP_GETCAP:
+		*(int *)result |= DDI_INTR_FLAG_PENDING;
+		*(int *)result |= DDI_INTR_FLAG_EDGE;
+		*(int *)result |= DDI_INTR_FLAG_LEVEL;
+		break;
+
+	case DDI_INTROP_SETCAP:
+		return (DDI_ENOTSUP);
+
 	/* Operations that are valid for us, but unimplemented */
 	case DDI_INTROP_BLOCKDISABLE:
 	case DDI_INTROP_BLOCKENABLE:
@@ -1439,14 +1795,11 @@ gicv3_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 	case DDI_INTROP_CLRMASK:
 	case DDI_INTROP_DUPVEC:
 	case DDI_INTROP_FREE:
-	case DDI_INTROP_GETCAP:
-	case DDI_INTROP_GETPENDING:
 	case DDI_INTROP_GETPOOL:
 	case DDI_INTROP_GETPRI:
 	case DDI_INTROP_GETTARGET:
 	case DDI_INTROP_NAVAIL:
 	case DDI_INTROP_NINTRS:
-	case DDI_INTROP_SETCAP:
 	case DDI_INTROP_SETMASK:
 	case DDI_INTROP_SETPRI:
 	case DDI_INTROP_SETTARGET:
@@ -1459,13 +1812,219 @@ gicv3_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 	return (DDI_SUCCESS);
 }
 
+/*
+ * LPI INTID allocation - for ITS and MBI drivers.
+ */
+int
+gicv3_alloc_lpi(dev_info_t *gic_dip, uint32_t *intid)
+{
+	gicv3_conf_t *gc = ddi_get_soft_state(gicv3_soft_state,
+	    ddi_get_instance(gic_dip));
+	void *id;
+
+	VERIFY3P(gc, !=, NULL);
+	if (gc->gc_lpi_arena == NULL)
+		return (ENOTSUP);
+
+	id = vmem_alloc(gc->gc_lpi_arena, 1, VM_NOSLEEP);
+	if (id == NULL)
+		return (ENOMEM);
+	*intid = (uint32_t)(uintptr_t)id;
+	return (0);
+}
+
+int
+gicv3_alloc_lpi_block(dev_info_t *gic_dip, uint32_t count, uint32_t align,
+    uint32_t *base)
+{
+	gicv3_conf_t *gc = ddi_get_soft_state(gicv3_soft_state,
+	    ddi_get_instance(gic_dip));
+	void *id;
+
+	VERIFY3P(gc, !=, NULL);
+	if (gc->gc_lpi_arena == NULL)
+		return (ENOTSUP);
+
+	id = vmem_xalloc(gc->gc_lpi_arena, count, align,
+	    0, 0, NULL, NULL, VM_NOSLEEP);
+	if (id == NULL)
+		return (ENOMEM);
+	*base = (uint32_t)(uintptr_t)id;
+	return (0);
+}
+
+void
+gicv3_free_lpi(dev_info_t *gic_dip, uint32_t intid)
+{
+	gicv3_conf_t *gc = ddi_get_soft_state(gicv3_soft_state,
+	    ddi_get_instance(gic_dip));
+
+	VERIFY3P(gc, !=, NULL);
+	vmem_free(gc->gc_lpi_arena, (void *)(uintptr_t)intid, 1);
+}
+
+void
+gicv3_free_lpi_block(dev_info_t *gic_dip, uint32_t base, uint32_t count)
+{
+	gicv3_conf_t *gc = ddi_get_soft_state(gicv3_soft_state,
+	    ddi_get_instance(gic_dip));
+
+	VERIFY3P(gc, !=, NULL);
+	vmem_xfree(gc->gc_lpi_arena, (void *)(uintptr_t)base, count);
+}
+
+size_t
+gicv3_lpi_navail(dev_info_t *gic_dip)
+{
+	gicv3_conf_t *gc = ddi_get_soft_state(gicv3_soft_state,
+	    ddi_get_instance(gic_dip));
+
+	VERIFY3P(gc, !=, NULL);
+	if (gc->gc_lpi_arena == NULL)
+		return (0);
+	return (vmem_size(gc->gc_lpi_arena, VMEM_FREE));
+}
+
+void
+gicv3_lpi_set_config(dev_info_t *gic_dip, uint32_t intid, uint8_t prio,
+    boolean_t enable)
+{
+	gicv3_conf_t *gc = ddi_get_soft_state(gicv3_soft_state,
+	    ddi_get_instance(gic_dip));
+
+	VERIFY3P(gc, !=, NULL);
+	VERIFY3U(intid, >=, GIC_INTID_LPI_MIN);
+	VERIFY3U(intid, <=, gc->gc_lpi_max_intid);
+
+	mutex_enter(&gc->gc_lpi_prop_lock);
+	gc->gc_lpi_prop[intid - GIC_INTID_LPI_MIN] =
+	    (prio & 0xfc) | (enable ? 1 : 0);
+
+	/*
+	 * Ensure the store to the property table is visible before
+	 * the caller issues an ITS INV command.  If the redistributor's
+	 * PROPBASER was programmed as non-shareable (hardware may
+	 * downgrade shareability), the store could sit in a CPU-private
+	 * write buffer without this barrier.
+	 */
+	membar_producer();
+	mutex_exit(&gc->gc_lpi_prop_lock);
+}
+
+uint8_t
+gicv3_lpi_get_config(dev_info_t *gic_dip, uint32_t intid)
+{
+	gicv3_conf_t *gc = ddi_get_soft_state(gicv3_soft_state,
+	    ddi_get_instance(gic_dip));
+	uint8_t val;
+
+	VERIFY3P(gc, !=, NULL);
+	VERIFY3U(intid, >=, GIC_INTID_LPI_MIN);
+	VERIFY3U(intid, <=, gc->gc_lpi_max_intid);
+
+	mutex_enter(&gc->gc_lpi_prop_lock);
+	val = gc->gc_lpi_prop[intid - GIC_INTID_LPI_MIN];
+	mutex_exit(&gc->gc_lpi_prop_lock);
+
+	return (val);
+}
+
+/*
+ * Return the pending state of an LPI from the redistributor's PENDBASER
+ * table.
+ *
+ * The pending table is DMA memory shared with the redistributor hardware.
+ * We sync for CPU read, then check the bit corresponding to the LPI INTID
+ * in the target CPU's pending table.
+ *
+ * This is inherently racy: the redistributor may set or clear the bit at
+ * any instant.  The result is a best-effort snapshot for diagnostic use.
+ */
+boolean_t
+gicv3_lpi_ispending(dev_info_t *gic_dip, uint32_t intid,
+    processorid_t cpuid)
+{
+	gicv3_conf_t *gc = ddi_get_soft_state(gicv3_soft_state,
+	    ddi_get_instance(gic_dip));
+	gicv3_redistributor_t *r;
+	uint8_t byte;
+
+	VERIFY3P(gc, !=, NULL);
+	VERIFY3U(intid, >=, GIC_INTID_LPI_MIN);
+	VERIFY3U(intid, <=, gc->gc_lpi_max_intid);
+	VERIFY3S(cpuid, >=, 0);
+	VERIFY3U((uint32_t)cpuid, <, gc->gc_num_redist);
+
+	r = &gc->gc_redist[cpuid];
+
+	/* Sync the pending table DMA memory for CPU read */
+	(void) ddi_dma_sync(r->gr_pend_dmah, 0, gc->gc_lpi_pend_sz,
+	    DDI_DMA_SYNC_FORCPU);
+
+	byte = ((uint8_t *)r->gr_pend)[intid / 8];
+	return ((byte & (1U << (intid % 8))) != 0);
+}
+
+uint64_t
+gicv3_redist_pa(dev_info_t *gic_dip, processorid_t cpuid)
+{
+	gicv3_conf_t *gc = ddi_get_soft_state(gicv3_soft_state,
+	    ddi_get_instance(gic_dip));
+
+	VERIFY3P(gc, !=, NULL);
+	VERIFY3S(cpuid, >=, 0);
+	VERIFY3U((uint32_t)cpuid, <, gc->gc_num_redist);
+
+	return (pfn_to_pa(hat_getpfnum(kas.a_hat,
+	    gc->gc_redist[cpuid].gr_rd_base)));
+}
+
+uint32_t
+gicv3_redist_procnum(dev_info_t *gic_dip, processorid_t cpuid)
+{
+	gicv3_conf_t *gc = ddi_get_soft_state(gicv3_soft_state,
+	    ddi_get_instance(gic_dip));
+
+	VERIFY3P(gc, !=, NULL);
+	VERIFY3S(cpuid, >=, 0);
+	VERIFY3U((uint32_t)cpuid, <, gc->gc_num_redist);
+
+	return (GICR_TYPER_PROCNUM(gc->gc_redist[cpuid].gr_typer));
+}
+
+uint32_t
+gicv3_num_redists(dev_info_t *gic_dip)
+{
+	gicv3_conf_t *gc = ddi_get_soft_state(gicv3_soft_state,
+	    ddi_get_instance(gic_dip));
+
+	VERIFY3P(gc, !=, NULL);
+	return (gc->gc_num_redist);
+}
+
+uint32_t
+gicv3_lpi_idbits(dev_info_t *gic_dip)
+{
+	gicv3_conf_t *gc = ddi_get_soft_state(gicv3_soft_state,
+	    ddi_get_instance(gic_dip));
+
+	VERIFY3P(gc, !=, NULL);
+	return (gc->gc_lpi_idbits);
+}
+
 static struct bus_ops gicv3_bus_ops = {
 	.busops_rev = BUSO_REV,
 	.bus_map = i_ddi_bus_map,
 	.bus_map_fault = i_ddi_map_fault,
-	.bus_dma_map = ddi_no_dma_map,
-	.bus_dma_allochdl = ddi_no_dma_allochdl,
+	.bus_dma_allochdl = ddi_dma_allochdl,
+	.bus_dma_freehdl = ddi_dma_freehdl,
+	.bus_dma_bindhdl = ddi_dma_bindhdl,
+	.bus_dma_unbindhdl = ddi_dma_unbindhdl,
+	.bus_dma_flush = ddi_dma_flush,
+	.bus_dma_win = ddi_dma_win,
+	.bus_dma_ctl = ddi_dma_mctl,
 	.bus_ctl = gicv3_bus_ctl,
+	.bus_prop_op = ddi_bus_prop_op,
 	.bus_intr_op = gicv3_intr_ops,
 };
 

--- a/usr/src/uts/armv8/io/gicv3_its.c
+++ b/usr/src/uts/armv8/io/gicv3_its.c
@@ -1,0 +1,1910 @@
+/*
+ * Derived from:
+ * $OpenBSD: agintc.c,v 1.65 2025/12/15 12:59:24 dlg Exp $
+ *
+ * Copyright (c) 2007, 2009, 2011, 2017 Dale Rahn <drahn@dalerahn.com>
+ * Copyright (c) 2018 Mark Kettenis <kettenis@openbsd.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2026 Michael van der Westhuizen
+ */
+
+/*
+ * GICv3 Interrupt Translation Service (ITS) Driver
+ *
+ * The ITS translates MSI/MSI-X writes from PCI devices into LPI interrupts
+ * on the GICv3 redistributor.  A PCI device writes an EventID to the
+ * GITS_TRANSLATER doorbell register; the ITS uses its device and interrupt
+ * translation tables to map the (DeviceID, EventID) pair to an (LPI INTID,
+ * target CPU) pair, which it forwards to the appropriate redistributor.
+ *
+ * Key hardware structures owned by this driver:
+ *
+ *   Command Queue   - ring buffer of 32-byte commands in DMA memory.
+ *                     Software writes commands and advances GITS_CWRITER;
+ *                     hardware reads commands and advances GITS_CREADR.
+ *
+ *   Device Table    - flat array indexed by DeviceID, pointing to per-device
+ *                     Interrupt Translation Tables (ITTs).  Programmed via
+ *                     GITS_BASERn and updated by MAPD commands.
+ *
+ *   Collection Table - maps CollectionIDs to redistributor targets.
+ *                      Programmed via GITS_BASERn (if HCC==0) or held
+ *                      internally by the ITS (if HCC>0).  Updated by MAPC.
+ *
+ *   ITT (per device) - maps EventIDs to (LPI, Collection) pairs.  Allocated
+ *                      by software in DMA memory; contents written by the
+ *                      ITS hardware via MAPTI/DISCARD commands.
+ *
+ * DeviceID arrives via hdlp->ih_private->ip_msi_devid.  The doorbell address
+ * and event data are set on the handle for framework use.
+ *
+ * Lock ordering
+ * =============
+ * The following lock ordering must be observed.  Never acquire in reverse.
+ *
+ *   cpu_lock  -->  its_dev_lock  -->  its_cmd_lock
+ *   its_dev_lock  -->  syspic_intrs_lock
+ *
+ * its_cmd_lock is acquired internally by the gicv3_its_cmd_* helper
+ * functions.  Callers that hold its_dev_lock and then issue commands
+ * follow the correct nesting order.
+ *
+ * cpu_lock is held by the framework when invoking cpu_setup_func callbacks.
+ * The callback acquires its_dev_lock (for migration) then issues commands
+ * (acquiring its_cmd_lock).
+ *
+ * syspic_intrs_lock is acquired via syspic_get_state() before add_avintr.
+ * It must not be held when calling ITS command functions.
+ *
+ * gc_lpi_prop_lock (in gicthree.c) is acquired independently via
+ * gicv3_lpi_set_config() - it is not nested with any ITS lock.
+ *
+ * Stall recovery
+ * ==============
+ * If the ITS encounters an unprocessable command, it sets
+ * GITS_CREADR.Stalled and halts.  We implement the "skip" recovery
+ * model from IHI 0069 §8.19.19: advance CREADR to CWRITER (skipping
+ * the entire pending batch), clear the Stalled bit, and return EIO
+ * to the caller.  This sacrifices the current command sequence but
+ * keeps the ITS alive for all other devices.  The stall count is
+ * tracked in its_stall_count for diagnostic and (future) FMA
+ * integration.
+ */
+
+#include <sys/types.h>
+#include <sys/stddef.h>
+#include <sys/inttypes.h>
+#include <sys/conf.h>
+#include <sys/ddi.h>
+#include <sys/ddi_impldefs.h>
+#include <sys/ddi_implfuncs.h>
+#include <sys/sunddi.h>
+#include <sys/sunndi.h>
+#include <sys/modctl.h>
+#include <sys/cmn_err.h>
+#include <sys/list.h>
+#include <sys/mutex.h>
+#include <sys/avintr.h>
+#include <sys/syspic.h>
+#include <sys/syspic_impl.h>
+#include <sys/gic_v3.h>
+#include <sys/gic_reg.h>
+#include <sys/byteorder.h>
+#include <sys/cpu.h>
+#include <sys/cpuvar.h>
+#include <sys/mach_intr.h>
+#include <sys/sysmacros.h>
+
+/* Command queue constants */
+#define	GICV3_ITS_CMDQ_SIZE		(64 * 1024)	/* 64KiB */
+#define	GICV3_ITS_CMDQ_NSLOTS		(GICV3_ITS_CMDQ_SIZE / 32)
+
+/* ITT minimum alignment (spec requirement) */
+#define	GICV3_ITS_ITT_ALIGN		256
+
+/* Timeout for command queue operations (microseconds) */
+#define	GICV3_ITS_CMD_TIMEOUT_US	1000000		/* 1 second */
+
+/* Timeout for ITS quiesce (microseconds) */
+#define	GICV3_ITS_QUIESCE_TIMEOUT_US	1000000		/* 1 second */
+
+/*
+ * ITS command opcodes
+ */
+#define	GITS_CMD_MOVI			0x01
+#define	GITS_CMD_INT			0x03
+#define	GITS_CMD_CLEAR			0x04
+#define	GITS_CMD_SYNC			0x05
+#define	GITS_CMD_MAPD			0x08
+#define	GITS_CMD_MAPC			0x09
+#define	GITS_CMD_MAPTI			0x0a
+#define	GITS_CMD_MAPI			0x0b
+#define	GITS_CMD_INV			0x0c
+#define	GITS_CMD_INVALL			0x0d
+#define	GITS_CMD_DISCARD		0x0f
+
+/*
+ * ITS command: 32 bytes, 4 DWORDs (little-endian).
+ * Built on stack, bcopy'd to queue.
+ */
+typedef struct gicv3_its_cmd {
+	uint64_t	raw[4];
+} gicv3_its_cmd_t;
+
+/*
+ * Per-vector state within a device's MSI allocation.
+ */
+typedef struct gicits_vec {
+	uint32_t	gv_eventid;	/* EventID for this vector */
+	uint32_t	gv_lpi;		/* LPI INTID */
+	processorid_t	gv_target_cpu;	/* current target CPU */
+	boolean_t	gv_enabled;	/* B_TRUE if MAPTI'd and active */
+} gicits_vec_t;
+
+/*
+ * Per-device MSI state.
+ *
+ * Tracks the ITT, LPI allocations, and per-vector mappings for a single
+ * PCI device.  ALLOC creates one and links it onto the ITS's device list.
+ * ENABLE/DISABLE manipulate individual vectors.  FREE tears it all down.
+ *
+ * Only one ALLOC per device is permitted (enforced with VERIFY).
+ */
+typedef struct gicits_dev_state {
+	list_node_t		ds_node;	/* linkage on its_devs */
+	dev_info_t		*ds_rdip;	/* owning PCI device */
+	uint32_t		ds_devid;	/* DeviceID */
+	int			ds_type;	/* DDI_INTR_TYPE_MSI[X] */
+	uint32_t		ds_nalloc;	/* vectors allocated */
+	uint32_t		ds_inum_base;	/* starting inum from ALLOC */
+
+	/* ITT (DMA memory, 256-byte aligned, hardware-opaque) */
+	caddr_t			ds_itt;		/* ITT VA */
+	uint64_t		ds_itt_pa;	/* ITT PA */
+	size_t			ds_itt_sz;	/* allocation size (bytes) */
+	uint8_t			ds_itt_bits;	/* log2(entries) for MAPD */
+	ddi_dma_handle_t	ds_itt_dmah;
+	ddi_acc_handle_t	ds_itt_acch;
+
+	/* Per-vector state (one per allocated interrupt) */
+	gicits_vec_t		*ds_vecs;
+	size_t			ds_vecs_sz;
+} gicits_dev_state_t;
+
+/*
+ * Soft state for each ITS instance.
+ */
+typedef struct gicv3_its_state {
+	dev_info_t		*its_dip;
+	dev_info_t		*its_gic_dip;		/* parent GICv3 */
+
+	/* MMIO */
+	caddr_t			its_base;		/* GITS register VA */
+	ddi_acc_handle_t	its_regh;
+	uint64_t		its_doorbell_pa;	/* PA of TRANSLATER */
+
+	/* GITS_TYPER parsed fields */
+	uint64_t		its_typer;		/* raw GITS_TYPER */
+	boolean_t		its_pta;		/* use PA for targets */
+	uint32_t		its_devbits;
+	uint32_t		its_idbits;
+	uint32_t		its_itt_entry_sz;
+	uint32_t		its_hcc;
+	uint32_t		its_max_colls;		/* usable collections */
+
+	/* Command queue */
+	caddr_t			its_cmd_base;		/* queue VA */
+	uint64_t		its_cmd_pa;		/* queue PA */
+	size_t			its_cmd_sz;		/* queue size */
+	uint32_t		its_cmd_write;		/* write offset */
+	kmutex_t		its_cmd_lock;
+	ddi_dma_handle_t	its_cmd_dmah;
+	ddi_acc_handle_t	its_cmd_acch;
+	boolean_t		its_cmd_needs_flush;
+	/* stall recoveries (its_cmd_lock) */
+	uint32_t		its_stall_count;
+
+	/* Device table (flat, 2^Devbits entries) */
+	caddr_t			its_devtab;
+	uint64_t		its_devtab_pa;
+	size_t			its_devtab_sz;
+	ddi_dma_handle_t	its_devtab_dmah;
+	ddi_acc_handle_t	its_devtab_acch;
+
+	/* Collection table (external, only if HCC == 0) */
+	caddr_t			its_colltab;
+	uint64_t		its_colltab_pa;
+	size_t			its_colltab_sz;
+	ddi_dma_handle_t	its_colltab_dmah;
+	ddi_acc_handle_t	its_colltab_acch;
+
+	/* Per-device state */
+	list_t			its_devs;		/* gicits_dev_state_t */
+	kmutex_t		its_dev_lock;
+
+	/* Global list linkage (in parent GICv3's its_list) */
+	list_node_t		its_node;
+} gicv3_its_state_t;
+
+static void *gicv3_its_soft_state;
+
+/* Forward declarations */
+static int gicv3_its_attach(dev_info_t *, ddi_attach_cmd_t);
+static int gicv3_its_detach(dev_info_t *, ddi_detach_cmd_t);
+static int gicv3_its_intr_ops(dev_info_t *, dev_info_t *,
+    ddi_intr_op_t, ddi_intr_handle_impl_t *, void *);
+static int gicv3_its_cpu_callback(cpu_setup_t, int, void *);
+
+/*
+ * Return B_TRUE if cpuid can be an ITS interrupt target.
+ *
+ * When HCC > 0, the ITS has a fixed number of internal collections
+ * and we use cpuid as the collection ID.  CPUs with IDs beyond the
+ * hardware limit cannot own a collection and therefore cannot be
+ * direct ITS targets.  When HCC == 0 we provide a software table
+ * sized for max_ncpus, so all CPUs are eligible (this is the common
+ * case on hardware that is not deeply embedded).
+ */
+static boolean_t
+gicv3_its_cpu_can_target(gicv3_its_state_t *sc, processorid_t cpuid)
+{
+	return ((uint32_t)cpuid < sc->its_max_colls);
+}
+
+/*
+ * MMIO helpers
+ */
+
+static inline uint32_t
+its_read32(gicv3_its_state_t *sc, uint32_t off)
+{
+	return (ddi_get32(sc->its_regh,
+	    (uint32_t *)(sc->its_base + off)));
+}
+
+static inline uint64_t
+its_read64(gicv3_its_state_t *sc, uint32_t off)
+{
+	return (ddi_get64(sc->its_regh,
+	    (uint64_t *)(sc->its_base + off)));
+}
+
+static inline void
+its_write32(gicv3_its_state_t *sc, uint32_t off, uint32_t val)
+{
+	ddi_put32(sc->its_regh,
+	    (uint32_t *)(sc->its_base + off), val);
+}
+
+static inline void
+its_write64(gicv3_its_state_t *sc, uint32_t off, uint64_t val)
+{
+	ddi_put64(sc->its_regh,
+	    (uint64_t *)(sc->its_base + off), val);
+}
+
+/*
+ * Per-device state lookup
+ */
+
+/*
+ * Find the per-device state for a given PCI device.
+ * Caller must hold sc->its_dev_lock.
+ */
+static gicits_dev_state_t *
+gicv3_its_find_dev(gicv3_its_state_t *sc, dev_info_t *rdip)
+{
+	gicits_dev_state_t *ds;
+
+	ASSERT(MUTEX_HELD(&sc->its_dev_lock));
+
+	for (ds = list_head(&sc->its_devs); ds != NULL;
+	    ds = list_next(&sc->its_devs, ds)) {
+		if (ds->ds_rdip == rdip)
+			return (ds);
+	}
+
+	return (NULL);
+}
+
+/*
+ * ITS command builder functions
+ *
+ * Each function populates a gicv3_its_cmd_t (on the caller's stack, passed
+ * in via a pointer).
+ *
+ * Wrapping the data in LE_64 is somewhat unnecessary, but free on the
+ * platforms we run on and useful as exposition.
+ */
+
+static void
+gicv3_its_cmd_build_mapd(gicv3_its_cmd_t *cmd, uint32_t devid,
+    uint8_t size, uint64_t itt_pa, boolean_t valid)
+{
+	bzero(cmd, sizeof (*cmd));
+	cmd->raw[0] = LE_64(((uint64_t)devid << 32) | GITS_CMD_MAPD);
+	cmd->raw[1] = LE_64((uint64_t)(size & 0x1f));
+	cmd->raw[2] = LE_64((valid ? (1ULL << 63) : 0) |
+	    (itt_pa & GITS_MAPD_ITT_ADDR));
+}
+
+static void
+gicv3_its_cmd_build_mapc(gicv3_its_cmd_t *cmd, uint16_t collid,
+    uint64_t target, boolean_t valid, boolean_t pta)
+{
+	bzero(cmd, sizeof (*cmd));
+	cmd->raw[0] = LE_64((uint64_t)GITS_CMD_MAPC);
+	if (pta) {
+		/* PTA=1: target is PA >> 16 in bits [51:16] */
+		cmd->raw[2] = LE_64((valid ? (1ULL << 63) : 0) |
+		    ((target & 0xFFFFFFFFFULL) << 16) | collid);
+	} else {
+		/* PTA=0: target is processor number in bits [15:0] */
+		cmd->raw[2] = LE_64((valid ? (1ULL << 63) : 0) |
+		    ((target & 0xFFFF) << 16) | collid);
+	}
+}
+
+static void
+gicv3_its_cmd_build_mapti(gicv3_its_cmd_t *cmd, uint32_t devid,
+    uint32_t eventid, uint32_t pintid, uint16_t collid)
+{
+	bzero(cmd, sizeof (*cmd));
+	cmd->raw[0] = LE_64(((uint64_t)devid << 32) | GITS_CMD_MAPTI);
+	cmd->raw[1] = LE_64(((uint64_t)pintid << 32) | eventid);
+	cmd->raw[2] = LE_64((uint64_t)collid);
+}
+
+static void
+gicv3_its_cmd_build_movi(gicv3_its_cmd_t *cmd, uint32_t devid,
+    uint32_t eventid, uint16_t collid)
+{
+	bzero(cmd, sizeof (*cmd));
+	cmd->raw[0] = LE_64(((uint64_t)devid << 32) | GITS_CMD_MOVI);
+	cmd->raw[1] = LE_64((uint64_t)eventid);
+	cmd->raw[2] = LE_64((uint64_t)collid);
+}
+
+static void
+gicv3_its_cmd_build_discard(gicv3_its_cmd_t *cmd, uint32_t devid,
+    uint32_t eventid)
+{
+	bzero(cmd, sizeof (*cmd));
+	cmd->raw[0] = LE_64(((uint64_t)devid << 32) | GITS_CMD_DISCARD);
+	cmd->raw[1] = LE_64((uint64_t)eventid);
+}
+
+static void
+gicv3_its_cmd_build_inv(gicv3_its_cmd_t *cmd, uint32_t devid,
+    uint32_t eventid)
+{
+	bzero(cmd, sizeof (*cmd));
+	cmd->raw[0] = LE_64(((uint64_t)devid << 32) | GITS_CMD_INV);
+	cmd->raw[1] = LE_64((uint64_t)eventid);
+}
+
+static void
+gicv3_its_cmd_build_sync(gicv3_its_cmd_t *cmd, uint64_t target,
+    boolean_t pta)
+{
+	bzero(cmd, sizeof (*cmd));
+	cmd->raw[0] = LE_64((uint64_t)GITS_CMD_SYNC);
+	if (pta) {
+		cmd->raw[2] = LE_64((target & 0xFFFFFFFFFULL) << 16);
+	} else {
+		cmd->raw[2] = LE_64((target & 0xFFFF) << 16);
+	}
+}
+
+/*
+ * Command queue submission and completion
+ */
+
+/*
+ * Recover from a command queue stall by skipping all pending commands.
+ *
+ * When the ITS encounters an unprocessable command, it sets
+ * GITS_CREADR.Stalled and halts.  We advance CREADR to the current
+ * CWRITER offset with Stalled=0, discarding all commands between the
+ * stalled entry and the write pointer.  This is the "skip" recovery
+ * model from the GICv3 specification (IHI 0069 §8.19.19).
+ *
+ * Skipping the entire batch (rather than advancing by one command) is
+ * deliberate: our command sequences (e.g. MAPTI+INV+SYNC) are submitted
+ * and polled for as atomic units under its_cmd_lock; if one command
+ * stalled, the remaining commands in the batch may depend on state it
+ * was meant to establish.
+ *
+ * The caller still receives EIO and propagates the failure through the
+ * DDI framework.  The ITS itself is left functional for subsequent
+ * commands from other devices.
+ *
+ * Caller must hold its_cmd_lock.
+ */
+static void
+gicv3_its_cmd_recover_stall(gicv3_its_state_t *sc, uint64_t creadr)
+{
+	uint64_t stall_offset = creadr & GITS_CREADR_Offset;
+	uint64_t cwriter = (uint64_t)sc->its_cmd_write;
+
+	ASSERT(MUTEX_HELD(&sc->its_cmd_lock));
+	ASSERT(creadr & GITS_CREADR_Stalled);
+
+	/*
+	 * Log the stalled command contents for post-mortem diagnosis.
+	 * The stall offset points at the command the hardware choked on.
+	 */
+	if (stall_offset < sc->its_cmd_sz) {
+		uint64_t *raw = (uint64_t *)(sc->its_cmd_base + stall_offset);
+		dev_err(sc->its_dip, CE_WARN,
+		    "ITS stall recovery: offset=0x%" PRIx64
+		    " CWRITER=0x%" PRIx64
+		    " cmd={0x%" PRIx64 ", 0x%" PRIx64
+		    ", 0x%" PRIx64 ", 0x%" PRIx64 "}",
+		    stall_offset, cwriter,
+		    raw[0], raw[1], raw[2], raw[3]);
+	}
+
+	/*
+	 * Advance CREADR to CWRITER with Stalled=0.
+	 * This discards all queued commands and clears the stall.
+	 */
+	its_write64(sc, GITS_CREADR, cwriter);
+
+	sc->its_stall_count++;
+
+	dev_err(sc->its_dip, CE_WARN,
+	    "ITS command queue stall cleared (recovery #%u)",
+	    sc->its_stall_count);
+}
+
+/*
+ * Submit a single 32-byte command to the ITS command queue.
+ * Caller must hold its_cmd_lock.
+ *
+ * Returns 0 on success, EIO if the queue is stalled, EBUSY if the
+ * queue did not drain within the timeout.
+ */
+static int
+gicv3_its_cmd_submit(gicv3_its_state_t *sc, gicv3_its_cmd_t *cmd)
+{
+	uint32_t next;
+	uint64_t creadr;
+	int timeout_us = GICV3_ITS_CMD_TIMEOUT_US;
+
+	ASSERT(MUTEX_HELD(&sc->its_cmd_lock));
+
+	/* Check for stall before writing, recover the queue if stalled */
+	creadr = its_read64(sc, GITS_CREADR);
+	if (creadr & GITS_CREADR_Stalled) {
+		gicv3_its_cmd_recover_stall(sc, creadr);
+		return (EIO);
+	}
+
+	next = (sc->its_cmd_write + sizeof (gicv3_its_cmd_t)) %
+	    sc->its_cmd_sz;
+
+	/* If queue is full, wait for hardware to consume entries */
+	while (next == (its_read64(sc, GITS_CREADR) & GITS_CREADR_Offset)) {
+		if (timeout_us <= 0) {
+			dev_err(sc->its_dip, CE_WARN,
+			    "command queue full timeout");
+			return (EBUSY);
+		}
+		drv_usecwait(10);
+		timeout_us -= 10;
+	}
+
+	/* Write command to queue slot */
+	bcopy(cmd, sc->its_cmd_base + sc->its_cmd_write,
+	    sizeof (gicv3_its_cmd_t));
+
+	/* Cache maintenance if shareability was downgraded */
+	if (sc->its_cmd_needs_flush) {
+		(void) ddi_dma_sync(sc->its_cmd_dmah,
+		    sc->its_cmd_write, sizeof (gicv3_its_cmd_t),
+		    DDI_DMA_SYNC_FORDEV);
+	}
+
+	/* Ensure command is visible before advancing CWRITER */
+	membar_producer();
+
+	/* Advance write pointer */
+	sc->its_cmd_write = next;
+	its_write64(sc, GITS_CWRITER, (uint64_t)next);
+
+	return (0);
+}
+
+/*
+ * Wait for the command queue to fully drain (CREADR == CWRITER).
+ * Caller must hold its_cmd_lock.
+ */
+static int
+gicv3_its_cmd_poll_completion(gicv3_its_state_t *sc)
+{
+	uint64_t creadr;
+	int timeout_us = GICV3_ITS_CMD_TIMEOUT_US;
+
+	ASSERT(MUTEX_HELD(&sc->its_cmd_lock));
+
+	for (;;) {
+		creadr = its_read64(sc, GITS_CREADR);
+
+		/*
+		 * Stall detected: recover by skipping all pending
+		 * commands to CWRITER.  The current batch is lost,
+		 * but the ITS remains usable for subsequent operations.
+		 */
+		if (creadr & GITS_CREADR_Stalled) {
+			gicv3_its_cmd_recover_stall(sc, creadr);
+			return (EIO);
+		}
+
+		if ((creadr & GITS_CREADR_Offset) == sc->its_cmd_write)
+			return (0);
+
+		if (timeout_us <= 0) {
+			dev_err(sc->its_dip, CE_WARN,
+			    "command queue timeout: CREADR=0x%" PRIx64
+			    " CWRITER=0x%x",
+			    creadr, sc->its_cmd_write);
+			return (ETIMEDOUT);
+		}
+
+		drv_usecwait(10);
+		timeout_us -= 10;
+	}
+}
+
+/*
+ * High-level command wrappers
+ *
+ * These acquire the command lock, build and submit the command(s),
+ * issue SYNC where appropriate, wait for drain, and release the lock.
+ */
+
+/*
+ * Compute the SYNC target value for a given CPU.
+ */
+static uint64_t
+gicv3_its_sync_target(gicv3_its_state_t *sc, processorid_t cpuid)
+{
+	if (sc->its_pta)
+		return (gicv3_redist_pa(sc->its_gic_dip, cpuid) >> 16);
+	else
+		return ((uint64_t)gicv3_redist_procnum(sc->its_gic_dip,
+		    cpuid));
+}
+
+static int
+gicv3_its_do_mapd(gicv3_its_state_t *sc, uint32_t devid, uint8_t size,
+    uint64_t itt_pa, boolean_t valid)
+{
+	gicv3_its_cmd_t cmd;
+	int ret;
+
+	mutex_enter(&sc->its_cmd_lock);
+
+	gicv3_its_cmd_build_mapd(&cmd, devid, size, itt_pa, valid);
+	ret = gicv3_its_cmd_submit(sc, &cmd);
+	if (ret == 0)
+		ret = gicv3_its_cmd_poll_completion(sc);
+
+	mutex_exit(&sc->its_cmd_lock);
+	return (ret);
+}
+
+static int
+gicv3_its_do_mapc(gicv3_its_state_t *sc, processorid_t cpuid,
+    boolean_t valid)
+{
+	gicv3_its_cmd_t cmd;
+	uint64_t target;
+	int ret;
+
+	target = gicv3_its_sync_target(sc, cpuid);
+
+	mutex_enter(&sc->its_cmd_lock);
+
+	gicv3_its_cmd_build_mapc(&cmd, (uint16_t)cpuid, target, valid,
+	    sc->its_pta);
+	ret = gicv3_its_cmd_submit(sc, &cmd);
+	if (ret == 0) {
+		gicv3_its_cmd_build_sync(&cmd, target, sc->its_pta);
+		ret = gicv3_its_cmd_submit(sc, &cmd);
+	}
+	if (ret == 0)
+		ret = gicv3_its_cmd_poll_completion(sc);
+
+	mutex_exit(&sc->its_cmd_lock);
+	return (ret);
+}
+
+static int
+gicv3_its_do_mapti(gicv3_its_state_t *sc, uint32_t devid, uint32_t eventid,
+    uint32_t lpi, uint16_t collid, processorid_t target_cpu)
+{
+	gicv3_its_cmd_t cmd;
+	uint64_t target;
+	int ret;
+
+	target = gicv3_its_sync_target(sc, target_cpu);
+
+	mutex_enter(&sc->its_cmd_lock);
+
+	gicv3_its_cmd_build_mapti(&cmd, devid, eventid, lpi, collid);
+	ret = gicv3_its_cmd_submit(sc, &cmd);
+	if (ret == 0) {
+		gicv3_its_cmd_build_inv(&cmd, devid, eventid);
+		ret = gicv3_its_cmd_submit(sc, &cmd);
+	}
+	if (ret == 0) {
+		gicv3_its_cmd_build_sync(&cmd, target, sc->its_pta);
+		ret = gicv3_its_cmd_submit(sc, &cmd);
+	}
+	if (ret == 0)
+		ret = gicv3_its_cmd_poll_completion(sc);
+
+	mutex_exit(&sc->its_cmd_lock);
+	return (ret);
+}
+
+static int
+gicv3_its_do_discard(gicv3_its_state_t *sc, uint32_t devid,
+    uint32_t eventid, processorid_t target_cpu)
+{
+	gicv3_its_cmd_t cmd;
+	uint64_t target;
+	int ret;
+
+	target = gicv3_its_sync_target(sc, target_cpu);
+
+	mutex_enter(&sc->its_cmd_lock);
+
+	gicv3_its_cmd_build_discard(&cmd, devid, eventid);
+	ret = gicv3_its_cmd_submit(sc, &cmd);
+	if (ret == 0) {
+		gicv3_its_cmd_build_sync(&cmd, target, sc->its_pta);
+		ret = gicv3_its_cmd_submit(sc, &cmd);
+	}
+	if (ret == 0)
+		ret = gicv3_its_cmd_poll_completion(sc);
+
+	mutex_exit(&sc->its_cmd_lock);
+	return (ret);
+}
+
+static int
+gicv3_its_do_movi(gicv3_its_state_t *sc, uint32_t devid,
+    uint32_t eventid, processorid_t new_cpu)
+{
+	gicv3_its_cmd_t cmd;
+	uint64_t target;
+	int ret;
+
+	target = gicv3_its_sync_target(sc, new_cpu);
+
+	mutex_enter(&sc->its_cmd_lock);
+
+	gicv3_its_cmd_build_movi(&cmd, devid, eventid, (uint16_t)new_cpu);
+	ret = gicv3_its_cmd_submit(sc, &cmd);
+	if (ret == 0) {
+		gicv3_its_cmd_build_sync(&cmd, target, sc->its_pta);
+		ret = gicv3_its_cmd_submit(sc, &cmd);
+	}
+	if (ret == 0)
+		ret = gicv3_its_cmd_poll_completion(sc);
+
+	mutex_exit(&sc->its_cmd_lock);
+	return (ret);
+}
+
+/*
+ * bus_intr_op handlers
+ */
+
+/*
+ * ALLOC: allocate LPIs and ITT for a PCI device.
+ *
+ * Creates per-device state, allocates LPI INTIDs from the parent GICv3's
+ * vmem arena, allocates the ITT via DMA, and issues MAPD to bind the
+ * device table entry to the ITT.
+ */
+static int
+gicv3_its_alloc(gicv3_its_state_t *sc, dev_info_t *rdip,
+    ddi_intr_handle_impl_t *hdlp, void *result)
+{
+	int count = hdlp->ih_scratch1;
+	int actual = 0;
+	ihdl_plat_t *priv = hdlp->ih_private;
+	uint32_t devid = priv->ip_msi_devid;
+	gicits_dev_state_t *ds;
+	int i;
+
+	/*
+	 * Validate that the DeviceID fits within the ITS device table.
+	 * GITS_TYPER.Devbits defines the supported range.
+	 */
+	if (devid >= (1U << sc->its_devbits)) {
+		dev_err(sc->its_dip, CE_WARN,
+		    "DeviceID 0x%x exceeds ITS limit (%u bits)",
+		    devid, sc->its_devbits);
+		return (DDI_FAILURE);
+	}
+
+	ds = kmem_zalloc(sizeof (*ds), KM_SLEEP);
+	ds->ds_rdip = rdip;
+	ds->ds_devid = devid;
+	ds->ds_type = hdlp->ih_type;
+	ds->ds_inum_base = hdlp->ih_inum;
+
+	/*
+	 * Allocate LPI INTIDs from the parent GICv3's vmem arena.
+	 *
+	 * Unlike v2m where SPIs must be contiguous for MSI, ITS EventIDs
+	 * are always 0..N-1 and MAPTI maps each EventID to an arbitrary
+	 * LPI.  Contiguity is not required for either MSI or MSI-X.
+	 */
+	ds->ds_vecs_sz = count * sizeof (gicits_vec_t);
+	ds->ds_vecs = kmem_zalloc(ds->ds_vecs_sz, KM_SLEEP);
+
+	for (actual = 0; actual < count; actual++) {
+		uint32_t lpi;
+
+		if (gicv3_alloc_lpi(sc->its_gic_dip, &lpi) != 0)
+			break;
+		ds->ds_vecs[actual].gv_lpi = lpi;
+		ds->ds_vecs[actual].gv_eventid = actual;
+		ds->ds_vecs[actual].gv_enabled = B_FALSE;
+	}
+
+	if (actual == 0) {
+		kmem_free(ds->ds_vecs, ds->ds_vecs_sz);
+		kmem_free(ds, sizeof (*ds));
+		return (DDI_INTR_NOTFOUND);
+	}
+
+	ds->ds_nalloc = actual;
+
+	/*
+	 * Allocate the Interrupt Translation Table (ITT) via DDI DMA.
+	 *
+	 * Size: 2^itt_bits entries * its_itt_entry_sz bytes per entry.
+	 * Minimum alignment: 256 bytes (spec requirement).
+	 *
+	 * We round up to page size to ensure the ITT gets its own
+	 * physical page(s).  Sub-page DMA allocations can share a
+	 * physical page with kmem, and the ITS hardware writing to
+	 * the ITT would corrupt adjacent kmem buffers on that page.
+	 */
+	ds->ds_itt_bits = highbit(actual);
+	if (actual == (1U << (ds->ds_itt_bits - 1)))
+		ds->ds_itt_bits--;	/* exact power of 2 */
+	if (ds->ds_itt_bits < 1)
+		ds->ds_itt_bits = 1;
+
+	ds->ds_itt_sz = P2ROUNDUP(
+	    (size_t)(1U << ds->ds_itt_bits) * sc->its_itt_entry_sz,
+	    PAGESIZE);
+
+	if (gicv3_contig_alloc(sc->its_dip, ds->ds_itt_sz,
+	    PAGESIZE, &ds->ds_itt, &ds->ds_itt_pa,
+	    &ds->ds_itt_dmah, &ds->ds_itt_acch) != DDI_SUCCESS) {
+		for (i = 0; i < actual; i++)
+			gicv3_free_lpi(sc->its_gic_dip,
+			    ds->ds_vecs[i].gv_lpi);
+		kmem_free(ds->ds_vecs, ds->ds_vecs_sz);
+		kmem_free(ds, sizeof (*ds));
+		return (DDI_FAILURE);
+	}
+
+	/* Tell the ITS about this device */
+	if (gicv3_its_do_mapd(sc, devid, ds->ds_itt_bits - 1,
+	    ds->ds_itt_pa, B_TRUE) != 0) {
+		gicv3_contig_free(&ds->ds_itt_dmah, &ds->ds_itt_acch);
+		for (i = 0; i < actual; i++)
+			gicv3_free_lpi(sc->its_gic_dip,
+			    ds->ds_vecs[i].gv_lpi);
+		kmem_free(ds->ds_vecs, ds->ds_vecs_sz);
+		kmem_free(ds, sizeof (*ds));
+		return (DDI_FAILURE);
+	}
+
+	/* Only one ALLOC per device — assert under the same lock as insert */
+	mutex_enter(&sc->its_dev_lock);
+	VERIFY3P(gicv3_its_find_dev(sc, rdip), ==, NULL);
+	list_insert_tail(&sc->its_devs, ds);
+	mutex_exit(&sc->its_dev_lock);
+
+	*(int *)result = actual;
+	return (DDI_SUCCESS);
+}
+
+/*
+ * FREE: release all MSI resources for a PCI device.
+ *
+ * Invalidates the device table entry, frees the ITT DMA memory, returns
+ * LPI INTIDs to the parent GICv3's vmem arena, and frees the per-device
+ * state structure.
+ */
+static int
+gicv3_its_free(gicv3_its_state_t *sc, dev_info_t *rdip,
+    ddi_intr_handle_impl_t *hdlp)
+{
+	gicits_dev_state_t *ds;
+	uint32_t i;
+
+	mutex_enter(&sc->its_dev_lock);
+	ds = gicv3_its_find_dev(sc, rdip);
+	if (ds == NULL) {
+		/* Already freed by a prior handle */
+		mutex_exit(&sc->its_dev_lock);
+		return (DDI_SUCCESS);
+	}
+	list_remove(&sc->its_devs, ds);
+	mutex_exit(&sc->its_dev_lock);
+
+	/* Invalidate device table entry */
+	(void) gicv3_its_do_mapd(sc, ds->ds_devid, 0, 0, B_FALSE);
+
+	/* Free ITT DMA memory (safe now - ITS won't access it) */
+	gicv3_contig_free(&ds->ds_itt_dmah, &ds->ds_itt_acch);
+
+	/*
+	 * Defensive: DDI requires DISABLE before FREE, so all vectors
+	 * should already be disabled and their LPI config scrubbed.
+	 * Assert and scrub anyway to catch driver bugs and ensure LPIs
+	 * go back to the arena in a clean state.
+	 */
+	for (i = 0; i < ds->ds_nalloc; i++) {
+		ASSERT3S(ds->ds_vecs[i].gv_enabled, ==, B_FALSE);
+		gicv3_lpi_set_config(sc->its_gic_dip,
+		    ds->ds_vecs[i].gv_lpi, 0, B_FALSE);
+		gicv3_free_lpi(sc->its_gic_dip, ds->ds_vecs[i].gv_lpi);
+	}
+
+	kmem_free(ds->ds_vecs, ds->ds_vecs_sz);
+	kmem_free(ds, sizeof (*ds));
+	return (DDI_SUCCESS);
+}
+
+/*
+ * ENABLE: activate a single MSI/MSI-X vector.
+ *
+ * 1. Set ih_vector to the LPI INTID for dispatch lookup.
+ * 2. Register the handler via add_avintr (addspl guard skips distributor
+ *    programming for LPI INTIDs >= 8192).  No hardware is touched.
+ * 3. Enable the LPI in the PROPBASER configuration table.
+ * 4. Issue MAPTI + INV + SYNC to create the ITS translation.
+ *    From this point interrupts can flow; the handler is already in place.
+ * 5. Set ip_msi_addr/data on the handle for framework use.
+ *
+ * Installing the handler (step 2) before enabling the hardware (steps 3-4)
+ * ensures there is no window where an LPI can be delivered without a
+ * registered handler in autovect.  In reality this is never a concern
+ * anyway, as programming of the MSI producer can only happen after
+ * this driver code has run, so this is purely defensive.
+ */
+static int
+gicv3_its_enable(gicv3_its_state_t *sc, dev_info_t *rdip,
+    ddi_intr_handle_impl_t *hdlp)
+{
+	gicits_dev_state_t *ds;
+	gicits_vec_t *vec;
+	ihdl_plat_t *priv = hdlp->ih_private;
+	syspic_intr_state_t *state;
+	uint32_t idx, lpi, eventid, devid;
+	processorid_t target_cpu;
+
+	mutex_enter(&sc->its_dev_lock);
+	ds = gicv3_its_find_dev(sc, rdip);
+	if (ds == NULL) {
+		mutex_exit(&sc->its_dev_lock);
+		dev_err(sc->its_dip, CE_WARN,
+		    "no MSI state for %s%d",
+		    ddi_driver_name(rdip), ddi_get_instance(rdip));
+		return (DDI_FAILURE);
+	}
+
+	idx = hdlp->ih_inum - ds->ds_inum_base;
+	VERIFY3U(idx, <, ds->ds_nalloc);
+	vec = &ds->ds_vecs[idx];
+	lpi = vec->gv_lpi;
+	eventid = vec->gv_eventid;
+	devid = ds->ds_devid;
+	mutex_exit(&sc->its_dev_lock);
+
+	target_cpu = CPU->cpu_id;
+
+	/*
+	 * If the current CPU cannot be an ITS target (HCC limit),
+	 * fall back to CPU 0 which is always within range.
+	 */
+	if (!gicv3_its_cpu_can_target(sc, target_cpu))
+		target_cpu = 0;
+
+	/* Set ih_vector so av_dispatch_autovect can find the handler */
+	hdlp->ih_vector = lpi;
+
+	/*
+	 * Register handler in autovect table.  The addspl guard skips
+	 * distributor programming for LPI INTIDs (>= 8192), so this
+	 * is a pure software operation - no hardware is touched.
+	 *
+	 * syspic_get_state() acquires syspic_intrs_lock and creates
+	 * the tracking record for this LPI - we must release the lock
+	 * after add_avintr.
+	 */
+	state = syspic_get_state(lpi);
+	VERIFY3P(state, !=, NULL);
+	state->si_edge_triggered = B_TRUE;
+	state->si_prio = hdlp->ih_pri;
+
+	if (!add_avintr((void *)hdlp, hdlp->ih_pri,
+	    hdlp->ih_cb_func, DEVI(rdip)->devi_name,
+	    lpi, hdlp->ih_cb_arg1, hdlp->ih_cb_arg2,
+	    NULL, rdip)) {
+		syspic_remove_state(lpi);
+		mutex_exit(&syspic_intrs_lock);
+		return (DDI_FAILURE);
+	}
+	mutex_exit(&syspic_intrs_lock);
+
+	/* Enable LPI in PROPBASER: set priority and enable */
+	gicv3_lpi_set_config(sc->its_gic_dip, lpi,
+	    GIC_IPL_TO_PRIO(hdlp->ih_pri), B_TRUE);
+
+	/* Program ITS translation: EventID -> (LPI, Collection) */
+	if (gicv3_its_do_mapti(sc, devid, eventid, lpi,
+	    (uint16_t)target_cpu, target_cpu) != 0) {
+		gicv3_lpi_set_config(sc->its_gic_dip, lpi,
+		    GIC_IPL_TO_PRIO(hdlp->ih_pri), B_FALSE);
+		rem_avintr((void *)hdlp, hdlp->ih_pri,
+		    hdlp->ih_cb_func, lpi);
+		return (DDI_FAILURE);
+	}
+
+	/*
+	 * Set MSI address/data on the handle for framework use.
+	 *
+	 * Address = GITS_TRANSLATER PA (same for all vectors on this ITS).
+	 * Data = EventID (ITS translates EventID -> LPI via the ITT).
+	 *
+	 * For MSI, the PCI device computes data as
+	 * (base_data & ~(count-1)) | vector_offset.  Since base EventID
+	 * is 0 and count is a power of 2, this yields vector_offset,
+	 * which equals our EventID.
+	 */
+	priv->ip_msi_addr = sc->its_doorbell_pa;
+	priv->ip_msi_data = eventid;
+
+	/*
+	 * PCI capability programming is handled by the pcierc nexus
+	 * (pci_common_intr_ops ENABLE) using ip_msi_addr/ip_msi_data.
+	 */
+
+	/*
+	 * Publish the vector as enabled and record its target CPU.
+	 *
+	 * Must hold its_dev_lock to be atomic with respect to
+	 * gicv3_its_cpu_offline()'s migration scan.
+	 */
+	mutex_enter(&sc->its_dev_lock);
+	vec->gv_target_cpu = target_cpu;
+	vec->gv_enabled = B_TRUE;
+	mutex_exit(&sc->its_dev_lock);
+
+	return (DDI_SUCCESS);
+}
+
+/*
+ * DISABLE: deactivate a single MSI/MSI-X vector.
+ *
+ * Order: stop device -> remove handler -> disable LPI -> remove translation.
+ * No window for handler-less interrupt delivery.
+ */
+static int
+gicv3_its_disable(gicv3_its_state_t *sc, dev_info_t *rdip,
+    ddi_intr_handle_impl_t *hdlp)
+{
+	gicits_dev_state_t *ds;
+	gicits_vec_t *vec;
+	uint32_t lpi, idx, eventid, devid;
+	processorid_t target_cpu;
+
+	lpi = hdlp->ih_vector;
+
+	mutex_enter(&sc->its_dev_lock);
+	ds = gicv3_its_find_dev(sc, rdip);
+	VERIFY3P(ds, !=, NULL);
+	idx = hdlp->ih_inum - ds->ds_inum_base;
+	VERIFY3U(idx, <, ds->ds_nalloc);
+	vec = &ds->ds_vecs[idx];
+	devid = ds->ds_devid;
+	eventid = vec->gv_eventid;
+	target_cpu = vec->gv_target_cpu;
+	mutex_exit(&sc->its_dev_lock);
+
+	/*
+	 * PCI capability deconfiguration is handled by the pcierc nexus
+	 * (pci_common_intr_ops DISABLE) prior to calling us.
+	 */
+
+	/* Remove handler from autovect */
+	rem_avintr((void *)hdlp, hdlp->ih_pri, hdlp->ih_cb_func, lpi);
+
+	/* Disable LPI in PROPBASER */
+	gicv3_lpi_set_config(sc->its_gic_dip, lpi,
+	    GIC_IPL_TO_PRIO(hdlp->ih_pri), B_FALSE);
+
+	/*
+	 * Mark the vector disabled and re-read target_cpu under the
+	 * lock.  This must be atomic with respect to
+	 * gicv3_its_cpu_offline()'s migration scan: once gv_enabled
+	 * is B_FALSE, the offline scan will skip this vector.
+	 * Re-reading gv_target_cpu ensures we DISCARD to the correct
+	 * collection if a concurrent MOVI moved the vector.
+	 */
+	mutex_enter(&sc->its_dev_lock);
+	vec->gv_enabled = B_FALSE;
+	target_cpu = vec->gv_target_cpu;
+	mutex_exit(&sc->its_dev_lock);
+
+	/* Remove ITS translation and flush */
+	(void) gicv3_its_do_discard(sc, devid, eventid, target_cpu);
+
+	return (DDI_SUCCESS);
+}
+
+/*
+ * SETTARGET: move a single vector to a different CPU.
+ */
+static int
+gicv3_its_settarget(gicv3_its_state_t *sc, dev_info_t *rdip,
+    ddi_intr_handle_impl_t *hdlp, void *result)
+{
+	gicits_dev_state_t *ds;
+	gicits_vec_t *vec;
+	processorid_t new_cpu;
+	uint32_t idx;
+
+	new_cpu = *(processorid_t *)result;
+
+	/* Reject targets beyond the hardware collection limit */
+	if (!gicv3_its_cpu_can_target(sc, new_cpu))
+		return (DDI_EINVAL);
+
+	mutex_enter(&sc->its_dev_lock);
+	ds = gicv3_its_find_dev(sc, rdip);
+	VERIFY3P(ds, !=, NULL);
+	idx = hdlp->ih_inum - ds->ds_inum_base;
+	VERIFY3U(idx, <, ds->ds_nalloc);
+	vec = &ds->ds_vecs[idx];
+
+	if (!vec->gv_enabled) {
+		mutex_exit(&sc->its_dev_lock);
+		return (DDI_FAILURE);
+	}
+
+	if (vec->gv_target_cpu == new_cpu) {
+		mutex_exit(&sc->its_dev_lock);
+		return (DDI_SUCCESS);
+	}
+
+	if (gicv3_its_do_movi(sc, ds->ds_devid, vec->gv_eventid,
+	    new_cpu) != 0) {
+		mutex_exit(&sc->its_dev_lock);
+		return (DDI_FAILURE);
+	}
+
+	vec->gv_target_cpu = new_cpu;
+	mutex_exit(&sc->its_dev_lock);
+	return (DDI_SUCCESS);
+}
+
+/*
+ * GETTARGET: return the current target CPU for a vector.
+ */
+static int
+gicv3_its_gettarget(gicv3_its_state_t *sc, dev_info_t *rdip,
+    ddi_intr_handle_impl_t *hdlp, void *result)
+{
+	gicits_dev_state_t *ds;
+	uint32_t idx;
+
+	mutex_enter(&sc->its_dev_lock);
+	ds = gicv3_its_find_dev(sc, rdip);
+	VERIFY3P(ds, !=, NULL);
+	idx = hdlp->ih_inum - ds->ds_inum_base;
+	VERIFY3U(idx, <, ds->ds_nalloc);
+	*(processorid_t *)result = ds->ds_vecs[idx].gv_target_cpu;
+	mutex_exit(&sc->its_dev_lock);
+
+	return (DDI_SUCCESS);
+}
+
+/*
+ * Return the pending state of an LPI from the redistributor's
+ * PENDBASER table.
+ *
+ * The LPI INTID and target CPU are looked up from the per-device
+ * vector state, then the pending bit is read from the target
+ * redistributor's pending table via gicv3_lpi_ispending().
+ */
+static int
+gicv3_its_getpending(gicv3_its_state_t *sc, dev_info_t *rdip,
+    ddi_intr_handle_impl_t *hdlp, void *result)
+{
+	gicits_dev_state_t *ds;
+	uint32_t idx;
+	uint32_t lpi;
+	processorid_t target_cpu;
+
+	mutex_enter(&sc->its_dev_lock);
+	ds = gicv3_its_find_dev(sc, rdip);
+	if (ds == NULL) {
+		mutex_exit(&sc->its_dev_lock);
+		return (DDI_FAILURE);
+	}
+
+	idx = hdlp->ih_inum - ds->ds_inum_base;
+	VERIFY3U(idx, <, ds->ds_nalloc);
+	lpi = ds->ds_vecs[idx].gv_lpi;
+	target_cpu = ds->ds_vecs[idx].gv_target_cpu;
+	mutex_exit(&sc->its_dev_lock);
+
+	*(int *)result = gicv3_lpi_ispending(sc->its_gic_dip,
+	    lpi, target_cpu) ? 1 : 0;
+	return (DDI_SUCCESS);
+}
+
+/*
+ * bus_intr_op entry point - dispatches interrupt operations from the
+ * DDI framework to per-operation handlers.
+ */
+static int
+gicv3_its_intr_ops(dev_info_t *dip, dev_info_t *rdip,
+    ddi_intr_op_t intr_op, ddi_intr_handle_impl_t *hdlp, void *result)
+{
+	gicv3_its_state_t *sc = ddi_get_soft_state(gicv3_its_soft_state,
+	    ddi_get_instance(dip));
+	VERIFY3P(sc, !=, NULL);
+
+	switch (intr_op) {
+	case DDI_INTROP_ALLOC:
+		return (gicv3_its_alloc(sc, rdip, hdlp, result));
+	case DDI_INTROP_FREE:
+		return (gicv3_its_free(sc, rdip, hdlp));
+	case DDI_INTROP_ENABLE:
+		return (gicv3_its_enable(sc, rdip, hdlp));
+	case DDI_INTROP_DISABLE:
+		return (gicv3_its_disable(sc, rdip, hdlp));
+	case DDI_INTROP_BLOCKENABLE:
+		return (DDI_ENOTSUP);
+	case DDI_INTROP_BLOCKDISABLE:
+		return (DDI_ENOTSUP);
+	case DDI_INTROP_SETTARGET:
+		return (gicv3_its_settarget(sc, rdip, hdlp, result));
+	case DDI_INTROP_GETTARGET:
+		return (gicv3_its_gettarget(sc, rdip, hdlp, result));
+	case DDI_INTROP_ADDISR:
+	case DDI_INTROP_REMISR:
+		return (DDI_SUCCESS);
+	case DDI_INTROP_SUPPORTED_TYPES:
+		*(int *)result = DDI_INTR_TYPE_MSI | DDI_INTR_TYPE_MSIX;
+		return (DDI_SUCCESS);
+	case DDI_INTROP_NAVAIL:
+		*(int *)result =
+		    (int)gicv3_lpi_navail(sc->its_gic_dip);
+		return (DDI_SUCCESS);
+	case DDI_INTROP_GETPENDING:
+		return (gicv3_its_getpending(sc, rdip, hdlp, result));
+	case DDI_INTROP_GETCAP:
+		*(int *)result &= ~DDI_INTR_FLAG_BLOCK;
+		*(int *)result |= DDI_INTR_FLAG_PENDING;
+		*(int *)result |= DDI_INTR_FLAG_EDGE;
+		*(int *)result &= ~DDI_INTR_FLAG_LEVEL;
+		return (DDI_SUCCESS);
+	default:
+		return (DDI_ENOTSUP);
+	}
+}
+
+/*
+ * CPU hotplug
+ */
+
+/*
+ * Pick a migration target for LPIs when a CPU goes offline.
+ * Policy: CPU 0 always (simple, safe, always online).
+ */
+static processorid_t
+gicv3_its_pick_migration_cpu(gicv3_its_state_t *sc, processorid_t dying)
+{
+	cpu_t *cp;
+
+	/*
+	 * Walk the online CPU list.  Pick the first one that isn't
+	 * the dying CPU and can be an ITS target (within collection
+	 * limit).  cpu_active is safe to walk here because we are
+	 * called under cpu_lock (from cpu_setup_func).
+	 */
+	cp = cpu_active;
+	do {
+		if (cp->cpu_id != dying &&
+		    gicv3_its_cpu_can_target(sc, cp->cpu_id))
+			return (cp->cpu_id);
+	} while ((cp = cp->cpu_next_onln) != cpu_active);
+
+	/* Should never happen - can't offline the last CPU */
+	panic("gicv3_its: no migration target for CPU %d", dying);
+	/* NOTREACHED */
+	return (0);
+}
+
+static int
+gicv3_its_cpu_online(gicv3_its_state_t *sc, processorid_t cpuid)
+{
+	/* No collection slot for this CPU — it just can't be an ITS target */
+	if (!gicv3_its_cpu_can_target(sc, cpuid))
+		return (0);
+	return (gicv3_its_do_mapc(sc, cpuid, B_TRUE));
+}
+
+static int
+gicv3_its_cpu_offline(gicv3_its_state_t *sc, processorid_t cpuid)
+{
+	gicits_dev_state_t *ds;
+	processorid_t dest;
+	uint32_t i;
+
+	/* This CPU never had a collection — nothing to tear down */
+	if (!gicv3_its_cpu_can_target(sc, cpuid))
+		return (0);
+
+	dest = gicv3_its_pick_migration_cpu(sc, cpuid);
+
+	/*
+	 * Walk all devices on this ITS.  For each enabled vector
+	 * targeting the dying CPU, issue MOVI to the new target.
+	 */
+	mutex_enter(&sc->its_dev_lock);
+	for (ds = list_head(&sc->its_devs); ds != NULL;
+	    ds = list_next(&sc->its_devs, ds)) {
+		for (i = 0; i < ds->ds_nalloc; i++) {
+			gicits_vec_t *vec = &ds->ds_vecs[i];
+
+			if (!vec->gv_enabled)
+				continue;
+			if (vec->gv_target_cpu != cpuid)
+				continue;
+
+			if (gicv3_its_do_movi(sc, ds->ds_devid,
+			    vec->gv_eventid, dest) == 0) {
+				vec->gv_target_cpu = dest;
+			} else {
+				cmn_err(CE_WARN, "gicv3_its: failed to "
+				    "migrate devid 0x%x eventid %u from "
+				    "CPU %d to CPU %d",
+				    ds->ds_devid, vec->gv_eventid,
+				    cpuid, dest);
+			}
+		}
+	}
+	mutex_exit(&sc->its_dev_lock);
+
+	/* Invalidate the collection for the dead CPU */
+	(void) gicv3_its_do_mapc(sc, cpuid, B_FALSE);
+
+	return (0);
+}
+
+/*
+ * CPU setup callback, registered via register_cpu_setup_func().
+ * Called under cpu_lock by the framework.
+ */
+static int
+gicv3_its_cpu_callback(cpu_setup_t what, int cpuid, void *arg)
+{
+	gicv3_its_state_t *sc = arg;
+
+	switch (what) {
+	case CPU_SETUP:		/* boot-time secondary CPUs (aarch64) */
+	case CPU_ON:		/* DR-onlined CPUs */
+		return (gicv3_its_cpu_online(sc, (processorid_t)cpuid));
+	case CPU_OFF:
+		return (gicv3_its_cpu_offline(sc, (processorid_t)cpuid));
+	default:
+		return (0);
+	}
+}
+
+/*
+ * ITS table allocation (BASERn)
+ *
+ * Scans GITS_BASERn[0..7] for the Device and Collection tables.
+ * For each, allocates DMA memory with page size escalation
+ * (4K -> 16K -> 64K) if the table doesn't fit in 256 pages.
+ * Programs the BASERn register with shareability/cacheability,
+ * reads back to check for downgrade, and retries if needed.
+ */
+
+static size_t
+gicv3_its_pgsz_to_bytes(uint32_t pgsz)
+{
+	switch (pgsz) {
+	case GITS_BASER_PGSZ_4K:
+		return (4096);
+	case GITS_BASER_PGSZ_16K:
+		return (16384);
+	case GITS_BASER_PGSZ_64K:
+		return (65536);
+	default:
+		return (4096);
+	}
+}
+
+/*
+ * Allocate and program a single BASERn table.
+ * Returns 0 on success, -1 on failure.
+ */
+static int
+gicv3_its_alloc_table(gicv3_its_state_t *sc, uint32_t baser_idx,
+    size_t num_entries, caddr_t *vap, uint64_t *pap, size_t *szp,
+    ddi_dma_handle_t *dma_hdlp, ddi_acc_handle_t *acc_hdlp)
+{
+	uint64_t baser_val, readback;
+	uint32_t pgsz_idx;
+	size_t entry_sz, table_sz, page_sz;
+	uint32_t num_pages;
+
+	baser_val = its_read64(sc, GITS_BASERn(baser_idx));
+	entry_sz = GITS_BASERn_ENTRY_SZ_VAL(baser_val);
+
+	/*
+	 * Try page sizes in order: 4K, 16K, 64K.
+	 * Each BASERn.Size field is 8 bits, encoding (num_pages - 1),
+	 * so the maximum is 256 pages at the chosen page size.
+	 */
+	for (pgsz_idx = GITS_BASER_PGSZ_4K;
+	    pgsz_idx <= GITS_BASER_PGSZ_64K; pgsz_idx++) {
+		page_sz = gicv3_its_pgsz_to_bytes(pgsz_idx);
+		table_sz = P2ROUNDUP(num_entries * entry_sz, page_sz);
+		num_pages = table_sz / page_sz;
+		if (num_pages <= 256)
+			break;
+	}
+
+	if (num_pages > 256) {
+		dev_err(sc->its_dip, CE_WARN,
+		    "BASERn[%u]: table too large (%zu entries * %zu bytes)",
+		    baser_idx, num_entries, entry_sz);
+		return (-1);
+	}
+
+	if (gicv3_contig_alloc(sc->its_dip, table_sz, page_sz,
+	    vap, pap, dma_hdlp, acc_hdlp) != DDI_SUCCESS) {
+		dev_err(sc->its_dip, CE_WARN,
+		    "BASERn[%u]: DMA allocation failed (%zu bytes)",
+		    baser_idx, table_sz);
+		return (-1);
+	}
+
+	*szp = table_sz;
+
+	/*
+	 * Construct the BASERn value:
+	 *   Valid | InnerCache(RaWaWb) | OuterCache(RaWaWb) |
+	 *   Share(IS) | PA | PageSize | (num_pages - 1)
+	 * Preserve the Type and Entry_Size fields from the hardware.
+	 */
+	baser_val = GITS_BASERn_Valid |
+	    GITS_BASERn_IC(GIC_CACHE_RaWaWb) |
+	    GITS_BASERn_OC(GIC_CACHE_RaWaWb) |
+	    GITS_BASERn_SHARE(GIC_SHARE_IS) |
+	    (*pap & GITS_BASERn_Physical_Address) |
+	    GITS_BASERn_PGSZ(pgsz_idx) |
+	    (uint64_t)(num_pages - 1) |
+	    (its_read64(sc, GITS_BASERn(baser_idx)) &
+	    (GITS_BASERn_Type | GITS_BASERn_Entry_Size));
+
+	its_write64(sc, GITS_BASERn(baser_idx), baser_val);
+
+	/*
+	 * Read back to check shareability and page size.
+	 *
+	 * The hardware may downgrade shareability to non-shareable,
+	 * in which case we retry with non-cacheable settings.
+	 *
+	 * The hardware may also reject the requested page size and
+	 * report a smaller one.  If this happens, the DMA memory we
+	 * allocated (aligned to the requested page size) doesn't
+	 * match what the ITS will use, so we must fail.
+	 */
+	readback = its_read64(sc, GITS_BASERn(baser_idx));
+
+	if (GITS_BASERn_PGSZ_VAL(readback) != pgsz_idx) {
+		dev_err(sc->its_dip, CE_WARN,
+		    "BASERn[%u]: hardware rejected page size "
+		    "(requested %u, got %lu)",
+		    baser_idx, pgsz_idx, GITS_BASERn_PGSZ_VAL(readback));
+		gicv3_contig_free(dma_hdlp, acc_hdlp);
+		*vap = NULL;
+		return (-1);
+	}
+
+	if (GITS_BASERn_SHARE_VAL(readback) == GIC_SHARE_NS) {
+		baser_val &= ~GITS_BASERn_InnerCache;
+		baser_val &= ~GITS_BASERn_OuterCache;
+		baser_val &= ~GITS_BASERn_Shareability;
+		baser_val |= GITS_BASERn_IC(GIC_CACHE_nC);
+		baser_val |= GITS_BASERn_OC(GIC_CACHE_nC);
+		baser_val |= GITS_BASERn_SHARE(GIC_SHARE_NS);
+		its_write64(sc, GITS_BASERn(baser_idx), baser_val);
+	}
+
+	return (0);
+}
+
+/*
+ * Scan all 8 BASERn registers and allocate the Device and Collection
+ * tables.
+ */
+static int
+gicv3_its_init_tables(gicv3_its_state_t *sc)
+{
+	uint64_t baser_val;
+	uint32_t type;
+	boolean_t have_devtab = B_FALSE;
+	boolean_t have_colltab = B_FALSE;
+	boolean_t need_colltab;
+	int i;
+
+	need_colltab = (sc->its_hcc == 0);
+
+	for (i = 0; i < 8; i++) {
+		baser_val = its_read64(sc, GITS_BASERn(i));
+		type = GITS_BASERn_TYPE_VAL(baser_val);
+
+		if (type == GITS_BASER_TYPE_DEVICES && !have_devtab) {
+			size_t ndev = 1ULL << sc->its_devbits;
+
+			if (gicv3_its_alloc_table(sc, i, ndev,
+			    &sc->its_devtab, &sc->its_devtab_pa,
+			    &sc->its_devtab_sz, &sc->its_devtab_dmah,
+			    &sc->its_devtab_acch) != 0)
+				return (DDI_FAILURE);
+			have_devtab = B_TRUE;
+
+		} else if (type == GITS_BASER_TYPE_COLLECTION &&
+		    need_colltab && !have_colltab) {
+			/*
+			 * HCC==0: software must provide a collection table.
+			 * Size it for max_ncpus collections.
+			 */
+			if (gicv3_its_alloc_table(sc, i,
+			    (size_t)max_ncpus,
+			    &sc->its_colltab, &sc->its_colltab_pa,
+			    &sc->its_colltab_sz, &sc->its_colltab_dmah,
+			    &sc->its_colltab_acch) != 0)
+				return (DDI_FAILURE);
+			have_colltab = B_TRUE;
+		}
+	}
+
+	if (!have_devtab) {
+		dev_err(sc->its_dip, CE_WARN,
+		    "no Device table found in BASERn registers");
+		return (DDI_FAILURE);
+	}
+
+	if (need_colltab && !have_colltab) {
+		dev_err(sc->its_dip, CE_WARN,
+		    "HCC==0 but no Collection table found in BASERn");
+		return (DDI_FAILURE);
+	}
+
+	return (DDI_SUCCESS);
+}
+
+/*
+ * Command queue allocation
+ *
+ * Allocates a 64KB command queue in DMA memory, programs GITS_CBASER
+ * with shareability/cacheability, reads back to check for downgrade.
+ */
+
+static int
+gicv3_its_init_cmdq(gicv3_its_state_t *sc)
+{
+	uint64_t cbaser_val, readback;
+
+	sc->its_cmd_sz = GICV3_ITS_CMDQ_SIZE;
+
+	if (gicv3_contig_alloc(sc->its_dip, sc->its_cmd_sz,
+	    sc->its_cmd_sz,	/* align to queue size */
+	    &sc->its_cmd_base, &sc->its_cmd_pa,
+	    &sc->its_cmd_dmah, &sc->its_cmd_acch) != DDI_SUCCESS) {
+		dev_err(sc->its_dip, CE_WARN,
+		    "failed to allocate command queue");
+		return (DDI_FAILURE);
+	}
+
+	sc->its_cmd_write = 0;
+
+	/*
+	 * Program GITS_CBASER:
+	 *   Valid | IC(RaWaWb) | OC(RaWaWb) | Share(IS) | PA | Size(15)
+	 * Size field = (num_4K_pages - 1) = (16 - 1) = 15
+	 */
+	cbaser_val = GITS_CBASER_Valid |
+	    GITS_CBASER_IC(GIC_CACHE_RaWaWb) |
+	    GITS_CBASER_OC(GIC_CACHE_RaWaWb) |
+	    GITS_CBASER_SHARE(GIC_SHARE_IS) |
+	    (sc->its_cmd_pa & GITS_CBASER_Physical_Address) |
+	    (uint64_t)((sc->its_cmd_sz / 4096) - 1);
+
+	its_write64(sc, GITS_CBASER, cbaser_val);
+
+	/*
+	 * Read back to check shareability.  If hardware downgraded to
+	 * non-shareable, the CPU cache and ITS may not be coherent.
+	 * Set the flush flag so submit will call ddi_dma_sync().
+	 */
+	readback = its_read64(sc, GITS_CBASER);
+	if (GITS_CBASER_SHARE_VAL(readback) == GIC_SHARE_NS) {
+		sc->its_cmd_needs_flush = B_TRUE;
+		cbaser_val &= ~GITS_CBASER_InnerCache;
+		cbaser_val &= ~GITS_CBASER_OuterCache;
+		cbaser_val &= ~GITS_CBASER_Shareability;
+		cbaser_val |= GITS_CBASER_IC(GIC_CACHE_nC);
+		cbaser_val |= GITS_CBASER_OC(GIC_CACHE_nC);
+		cbaser_val |= GITS_CBASER_SHARE(GIC_SHARE_NS);
+		its_write64(sc, GITS_CBASER, cbaser_val);
+	} else {
+		sc->its_cmd_needs_flush = B_FALSE;
+	}
+
+	/* Reset command queue read/write pointers */
+	its_write64(sc, GITS_CWRITER, 0);
+
+	return (DDI_SUCCESS);
+}
+
+/*
+ * Instance lifecycle
+ */
+
+static int
+gicv3_its_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
+{
+	int instance;
+	int nregs;
+	gicv3_its_state_t *sc;
+	uint32_t ctlr;
+	int timeout_us;
+	cpu_t *cp;
+	struct regspec *rp;
+	struct regspec reg;
+	ddi_device_acc_attr_t reg_acc_attr = {
+		.devacc_attr_version		= DDI_DEVICE_ATTR_V0,
+		.devacc_attr_endian_flags	= DDI_STRUCTURE_LE_ACC,
+		.devacc_attr_dataorder		= DDI_STRICTORDER_ACC,
+	};
+
+	switch (cmd) {
+	case DDI_ATTACH:
+		break;
+	case DDI_RESUME:
+	case DDI_PM_RESUME:
+		return (DDI_SUCCESS);
+	default:
+		return (DDI_FAILURE);
+	}
+
+	ASSERT3U(cmd, ==, DDI_ATTACH);
+	instance = ddi_get_instance(dip);
+
+	/*
+	 * Verify required DT properties.
+	 *
+	 * msi-controller: marks this node as an MSI controller.
+	 * #msi-cells: must be 1 (single cell = DeviceID).
+	 */
+	if (!ddi_prop_exists(DDI_DEV_T_ANY, dip,
+	    DDI_PROP_DONTPASS, OBP_MSI_CONTROLLER)) {
+		dev_err(dip, CE_WARN,
+		    "ITS node missing required %s property",
+		    OBP_MSI_CONTROLLER);
+		return (DDI_FAILURE);
+	}
+	if (ddi_prop_get_int(DDI_DEV_T_ANY, dip,
+	    DDI_PROP_DONTPASS, "#msi-cells", -1) != 1) {
+		dev_err(dip, CE_WARN,
+		    "ITS node #msi-cells must be 1");
+		return (DDI_FAILURE);
+	}
+
+	if (ddi_dev_nregs(dip, &nregs) != DDI_SUCCESS)
+		return (DDI_FAILURE);
+	if (nregs != 1)
+		return (DDI_FAILURE);
+
+	if (ddi_soft_state_zalloc(gicv3_its_soft_state,
+	    instance) != DDI_SUCCESS) {
+		return (DDI_FAILURE);
+	}
+
+	sc = ddi_get_soft_state(gicv3_its_soft_state, instance);
+	VERIFY3P(sc, !=, NULL);
+	sc->its_dip = dip;
+	sc->its_gic_dip = ddi_get_parent(dip);
+	VERIFY3P(sc->its_gic_dip, !=, NULL);
+
+	/* Initialise locks */
+	mutex_init(&sc->its_cmd_lock, NULL, MUTEX_DRIVER, NULL);
+	mutex_init(&sc->its_dev_lock, NULL, MUTEX_DRIVER, NULL);
+
+	/* Initialise per-device state list */
+	list_create(&sc->its_devs, sizeof (gicits_dev_state_t),
+	    offsetof(gicits_dev_state_t, ds_node));
+
+	/* Map the ITS MMIO frame */
+	if (ddi_regs_map_setup(dip, 0, &sc->its_base, 0, 0,
+	    &reg_acc_attr, &sc->its_regh) != DDI_SUCCESS) {
+		dev_err(dip, CE_WARN, "failed to map ITS registers");
+		goto fail_list;
+	}
+
+	/*
+	 * Determine the doorbell physical address.
+	 *
+	 * PCI MSI address registers need the physical address of
+	 * GITS_TRANSLATER (offset 0x10040 from the ITS base).  We
+	 * obtain the base from the parent-private regspec and apply
+	 * the parent's ranges for address translation.
+	 */
+	rp = i_ddi_rnumber_to_regspec(dip, 0);
+	if (rp == NULL) {
+		dev_err(dip, CE_WARN,
+		    "no reg property for ITS frame");
+		goto fail_regs;
+	}
+	reg = *rp;
+	if (i_ddi_apply_range(sc->its_gic_dip, dip, &reg) != 0) {
+		dev_err(dip, CE_WARN,
+		    "failed to translate ITS register address");
+		goto fail_regs;
+	}
+	sc->its_doorbell_pa = reg.regspec_addr + GITS_TRANSLATER;
+
+	/*
+	 * Disable the ITS and wait for quiescence before reconfiguring.
+	 */
+	ctlr = its_read32(sc, GITS_CTLR);
+	if (ctlr & GITS_CTLR_Enabled) {
+		its_write32(sc, GITS_CTLR, ctlr & ~GITS_CTLR_Enabled);
+
+		timeout_us = GICV3_ITS_QUIESCE_TIMEOUT_US;
+		while (!(its_read32(sc, GITS_CTLR) &
+		    GITS_CTLR_Quiescent)) {
+			if (timeout_us <= 0) {
+				dev_err(dip, CE_WARN,
+				    "ITS failed to quiesce");
+				goto fail_regs;
+			}
+			drv_usecwait(10);
+			timeout_us -= 10;
+		}
+	}
+
+	/*
+	 * Parse GITS_TYPER.
+	 */
+	sc->its_typer = its_read64(sc, GITS_TYPER);
+	sc->its_pta = GITS_TYPER_PTA_BIT(sc->its_typer);
+	sc->its_devbits = GITS_TYPER_DEVBITS(sc->its_typer);
+	sc->its_idbits = GITS_TYPER_IDBITS(sc->its_typer);
+	sc->its_itt_entry_sz = GITS_TYPER_ITT_ENTRY_SZ(sc->its_typer);
+	sc->its_hcc = GITS_TYPER_HCC_VAL(sc->its_typer);
+
+	/*
+	 * Compute the maximum usable collection count.  When HCC > 0
+	 * the ITS has a fixed number of internal collection slots and
+	 * we use cpuid as the collection ID, so CPUs with IDs at or
+	 * above HCC simply cannot be ITS interrupt targets.  When
+	 * HCC == 0 we allocate a software collection table sized for
+	 * max_ncpus.
+	 */
+	if (sc->its_hcc > 0) {
+		sc->its_max_colls = sc->its_hcc;
+		if (sc->its_max_colls < (uint32_t)max_ncpus) {
+			dev_err(dip, CE_WARN,
+			    "ITS has %u hardware collections but system "
+			    "supports %d CPUs; LPI targeting limited to "
+			    "CPUs 0-%u",
+			    sc->its_max_colls, max_ncpus,
+			    sc->its_max_colls - 1);
+		}
+	} else {
+		sc->its_max_colls = (uint32_t)max_ncpus;
+	}
+
+	/*
+	 * Allocate and program the command queue.
+	 */
+	if (gicv3_its_init_cmdq(sc) != DDI_SUCCESS)
+		goto fail_regs;
+
+	/*
+	 * Allocate and program the device and collection tables.
+	 */
+	if (gicv3_its_init_tables(sc) != DDI_SUCCESS)
+		goto fail_tables;
+
+	/*
+	 * Enable the ITS.
+	 */
+	ctlr = its_read32(sc, GITS_CTLR);
+	its_write32(sc, GITS_CTLR, ctlr | GITS_CTLR_Enabled);
+
+	/*
+	 * Issue MAPC for all currently online CPUs and register the
+	 * CPU callback atomically under cpu_lock.  Holding cpu_lock
+	 * across both the iteration and register_cpu_setup_func()
+	 * ensures no CPU can come online in the gap between the two
+	 * (pattern from uts/i86pc/os/hma.c).
+	 *
+	 * NOTE: CPU_SETUP for boot-time secondaries may fire before
+	 * the ITS driver loads, in which case the callback never
+	 * sees them.  The explicit iteration handles this case.
+	 */
+	mutex_enter(&cpu_lock);
+	cp = cpu_active;
+	do {
+		if (gicv3_its_cpu_can_target(sc, cp->cpu_id))
+			(void) gicv3_its_do_mapc(sc, cp->cpu_id, B_TRUE);
+	} while ((cp = cp->cpu_next_onln) != cpu_active);
+
+	register_cpu_setup_func(gicv3_its_cpu_callback, sc);
+	mutex_exit(&cpu_lock);
+
+	dev_err(dip, CE_CONT,
+	    "!GICv3 ITS: Devbits=%u IDbits=%u ITT_entry=%u HCC=%u "
+	    "max_colls=%u PTA=%s doorbell PA 0x%" PRIx64 "\n",
+	    sc->its_devbits, sc->its_idbits, sc->its_itt_entry_sz,
+	    sc->its_hcc, sc->its_max_colls,
+	    sc->its_pta ? "yes" : "no",
+	    sc->its_doorbell_pa);
+
+	ddi_report_dev(dip);
+	return (DDI_SUCCESS);
+
+fail_tables:
+	if (sc->its_devtab != NULL)
+		gicv3_contig_free(&sc->its_devtab_dmah,
+		    &sc->its_devtab_acch);
+	if (sc->its_colltab != NULL)
+		gicv3_contig_free(&sc->its_colltab_dmah,
+		    &sc->its_colltab_acch);
+	gicv3_contig_free(&sc->its_cmd_dmah, &sc->its_cmd_acch);
+fail_regs:
+	ddi_regs_map_free(&sc->its_regh);
+fail_list:
+	list_destroy(&sc->its_devs);
+	mutex_destroy(&sc->its_dev_lock);
+	mutex_destroy(&sc->its_cmd_lock);
+	ddi_soft_state_free(gicv3_its_soft_state, instance);
+	return (DDI_FAILURE);
+}
+
+static int
+gicv3_its_detach(dev_info_t *dip, ddi_detach_cmd_t cmd)
+{
+	/*
+	 * Cannot evacuate an interrupt controller.
+	 */
+	return (DDI_FAILURE);
+}
+
+/*
+ * Module plumbing
+ *
+ * bus_ops is required so that process_intr_ops() can find the bus_intr_op
+ * entry point when the DDI framework routes operations to the ITS node.
+ *
+ * The ITS acts as a nexus for interrupt operations only.  It does not
+ * enumerate child devices.
+ */
+static struct bus_ops gicv3_its_bus_ops = {
+	.busops_rev		= BUSO_REV,
+	.bus_intr_op		= gicv3_its_intr_ops,
+};
+
+static struct dev_ops gicv3_its_ops = {
+	.devo_rev		= DEVO_REV,
+	.devo_refcnt		= 0,
+	.devo_getinfo		= ddi_no_info,
+	.devo_identify		= nulldev,
+	.devo_probe		= nulldev,
+	.devo_attach		= gicv3_its_attach,
+	.devo_detach		= gicv3_its_detach,
+	.devo_reset		= nodev,
+	.devo_cb_ops		= NULL,
+	.devo_bus_ops		= &gicv3_its_bus_ops,
+	.devo_power		= NULL,
+	.devo_quiesce		= ddi_quiesce_not_needed,
+};
+
+static struct modldrv modldrv = {
+	.drv_modops		= &mod_driverops,
+	.drv_linkinfo		= "GICv3 ITS MSI Controller",
+	.drv_dev_ops		= &gicv3_its_ops,
+};
+
+static struct modlinkage modlinkage = {
+	.ml_rev			= MODREV_1,
+	.ml_linkage		= { &modldrv, NULL },
+};
+
+int
+_init(void)
+{
+	int ret;
+
+	if ((ret = ddi_soft_state_init(&gicv3_its_soft_state,
+	    sizeof (gicv3_its_state_t), 1)) != 0) {
+		return (ret);
+	}
+
+	if ((ret = mod_install(&modlinkage)) != 0) {
+		ddi_soft_state_fini(&gicv3_its_soft_state);
+		return (ret);
+	}
+
+	return (ret);
+}
+
+int
+_fini(void)
+{
+	int ret;
+
+	if ((ret = mod_remove(&modlinkage)) != 0)
+		return (ret);
+
+	ddi_soft_state_fini(&gicv3_its_soft_state);
+	return (ret);
+}
+
+int
+_info(struct modinfo *modinfop)
+{
+	return (mod_info(&modlinkage, modinfop));
+}

--- a/usr/src/uts/armv8/sys/gic_reg.h
+++ b/usr/src/uts/armv8/sys/gic_reg.h
@@ -157,6 +157,8 @@ extern "C" {
 
 #define	GICD_TYPER_CPUNUMBER(n)			(((n)&(GICD_TYPER_CPUNumber)) \
 						>> (GICD_TYPER_CPUNumber_SHIFT))
+#define	GICD_TYPER_IDBITS(n)			((((n) & GICD_TYPER_IDbits) \
+						>> 19) + 1)
 
 #define	GICD_IIDR				0x0008
 #define	GICD_IIDR_ProductID			0xFF000000
@@ -392,6 +394,8 @@ extern "C" {
 #define	GICR_TYPER_Dirty			0x00000004
 #define	GICR_TYPER_VLPIS			0x00000002
 #define	GICR_TYPER_PLPIS			0x00000001
+#define	GICR_TYPER_PROCNUM(n)			\
+	(((n) & GICR_TYPER_Processor_Number) >> 8)
 
 /*
  * Transform a redistributor typer affinity value to a normalized affinity
@@ -442,6 +446,39 @@ extern "C" {
 #define	GICR_PENDBASER_Physical_Address		0x000FFFFFFFFF0000
 #define	GICR_PENDBASER_Shareability		0x0000000000000C00
 #define	GICR_PENDBASER_InnerCache		0x0000000000000380
+
+/*
+ * Shareability field encodings for GICR_PROPBASER, GICR_PENDBASER,
+ * GITS_BASERn, and GITS_CBASER.  The field position varies by register;
+ * these are the raw 2-bit values to be shifted into the appropriate position.
+ */
+#define	GIC_SHARE_NS			0x0	/* Non-shareable */
+#define	GIC_SHARE_IS			0x1	/* Inner Shareable */
+#define	GIC_SHARE_OS			0x2	/* Outer Shareable */
+
+/*
+ * Cacheability field encodings (inner and outer) for the same registers.
+ * Again, raw 3-bit values before shifting.
+ */
+#define	GIC_CACHE_nC			0x1	/* Non-cacheable */
+#define	GIC_CACHE_RaWt			0x2	/* Read-alloc, Write-through */
+#define	GIC_CACHE_RaWb			0x3	/* Read-alloc, Write-back */
+#define	GIC_CACHE_WaWt			0x4	/* Write-alloc, Write-through */
+#define	GIC_CACHE_WaWb			0x5	/* Write-alloc, Write-back */
+#define	GIC_CACHE_RaWaWt		0x6	/* R/W-alloc, Write-through */
+#define	GIC_CACHE_RaWaWb		0x7	/* R/W-alloc, Write-back */
+
+/*
+ * Helper macros to construct PROPBASER/PENDBASER register values.
+ * These shift the raw encoding values into the correct field positions.
+ */
+#define	GICR_PROPBASER_SHARE(v)		((uint64_t)(v) << 10)
+#define	GICR_PROPBASER_IC(v)		((uint64_t)(v) << 7)
+#define	GICR_PROPBASER_OC(v)		((uint64_t)(v) << 56)
+
+#define	GICR_PENDBASER_SHARE(v)		((uint64_t)(v) << 10)
+#define	GICR_PENDBASER_IC(v)		((uint64_t)(v) << 7)
+#define	GICR_PENDBASER_OC(v)		((uint64_t)(v) << 56)
 
 #define	GICR_INVLPIR				0x00a0
 #define	GICR_INVLPIR_V				0x8000000000000000
@@ -860,6 +897,14 @@ extern "C" {
 #define	GITS_TYPER_Virtual			0x0000000000000002
 #define	GITS_TYPER_Physical			0x0000000000000001
 
+/* GITS_TYPER extraction macros */
+#define	GITS_TYPER_PTA_BIT(v)		(((v) & GITS_TYPER_PTA) != 0)
+#define	GITS_TYPER_DEVBITS(v)		((((v) & GITS_TYPER_Devbits) >> 13) + 1)
+#define	GITS_TYPER_IDBITS(v)		((((v) & GITS_TYPER_ID_bits) >> 8) + 1)
+#define	GITS_TYPER_ITT_ENTRY_SZ(v)	((((v) & GITS_TYPER_ITT_entry_size) \
+					>> 4) + 1)
+#define	GITS_TYPER_HCC_VAL(v)		(((v) & GITS_TYPER_HCC) >> 24)
+
 #define	GITS_MPAMIDR				0x0010
 #define	GITS_MPAMIDR_PMGmax			0x00FF0000
 #define	GITS_MPAMIDR_PARTIDmax			0x0000FFFF
@@ -895,6 +940,11 @@ extern "C" {
 #define	GITS_CBASER_Shareability		0x0000000000000C00
 #define	GITS_CBASER_Size			0x00000000000000FF
 
+#define	GITS_CBASER_IC(v)		((uint64_t)(v) << 59)
+#define	GITS_CBASER_OC(v)		((uint64_t)(v) << 53)
+#define	GITS_CBASER_SHARE(v)		((uint64_t)(v) << 10)
+#define	GITS_CBASER_SHARE_VAL(v)	(((v) & GITS_CBASER_Shareability) >> 10)
+
 #define	GITS_CWRITER				0x0088
 #define	GITS_CWRITER_Offset			0x00000000000FFFE0
 #define	GITS_CWRITER_Retry			0x0000000000000001
@@ -903,7 +953,7 @@ extern "C" {
 #define	GITS_CREADR_Offset			0x00000000000FFFE0
 #define	GITS_CREADR_Stalled			0x0000000000000001
 
-#define	GITS_BASERn(n)				(0x0100+(4*(n)))
+#define	GITS_BASERn(n)				(0x0100+(8*(n)))
 #define	GITS_BASERn_Valid			0x8000000000000000
 #define	GITS_BASERn_Indirect			0x4000000000000000
 #define	GITS_BASERn_InnerCache			0x3800000000000000
@@ -915,8 +965,38 @@ extern "C" {
 #define	GITS_BASERn_Page_Size			0x0000000000000300
 #define	GITS_BASERn_Size			0x00000000000000FF
 
+/* MAPD command DW2: ITT address field, bits [51:8] */
+#define	GITS_MAPD_ITT_ADDR			0x000FFFFFFFFFFF00ULL
+
+/* BASERn field extraction */
+#define	GITS_BASERn_TYPE_VAL(v)		(((v) & GITS_BASERn_Type) >> 56)
+#define	GITS_BASERn_ENTRY_SZ_VAL(v)	((((v) & GITS_BASERn_Entry_Size) \
+					>> 48) + 1)
+#define	GITS_BASERn_PGSZ_VAL(v)		(((v) & GITS_BASERn_Page_Size) >> 8)
+#define	GITS_BASERn_SIZE_VAL(v)		((v) & GITS_BASERn_Size)
+#define	GITS_BASERn_SHARE_VAL(v)	(((v) & GITS_BASERn_Shareability) >> 10)
+
+/* BASERn type values */
+#define	GITS_BASER_TYPE_NONE		0
+#define	GITS_BASER_TYPE_DEVICES		1
+#define	GITS_BASER_TYPE_VPES		2
+#define	GITS_BASER_TYPE_COLLECTION	4
+
+/* BASERn page size values */
+#define	GITS_BASER_PGSZ_4K		0
+#define	GITS_BASER_PGSZ_16K		1
+#define	GITS_BASER_PGSZ_64K		2
+
+/* BASERn/CBASER field construction helpers */
+#define	GITS_BASERn_IC(v)		((uint64_t)(v) << 59)
+#define	GITS_BASERn_OC(v)		((uint64_t)(v) << 53)
+#define	GITS_BASERn_SHARE(v)		((uint64_t)(v) << 10)
+#define	GITS_BASERn_PGSZ(v)		((uint64_t)(v) << 8)
+
 #define	GITS_PIDR2				0xffe8
 #define	GITS_PIDR2_ArchRev			0x000000F0
+
+#define	GITS_TRANSLATER				0x10040
 
 /*
  * GICv2m MSI frame registers

--- a/usr/src/uts/armv8/sys/gic_v3.h
+++ b/usr/src/uts/armv8/sys/gic_v3.h
@@ -1,0 +1,67 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2026 Michael van der Westhuizen
+ */
+
+#ifndef _SYS_GIC_V3_H
+#define	_SYS_GIC_V3_H
+
+#include <sys/types.h>
+#include <sys/sunddi.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * GICv3 LPI exports for ITS and MBI drivers.
+ *
+ * This is a private interface between the GIC and the subordinate ITS driver
+ * or embedded MBI driver.
+ */
+
+#define	GICV3_ITS_PEND_ALIGN	(64 * 1024)	/* 64KiB alignment */
+
+/* Contiguous memory allocation */
+extern int
+gicv3_contig_alloc(dev_info_t *dip, size_t size, size_t align,
+    caddr_t *vap, uint64_t *pap, ddi_dma_handle_t *dma_hdlp,
+    ddi_acc_handle_t *acc_hdlp);
+extern void
+gicv3_contig_free(ddi_dma_handle_t *dma_hdlp, ddi_acc_handle_t *acc_hdlp);
+
+/* LPI INTID allocation */
+extern int	gicv3_alloc_lpi(dev_info_t *, uint32_t *);
+extern int	gicv3_alloc_lpi_block(dev_info_t *, uint32_t, uint32_t,
+		    uint32_t *);
+extern void	gicv3_free_lpi(dev_info_t *, uint32_t);
+extern void	gicv3_free_lpi_block(dev_info_t *, uint32_t, uint32_t);
+extern size_t	gicv3_lpi_navail(dev_info_t *);
+
+/* LPI configuration (PROPBASER table access) */
+extern void	gicv3_lpi_set_config(dev_info_t *, uint32_t, uint8_t,
+		    boolean_t);
+extern uint8_t	gicv3_lpi_get_config(dev_info_t *, uint32_t);
+extern boolean_t gicv3_lpi_ispending(dev_info_t *, uint32_t, processorid_t);
+
+/* Redistributor info for ITS MAPC commands */
+extern uint64_t	gicv3_redist_pa(dev_info_t *, processorid_t);
+extern uint32_t	gicv3_redist_procnum(dev_info_t *, processorid_t);
+extern uint32_t	gicv3_num_redists(dev_info_t *);
+extern uint32_t	gicv3_lpi_idbits(dev_info_t *);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _SYS_GIC_V3_H */


### PR DESCRIPTION
_This is one of five PRs for initial MSI/MSI-X support, and depends on #237. This PR is a pre-requisite for the DDI + PCI MSI/MSI-X framework #240._

Add MSI/MSI-X support for GICv3-based platforms via the Interrupt Translation Service (ITS).

Depends on the MSI/MSI-X preparation PR (#237) for syspic dip tracking, `ihdl_plat` MSI fields, and OBP MSI property constants, and on the GICv2 MSI/MSI-X PR (#238) for shared edits to the `gic_reg.h` register definitions.

### gicv3: prepare gicthree for ITS

Add LPI infrastructure and exported interfaces to the GICv3 driver in preparation for the ITS driver.
LPI table management:
* Allocate the per-GIC LPI properties table (one byte per LPI INTID, index 0 = INTID 8192) and per-redistributor pending tables (one bit per INTID, index 0 = INTID 0: the first 8192 bits are architecturally wasted).
* Enable LPIs on each redistributor via `GICR_CTLR.EnableLPIs`.
* Add a `vmem` arena for LPI INTID allocation/deallocation.

A number of interfaces are exported for use by the ITS driver, dealing with LPI INTID allocation, LPI configuration, and redistributor information for ITS MAPC commands.

Add `gic_v3.h` describing the private interface between the GICv3 driver and the ITS driver.

Document lock ordering in the file header.

Bug fixes:
* Fix spinlock leak on error path in `gicv3_config_irq_spi` (bare return without unlock, now goto unlock)
* Correct `GITS_BASERn` macro stride from 4 to 8 bytes

Additional bus_intr_op support:
* `GETCAP` and `GETPENDING` for `FIXED` interrupts (`gicv3_irq_ispending` via `GICR_ISPENDR0`/`GICD_ISPENDRn`)
* Explicit `DDI_ENOTSUP` for `SETCAP` (unused in the tree)
* No-op handling of LPIs in `addspl`/`delspl`

### gicv3: add an ITS driver

Add a driver for the GICv3 Interrupt Translation Service (ITS), the MSI controller used alongside the GICv3.

The ITS is a translation service: a PCI device writes an EventID to the `GITS_TRANSLATER` doorbell, and the ITS maps `{DeviceID, EventID}` through its device and interrupt translation tables to a target `{LPI INTID, collection}`, where each collection is bound to a CPU's redistributor.

LPIs start at INTID 8192 and the INTID space is global, shared across all ITS instances on a GIC (there may be many, typically one per I/O domain: `ITS` <-> `SMMU` <-> `PCIERC`).

Pending state is stored per-redistributor and LPI configuration is per-GIC, both managed by the base GICv3 driver.

Per-ITS state managed by this driver:
* Device table (flat, `2^Devbits` entries)
* Per-device interrupt translation tables
* Collection table (one entry per CPU)
* Command queue ring buffer with stall recovery (IHI 0069 §8.19.19 skip model)
* CPU hotplug migration (`MOVI` + `MAPC` via `cpu_setup` callback)

The driver implements the bus_intr_op interface for `ALLOC`, `FREE`, `ENABLE`, `DISABLE`, `ADDISR`, `REMISR`, `GETCAP`, `GETPENDING`, `NAVAIL`, `GETTARGET`, and `SETTARGET`.

### Testing

All base FDT testing on my [feature/msi-msix](https://github.com/r1mikey/illumos-gate/tree/feature/msi-msix) branch, all ACPI testing on my [r1mikey/armh-sbbr-msi-msix](https://github.com/r1mikey/illumos-gate/tree/r1mikey/armh-sbbr-msi-msix) branch.

* [QEMU virt FDT](https://gist.github.com/r1mikey/915102a57815af1fc81e226b95ad921a) (GICv2): vioblk on SPIs 80+81, clean boot
* [QEMU virt FDT](https://gist.github.com/r1mikey/8b6b98c66f7acd130e05bf49b364fe96) (GICv3): vioblk on LPIs 8192+8193, clean boot
* [RPi4 FDT](https://gist.github.com/r1mikey/4952a56c12bb10f770536132de934b89): intentionally still on the INTx path, no regression
* [QEMU virt ACPI](https://gist.github.com/r1mikey/d4e76c63e21bf1fc2b9f98357b1207d4) (GICv3): 6 LPIs across vioblk/vioif/xhci, clean boot
* Ampere [Altra Max ACPI](https://gist.github.com/r1mikey/38de5803a035bf402c724ccdcd3161e0) (GICv3): nvme*2, ixgbe*2, xhci, igb, [67 LPIs](https://gist.github.com/r1mikey/c676ee43f158b9bac98a89d66b01f8f3), INTx on pcieb