### PR TITLE
sha2: don't overrun src when aligning a transform buffer

### DIFF
--- a/usr/src/common/crypto/sha2/sha2.c
+++ b/usr/src/common/crypto/sha2/sha2.c
@@ -198,7 +198,7 @@ SHA256Transform(SHA2_CTX *ctx, const uint8_t *blk)
 #endif	/* __sparc */
 
 	if ((uintptr_t)blk & 0x3) {		/* not 4-byte aligned? */
-		bcopy(blk, ctx->buf_un.buf32,  sizeof (ctx->buf_un.buf32));
+		bcopy(blk, ctx->buf_un.buf32, SHA256_BLOCK_SIZE);
 		blk = (uint8_t *)ctx->buf_un.buf32;
 	}
 
@@ -414,7 +414,7 @@ SHA512Transform(SHA2_CTX *ctx, const uint8_t *blk)
 
 
 	if ((uintptr_t)blk & 0x7) {		/* not 8-byte aligned? */
-		bcopy(blk, ctx->buf_un.buf64,  sizeof (ctx->buf_un.buf64));
+		bcopy(blk, ctx->buf_un.buf64, SHA512_BLOCK_SIZE);
 		blk = (uint8_t *)ctx->buf_un.buf64;
 	}
 
@@ -810,7 +810,7 @@ SHA2Update(SHA2_CTX *ctx, const void *inptr, size_t input_len)
 		uint32_t il = input_len & UINT32_MAX;
 
 		il = il << 3;
-		buf_limit = 64;
+		buf_limit = SHA256_BLOCK_SIZE;
 
 		/* compute number of bytes mod 64 */
 		buf_index = (ctx->count.c32[1] >> 3) & 0x3F;
@@ -825,7 +825,7 @@ SHA2Update(SHA2_CTX *ctx, const void *inptr, size_t input_len)
 		uint64_t il = input_len;
 
 		il = il << 3;
-		buf_limit = 128;
+		buf_limit = SHA512_BLOCK_SIZE;
 
 		/* compute number of bytes mod 128 */
 		buf_index = (ctx->count.c64[1] >> 3) & 0x7F;

--- a/usr/src/uts/common/sys/sha2.h
+++ b/usr/src/uts/common/sys/sha2.h
@@ -47,6 +47,9 @@ extern "C" {
 #define	SHA256_HMAC_BLOCK_SIZE	64	/* SHA256-HMAC block size */
 #define	SHA512_HMAC_BLOCK_SIZE	128	/* SHA512-HMAC block size */
 
+#define	SHA256_BLOCK_SIZE	64	/* SHA256 block size */
+#define	SHA512_BLOCK_SIZE	128	/* SHA512 block size */
+
 #define	SHA256			0
 #define	SHA256_HMAC		1
 #define	SHA256_HMAC_GEN		2


### PR DESCRIPTION
I found this as part of soak-testing ASID and FPU work for correctness and stability. It's unrelated to either of those, so I thought I'd get it into the tree now.

SHA256 has a 64 byte transform buffer.  When aligning we always copy 128 bytes from the source to the alignment buffer, based on the size of the destination, which is sized to handle sha512.

This at best results in copying unnecessary trailing garbage, which is not transformed.  At worst this results in crossing into the next page to attempt to copy garbage, and that next page may not be mapped.

This code path is not taken on i86pc, which has an accelerated codepath.

## The Crash

```
root@braich:~# mdb -k /var/crash/braich/unix.0 /var/crash/braich/vmcore.0
Loading modules: [ unix genunix specfs mac scsi_vhci zfs ip hook neti sockfs arp xhci usba stmf_sbd stmf mm idm crypto random smbios ufs logindmux nsmb ptm smbsrv klmmod nfs sppp ipc ]
> ::panicinfo
             cpu              113
          thread ffff800416c90c20
         message BAD TRAP: type=25 (#NV2_DATA_ABORT Data abort) rp=ffff800416c90750 addr=ffff83d8d43f5000 esr=96000007
              x0 ffff820a681a3538
              x1 ffff83d8d43f5010
              x2 fffffffffffffff9
              x3               30
              x4                7
              x5         f4616253
              x6 ffff820a681a35af
              x7 ffff83d7cf34abf8
              x8 ffff83d76e246315
              x9 3e93e6194cdf00bf
             x10 5256a91eb3361e5a
             x11  97afc7ecd28fa82
             x12 e254f00b7fe95776
             x13 f05e84990191ae37
             x14 baddcafebb9aac0d
             x15          a7f2176
             x16         a9b12e75
             x17         14e13d4d
             x18         384447e4
             x19 ffff820a681a34e0
             x20         11ffdbd4
             x21         b36dac5a
             x22         6733b73f
             x23         c44e420a
             x24         9ae20a7c
             x25         ca6a7d6b
             x26         8b64150c
             x27         fc9b599d
             x28         8ab5601a
             x29 ffff800416c90890
             x30 fffffffffe0618dc
              sp ffff800416c90890
              pc fffffffffe062b00
            spsr         20000149
              tp ffff800416c90c20
             esr         96000007
             far ffff83d8d43f5000
          trapno               25
       tpidr_el0     7fffee902c30
       tpidr_el1 ffff800416c90c20
           ttbr0 2ae40e1f4177c000
           ttbr1         90001000
             tcr       15b5103590
>
```

## The Disassembly

```
SHA256Transform+0x1dcc:         add x1, x19, #0x58       ; dst = ctx->buf_un (offset 0x58)
SHA256Transform+0x1dd0:         mov x2, #0x80            ; len = 128 !!!
SHA256Transform+0x1dd8:         bl bcopy                 ; bcopy(blk, ctx->buf_un.buf32, 128)
SHA256Transform+0x1ddc:         ldr x0, [sp, #120]       ; return lands here (crash frame)
SHA256Transform+0x1de0:         b SHA256Transform+0x78   ; jump back to main body
```

## The Code

```
union {
    uint8_t     buf8[128];      /* undigested input */
    uint32_t    buf32[32];      /* realigned input */
    uint64_t    buf64[16];      /* realigned input */
} buf_un;
...
if ((uintptr_t)blk & 0x3) {
    bcopy(blk, ctx->buf_un.buf32, sizeof(ctx->buf_un.buf32));
```