### PR TITLE
switch to illumos page level numbering scheme

### DIFF
--- a/usr/src/uts/armv8/dboot/dboot_standalloc.c
+++ b/usr/src/uts/armv8/dboot/dboot_standalloc.c
@@ -41,16 +41,16 @@
 #include <sys/framebuffer.h>
 #include <sys/efifb.h>
 
+#include <vm/hat_pte.h>
+
 #include "saio.h"
 #include "dboot.h"
 #include "dboot_printf.h"
 
 extern void kmem_init(void);
-extern void map_phys(pte_t pte_attr, caddr_t vaddr,
+extern void map_phys(pte_t pte_attr, uintptr_t vaddr,
     uint64_t paddr, size_t bytes);
 extern uint64_t memlist_get(uint64_t size, int align, struct memlist **listp);
-
-#define	IS_KERNEL_MAPPING(__va)	(((uint64_t)(__va)) & (1UL << 55))
 
 extern struct efi_map_header *efi_map_header;
 extern struct memlist *pfreelistp;
@@ -61,42 +61,15 @@ extern caddr_t _BootScratchEnd;
 extern void init_physmem(void);
 
 static caddr_t scratch_used_top;
-static pte_t *l1_ptbl0;
-static pte_t *l1_ptbl1;
+
+static pte_t *l3_ptbl0;
+static pte_t *l3_ptbl1;
 
 static void init_pt(void);
 
 #if 0
 static void dump_tables(uint64_t tab, uint64_t va_offset);
 #endif
-
-static inline int
-l1_pteidx(caddr_t vaddr)
-{
-	return ((((uintptr_t)vaddr) >> (PAGESHIFT + 3 * NPTESHIFT)) &
-	    ((1 << NPTESHIFT) - 1));
-}
-
-static inline int
-l2_pteidx(caddr_t vaddr)
-{
-	return ((((uintptr_t)vaddr) >> (PAGESHIFT + 2 * NPTESHIFT)) &
-	    ((1 << NPTESHIFT) - 1));
-}
-
-static inline int
-l3_pteidx(caddr_t vaddr)
-{
-	return ((((uintptr_t)vaddr) >> (PAGESHIFT + 1 * NPTESHIFT)) &
-	    ((1 << NPTESHIFT) - 1));
-}
-
-static inline int
-l4_pteidx(caddr_t vaddr)
-{
-	return ((((uintptr_t)vaddr) >> (PAGESHIFT)) & ((1 << NPTESHIFT) - 1));
-}
-
 
 void
 init_memory(void)
@@ -135,14 +108,14 @@ init_pt(void)
 	}
 
 	if ((paddr = memlist_get(MMU_PAGESIZE, MMU_PAGESIZE, &pfreelistp)) == 0)
-		panic("phy alloc error for L1 PT\n");
+		panic("phy alloc error for L3 PT\n");
 	memset((void *)paddr, 0, MMU_PAGESIZE);
-	l1_ptbl0 = (pte_t *)paddr;
+	l3_ptbl0 = (pte_t *)paddr;
 
 	if ((paddr = memlist_get(MMU_PAGESIZE, MMU_PAGESIZE, &pfreelistp)) == 0)
-		panic("phy alloc error for L1 PT\n");
+		panic("phy alloc error for L3 PT\n");
 	memset((void *)paddr, 0, MMU_PAGESIZE);
