### PR TITLE
implement the mdb support for the armv8 HAT

### DIFF
--- a/usr/src/cmd/mdb/aarch64/modules/unix/Makefile
+++ b/usr/src/cmd/mdb/aarch64/modules/unix/Makefile
@@ -27,8 +27,10 @@
 MODULE = unix.so
 MDBTGT = kvm
 
-MODSRCS =	\
-	mmu.c	\
+MODSRCS =		\
+	htable.c	\
+	memseg.c	\
+	mmu.c		\
 	unix.c
 
 include ../../../../Makefile.cmd

--- a/usr/src/cmd/mdb/aarch64/modules/unix/htable.c
+++ b/usr/src/cmd/mdb/aarch64/modules/unix/htable.c
@@ -1,0 +1,139 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+ * Use is subject to license terms.
+ *
+ * Copyright 2019 Joyent, Inc.
+ */
+
+#include <sys/types.h>
+
+#include <vm/hat_aarch64.h>
+
+#include <mdb/mdb_modapi.h>
+
+#include "mmu.h"
+
+typedef struct {
+	hat_t htw_hat;
+	uint_t htw_bucket;
+} htables_walk_data_t;
+
+int
+htables_walk_init(mdb_walk_state_t *wsp)
+{
+	init_mmu();
+
+	if (mmu.num_level == 0)
+		return (WALK_ERR);
+
+	if (wsp->walk_addr == 0) {
+		mdb_warn("missing hat address\n");
+		return (WALK_ERR);
+	}
+
+	htables_walk_data_t *htw = mdb_zalloc(sizeof (htables_walk_data_t),
+	    UM_SLEEP);
+
+	if (mdb_vread(&htw->htw_hat, sizeof (hat_t), wsp->walk_addr) == -1) {
+		mdb_warn("couldn't read struct hat");
+		mdb_free(htw, sizeof (htables_walk_data_t));
+		return (WALK_ERR);
+	}
+
+	wsp->walk_addr = 0;
+	wsp->walk_data = htw;
+
+	while (wsp->walk_addr == 0) {
+		uintptr_t baddr = (uintptr_t)(htw->htw_hat.hat_ht_hash +
+		    htw->htw_bucket);
+
+		if (mdb_vread(&wsp->walk_addr, sizeof (htable_t *),
+		    baddr) == -1) {
+			mdb_warn("couldn't read htable ptr %p", baddr);
+			mdb_free(wsp->walk_data, sizeof (htables_walk_data_t));
+			wsp->walk_data = NULL;
+			return (WALK_ERR);
+		}
+
+		if (wsp->walk_addr != 0)
+			break;
+
+		htw->htw_bucket += 1;
+		if (htw->htw_bucket >= mmu.hash_cnt) {
+			mdb_free(wsp->walk_data, sizeof (htables_walk_data_t));
+			wsp->walk_data = NULL;
+			return (WALK_DONE);
+		}
+	}
+
+	return (WALK_NEXT);
+}
+
+int
+htables_walk_step(mdb_walk_state_t *wsp)
+{
+	htables_walk_data_t *htw = wsp->walk_data;
+	int status;
+
+	status = wsp->walk_callback(wsp->walk_addr, wsp->walk_data,
+	    wsp->walk_cbdata);
+
+	if (status != WALK_NEXT) {
+		return (status);
+	}
+
+	htable_t ht;
+	if (mdb_vread(&ht, sizeof (ht), wsp->walk_addr) == -1) {
+		mdb_warn("failed to read htable %p", wsp->walk_addr);
+		return (WALK_ERR);
+	}
+
+	if (ht.ht_next != NULL) {	/* Continue down the chain */
+		wsp->walk_addr = (uintptr_t)ht.ht_next;
+		return (WALK_NEXT);
+	} else { /* Go to the next bucket */
+		uintptr_t next = 0;
+
+		while ((next == 0) && (htw->htw_bucket < (mmu.hash_cnt - 1))) {
+			htw->htw_bucket += 1;
+
+			uintptr_t baddr = (uintptr_t)(htw->htw_hat.hat_ht_hash +
+			    htw->htw_bucket);
+
+			if (mdb_vread(&next, sizeof (htable_t *),
+			    baddr) == -1) {
+				mdb_warn("couldn't read htable ptr %p", baddr);
+				return (WALK_ERR);
+			}
+		}
+		wsp->walk_addr = next;
+
+		return ((next == 0) ? WALK_DONE : WALK_NEXT);
+	}
+}
+
+void
+htables_walk_fini(mdb_walk_state_t *wsp)
+{
+	mdb_free(wsp->walk_data, sizeof (htables_walk_data_t));
+}

--- a/usr/src/cmd/mdb/aarch64/modules/unix/htable.h
+++ b/usr/src/cmd/mdb/aarch64/modules/unix/htable.h
@@ -13,25 +13,19 @@
  * Copyright 2026 Richard Lowe
  */
 
-#ifndef _MMU_H
-#define	_MMU_H
+#ifndef _HTABLE_H
+#define	_HTABLE_H
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#include <vm/hat_pte.h>
-
-extern struct hat_mmu_info mmu;
-
-extern void init_mmu(void);
-extern int pte_dcmd(uintptr_t, uint_t, int, const mdb_arg_t *);
-extern int ptable_dcmd(uintptr_t, uint_t, int, const mdb_arg_t *);
-extern int vatopa(uintptr_t, uint_t, int, const mdb_arg_t *);
-extern int patova(uintptr_t, uint_t, int, const mdb_arg_t *);
+extern int htables_walk_init(mdb_walk_state_t *);
+extern int htables_walk_step(mdb_walk_state_t *);
+extern void htables_walk_fini(mdb_walk_state_t *);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* _MMU_H */
+#endif /* _HTABLE_H */

