### PR TITLE
armv8/vm: re-parameterize the HAT through the global `mmu.`

### DIFF
--- a/usr/src/uts/armv8/vm/aarch64_mmu.c
+++ b/usr/src/uts/armv8/vm/aarch64_mmu.c
@@ -166,7 +166,7 @@ hat_kern_alloc(
 	 * the entire top level page table for the kernel. Make sure there's
 	 * enough reserve for that too.
 	 */
-	table_cnt += NPTEPERPT - ((kernelbase >> LEVEL_SHIFT(MAX_PAGE_LEVEL)) &
+	table_cnt += NPTEPERPT - ((kernelbase >> LEVEL_SHIFT(mmu.max_level)) &
 	    (NPTEPERPT - 1));
 
 	/*

--- a/usr/src/uts/armv8/vm/hat_aarch64.c
+++ b/usr/src/uts/armv8/vm/hat_aarch64.c
@@ -150,12 +150,15 @@ hat_alloc(struct as *as)
 	ASSERT(hat->hat_flags == 0);
 
 	hat->hat_ht_hash = kmem_cache_alloc(hat_hash_cache, KM_SLEEP);
-	bzero(hat->hat_ht_hash, HTABLE_NUM_HASH * sizeof (htable_t *));
+	bzero(hat->hat_ht_hash, mmu.hash_cnt * sizeof (htable_t *));
 
+	/*
+	 * Initialize Kernel HAT entries at the top of the top level page
+	 * tables for the new hat.
+	 */
 	hat->hat_htable = NULL;
 	hat->hat_ht_cached = NULL;
-	/* create top level */
-	ht = htable_create(hat, (uintptr_t)0, MAX_PAGE_LEVEL, NULL);
+	ht = htable_create(hat, (uintptr_t)0, TOP_LEVEL(hat), NULL);
 	hat->hat_htable = ht;
 
 	/*
@@ -255,9 +258,32 @@ mmu_init(void)
 {
 	hole_start = HOLE_START;
 	hole_end = HOLE_END;
-	mmu.max_asid = ((read_tcr() & TCR_AS)? 0xFFFF: 0xFF);
-	mmu.max_level = MAX_PAGE_LEVEL;
-	mmu.kernelbase = ~((1ul << (VA_BITS - 1)) - 1);
+
+	mmu.max_asid = ((read_tcr() & TCR_AS) ? 0xFFFF : 0xFF);
+
+	mmu.num_level = MMU_PAGE_LEVELS;
+	mmu.max_level = mmu.num_level - 1;
+	mmu.max_page_level = MMU_PAGE_SIZES - 1;
+
+	/*
+	 * Compute how many hash table entries to have per process for htables.
+	 * We start with 1 page's worth of entries.
+	 *
+	 * If physical memory is small, reduce the amount needed to cover it.
+	 */
+	uint64_t max_htables = physmax / NPTEPERPT;
+	mmu.hash_cnt = MMU_PAGESIZE / sizeof (htable_t *);
+	while (mmu.hash_cnt > 16 && mmu.hash_cnt >= max_htables)
+		mmu.hash_cnt >>= 1;
+
+	/*
+	 * If running in 64 bits and physical memory is large,
+	 * increase the size of the cache to cover all of memory for
+	 * a 64 bit process.
+	 */
+#define	HASH_MAX_LENGTH 4
+	while (mmu.hash_cnt * HASH_MAX_LENGTH < max_htables)
+		mmu.hash_cnt <<= 1;
 }
 
 /*
@@ -276,8 +302,9 @@ hat_init()
 
 	hat_cache = kmem_cache_create("hat_t", sizeof (hat_t),
 	    0, hati_constructor, NULL, NULL, NULL, 0, 0);
-	hat_hash_cache = kmem_cache_create("HatHash", MMU_PAGESIZE,
-	    0, NULL, NULL, NULL, NULL, 0, 0);
+	hat_hash_cache = kmem_cache_create("HatHash",
+	    mmu.hash_cnt * sizeof (htable_t *), 0, NULL, NULL, NULL,
+	    NULL, 0, 0);
 
 	/*
 	 * Set up the kernel's hat
@@ -302,7 +329,7 @@ hat_init()
 	 * XX64 - tune for 64 bit procs
 	 */
 	kas.a_hat->hat_ht_hash = kmem_cache_alloc(hat_hash_cache, KM_NOSLEEP);
-	bzero(kas.a_hat->hat_ht_hash, MMU_PAGESIZE);
+	bzero(kas.a_hat->hat_ht_hash, mmu.hash_cnt * sizeof (htable_t *));
 
 	/*
 	 * zero out the top level and cached htable pointers
@@ -1004,7 +1031,7 @@ hat_memload_array(
 		 * decide what level mapping to use (ie. pagesize)
 		 */
 		pfn = page_pptonum(pages[pgindx]);
-		for (level = MAX_PAGE_LEVEL; ; --level) {
+		for (level = mmu.max_page_level; ; --level) {
 			pgsize = LEVEL_SIZE(level);
 			if (level == 0)
 				break;
@@ -1127,7 +1154,7 @@ hat_devload(
 		/*
 		 * decide what level mapping to use (ie. pagesize)
 		 */
-		for (level = MAX_PAGE_LEVEL; ; --level) {
+		for (level = mmu.max_page_level; ; --level) {
 			pgsize = LEVEL_SIZE(level);
 			if (level == 0)
 				break;
@@ -1551,7 +1578,7 @@ hat_unload_callback(
 		 */
 		entry = htable_va2entry(vaddr, ht);
 		hat_pte_unmap(ht, entry, flags, old_pte, NULL, B_FALSE);
-		ASSERT(ht->ht_level <= MAX_PAGE_LEVEL);
+		ASSERT(ht->ht_level <= mmu.max_page_level);
 		vaddr += LEVEL_SIZE(ht->ht_level);
 		contig_va = vaddr;
 		++r[r_cnt - 1].rng_cnt;
@@ -1697,7 +1724,7 @@ hat_getattr(hat_t *hat, caddr_t addr, uint_t *attr)
 	if (IN_VA_HOLE(vaddr))
 		return ((uint_t)-1);
 
-	ht = htable_getpte(hat, vaddr, NULL, &pte, MAX_PAGE_LEVEL);
+	ht = htable_getpte(hat, vaddr, NULL, &pte, mmu.max_page_level);
 	if (ht == NULL)
 		return ((uint_t)-1);
 
@@ -2088,7 +2115,7 @@ hat_share(
 		/*
 		 * Can't ever share top table.
 		 */
-		if (l == MAX_PAGE_LEVEL)
+		if (l == mmu.max_level)
 			goto not_shared;
 
 		/*
@@ -2240,8 +2267,8 @@ hat_unshare(hat_t *hat, caddr_t addr, size_t len, uint_t ismszc)
 	 * finished, because if hat_pageunload() were to unload a shared
 	 * pagetable page, its hat_tlb_inval() will do a global TLB invalidate.
 	 */
-	l = MAX_PAGE_LEVEL;
-	if (l == MAX_PAGE_LEVEL)
+	l = mmu.max_page_level;
+	if (l == mmu.max_level)
 		--l;
 	for (; l >= 0; --l) {
 		for (vaddr = (uintptr_t)addr; vaddr < eaddr;
@@ -3095,7 +3122,7 @@ hat_page_fault(hat_t *hat, caddr_t vaddr)
 		uint_t entry;
 		pte_t oldpte;
 		htable_t *ht = htable_getpte(hat, (uintptr_t)vaddr, &entry,
-		    &oldpte, MAX_PAGE_LEVEL);
+		    &oldpte, mmu.max_page_level);
 		if (ht == NULL)
 			break;
 

--- a/usr/src/uts/armv8/vm/hat_pte.h
+++ b/usr/src/uts/armv8/vm/hat_pte.h
@@ -36,7 +36,14 @@ extern "C" {
 #include <sys/pte.h>
 #include <sys/machparam.h>
 
-typedef int32_t level_t;
+/*
+ * The type of "level_t" is signed so that it can be used like:
+ *	level_t	l;
+ *	...
+ *	while (--l >= 0)
+ *		...
+ */
+typedef int8_t level_t;
 
 /*
  * The software bits are used by the HAT to track attributes.
@@ -49,7 +56,6 @@ typedef int32_t level_t;
  *
  */
 #define	PAGE_LEVEL		(0)
-#define	MAX_PAGE_LEVEL		(MMU_PAGE_LEVELS - 1)
 
 #define	PTE_SOFTWARE		PTE_SFW_MASK
 #define	PTE_NOSYNC		(0x4ul << PTE_SFW_SHIFT)
@@ -65,10 +71,10 @@ typedef int32_t level_t;
 #define	MAKEPTP(pfn, l, k)	(((pfn) << MMU_PAGESHIFT) | PTE_TABLE | \
 	((k)? (PTE_TABLE_UXNT | PTE_TABLE_APT_NOUSER): PTE_TABLE_PXNT))
 
-#define	TOP_LEVEL(hat)		MAX_PAGE_LEVEL
+#define	TOP_LEVEL(hat)		(mmu.max_level)
 
 /*
- * HAT/MMU parameters that depend on kernel mode and/or processor type
+ * HAT/MMU parameters that depend on processor type or configuration
  */
 struct htable;
 struct hat_mmu_info {
@@ -76,9 +82,13 @@ struct hat_mmu_info {
 	uintptr_t kmap_eaddr;	/* end addr of kmap */
 	struct htable **kmap_htables; /* htables for segmap + 32 bit heap */
 	pte_t *kmap_ptes;	/* mapping of pagetables that map kmap */
-	uint32_t max_asid;
-	int max_level;
-	uintptr_t kernelbase;
+	uint16_t max_asid;	/* maximum address-space identifier */
+
+	uint_t num_level;	/* Number of paging levels in use */
+	uint_t max_level;	/* num_level - 1 */
+	uint_t max_page_level;	/* maximum level at which we can map a page */
+
+	uint_t hash_cnt;	/* cnt of entries in htable_hash_cache */
 };
 extern struct hat_mmu_info mmu;
 

--- a/usr/src/uts/armv8/vm/htable.c
+++ b/usr/src/uts/armv8/vm/htable.c
@@ -294,7 +294,7 @@ htable_steal_active(hat_t *hat, uint_t cnt, uint_t threshold,
 	uintptr_t	va;
 	pte_t	pte;
 
-	h = h_start = h_seed++ % (MMU_PAGESIZE / sizeof (htable_t *));
+	h = h_start = h_seed++ % mmu.hash_cnt;
 	do {
 		higher = NULL;
 		HTABLE_ENTER(h);
@@ -379,7 +379,7 @@ htable_steal_active(hat_t *hat, uint_t cnt, uint_t threshold,
 		HTABLE_EXIT(h);
 		if (higher != NULL)
 			htable_release(higher);
-		if (++h == (MMU_PAGESIZE / sizeof (htable_t *)))
+		if (++h == mmu.hash_cnt)
 			h = 0;
 	} while (*stolen < cnt && h != h_start);
 }
@@ -851,7 +851,7 @@ htable_purge_hat(hat_t *hat)
 	/*
 	 * walk thru the htable hash table and free all the htables in it.
 	 */
-	for (h = 0; h < (MMU_PAGESIZE / sizeof (htable_t *)); ++h) {
+	for (h = 0; h < mmu.hash_cnt; ++h) {
 		while ((ht = hat->hat_ht_hash[h]) != NULL) {
 			if (ht->ht_next)
 				ht->ht_next->ht_prev = ht->ht_prev;
@@ -914,9 +914,8 @@ link_ptp(htable_t *higher, htable_t *new, uintptr_t vaddr, boolean_t is_kernel)
 	pte_t	newptp = MAKEPTP(new->ht_pfn, new->ht_level, is_kernel);
 	pte_t	found;
 
-	ASSERT(higher->ht_busy > 0);
-
-	ASSERT(new->ht_level != MAX_PAGE_LEVEL);
+	ASSERT3U(higher->ht_busy, >, 0);
+	ASSERT3U(new->ht_level, !=, mmu.max_level);
 
 	HTABLE_INC(higher->ht_valid_cnt);
 
@@ -982,7 +981,7 @@ htable_release(htable_t *ht)
 				 * At and above max_page_level, free if it's for
 				 * a boot-time kernel mapping below kernelbase.
 				 */
-				if (level >= MAX_PAGE_LEVEL &&
+				if (level >= mmu.max_page_level &&
 				    (hat != kas.a_hat || va >= kernelbase))
 					break;
 			}
@@ -1258,7 +1257,7 @@ htable_attach(
 	extern page_t	*boot_claim_page(pfn_t);
 
 	ht = htable_get_reserve();
-	if (level == MAX_PAGE_LEVEL)
+	if (level == mmu.max_level)
 		kas.a_hat->hat_htable = ht;
 	ht->ht_hat = hat;
 	ht->ht_parent = parent;
@@ -1454,10 +1453,10 @@ htable_walk(
 	 * Find the level of the largest pagesize used by this HAT.
 	 */
 	if (hat->hat_ism_pgcnt > 0) {
-		max_mapped_level = MAX_PAGE_LEVEL;
+		max_mapped_level = mmu.max_page_level;
 	} else {
 		max_mapped_level = 0;
-		for (l = 1; l <= MAX_PAGE_LEVEL; ++l)
+		for (l = 1; l <= mmu.max_page_level; ++l)
 			if (hat->hat_pages_mapped[l] != 0)
 				max_mapped_level = l;
 	}
@@ -1518,7 +1517,7 @@ htable_getpte(
 	level_t		l;
 	uint_t		e;
 
-	ASSERT(level <= MAX_PAGE_LEVEL);
+	ASSERT(level <= mmu.max_page_level);
 
 	for (l = 0; l <= level; ++l) {
 		ht = htable_lookup(hat, vaddr, l);
@@ -1547,7 +1546,7 @@ htable_getpage(struct hat *hat, uintptr_t vaddr, uint_t *entry)
 	uint_t		e;
 	pte_t	pte;
 
-	ht = htable_getpte(hat, vaddr, &e, &pte, MAX_PAGE_LEVEL);
+	ht = htable_getpte(hat, vaddr, &e, &pte, mmu.max_page_level);
 	if (ht == NULL)
 		return (NULL);
 
@@ -1756,7 +1755,7 @@ pte_inval(
 	pte_t	found;
 
 	ASSERT(!(ht->ht_flags & HTABLE_SHARED_PFN));
-	ASSERT(ht->ht_level <= MAX_PAGE_LEVEL);
+	ASSERT(ht->ht_level <= mmu.max_page_level);
 
 	if (pte_ptr != NULL)
 		ptep = pte_ptr;
@@ -1797,7 +1796,7 @@ pte_update(
 
 	ASSERT(new != 0);
 	ASSERT(!(ht->ht_flags & HTABLE_SHARED_PFN));
-	ASSERT(ht->ht_level <= MAX_PAGE_LEVEL);
+	ASSERT(ht->ht_level <= mmu.max_page_level);
 
 	ptep = PT_INDEX_PTR(hat_kpm_pfn2va(ht->ht_pfn), entry);
 	found = CAS_PTE(ptep, expect, new);
@@ -1869,7 +1868,7 @@ hat_dump(void)
 	 * Dump all page tables
 	 */
 	for (hat = kas.a_hat; hat != NULL; hat = hat->hat_next) {
-		for (h = 0; h < (MMU_PAGESIZE / sizeof (htable_t *)); ++h) {
+		for (h = 0; h < mmu.hash_cnt; ++h) {
 			for (ht = hat->hat_ht_hash[h]; ht; ht = ht->ht_next) {
 				dump_page(ht->ht_pfn);
 			}

--- a/usr/src/uts/armv8/vm/htable.h
+++ b/usr/src/uts/armv8/vm/htable.h
@@ -88,10 +88,9 @@ typedef struct htable htable_t;
  * that the secondary hash for the htable mutex winds up begin different in
  * every address space.
  */
-#define	HTABLE_NUM_HASH	(MMU_PAGESIZE / sizeof (htable_t *))
 #define	HTABLE_HASH(hat, va, lvl)					\
 	((((va) >> LEVEL_SHIFT(1)) + ((va) >> 28) + (lvl) +		\
-	((uintptr_t)(hat) >> 4)) & (HTABLE_NUM_HASH - 1))
+	((uintptr_t)(hat) >> 4)) & (mmu.hash_cnt - 1))
 
 /*
  * Compute the last page aligned VA mapped by an htable.

--- a/usr/src/uts/armv8/vm/vm_machdep.c
+++ b/usr/src/uts/armv8/vm/vm_machdep.c
@@ -234,8 +234,11 @@ page_t ***page_cachelists;
 
 /*
  * Used by page layer to know about page sizes
+ *
+ * This array is terminated by an entry which is all 0s, hence the + 1.
+ * See at least page_szc() for this.
  */
-hw_pagesize_t hw_page_array[MAX_PAGE_LEVEL + 1];
+hw_pagesize_t hw_page_array[MMU_PAGE_SIZES + 1];
 
 kmutex_t	*fpc_mutex[NPC_MUTEX];
 kmutex_t	*cpc_mutex[NPC_MUTEX];
@@ -276,7 +279,7 @@ map_pgsz(int maptype, struct proc *p, caddr_t addr, size_t len, int memcntl)
 		/*
 		 * use the pages size that best fits len
 		 */
-		for (l = MAX_PAGE_LEVEL; l > 0; --l) {
+		for (l = mmu.max_page_level; l > 0; --l) {
 			if (LEVEL_SIZE(l) > max_lpsize || len < LEVEL_SIZE(l)) {
 				continue;
 			} else {
@@ -293,7 +296,7 @@ map_pgsz(int maptype, struct proc *p, caddr_t addr, size_t len, int memcntl)
 		return (pgsz);
 
 	case MAPPGSZ_ISM:
-		for (l = MAX_PAGE_LEVEL; l > 0; --l) {
+		for (l = mmu.max_page_level; l > 0; --l) {
 			if (len >= LEVEL_SIZE(l))
 				return (LEVEL_SIZE(l));
 		}
@@ -531,7 +534,7 @@ map_addr_proc(
 		 */
 		align_amount = ELF_AARCH64_MAXPGSZ;
 	} else {
-		int lvl = MAX_PAGE_LEVEL;
+		int lvl = mmu.max_page_level;
 
 		while (lvl && len < LEVEL_SIZE(lvl))
 			--lvl;
@@ -1009,7 +1012,7 @@ page_coloring_init(uint_t l2_sz, int l2_linesz, int l2_assoc)
 	page_coloring_shift = lowbit(CPUSETSIZE());
 
 	/* initialize number of colors per page size */
-	for (i = 0; i <= MAX_PAGE_LEVEL; i++) {
+	for (i = 0; i <= mmu.max_page_level; i++) {
 		hw_page_array[i].hp_size = LEVEL_SIZE(i);
 		hw_page_array[i].hp_shift = LEVEL_SHIFT(i);
 		hw_page_array[i].hp_pgcnt = LEVEL_SIZE(i) >> LEVEL_SHIFT(0);
@@ -1029,7 +1032,7 @@ page_coloring_init(uint_t l2_sz, int l2_linesz, int l2_assoc)
 		ASSERT(a > 0);
 		ASSERT(a < 16);
 
-		for (i = 0; i <= MAX_PAGE_LEVEL; i++) {
+		for (i = 0; i <= mmu.max_page_level; i++) {
 			if ((colors = hw_page_array[i].hp_colors) <= 1) {
 				colorequivszc[i] = 0;
 				continue;
@@ -1050,7 +1053,7 @@ page_coloring_init(uint_t l2_sz, int l2_linesz, int l2_assoc)
 		if (a > 15)
 			a = 15;
 
-		for (i = 0; i <= MAX_PAGE_LEVEL; i++) {
+		for (i = 0; i <= mmu.max_page_level; i++) {
 			if ((colors = hw_page_array[i].hp_colors) <= 1) {
 				continue;
 			}

--- a/usr/src/uts/i86pc/vm/vm_machdep.c
+++ b/usr/src/uts/i86pc/vm/vm_machdep.c
@@ -345,6 +345,9 @@ page_t ***page_cachelists;
 
 /*
  * Used by page layer to know about page sizes
+ *
+ * This array is terminated by an entry which is all 0s, hence the + 1.
+ * See at least page_szc() for this.
  */
 hw_pagesize_t hw_page_array[MAX_NUM_LEVEL + 1];
 


### PR DESCRIPTION
The x86 HAT indirects through the global `mmu.` to allow for runtime-variance in the number of levels, page sizes, etc, and the scaling of the htable hash.

Restore all of this on ARM, as all of these can also vary there (though they don't, right now).

There are some issues where I have replicated the x86 code but I'm unsure about:
  In cases where we check against the maximum level, and then decrement seem
  to be making the assumption that a page may always live at the
  (top level - 1), which is not true on ARM with larger virtual address
  spaces.

In doing this also:

  - bring in the smaller level_t and description from x86.
  - remove the duplicative MAX_* constants

The MAX_* constants exist for reasons I don't understand, it is apparent from the code that the equivalent MMU_* constants _also_ represent the architectural maximums (we use them to size arrays, and also on SPARC explicitly say so).

Also document that `hw_page_array` is 0-terminated and so bigger than you'd expect, and point to `page_szc` as evidence.

@r1mikey I have tried to get the MMU_* -> mmu. translation correct, rather than literal (except the one I mentioned, where I'm not sure)