-	l1_ptbl1 = (pte_t *)paddr;
+	l3_ptbl1 = (pte_t *)paddr;
 
 	/*
 	 * Memory that can be normally mapped. This is a subset of physical
@@ -157,11 +130,11 @@ init_pt(void)
 	for (ml = pmappablep; ml != NULL; ml = ml->ml_next) {
 		map_phys(PTE_UXN|PTE_AF|PTE_NG|PTE_SH_INNER|
 		    PTE_AP_KRWUNA|PTE_ATTR_NORMEM,
-		    (caddr_t)ml->ml_address,
+		    ml->ml_address,
 		    ml->ml_address, ml->ml_size);
 		map_phys(PTE_UXN|PTE_PXN|PTE_AF|PTE_NG|PTE_SH_INNER|
 		    PTE_AP_KRWUNA|PTE_ATTR_NORMEM,
-		    (caddr_t)(ml->ml_address + SEGKPM_BASE),
+		    (ml->ml_address + SEGKPM_BASE),
 		    ml->ml_address, ml->ml_size);
 	}
 
@@ -177,11 +150,11 @@ init_pt(void)
 	for (ml = prsvdlistp; ml != NULL; ml = ml->ml_next) {
 		map_phys(PTE_UXN|PTE_PXN|PTE_AF|PTE_SH_INNER|
 		    PTE_AP_KROUNA|PTE_ATTR_NORMEM,
-		    (caddr_t)ml->ml_address,
+		    ml->ml_address,
 		    ml->ml_address, ml->ml_size);
 		map_phys(PTE_UXN|PTE_PXN|PTE_AF|PTE_SH_INNER|
 		    PTE_AP_KROUNA|PTE_ATTR_NORMEM,
-		    (caddr_t)(ml->ml_address + SEGKPM_BASE),
+		    (ml->ml_address + SEGKPM_BASE),
 		    ml->ml_address, ml->ml_size);
 	}
 
@@ -195,11 +168,11 @@ init_pt(void)
 	for (ml = pfwcodelistp; ml != NULL; ml = ml->ml_next) {
 		map_phys(PTE_UXN|PTE_AF|PTE_SH_INNER|
 		    PTE_AP_KRWUNA|PTE_ATTR_NORMEM,
-		    (caddr_t)ml->ml_address,
+		    ml->ml_address,
 		    ml->ml_address, ml->ml_size);
 		map_phys(PTE_UXN|PTE_PXN|PTE_AF|PTE_SH_INNER|
 		    PTE_AP_KROUNA|PTE_ATTR_NORMEM,
-		    (caddr_t)(ml->ml_address + SEGKPM_BASE),
+		    (ml->ml_address + SEGKPM_BASE),
 		    ml->ml_address, ml->ml_size);
 	}
 
@@ -213,11 +186,11 @@ init_pt(void)
 	for (ml = pfwdatalistp; ml != NULL; ml = ml->ml_next) {
 		map_phys(PTE_UXN|PTE_PXN|PTE_AF|PTE_SH_INNER|
 		    PTE_AP_KRWUNA|PTE_ATTR_NORMEM,
-		    (caddr_t)ml->ml_address,
+		    ml->ml_address,
 		    ml->ml_address, ml->ml_size);
 		map_phys(PTE_UXN|PTE_PXN|PTE_AF|PTE_SH_INNER|
 		    PTE_AP_KROUNA|PTE_ATTR_NORMEM,
-		    (caddr_t)(ml->ml_address + SEGKPM_BASE),
+		    (ml->ml_address + SEGKPM_BASE),
 		    ml->ml_address, ml->ml_size);
 	}
 
@@ -230,14 +203,14 @@ init_pt(void)
 			/* XXXARM: we need a proper write-combining mapping */
 			map_phys(PTE_UXN|PTE_PXN|PTE_AF|PTE_NG|PTE_SH_INNER|
 			    PTE_AP_KRWUNA|PTE_ATTR_UNORDERED,
-			    (caddr_t)ml->ml_address,
+			    ml->ml_address,
 			    ml->ml_address, ml->ml_size);
 			continue;
 		}
 
 		map_phys(PTE_UXN|PTE_PXN|PTE_AF|PTE_NG|PTE_SH_INNER|
 		    PTE_AP_KRWUNA|PTE_ATTR_DEVICE,
-		    (caddr_t)ml->ml_address,
+		    ml->ml_address,
 		    ml->ml_address, ml->ml_size);
 	}
 
@@ -259,16 +232,16 @@ init_pt(void)
 
 	write_mair(mair);
 	write_tcr(tcr);