--- a/usr/src/cmd/mdb/aarch64/modules/unix/memseg.c
+++ b/usr/src/cmd/mdb/aarch64/modules/unix/memseg.c
@@ -1,0 +1,117 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+ * Use is subject to license terms.
+ *
+ * Copyright 2019 Joyent, Inc.
+ */
+
+#include <sys/controlregs.h>
+#include <sys/types.h>
+
+#include <vm/page.h>
+
+#include <mdb/mdb_err.h>
+#include <mdb/mdb_modapi.h>
+
+/*
+ * ::memseg_list dcmd and walker to implement it.
+ */
+/*ARGSUSED*/
+int
+memseg_list(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv)
+{
+	struct memseg ms;
+
+	if (!(flags & DCMD_ADDRSPEC)) {
+		if (mdb_pwalk_dcmd("memseg", "memseg_list",
+		    0, NULL, 0) == -1) {
+			mdb_warn("can't walk memseg");
+			return (DCMD_ERR);
+		}
+		return (DCMD_OK);
+	}
+
+	if (DCMD_HDRSPEC(flags))
+		mdb_printf("%<u>%?s %?s %?s %?s %?s%</u>\n", "ADDR",
+		    "PAGES", "EPAGES", "BASE", "END");
+
+	if (mdb_vread(&ms, sizeof (struct memseg), addr) == -1) {
+		mdb_warn("can't read memseg at %#lx", addr);
+		return (DCMD_ERR);
+	}
+
+	mdb_printf("%0?lx %0?lx %0?lx %0?lx %0?lx\n", addr,
+	    ms.pages, ms.epages, ms.pages_base, ms.pages_end);
+
+	return (DCMD_OK);
+}
+
+/*
+ * walk the memseg structures
+ */
+int
+memseg_walk_init(mdb_walk_state_t *wsp)
+{
+	if (wsp->walk_addr != 0) {
+		mdb_warn("memseg only supports global walks\n");
+		return (WALK_ERR);
+	}
+
+	if (mdb_readvar(&wsp->walk_addr, "memsegs") == -1) {
+		mdb_warn("symbol 'memsegs' not found");
+		return (WALK_ERR);
+	}
+
+	wsp->walk_data = mdb_alloc(sizeof (struct memseg), UM_SLEEP);
+	return (WALK_NEXT);
+
+}
+
+int
+memseg_walk_step(mdb_walk_state_t *wsp)
+{
+	int status;
+
+	if (wsp->walk_addr == 0) {
+		return (WALK_DONE);
+	}
+
+	if (mdb_vread(wsp->walk_data, sizeof (struct memseg),
+	    wsp->walk_addr) == -1) {
+		mdb_warn("failed to read struct memseg at %p", wsp->walk_addr);
+		return (WALK_DONE);
+	}
+
+	status = wsp->walk_callback(wsp->walk_addr, wsp->walk_data,
+	    wsp->walk_cbdata);
+
+	wsp->walk_addr = (uintptr_t)(((struct memseg *)wsp->walk_data)->next);
+
+	return (status);
+}
+
+void
+memseg_walk_fini(mdb_walk_state_t *wsp)
+{
+	mdb_free(wsp->walk_data, sizeof (struct memseg));
+}

--- a/usr/src/cmd/mdb/aarch64/modules/unix/memseg.h
+++ b/usr/src/cmd/mdb/aarch64/modules/unix/memseg.h
@@ -1,0 +1,45 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+ * Use is subject to license terms.
+ *
+ * Copyright 2018 Joyent, Inc.
+ */
+
+#ifndef _MEMSEG_H
+#define	_MEMSEG_H
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+extern int memseg_list(uintptr_t, uint_t, int, const mdb_arg_t *);
+
+extern int memseg_walk_init(mdb_walk_state_t *);
+extern int memseg_walk_step(mdb_walk_state_t *);
+extern void memseg_walk_fini(mdb_walk_state_t *);
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif	/* _MEMSEG_H */

--- a/usr/src/cmd/mdb/aarch64/modules/unix/mmu.c
+++ b/usr/src/cmd/mdb/aarch64/modules/unix/mmu.c
@@ -1,115 +1,476 @@
 /*
- * CDDL HEADER START
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
  *
- * The contents of this file are subject to the terms of the
- * Common Development and Distribution License (the "License").
- * You may not use this file except in compliance with the License.
- *
- * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
- * or http://www.opensolaris.org/os/licensing.
- * See the License for the specific language governing permissions
- * and limitations under the License.
- *
- * When distributing Covered Code, include this CDDL HEADER in each
- * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
- * If applicable, add the following below this CDDL HEADER, with the
- * fields enclosed by brackets "[]" replaced with your own identifying
- * information: Portions Copyright [yyyy] [name of copyright owner]
- *
- * CDDL HEADER END
- */
-/*
- * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
- * Use is subject to license terms.
- *
- * Copyright 2019 Joyent, Inc.
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
  */
 
+/*
+ * Copyright 2025 Richard Lowe
+ * Portions Copyright 2022 Oxide Computer Company
+ */
+
+/*
+ * Commands dealing with the VMSAv8-64 compatible memory management unit
+ */
+
+#include <sys/controlregs.h>
+#include <sys/debug.h>
+#include <sys/machparam.h>
+#include <sys/sysmacros.h>
 #include <sys/types.h>
 
-#include <vm/page.h>
+#include <vm/as.h>
+#include <vm/hat_aarch64.h>
 
+#include <stdbool.h>
+
+#include <mdb/mdb_err.h>
 #include <mdb/mdb_modapi.h>
 
