### PR TITLE
ns16550a: don't crash on detach

### DIFF
--- a/usr/src/uts/armv8/io/ns16550a/ns16550a.c
+++ b/usr/src/uts/armv8/io/ns16550a/ns16550a.c
@@ -925,6 +925,18 @@ ns16550detach(dev_info_t *devi, ddi_detach_cmd_t cmd)
 			nsasync->nsasync_dtrtid = 0;
 		}
 
+		/* cancel untimed break hold timeout */
+		if (nsasync->nsasync_utbrktid != 0) {
+			(void) untimeout(nsasync->nsasync_utbrktid);
+			nsasync->nsasync_utbrktid = 0;
+		}
+
+		/* cancel close drain progress timer */
+		if (nsasync->nsasync_timer != 0) {
+			(void) untimeout(nsasync->nsasync_timer);
+			nsasync->nsasync_timer = 0;
+		}
+
 		/* remove all minor device node(s) for this device */
 		ddi_remove_minor_node(devi, NULL);
 

--- a/usr/src/uts/armv8/io/ns16550a/ns16550a.c
+++ b/usr/src/uts/armv8/io/ns16550a/ns16550a.c
@@ -912,6 +912,13 @@ ns16550detach(dev_info_t *devi, ddi_detach_cmd_t cmd)
 		DEBUGNOTE2(NS16550_DEBUG_INIT, "ns16550%d: %s shutdown.",
 		    instance, ns16550_hw_name(ns16550));
 
+		/*
+		 * Disable interrupts before destroying any state they
+		 * depend on.  Hard interrupt first, then soft interrupt.
+		 */
+		ddi_remove_intr(devi, 0, ns16550->ns16550_iblock);
+		ddi_remove_softintr(ns16550->ns16550_softintr_id);
+
 		/* cancel DTR hold timeout */
 		if (nsasync->nsasync_dtrtid != 0) {
 			(void) untimeout(nsasync->nsasync_dtrtid);
@@ -921,13 +928,11 @@ ns16550detach(dev_info_t *devi, ddi_detach_cmd_t cmd)
 		/* remove all minor device node(s) for this device */
 		ddi_remove_minor_node(devi, NULL);
 
+		cv_destroy(&nsasync->nsasync_flags_cv);
 		mutex_destroy(&ns16550->ns16550_excl);
 		mutex_destroy(&ns16550->ns16550_excl_hi);
-		cv_destroy(&nsasync->nsasync_flags_cv);
-		ddi_remove_intr(devi, 0, ns16550->ns16550_iblock);
-		ddi_regs_map_free(&ns16550->ns16550_iohandle);
-		ddi_remove_softintr(ns16550->ns16550_softintr_id);
 		mutex_destroy(&ns16550->ns16550_soft_lock);
+		ddi_regs_map_free(&ns16550->ns16550_iohandle);
 		ns16550_soft_state_free(ns16550);
 		DEBUGNOTE1(NS16550_DEBUG_INIT, "ns16550%d: shutdown complete",
 		    instance);

--- a/usr/src/uts/common/io/avintr.c
+++ b/usr/src/uts/common/io/avintr.c
@@ -511,7 +511,7 @@ av_rem_softintr(void *intr_id, int lvl, avfunc xxintr, boolean_t rem_softinfo)
 		return (0);
 	}
 	vecp = &softvect[lvl];
-	remove_av(intr_id, vecp, xxintr, lvl, 0);
+	remove_av(intr_id, vecp, xxintr, lvl, NO_VECT);
 
 	if (rem_softinfo) {
 		kmem_free(infop, sizeof (av_softinfo_t));


### PR DESCRIPTION
I've been carrying https://github.com/r1mikey/illumos-gate/commit/7d8183ada7dcf433899cb18b16836a68d25837ef in my ACPI tree for a while to get around crashes that happen on Altra Max when the second pl011 UART goes inactive and detaches.

There are a few reasons for the crashes - the first is that the softint handler cannot deregister due to bugs in avintr that are exposed by Arm being a lot stricter in checking vectors in a hash bucket.

Then there's a reordering of detach to get around race conditions - this I later found mirrors the fix for 16972/16990 in asy (bd237d3e627eb2af9f7ef6d5f2affc7699ffe899).

Finally, not all timer actions were being cancelled - when these fired with a deleted softstate crashes would happen.

There are a few more changes needed to get back to parity with asy, but this is the subset that addresses the crashes on Altra Max.