-	write_ttbr0((uint64_t)l1_ptbl0);
-	write_ttbr1((uint64_t)l1_ptbl1);
+	write_ttbr0((uint64_t)l3_ptbl0);
+	write_ttbr1((uint64_t)l3_ptbl1);
 	isb();
 
 #if 0
 	if (debug) {
 		dboot_printf("Lower Memory Tables\n");
-		dump_tables((uint64_t)l1_ptbl0, 0);
+		dump_tables((uint64_t)l3_ptbl0, 0);
 		dboot_printf("Upper Memory Tables\n");
-		dump_tables((uint64_t)l1_ptbl1, SEGKPM_BASE);
+		dump_tables((uint64_t)l3_ptbl1, SEGKPM_BASE);
 	}
 #endif
 
@@ -292,28 +265,28 @@ alloc_pagetable_page(const char *lvl)
 }
 
 static void
-map_pages(pte_t pte_attr, caddr_t vaddr, uint64_t paddr, size_t bytes)
+map_pages(pte_t pte_attr, uintptr_t vaddr, uint64_t paddr, size_t bytes)
 {
-	int l1_idx = l1_pteidx(vaddr);
-	int l2_idx = l2_pteidx(vaddr);
-	int l3_idx = l3_pteidx(vaddr);
-	int l4_idx = l4_pteidx(vaddr);
+	int l3_idx = LEVEL_INDEX(vaddr, 3);
+	int l2_idx = LEVEL_INDEX(vaddr, 2);
+	int l1_idx = LEVEL_INDEX(vaddr, 1);
+	int l0_idx = LEVEL_INDEX(vaddr, 0);
 
-	pte_t *l1_ptbl = IS_KERNEL_MAPPING(vaddr) ? l1_ptbl1 : l1_ptbl0;
+	pte_t *l3_ptbl = IS_KERNEL_MAPPING(vaddr) ? l3_ptbl1 : l3_ptbl0;
 
-	if ((l1_ptbl[l1_idx] & PTE_TYPE_MASK) == 0)
-		l1_ptbl[l1_idx] = PTE_TABLE_APT_NOUSER|PTE_TABLE_UXNT|
-		    PTE_TABLE|alloc_pagetable_page("L1");
-	if ((l1_ptbl[l1_idx] & PTE_VALID) == 0)
-		panic("invalid L1 PT\n");
+	if ((l3_ptbl[l3_idx] & PTE_TYPE_MASK) == 0)
+		l3_ptbl[l3_idx] = PTE_TABLE_APT_NOUSER|PTE_TABLE_UXNT|
+		    PTE_TABLE|alloc_pagetable_page("L3");
+	if ((l3_ptbl[l3_idx] & PTE_VALID) == 0)
+		panic("invalid L3 PT\n");
 
-	pte_t *l2_ptbl = (pte_t *)(uintptr_t)(l1_ptbl[l1_idx] & PTE_PFN_MASK);
+	pte_t *l2_ptbl = (pte_t *)(uintptr_t)(l3_ptbl[l3_idx] & PTE_PFN_MASK);
 
 	if (bytes == MMU_PAGESIZE1G) {
-		if ((uintptr_t)vaddr & (MMU_PAGESIZE1G - 1))
-			panic("invalid vaddr slignment (1G)\n");
+		if (vaddr & (MMU_PAGESIZE1G - 1))
+			panic("invalid vaddr alignment (1G)\n");
 		if (paddr & (MMU_PAGESIZE1G - 1))
-			panic("invalid paddr slignment (1G)\n");
+			panic("invalid paddr alignment (1G)\n");
 		if (l2_ptbl[l2_idx] & PTE_VALID)
 			panic("invalid L2 PT\n");
 		l2_ptbl[l2_idx] = paddr|pte_attr|PTE_BLOCK;
@@ -327,35 +300,35 @@ map_pages(pte_t pte_attr, caddr_t vaddr, uint64_t paddr, size_t bytes)
 	if ((l2_ptbl[l2_idx] & PTE_TYPE_MASK) != PTE_TABLE)
 		panic("invalid L2 PT\n");
 
-	pte_t *l3_ptbl = (pte_t *)(uintptr_t)(l2_ptbl[l2_idx] & PTE_PFN_MASK);
+	pte_t *l1_ptbl = (pte_t *)(uintptr_t)(l2_ptbl[l2_idx] & PTE_PFN_MASK);
 
 	if (bytes == MMU_PAGESIZE2M) {
-		if ((uintptr_t)vaddr & (MMU_PAGESIZE2M - 1))
+		if (vaddr & (MMU_PAGESIZE2M - 1))
 			panic("invalid vaddr alignment (2M)\n");
 		if (paddr & (MMU_PAGESIZE2M - 1))
 			panic("invalid paddr alignment (2M)\n");
-		if (l3_ptbl[l3_idx] & PTE_VALID)
-			panic("invalid L3 PT\n");
-		l3_ptbl[l3_idx] = paddr|pte_attr|PTE_BLOCK;
+		if (l1_ptbl[l1_idx] & PTE_VALID)
+			panic("invalid L1 PT\n");
+		l1_ptbl[l1_idx] = paddr|pte_attr|PTE_BLOCK;
 		dsb(ish);
 		return;
 	}
 
-	if ((l3_ptbl[l3_idx] & PTE_TYPE_MASK) == 0)
-		l3_ptbl[l3_idx] = PTE_TABLE_APT_NOUSER|PTE_TABLE_UXNT|
-		    PTE_TABLE|alloc_pagetable_page("L3");
-	if ((l3_ptbl[l3_idx] & PTE_TYPE_MASK) != PTE_TABLE)
-		panic("invalid L3 PT\n");
+	if ((l1_ptbl[l1_idx] & PTE_TYPE_MASK) == 0)
+		l1_ptbl[l1_idx] = PTE_TABLE_APT_NOUSER|PTE_TABLE_UXNT|
+		    PTE_TABLE|alloc_pagetable_page("L1");
+	if ((l1_ptbl[l1_idx] & PTE_TYPE_MASK) != PTE_TABLE)
+		panic("invalid L1 PT\n");
 
-	pte_t *l4_ptbl = (pte_t *)(uintptr_t)(l3_ptbl[l3_idx] & PTE_PFN_MASK);
+	pte_t *l0_ptbl = (pte_t *)(uintptr_t)(l1_ptbl[l1_idx] & PTE_PFN_MASK);
 	if (bytes == MMU_PAGESIZE) {
-		if ((uintptr_t)vaddr & (MMU_PAGESIZE - 1))
+		if (vaddr & (MMU_PAGESIZE - 1))
 			panic("invalid vaddr alignment (4K)\n");
 		if (paddr & (MMU_PAGESIZE - 1))
 			panic("invalid paddr alignment (4K)\n");
-		if (l4_ptbl[l4_idx] & PTE_VALID)
-			panic("invalid L4 PT\n");
-		l4_ptbl[l4_idx] = paddr|pte_attr|PTE_PAGE;
+		if (l0_ptbl[l0_idx] & PTE_VALID)
+			panic("invalid L0 PT\n");
+		l0_ptbl[l0_idx] = paddr|pte_attr|PTE_PAGE;
 		dsb(ish);
 		return;
 	}
@@ -364,9 +337,9 @@ map_pages(pte_t pte_attr, caddr_t vaddr, uint64_t paddr, size_t bytes)
 }
 
 void
-map_phys(pte_t pte_attr, caddr_t vaddr, uint64_t paddr, size_t bytes)
+map_phys(pte_t pte_attr, uintptr_t vaddr, uint64_t paddr, size_t bytes)
 {
-	if (((uintptr_t)vaddr % MMU_PAGESIZE) != 0) {
+	if ((vaddr % MMU_PAGESIZE) != 0) {
 		panic("map_phys invalid vaddr\n");
 	}
 	if ((paddr % MMU_PAGESIZE) != 0) {
@@ -377,8 +350,7 @@ map_phys(pte_t pte_attr, caddr_t vaddr, uint64_t paddr, size_t bytes)
 	}
 
 	while (bytes) {
-		uintptr_t va = (uintptr_t)vaddr;
-		size_t maxalign = va & (-va);
+		size_t maxalign = vaddr & (-vaddr);
 		size_t mapsz;
 
 		/*
@@ -449,7 +421,7 @@ resalloc(enum RESOURCES type, size_t bytes, caddr_t virthint, int align)
 					panic("phys mem allocate error\n");
 				}
 				map_phys(PTE_AF | PTE_SH_INNER | PTE_AP_KRWUNA |
-				    PTE_ATTR_NORMEM, virthint, paddr, mapsz);
+				    PTE_ATTR_NORMEM, va, paddr, mapsz);
 				bytes -= mapsz;
 				virthint += mapsz;
 			}

--- a/usr/src/uts/armv8/os/fakebop.c
+++ b/usr/src/uts/armv8/os/fakebop.c
@@ -175,33 +175,6 @@ boot_compinfo(int fd, struct compinfo *cbp)
 	return (0);
 }
 
-static inline int
-l1_pteidx(caddr_t vaddr)
-{
-	return ((((uintptr_t)vaddr) >>
-	    (PAGESHIFT+3*NPTESHIFT)) & ((1<<NPTESHIFT)-1));
-}
-
-static inline int
-l2_pteidx(caddr_t vaddr)
-{
-	return ((((uintptr_t)vaddr) >>
-	    (PAGESHIFT+2*NPTESHIFT)) & ((1<<NPTESHIFT)-1));
-}
-
-static inline int
-l3_pteidx(caddr_t vaddr)
-{
-	return ((((uintptr_t)vaddr) >>
-	    (PAGESHIFT+1*NPTESHIFT)) & ((1<<NPTESHIFT)-1));
-}
-
-static inline int
-l4_pteidx(caddr_t vaddr)
-{
-	return ((((uintptr_t)vaddr) >> (PAGESHIFT)) & ((1<<NPTESHIFT)-1));
-}
-
 static paddr_t
 pt_alloc(bootops_t *bop)
 {
@@ -223,28 +196,28 @@ pt_alloc(bootops_t *bop)
 }
 
 static void
-map_phys(bootops_t *bop, pte_t pte_attr, caddr_t vaddr, uint64_t paddr)
+map_phys(bootops_t *bop, pte_t pte_attr, uintptr_t vaddr, uint64_t paddr)
 {
-	int l1_idx = l1_pteidx(vaddr);
-	int l2_idx = l2_pteidx(vaddr);
-	int l3_idx = l3_pteidx(vaddr);
-	int l4_idx = l4_pteidx(vaddr);
+	int l3_idx = LEVEL_INDEX(vaddr, 3);
+	int l2_idx = LEVEL_INDEX(vaddr, 2);
+	int l1_idx = LEVEL_INDEX(vaddr, 1);
+	int l0_idx = LEVEL_INDEX(vaddr, 0);
 
-	pte_t *l1_ptbl =
-	    (pte_t *)((((uint64_t)vaddr) >> 63)? read_ttbr1(): read_ttbr0());
+	pte_t *l3_ptbl = (pte_t *)(IS_KERNEL_MAPPING(vaddr) ?
+	    read_ttbr1() : read_ttbr0());
 
-	if ((l1_ptbl[l1_idx] & PTE_TYPE_MASK) == 0) {
+	if ((l3_ptbl[l3_idx] & PTE_TYPE_MASK) == 0) {
 		paddr_t pa = pt_alloc(bop);
 		dsb(ish);
-		l1_ptbl[l1_idx] =
+		l3_ptbl[l3_idx] =
 		    PTE_TABLE_UXNT | PTE_TABLE_APT_NOUSER | pa | PTE_TABLE;
 	}
 
-	if ((l1_ptbl[l1_idx] & PTE_VALID) == 0) {
-		bop_panic("invalid L1 PT\n");
+	if ((l3_ptbl[l3_idx] & PTE_VALID) == 0) {
+		bop_panic("invalid L3 PT\n");
 	}
 
-	pte_t *l2_ptbl = (pte_t *)(uintptr_t)(l1_ptbl[l1_idx] & PTE_PFN_MASK);
+	pte_t *l2_ptbl = (pte_t *)(uintptr_t)(l3_ptbl[l3_idx] & PTE_PFN_MASK);
 
 	if ((l2_ptbl[l2_idx] & PTE_TYPE_MASK) == 0) {
 		paddr_t pa = pt_alloc(bop);
@@ -257,25 +230,25 @@ map_phys(bootops_t *bop, pte_t pte_attr, caddr_t vaddr, uint64_t paddr)
 		bop_panic("invalid L2 PT\n");
 	}
 
-	pte_t *l3_ptbl = (pte_t *)(uintptr_t)(l2_ptbl[l2_idx] & PTE_PFN_MASK);
+	pte_t *l1_ptbl = (pte_t *)(uintptr_t)(l2_ptbl[l2_idx] & PTE_PFN_MASK);
 
-	if ((l3_ptbl[l3_idx] & PTE_TYPE_MASK) == 0) {
+	if ((l1_ptbl[l1_idx] & PTE_TYPE_MASK) == 0) {
 		paddr_t pa = pt_alloc(bop);
 		bzero((void *)(uintptr_t)pa, MMU_PAGESIZE);
 		dsb(ish);
-		l3_ptbl[l3_idx] =
+		l1_ptbl[l1_idx] =
 		    PTE_TABLE_UXNT | PTE_TABLE_APT_NOUSER | pa | PTE_TABLE;
 	}
 
-	if ((l3_ptbl[l3_idx] & PTE_TYPE_MASK) != PTE_TABLE) {
-		bop_panic("invalid L3 PT\n");
+	if ((l1_ptbl[l1_idx] & PTE_TYPE_MASK) != PTE_TABLE) {
+		bop_panic("invalid L1 PT\n");
 	}
 
-	pte_t *l4_ptbl = (pte_t *)(uintptr_t)(l3_ptbl[l3_idx] & PTE_PFN_MASK);
-	if (l4_ptbl[l4_idx] & PTE_VALID) {
-		bop_panic("invalid L4 PT\n");
+	pte_t *l0_ptbl = (pte_t *)(uintptr_t)(l1_ptbl[l1_idx] & PTE_PFN_MASK);
+	if (l0_ptbl[l0_idx] & PTE_VALID) {
+		bop_panic("invalid L0 PT\n");
 	}
-	l4_ptbl[l4_idx] = paddr | pte_attr | PTE_PAGE;
+	l0_ptbl[l0_idx] = paddr | pte_attr | PTE_PAGE;
 	dsb(ish);
 	isb();
 }
@@ -415,7 +388,7 @@ do_bsys_alloc(bootops_t *bop, caddr_t virthint, size_t size, int align)
 {
 	paddr_t a = align;	/* same type as pa for masking */
 	paddr_t pa;
-	caddr_t va;
+	uintptr_t va;
 	ssize_t s;		/* the aligned size */
 
 	if (a < MMU_PAGESIZE)
@@ -439,7 +412,7 @@ do_bsys_alloc(bootops_t *bop, caddr_t virthint, size_t size, int align)
 	/*
 	 * Add the mappings to the page tables, try large pages first.
 	 */
-	va = virthint;
+	va = (uintptr_t)virthint;
 	s = size;
 	while (s > 0) {
 		/*

--- a/usr/src/uts/armv8/vm/aarch64_mmu.c
+++ b/usr/src/uts/armv8/vm/aarch64_mmu.c
@@ -137,23 +137,23 @@ hat_kern_alloc(
 	uint_t		table_cnt = 1;
 	uint_t		mapping_cnt;
 
-	pte_t *l1_ptbl = (pte_t *)pa_to_kseg(TTBR_BADDR48(read_ttbr1()));
+	pte_t *l3_ptbl = (pte_t *)pa_to_kseg(TTBR_BADDR48(read_ttbr1()));
 
 	for (int i = 0; i < NPTEPERPT; i++) {
-		if ((l1_ptbl[i] & PTE_TYPE_MASK) != PTE_TABLE)
+		if ((l3_ptbl[i] & PTE_TYPE_MASK) != PTE_TABLE)
 			continue;
 		++table_cnt;
 
-		pte_t *l2_ptbl = (pte_t *)pa_to_kseg(l1_ptbl[i] & PTE_PFN_MASK);
+		pte_t *l2_ptbl = (pte_t *)pa_to_kseg(l3_ptbl[i] & PTE_PFN_MASK);
 		for (int j = 0; j < NPTEPERPT; j++) {
 			if ((l2_ptbl[j] & PTE_TYPE_MASK) != PTE_TABLE)
 				continue;
 			++table_cnt;
 
-			pte_t *l3_ptbl = (pte_t *)pa_to_kseg(l2_ptbl[j] &
+			pte_t *l1_ptbl = (pte_t *)pa_to_kseg(l2_ptbl[j] &
 			    PTE_PFN_MASK);
 			for (int k = 0; k < NPTEPERPT; k++) {
-				if ((l3_ptbl[k] & PTE_TYPE_MASK) != PTE_TABLE)
+				if ((l1_ptbl[k] & PTE_TYPE_MASK) != PTE_TABLE)
 					continue;
 				++table_cnt;
 

--- a/usr/src/uts/armv8/vm/hat_pte.h
+++ b/usr/src/uts/armv8/vm/hat_pte.h
@@ -74,6 +74,17 @@ typedef int8_t level_t;
 #define	TOP_LEVEL(hat)		(mmu.max_level)
 
 /*
+ * Bit 55 is guaranteed to fall in the hole, be safe for pointer
+ * authenticacion or top-byte ignore, and is specified by ARM as the one to
+ * use:
+ *
+ * Arm Architecture Reference Manual for A-profile architecture
+ *     D8.1.8 Supported virtual address ranges
+ *     (ARM DDI 0487L.b)
+ */
+#define	IS_KERNEL_MAPPING(__va)	(((uintptr_t)(__va)) & (1UL << 55))
+
+/*
  * HAT/MMU parameters that depend on processor type or configuration
  */
 struct htable;
@@ -102,10 +113,24 @@ extern struct hat_mmu_info mmu;
 #define	FMT_PTE			"0x%lx"
 #define	GET_PTE(ptr)		(*(volatile pte_t *)(ptr))
 #define	SET_PTE(ptr, pte)	(*(volatile pte_t *)(ptr) = (pte))
+
 #define	LEVEL_SHIFT(l)		(MMU_PAGESHIFT + (l) * NPTESHIFT)
 #define	LEVEL_SIZE(l)		(1ul << LEVEL_SHIFT(l))
 #define	LEVEL_OFFSET(l)		(LEVEL_SIZE(l)-1)
 #define	LEVEL_MASK(l)		(~LEVEL_OFFSET(l))
+
+/*
+ * Return the part of addr, appropriately shifted and masked, to index into a
+ * page table of specified level.
+ *
+ * would paste `level` multiple times so is a bad macro
+ */
+extern __GNU_INLINE uint_t
+LEVEL_INDEX(uintptr_t addr, uint_t level)
+{
+	return (((addr & LEVEL_MASK(level)) >> LEVEL_SHIFT(level)) &
+	    ((1 << NPTESHIFT) - 1));
+}
 
 #define	PTE_SET(p, f)		((p) |= (f))
 #define	PTE_CLR(p, f)		((p) &= ~(pte_t)(f))

--- a/usr/src/uts/armv8/vm/htable.c
+++ b/usr/src/uts/armv8/vm/htable.c
@@ -1583,11 +1583,10 @@ htable_init()
 uint_t
 htable_va2entry(uintptr_t va, htable_t *ht)
 {
-	level_t	l = ht->ht_level;
+	ASSERT3U(va, >=, ht->ht_vaddr);
+	ASSERT3U(va, <=, HTABLE_LAST_PAGE(ht));
 
-	ASSERT(va >= ht->ht_vaddr);
-	ASSERT(va <= HTABLE_LAST_PAGE(ht));
-	return ((va >> LEVEL_SHIFT(l)) & (HTABLE_NUM_PTES(ht) - 1));
+	return (LEVEL_INDEX(va, ht->ht_level));
 }
 
 /*


### PR DESCRIPTION
This depends on (and contains) #241 

This lines up the concept of page level with the illumos notion of it, not sometimes using the ARM notion and sometimes the illumos notion.

It's from the arm64/dynahat branch, and on that branch are further improvements that are hard to pick out into a single change, so the page allocation algorithms change markedly in the future don't look too hard at them unless they're broken now, by the translation of the level schemes.

Next steps (modulo the difficulty of tidying a branch I accidentally let grow 10x too large) are the mdb support and the kboot_mmu bits...

@r1mikey