-/*
- * ::memseg_list dcmd and walker to implement it.
- */
-/*ARGSUSED*/
-int
-memseg_list(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv)
+#include "mmu.h"
+
+struct hat_mmu_info mmu;
+
+static inline uint64_t
+takebits(uint64_t reg, uint_t high, uint_t low)
 {
-	struct memseg ms;
+	uint64_t mask;
 
-	if (!(flags & DCMD_ADDRSPEC)) {
-		if (mdb_pwalk_dcmd("memseg", "memseg_list",
-		    0, NULL, 0) == -1) {
-			mdb_warn("can't walk memseg");
-			return (DCMD_ERR);
+	ASSERT3U(high, >=, low);
+	ASSERT3U(high, <, 64);
+	ASSERT3U(low, <, 64);
+
+	mask = ((1ULL << (high - low + 1)) - 1ULL) << low;
+	return (reg & mask);
+}
+
+void
+init_mmu(void)
+{
+	if (mmu.num_level != 0)
+		return;
+
+	if (mdb_readsym(&mmu, sizeof (mmu), "mmu") == -1)
+		mdb_warn("Can't use HAT information before mmu_init()\n");
+}
+
+int
+pte_table(uintptr_t addr, uint_t level)
+{
+	mdb_printf("pte=%lx table addr=%p level=%d", addr,
+	    takebits(addr, 47, MMU_PAGESHIFT), level);
+
+	if (addr & PTE_TABLE_NST)
+		mdb_printf(", non-secure");
+
+	if ((addr & PTE_TABLE_APT_RO) && (addr & PTE_TABLE_APT_NOUSER))
+		mdb_printf(", ap=ro,nouser");
+	else if (addr & PTE_TABLE_APT_RO)
+		mdb_printf(", ap=ro");
+	else if (addr & PTE_TABLE_APT_NOUSER)
+		mdb_printf(", ap=nouser");
+
+	if (addr & PTE_TABLE_UXNT)
+		mdb_printf(", uxn");
+	if (addr & PTE_TABLE_PXNT)
+		mdb_printf(", pxn");
+	if (addr & PTE_TABLE_PROTECTED)
+		mdb_printf(", protected");
+	if (addr & PTE_AF)
+		mdb_printf(", af");
+
+	mdb_printf("\n");
+	return (DCMD_OK);
+}
+
+static int
+pte_page_block(uintptr_t addr, uint_t level)
+{
+	const char *type = NULL;
+
+	if (((addr & PTE_TYPE_MASK) == PTE_BLOCK)) {
+		if (level == 0) {
+			mdb_warn("block descriptors are invalid at level 0\n");
+			/* Decode the rest of it anyway, in case it helps */
 		}
-		return (DCMD_OK);
+		type = "block";
+	} else {
+		type = "page";
 	}
 
-	if (DCMD_HDRSPEC(flags))
-		mdb_printf("%<u>%?s %?s %?s %?s %?s%</u>\n", "ADDR",
-		    "PAGES", "EPAGES", "BASE", "END");
+	mdb_printf("pte=%lx %s addr=%p level=%d size=%H", addr, type,
+	    takebits(addr, 47, MMU_PAGESHIFT), level, LEVEL_SIZE(level));
 
-	if (mdb_vread(&ms, sizeof (struct memseg), addr) == -1) {
-		mdb_warn("can't read memseg at %#lx", addr);
-		return (DCMD_ERR);
+	if (addr & PTE_NOSYNC)
+		mdb_printf(", nosync");
+	if (addr & PTE_NOCONSIST)
+		mdb_printf(", noconsist");
+	if (addr & PTE_UXN)
+		mdb_printf(", uxn");
+	if (addr & PTE_PXN)
+		mdb_printf(", pxn");
+	if (addr & PTE_CONTIG_HINT)
+		mdb_printf(", contig");
+	if (addr & PTE_DBM)
+		mdb_printf(", dbm");
+	if (addr & PTE_GP)
+		mdb_printf(", guarded");
+	if ((addr & PTE_nT) && ((addr & PTE_TYPE_MASK) == PTE_BLOCK))
+		mdb_printf(", nT");
+	if (addr & PTE_NG)
+		mdb_printf(", ng");
+	if (addr & PTE_AF)
+		mdb_printf(", af");
+
+	switch (addr & PTE_SH_MASK) {
+	case PTE_SH_INNER:
+		mdb_printf(", sh=inner");
+		break;
+	case PTE_SH_OUTER:
+		mdb_printf(", sh=outer");
+		break;
+	case PTE_SH_NONSHARE:
+		mdb_printf(", sh=none");
+		break;
+	default:
+		mdb_printf(", sh=0x%x", addr & PTE_SH_MASK);
+		break;
 	}
 
-	mdb_printf("%0?lx %0?lx %0?lx %0?lx %0?lx\n", addr,
-	    ms.pages, ms.epages, ms.pages_base, ms.pages_end);
+	if ((addr & PTE_AP_USER) && (addr & PTE_AP_RO))
+		mdb_printf(", ap=ro,user");
+	else if (addr & PTE_AP_USER)
+		mdb_printf(", ap=user");
+	else if (addr & PTE_AP_RO)
+		mdb_printf(", ap=ro");
+
+	switch (addr & PTE_ATTR_MASK) {
+	case PTE_ATTR_STRONG:
+		mdb_printf(", attr=strong");
+		break;
+	case PTE_ATTR_DEVICE:
+		mdb_printf(", attr=device");
+		break;
+	case PTE_ATTR_NORMEM:
+		mdb_printf(", attr=normem");
+		break;
+	case PTE_ATTR_NORMEM_WT:
+		mdb_printf(", attr=writethru");
+		break;
+	case PTE_ATTR_NORMEM_UC:
+		mdb_printf(", attr=uncached");
+		break;
+	case PTE_ATTR_UNORDERED:
+		mdb_printf(", attr=unordered");
+		break;
+	default:
+		mdb_warn("unknown pte attribute index\n");
+		mdb_printf(", attr=%x",
+		    (addr & PTE_ATTR_MASK) >> PTE_ATTR_SHIFT);
+	}
+	mdb_printf("\n");
 
 	return (DCMD_OK);
 }
 
 /*
- * walk the memseg structures
+ * Note that level here is in the illumos sense, where level 0 is the deepest,
+ * smallest, page size.  This is unfortunately the opposite to the order ARM
+ * refer to things.
+ *
+ * Also, for future purposes, this won't work for VMSAv9-128, because mdb
+ * lacks 128bit literals.
  */
 int
-memseg_walk_init(mdb_walk_state_t *wsp)
+pte_dcmd(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv)
 {
-	if (wsp->walk_addr != 0) {
-		mdb_warn("memseg only supports global walks\n");
-		return (WALK_ERR);
+	uint64_t level = 0;
+
+	init_mmu();
+
+	if (mmu.num_level == 0)
+		return (DCMD_ERR);
+
+	if ((flags & DCMD_ADDRSPEC) == 0)
+		return (DCMD_USAGE);
+
+	if (mdb_getopts(argc, argv,
+	    'l', MDB_OPT_UINT64, &level, NULL) != argc) {
+		return (DCMD_USAGE);
 	}
 
-	if (mdb_readvar(&wsp->walk_addr, "memsegs") == -1) {
-		mdb_warn("symbol 'memsegs' not found");
-		return (WALK_ERR);
+	if (level > mmu.max_level) {
+		mdb_warn("invalid level %lu, max is %lu\n", level,
+		    mmu.max_level);
+		return (DCMD_ERR);
 	}
 
-	wsp->walk_data = mdb_alloc(sizeof (struct memseg), UM_SLEEP);
-	return (WALK_NEXT);
+	/*
+	 * Note the level check is necessary as page and table share the same
+	 * encoding.  I'm sure there's a reason it's not page and block that
+	 * share, given they share everything else.
+	 */
+	if (!PTE_ISVALID(addr)) {
+		mdb_printf("invalid %p\n", addr);
+		return (DCMD_OK);
+	} else if (PTE_ISPAGE(addr, level)) {
+		return (pte_page_block(addr, level));
+	} else if (PTE_ISTABLE(addr, level)) {
+		return (pte_table(addr, level));
+	} else {
+		mdb_warn("impossible pte type: %d\n", addr & PTE_TYPE_MASK);
+		return (DCMD_ERR);
+	}
 
+	/* Unreachable */
+	return (DCMD_ERR);
 }
 
 int
-memseg_walk_step(mdb_walk_state_t *wsp)
+ptable_dcmd(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv)
 {
-	int status;
+	uint64_t level = 0;
+	bool opt_v = false;
+	bool opt_r = false;
+	bool opt_R = false;
 
-	if (wsp->walk_addr == 0) {
-		return (WALK_DONE);
+	init_mmu();
+
+	if (mmu.num_level == 0)
+		return (DCMD_ERR);
+
+	if (!(flags & DCMD_ADDRSPEC)) {
+		mdb_warn("missing page table (physical) address");
+		return (DCMD_USAGE);
 	}
 
-	if (mdb_vread(wsp->walk_data, sizeof (struct memseg),
-	    wsp->walk_addr) == -1) {
-		mdb_warn("failed to read struct memseg at %p", wsp->walk_addr);
-		return (WALK_DONE);
+	if (mdb_getopts(argc, argv,
+	    'l', MDB_OPT_UINT64, &level,
+	    'v', MDB_OPT_SETBITS, 1, &opt_v,
+	    'r', MDB_OPT_SETBITS, 1, &opt_r,
+	    'R', MDB_OPT_SETBITS, 1, &opt_R,
+	    NULL) != argc) {
+		return (DCMD_USAGE);
 	}
 
-	status = wsp->walk_callback(wsp->walk_addr, wsp->walk_data,
-	    wsp->walk_cbdata);
+	if (level > mmu.max_level) {
+		mdb_warn("invalid level %lu, max is %lu\n", level,
+		    mmu.max_level);
+		return (DCMD_ERR);
+	}
 
-	wsp->walk_addr = (uintptr_t)(((struct memseg *)wsp->walk_data)->next);
+	/* We have as many PTEs as fit on a page in the current granule */
+	for (int i = 0; i < MMU_PAGESIZE / sizeof (pte_t); i++) {
+		uint64_t pte = 0;
 
-	return (status);
+		if (mdb_pread(&pte, sizeof (pte),
+		    addr + (i * sizeof (pte))) != sizeof (pte)) {
+			mdb_warn("failed to read page table entry");
+			return (DCMD_ERR);
+		}
+
+		if ((pte == 0) && (opt_v == 0))
+			continue;
+
+		if (opt_r) {
+			mdb_printf("[%x]\t%lx\n", i, pte);
+		} else {
+			mdb_arg_t v[] = {
+				{ MDB_TYPE_STRING, { "-l" } },
+				{ MDB_TYPE_IMMEDIATE, { .a_val = level } }
+			};
+			mdb_printf("[%x] ", i);
+			mdb_call_dcmd("unix`pte", pte, DCMD_ADDRSPEC,
+			    ARRAY_SIZE(v), v);
+
+			if (opt_R && PTE_ISTABLE(pte, level)) {
+				mdb_arg_t rv[] = {
+					{ MDB_TYPE_STRING, { "-R" } },
+					{ MDB_TYPE_STRING, { "-l" } },
+					{ MDB_TYPE_IMMEDIATE,
+					    { .a_val = level - 1} }
+				};
+
+				mdb_inc_indent(4);
+				mdb_call_dcmd("unix`ptable",
+				    takebits(pte, 47, MMU_PAGESHIFT),
+				    DCMD_ADDRSPEC, ARRAY_SIZE(rv), rv);
+				mdb_dec_indent(4);
+			}
+		}
+
+	}
+
+	return (DCMD_OK);
 }
 
-void
-memseg_walk_fini(mdb_walk_state_t *wsp)
+int
+vatopa(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv)
 {
-	mdb_free(wsp->walk_data, sizeof (struct memseg));
+	init_mmu();
+
+	if (mmu.num_level == 0)
+		return (DCMD_ERR);
+
+	if (!(flags & DCMD_ADDRSPEC))
+		return (DCMD_USAGE);
+
+	struct as as;
+	struct hat hat;
+	struct htable htable;
+	uintptr_t asaddr = 0;
+
+	if (mdb_getopts(argc, argv,
+	    'a', MDB_OPT_UINT64, &asaddr, NULL) != argc) {
+		return (DCMD_USAGE);
+	}
+
+	if (asaddr == 0) {	/* Default is the kernel address space */
+		if (mdb_readsym(&as, sizeof (struct as), "kas") !=
+		    sizeof (struct as)) {
+			mdb_warn("couldn't read kernel address space (kas)");
+			return (DCMD_ERR);
+		}
+	} else {
+		if (mdb_vread(&as, sizeof (as), asaddr) != sizeof (as)) {
+			mdb_warn("couldn't read address space from %p", asaddr);
+			return (DCMD_ERR);
+		}
+	}
+
+	if (mdb_vread(&hat, sizeof (hat),
+	    (uintptr_t)as.a_hat) != sizeof (hat)) {
+		mdb_warn("failed to read hardware address translations");
+		return (DCMD_ERR);
+	}
+
+	if (mdb_vread(&htable, sizeof (htable),
+	    (uintptr_t)hat.hat_htable) != sizeof (htable)) {
+		mdb_warn("failed to read hardware address translations");
+		return (DCMD_ERR);
+	}
+
+	uintptr_t next_table = mmu_ptob(htable.ht_pfn);
+
+	for (int i = mmu.max_level; i >= 0; i--) {
+		uint_t idx = LEVEL_INDEX(addr, i);
+
+		pte_t pte;
+		if (mdb_pread(&pte, sizeof (pte),
+		    next_table + (idx * sizeof (pte))) != sizeof (pte)) {
+			mdb_warn("couldn't read page table entry at %p+%x",
+			    next_table, idx);
+			return (DCMD_ERR);
+		}
+
+		mdb_arg_t v[] = {
+			{ MDB_TYPE_STRING, { "-l" } },
+			{ MDB_TYPE_IMMEDIATE, { .a_val = i } }
+		};
+
+		if (!(flags & DCMD_PIPE_OUT)) {
+			mdb_printf("[%p+%x] ", next_table, idx);
+			mdb_call_dcmd("unix`pte", pte, DCMD_ADDRSPEC,
+			    ARRAY_SIZE(v), v);
+		}
+
+		if (PTE_ISTABLE(pte, i)) {
+			next_table = takebits(pte, 47, MMU_PAGESHIFT);
+			continue;
+		} else if (PTE_ISPAGE(pte, i)) {
+			mdb_printf("%p\n",
+			    takebits(pte, 47, LEVEL_SHIFT(i)) |
+			    (addr & LEVEL_OFFSET(i)));
+			break;
+		} else {
+			mdb_printf("not mapped");
+			break;
+		}
+	}
+
+	return (DCMD_OK);
+}
+
+/*
+ * It is important that this interrogates the HAT and MMU, and not the entire
+ * virtual memory subsystem (even though the reverse mappings in the VM make
+ * it much faster and easier).  We are specifically looking for hardware
+ * reality, not what the VM subsystem believes to be true.
+ */
+static int
+patova_cb(uintptr_t addr, const void *data, void *cbdata)
+{
+	uintptr_t target = (uintptr_t)cbdata;
+	htable_t htable;
+
+	if (mdb_vread(&htable, sizeof (htable), addr) != sizeof (htable)) {
+		mdb_warn("failed to read htable: %p", addr);
+		return (WALK_ERR);
+	}
+
+	uintptr_t pfnpa = mmu_ptob(htable.ht_pfn);
+	uintptr_t offset = target & ~LEVEL_MASK(htable.ht_level);
+
+	for (int i = 0; i < MMU_PAGESIZE / sizeof (pte_t); i++) {
+		uintptr_t pteaddr = (uintptr_t)PT_INDEX_PTR(pfnpa, i);
+		pte_t pte;
+
+		if (mdb_pread(&pte, sizeof (pte), pteaddr) != sizeof (pte_t)) {
+			mdb_warn("failed to read pte: %lx", pteaddr);
+			return (WALK_ERR);
+		}
+
+		if (!PTE_ISPAGE(pte, htable.ht_level)) {
+			continue;
+		}
+
+		uintptr_t pfnmaps = pte & PTE_PFN_MASK;
+
+		if ((target >= pfnmaps) &&
+		    (target < (pfnmaps + LEVEL_SIZE(htable.ht_level)))) {
+			mdb_printf("%p\n",
+			    htable.ht_vaddr +
+			    (i << LEVEL_SHIFT(htable.ht_level)) +
+			    offset);
+		}
+	}
+
+	return (WALK_NEXT);
+}
+
+int
+patova(uintptr_t addr, uint_t flags, int argc, const mdb_arg_t *argv)
+{
+	if (!(flags & DCMD_ADDRSPEC)) {
+		mdb_warn("missing physical address\n");
+		return (DCMD_USAGE);
+	}
+
+	struct as as;
+	uintptr_t asaddr = 0;
+
+	if (mdb_getopts(argc, argv,
+	    'a', MDB_OPT_UINT64, &asaddr, NULL) != argc) {
+		return (DCMD_USAGE);
+	}
+
+	if (asaddr == 0) {	/* Default is the kernel address space */
+		if (mdb_readsym(&as, sizeof (as), "kas") != sizeof (as)) {
+			mdb_warn("couldn't read kernel address space (kas)");
+			return (DCMD_ERR);
+		}
+	} else {
+		if (mdb_vread(&as, sizeof (as), asaddr) != sizeof (as)) {
+			mdb_warn("couldn't read address space from %p", asaddr);
+			return (DCMD_ERR);
+		}
+	}
+
+	return (mdb_pwalk("htables", patova_cb, (void *)addr,
+	    (uintptr_t)as.a_hat));
 }

--- a/usr/src/cmd/mdb/aarch64/modules/unix/unix.c
+++ b/usr/src/cmd/mdb/aarch64/modules/unix/unix.c
@@ -22,6 +22,8 @@
 #include <sys/modctl.h>
 #include <sys/sunddi.h>
 
+#include "htable.h"
+#include "memseg.h"
 #include "mmu.h"
 
 static int
@@ -209,12 +211,21 @@ static const mdb_dcmd_t dcmds[] = {
 	    arm_features_dcmd },
 	{ "interrupts", "", "print interrupts", gic_interrupts_dcmd },
 	{ "memseg_list", ":", "show memseg list", memseg_list },
+	{ "ptable", ":[-rRvl N]", "decode page table given a physaddr",
+	    ptable_dcmd },
+	{ "pte", ":[-l N]", "decode page table entries", pte_dcmd },
+	{ "vatopa", ":[-a as]", "translate a virtual to a physical address",
+	    vatopa },
+	{ "patova", ":[-a as]", "translate a physical into its virtual "
+	    "addresses", patova },
 	{ NULL },
 };
 
 static const mdb_walker_t walkers[] = {
 	{ "memseg", "walk the memseg structures",
 	    memseg_walk_init, memseg_walk_step, memseg_walk_fini },
+	{ "htables", "walk a hat's htables",
+	    htables_walk_init, htables_walk_step, htables_walk_fini },
 	{ NULL }
 };
 

--- a/usr/src/cmd/mdb/i86pc/modules/unix/i86mmu.c
+++ b/usr/src/cmd/mdb/i86pc/modules/unix/i86mmu.c
@@ -971,7 +971,7 @@ do_htables_dcmd(hat_t *hatp)
 	for (h = 0; h < hat.hat_num_hash; ++h) {
 		if (mdb_vread(&ht, sizeof (htable_t *),
 		    (uintptr_t)(hat.hat_ht_hash + h)) == -1) {
-			mdb_warn("Couldn't read htable ptr\\n");
+			mdb_warn("Couldn't read htable ptr\n");
 			return (DCMD_ERR);
 		}
 		for (; ht != NULL; ht = htable.ht_next) {

--- a/usr/src/pkg/manifests/system-test-utiltest.p5m
+++ b/usr/src/pkg/manifests/system-test-utiltest.p5m
@@ -1741,6 +1741,9 @@ file path=opt/util-tests/tests/libsff/libsff_wave mode=0555
 file path=opt/util-tests/tests/libsff/libsff_wave.out mode=0444
 file path=opt/util-tests/tests/make_test mode=0555
 dir  path=opt/util-tests/tests/mdb
+$(aarch64_ONLY)dir path=opt/util-tests/tests/mdb/aarch64
+$(aarch64_ONLY)file \
+    path=opt/util-tests/tests/mdb/aarch64/tst.address-translation.ksh mode=0444
 dir  path=opt/util-tests/tests/mdb/exit-e
 file path=opt/util-tests/tests/mdb/exit-e/err.cmdbadopt.ksh mode=0444
 file path=opt/util-tests/tests/mdb/exit-e/err.enocmd.ksh mode=0444

--- a/usr/src/test/util-tests/tests/mdb/Makefile
+++ b/usr/src/test/util-tests/tests/mdb/Makefile
@@ -33,6 +33,8 @@ MAKEDIRS = \
 	sou \
 	typedef
 
+$(AARCH64_BLD)MAKEDIRS += aarch64
+
 FILES = \
 	exit-e/err.cmdbadopt.ksh \
 	exit-e/err.enocmd.ksh \
@@ -123,7 +125,9 @@ FILES = \
 	typedef/tst.structvla.mdb \
 	typedef/tst.structvla.mdb.out \
 	typedef/tst.union.mdb \
-	typedef/tst.union.mdb.out \
+	typedef/tst.union.mdb.out
+
+$(AARCH64_BLD)FILES += aarch64/tst.address-translation.ksh
 
 ROOTFILES = $(FILES:%=$(TESTDIR)/%)
 ROOTMAKEDIRS = $(MAKEDIRS:%=$(TESTDIR)/%)

--- a/usr/src/test/util-tests/tests/mdb/aarch64/tst.address-translation.ksh
+++ b/usr/src/test/util-tests/tests/mdb/aarch64/tst.address-translation.ksh
@@ -1,0 +1,58 @@
+#! /usr/bin/ksh
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2026 Richard Lowe
+#
+
+# Test that the address translation dcmds form a (sort of) identity:
+#     patova(vatopa(X)) ⊇ X
+
+error() {
+	print -u2 "ERROR: $@"
+	exit 1;
+}
+
+fail() {
+	print -u2 "FAIL: $@"
+	exit 1;
+}
+
+address_of() {
+	sym=$1
+
+	mdb -ke "${sym}=K" || error "could't get address of '${sym}'"
+}
+
+vatopa_patova() {
+	sym=$1
+
+	mdb -ke "${sym}::vatopa | ::patova" || error "couldn't vatopa patova '${sym}'"
+}
+
+# Buffer stdin to stdout through a 4kB buffer, this is because mdb fails if
+# writes to stdout fail, which they will if a later command in the pipeline
+# such as `grep -q` exits early (when it short circuits successfully)
+buffer() {
+	dd bs=4096 conv=block 2>/dev/null
+}
+
+check() {
+	sym=$1
+	addr=$(address_of $sym)
+
+	(vatopa_patova "${sym}" | buffer | grep -q $addr) || fail "${sym} doesn't map back to ${addr}"
+}
+
+check sched
+
+exit 0

--- a/usr/src/test/util-tests/tests/mdb/numbers/tst.prefsym.ksh
+++ b/usr/src/test/util-tests/tests/mdb/numbers/tst.prefsym.ksh
@@ -30,13 +30,20 @@ tst_sym2="_007"
 tst_out=
 tst_err=0
 
-$MDB -e "$tst_sym0=K" $tst_prog | grep -q "$tst_sym0"
+# Buffer stdin to stdout through a 4kB buffer, this is because mdb fails if
+# writes to stdout fail, which they will if a later command in the pipeline
+# such as `grep -q` exits early (when it short circuits successfully)
+buffer() {
+	dd bs=4096 conv=block 2>/dev/null
+}
+
+$MDB -e "$tst_sym0=K" $tst_prog | buffer | grep -q "$tst_sym0"
 if (( $? == 0 )); then
 	printf >&2 "%s=K somehow returned itself, did it become a number?\n" \
 	    "$tst_sym0"
 fi
 
-$MDB -e "$tst_sym0/K | ::eval ./s" $tst_prog | grep -q 'Am I a string?'
+$MDB -e "$tst_sym0/K | ::eval ./s" $tst_prog | buffer | grep -q 'Am I a string?'
 if (( $? != 0 )); then
 	printf >&2 "Failed to find expected output for %s\n" "$tst_sym0"
 	tst_err=1
@@ -46,27 +53,27 @@ fi
 # We grep against tst_sym0 as if mdb does interpret this as a number,
 # then it'll show it without the '_' characters.
 #
-$MDB -e "$tst_sym1=K" $tst_prog | grep -q "$tst_sym0"
+$MDB -e "$tst_sym1=K" $tst_prog | buffer | grep -q "$tst_sym0"
 if (( $? == 0 )); then
 	printf >&2 "%s=K somehow returned itself, did it become a number?\n" \
 	    "$tst_sym0"
 	tst_err=1
 fi
 
-$MDB -e "$tst_sym1/K | ::eval ./s" $tst_prog | grep -q 'I am not a string'
+$MDB -e "$tst_sym1/K | ::eval ./s" $tst_prog | buffer | grep -q 'I am not a string'
 if (( $? != 0 )); then
 	printf >&2 "Failed to find expected output for %s\n" "$tst_sym1"
 	tst_err=1
 fi
 
-$MDB -e "$tst_sym2=K" $tst_prog | grep -q "$tst_sym2"
+$MDB -e "$tst_sym2=K" $tst_prog | buffer | grep -q "$tst_sym2"
 if (( $? == 0 )); then
 	printf >&2 "%s=K somehow returned itself, did it become a number?\n" \
 	    "$tst_sym2"
 	tst_err=1
 fi
 
-$MDB -e "$tst_sym2::dis" $tst_prog | egrep -qi '^_007:'
+$MDB -e "$tst_sym2::dis" $tst_prog | buffer | egrep -qi '^_007:'
 if (( $? != 0 )); then
 	printf >&2 "Failed to find expected output for %s::dis\n" "$tst_sym2"
 	tst_err=1

--- a/usr/src/uts/armv8/dboot/dboot_standalloc.c
+++ b/usr/src/uts/armv8/dboot/dboot_standalloc.c
@@ -283,11 +283,14 @@ map_pages(pte_t pte_attr, uintptr_t vaddr, uint64_t paddr, size_t bytes)
 
 	pte_t *l3_ptbl = IS_KERNEL_MAPPING(vaddr) ? l3_ptbl1 : l3_ptbl0;
 
-	if ((l3_ptbl[l3_idx] & PTE_TYPE_MASK) == 0)
+	if (!PTE_ISVALID((l3_ptbl[l3_idx]))) {
 		l3_ptbl[l3_idx] = PTE_TABLE_APT_NOUSER|PTE_TABLE_UXNT|
 		    PTE_TABLE|alloc_pagetable_page("L3");
-	if ((l3_ptbl[l3_idx] & PTE_VALID) == 0)
+	}
+
+	if (!PTE_ISTABLE(l3_ptbl[l3_idx], 3)) {
 		panic("invalid L3 PT\n");
+	}
 
 	pte_t *l2_ptbl = (pte_t *)(uintptr_t)(l3_ptbl[l3_idx] & PTE_PFN_MASK);
 
@@ -296,18 +299,21 @@ map_pages(pte_t pte_attr, uintptr_t vaddr, uint64_t paddr, size_t bytes)
 			panic("invalid vaddr alignment (1G)\n");
 		if (paddr & (MMU_PAGESIZE1G - 1))
 			panic("invalid paddr alignment (1G)\n");
-		if (l2_ptbl[l2_idx] & PTE_VALID)
-			panic("invalid L2 PT\n");
+		if (PTE_ISVALID(l2_ptbl[l2_idx]))
+			panic("L2 PT already used\n");
 		l2_ptbl[l2_idx] = paddr|pte_attr|PTE_BLOCK;
 		dsb(ish);
 		return;
 	}
 
-	if ((l2_ptbl[l2_idx] & PTE_TYPE_MASK) == 0)
+	if (!PTE_ISVALID(l2_ptbl[l2_idx])) {
 		l2_ptbl[l2_idx] = PTE_TABLE_APT_NOUSER|PTE_TABLE_UXNT|
 		    PTE_TABLE|alloc_pagetable_page("L2");
-	if ((l2_ptbl[l2_idx] & PTE_TYPE_MASK) != PTE_TABLE)
+	}
+
+	if (!PTE_ISTABLE(l2_ptbl[l2_idx], 2)) {
 		panic("invalid L2 PT\n");
+	}
 
 	pte_t *l1_ptbl = (pte_t *)(uintptr_t)(l2_ptbl[l2_idx] & PTE_PFN_MASK);
 
@@ -316,18 +322,21 @@ map_pages(pte_t pte_attr, uintptr_t vaddr, uint64_t paddr, size_t bytes)
 			panic("invalid vaddr alignment (2M)\n");
 		if (paddr & (MMU_PAGESIZE2M - 1))
 			panic("invalid paddr alignment (2M)\n");
-		if (l1_ptbl[l1_idx] & PTE_VALID)
-			panic("invalid L1 PT\n");
+		if (PTE_ISVALID(l1_ptbl[l1_idx]))
+			panic("L1 PT already used\n");
 		l1_ptbl[l1_idx] = paddr|pte_attr|PTE_BLOCK;
 		dsb(ish);
 		return;
 	}
 
-	if ((l1_ptbl[l1_idx] & PTE_TYPE_MASK) == 0)
+	if (!PTE_ISVALID(l1_ptbl[l1_idx])) {
 		l1_ptbl[l1_idx] = PTE_TABLE_APT_NOUSER|PTE_TABLE_UXNT|
 		    PTE_TABLE|alloc_pagetable_page("L1");
-	if ((l1_ptbl[l1_idx] & PTE_TYPE_MASK) != PTE_TABLE)
+	}
+
+	if (!PTE_ISTABLE(l1_ptbl[l1_idx], 1)) {
 		panic("invalid L1 PT\n");
+	}
 
 	pte_t *l0_ptbl = (pte_t *)(uintptr_t)(l1_ptbl[l1_idx] & PTE_PFN_MASK);
 	if (bytes == MMU_PAGESIZE) {
@@ -335,8 +344,8 @@ map_pages(pte_t pte_attr, uintptr_t vaddr, uint64_t paddr, size_t bytes)
 			panic("invalid vaddr alignment (4K)\n");
 		if (paddr & (MMU_PAGESIZE - 1))
 			panic("invalid paddr alignment (4K)\n");
-		if (l0_ptbl[l0_idx] & PTE_VALID)
-			panic("invalid L0 PT\n");
+		if (PTE_ISVALID(l0_ptbl[l0_idx]))
+			panic("L0 PT already in use\n");
 		l0_ptbl[l0_idx] = paddr|pte_attr|PTE_PAGE;
 		dsb(ish);
 		return;
@@ -481,20 +490,19 @@ dump_tables(uint64_t tab, uint64_t va_offset)
 	for (index = 0; index < ptes_per_table; ++index) {
 		pgsize = 1ull << shift_amt[l];
 		pteval = ((pte_t *)table)[index];
-		if (!(pteval & PTE_VALID))
+		if (!PTE_ISVALID(pteval))
 			goto next_entry;
 
 		dboot_printf("%s [L%u] 0x%p[%u] = 0x%" PRIx64 ", va=0x%" PRIx64,
 		    tabs + l, l, (void *)table, index, (uint64_t)pteval, va);
 		pa = pteval & PTE_PFN_MASK;
-		if (l == 0 ||
-		    (l != 0 && (pteval & PTE_TYPE_MASK) == PTE_BLOCK)) {
+		if (PTE_ISPAGE(pteval, l)) {
 			dboot_printf(" physaddr=0x%" PRIx64 "\n", pa);
 		} else {
 			dboot_printf(" => 0x%" PRIx64 "\n", pa);
 		}
 
-		if (l > 0 && (pteval & PTE_TYPE_MASK) == PTE_TABLE) {
+		if (PTE_ISTABLE(pteval, l)) {
 			save_table[l] = table;
 			save_index[l] = index;
 			--l;
@@ -508,7 +516,7 @@ dump_tables(uint64_t tab, uint64_t va_offset)
 		 */
 		for (i = 1; index + i < ptes_per_table; ++i) {
 			pteval = ((pte_t *)table)[index + i];
-			if (!(pteval & PTE_TYPE_MASK))
+			if (!PTE_ISVALID(pteval))
 				break;
 			pa1 = (pteval & PTE_PFN_MASK);
 			if (pa1 != pa + (i * pgsize))

--- a/usr/src/uts/armv8/os/fakebop.c
+++ b/usr/src/uts/armv8/os/fakebop.c
@@ -206,33 +206,33 @@ map_phys(bootops_t *bop, pte_t pte_attr, uintptr_t vaddr, uint64_t paddr)
 	pte_t *l3_ptbl = (pte_t *)(IS_KERNEL_MAPPING(vaddr) ?
 	    read_ttbr1() : read_ttbr0());
 
-	if ((l3_ptbl[l3_idx] & PTE_TYPE_MASK) == 0) {
+	if (!PTE_ISVALID(l3_ptbl[l3_idx])) {
 		paddr_t pa = pt_alloc(bop);
 		dsb(ish);
 		l3_ptbl[l3_idx] =
 		    PTE_TABLE_UXNT | PTE_TABLE_APT_NOUSER | pa | PTE_TABLE;
 	}
 
-	if ((l3_ptbl[l3_idx] & PTE_VALID) == 0) {
-		bop_panic("invalid L3 PT\n");
+	if (!PTE_ISTABLE(l3_ptbl[l3_idx], 3)) {
+		bop_panic("invalid L2 PT\n");
 	}
 
 	pte_t *l2_ptbl = (pte_t *)(uintptr_t)(l3_ptbl[l3_idx] & PTE_PFN_MASK);
 
-	if ((l2_ptbl[l2_idx] & PTE_TYPE_MASK) == 0) {
+	if (!PTE_ISVALID(l2_ptbl[l2_idx])) {
 		paddr_t pa = pt_alloc(bop);
 		dsb(ish);
 		l2_ptbl[l2_idx] =
 		    PTE_TABLE_UXNT | PTE_TABLE_APT_NOUSER | pa | PTE_TABLE;
 	}
 
-	if ((l2_ptbl[l2_idx] & PTE_TYPE_MASK) != PTE_TABLE) {
+	if (!PTE_ISTABLE(l2_ptbl[l2_idx], 2)) {
 		bop_panic("invalid L2 PT\n");
 	}
 
 	pte_t *l1_ptbl = (pte_t *)(uintptr_t)(l2_ptbl[l2_idx] & PTE_PFN_MASK);
 
-	if ((l1_ptbl[l1_idx] & PTE_TYPE_MASK) == 0) {
+	if (!PTE_ISVALID(l1_ptbl[l1_idx])) {
 		paddr_t pa = pt_alloc(bop);
 		bzero((void *)(uintptr_t)pa, MMU_PAGESIZE);
 		dsb(ish);
@@ -240,13 +240,13 @@ map_phys(bootops_t *bop, pte_t pte_attr, uintptr_t vaddr, uint64_t paddr)
 		    PTE_TABLE_UXNT | PTE_TABLE_APT_NOUSER | pa | PTE_TABLE;
 	}
 
-	if ((l1_ptbl[l1_idx] & PTE_TYPE_MASK) != PTE_TABLE) {
+	if (!PTE_ISTABLE(l1_ptbl[l1_idx], 1)) {
 		bop_panic("invalid L1 PT\n");
 	}
 
 	pte_t *l0_ptbl = (pte_t *)(uintptr_t)(l1_ptbl[l1_idx] & PTE_PFN_MASK);
-	if (l0_ptbl[l0_idx] & PTE_VALID) {
-		bop_panic("invalid L0 PT\n");
+	if (PTE_ISVALID(l0_ptbl[l0_idx])) {
+		bop_panic("L0 page table entry in use\n");
 	}
 	l0_ptbl[l0_idx] = paddr | pte_attr | PTE_PAGE;
 	dsb(ish);

--- a/usr/src/uts/armv8/vm/aarch64_mmu.c
+++ b/usr/src/uts/armv8/vm/aarch64_mmu.c
@@ -140,21 +140,24 @@ hat_kern_alloc(
 	pte_t *l3_ptbl = (pte_t *)pa_to_kseg(TTBR_BADDR48(read_ttbr1()));
 
 	for (int i = 0; i < NPTEPERPT; i++) {
-		if ((l3_ptbl[i] & PTE_TYPE_MASK) != PTE_TABLE)
+		if (!PTE_ISTABLE(l3_ptbl[i], 3)) {
 			continue;
+		}
 		++table_cnt;
 
 		pte_t *l2_ptbl = (pte_t *)pa_to_kseg(l3_ptbl[i] & PTE_PFN_MASK);
 		for (int j = 0; j < NPTEPERPT; j++) {
-			if ((l2_ptbl[j] & PTE_TYPE_MASK) != PTE_TABLE)
+			if (!PTE_ISTABLE(l2_ptbl[j], 2)) {
 				continue;
+			}
 			++table_cnt;
 
 			pte_t *l1_ptbl = (pte_t *)pa_to_kseg(l2_ptbl[j] &
 			    PTE_PFN_MASK);
 			for (int k = 0; k < NPTEPERPT; k++) {
-				if ((l1_ptbl[k] & PTE_TYPE_MASK) != PTE_TABLE)
+				if (!PTE_ISTABLE(l1_ptbl[k], 1)) {
 					continue;
+				}
 				++table_cnt;
 
 			}
@@ -373,7 +376,7 @@ boot_reserve(void)
 			ptbl[l] += SEGKPM_SIZE / page_size;
 			continue;
 		}
-		if ((*ptbl[l] & PTE_VALID) == 0) {
+		if (!PTE_ISVALID(*ptbl[l])) {
 			va += page_size;
 			++ptbl[l];
 			if (((uintptr_t)ptbl[l] & MMU_PAGEOFFSET) == 0) {
@@ -382,7 +385,7 @@ boot_reserve(void)
 			continue;
 		}
 
-		if (l > 0 && (*ptbl[l] & PTE_TYPE_MASK) == PTE_TABLE) {
+		if (PTE_ISTABLE(*ptbl[l], l)) {
 			ASSERT(ptbl[l - 1] == NULL);
 			ptbl[l - 1] = (pte_t *)pa_to_kseg(*ptbl[l] &
 			    PTE_PFN_MASK);

--- a/usr/src/uts/armv8/vm/hat_pte.h
+++ b/usr/src/uts/armv8/vm/hat_pte.h
@@ -63,8 +63,26 @@ typedef int8_t level_t;
 
 #define	PTE_ISVALID(pte)	((pte) & PTE_VALID)
 #define	PTE_EQUIV(a, b)		(((a) | PTE_AF) == ((b) | PTE_AF))
-#define	PTE_ISPAGE(p, l)	(PTE_ISVALID(p) && (((l) == PAGE_LEVEL) || \
-	(((p) & PTE_TYPE_MASK) == PTE_BLOCK)))
+
+extern __GNU_INLINE boolean_t
+PTE_ISTABLE(uint64_t pte, uint_t level)
+{
+	if (!PTE_ISVALID(pte)) {
+		return (B_FALSE);
+	}
+
+	return ((((pte) & PTE_TYPE_MASK) == PTE_TABLE) && (level != 0));
+}
+
+extern __GNU_INLINE boolean_t
+PTE_ISPAGE(uint64_t pte, uint_t level)
+{
+	if (!PTE_ISVALID(pte)) {
+		return (B_FALSE);
+	}
+
+	return (!PTE_ISTABLE(pte, level));
+}
 
 #define	MAKEPTE(pfn, l)		(((pfn) << MMU_PAGESHIFT) | PTE_SH_INNER | \
 	(l == PAGE_LEVEL? PTE_PAGE: PTE_BLOCK))

--- a/usr/src/uts/armv8/vm/htable.c
+++ b/usr/src/uts/armv8/vm/htable.c
@@ -1688,7 +1688,7 @@ pte_set(htable_t *ht, uint_t entry, pte_t new, void *ptr)
 		 * Detect if we have a collision of installing a large
 		 * page mapping where there already is a lower page table.
 		 */
-		if (l > 0 && (prev & PTE_TYPE_MASK) == PTE_TABLE) {
+		if (PTE_ISTABLE(prev, l)) {
 			old = LPAGE_ERROR;
 			goto done;
 		}


### PR DESCRIPTION
This mostly adds mdb support for address-related things, there's some cleanup with `PTE_IS*` and a workaround taken from the test and applied to another test which also suffers.

These are taken from my arm64/dynahat branch which became unwieldy, so there are future changes on top of this (including the page-table allocation bits).

@r1mikey