### PR TITLE
cmd/svc/settle: a private tool to wait for SMF to settle

### DIFF
--- a/usr/src/cmd/.gitignore
+++ b/usr/src/cmd/.gitignore
@@ -1981,6 +1981,7 @@ svc/seed/lib/
 svc/seed/miniroot.db
 svc/seed/nonglobal.db
 svc/servinfo/servinfo
+svc/settle/settle
 svc/startd/svc.startd
 svc/svcadm/svcadm
 svc/svccfg/svccfg

--- a/usr/src/cmd/svc/Makefile
+++ b/usr/src/cmd/svc/Makefile
@@ -30,6 +30,7 @@ SUBDIR_CMD=		\
 	mfstscan	\
 	rootisramdisk	\
 	servinfo	\
+	settle		\
 	svcadm		\
 	svccfg		\
 	svcprop		\

--- a/usr/src/cmd/svc/settle/Makefile
+++ b/usr/src/cmd/svc/settle/Makefile
@@ -1,0 +1,49 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+#
+# Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
+# Use is subject to license terms.
+#
+
+PROG =		settle
+OBJS =		settle.o
+SRCS =		$(OBJS:%.o=%.c)
+POFILES = 	$(OBJS:.o=.po)
+
+include ../../Makefile.cmd
+include ../../Makefile.ctf
+
+LDLIBS +=	-lscf
+
+.KEEP_STATE:
+
+all: $(PROG)
+
+$(PROG): $(OBJS)
+	$(LINK.c) -o $@ $(OBJS) $(LDLIBS)
+	$(POST_PROCESS)
+
+install: all $(ROOTLIBSVCBINPROG)
+
+clean:
+	$(RM) $(OBJS)
+
+include ../../Makefile.targ

--- a/usr/src/cmd/svc/settle/settle.c
+++ b/usr/src/cmd/svc/settle/settle.c
@@ -1,0 +1,139 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2026 Richard Lowe
+ */
+
+/*
+ * Wait for the service management facility to reach a steady state
+ */
+
+#include <err.h>
+#include <limits.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#include <libscf.h>
+
+extern const char *__progname;
+
+/* Just count up any instances we see */
+int
+count_instances_cb(scf_handle_t *hdl, scf_instance_t *inst, void *arg)
+{
+	*(int *)arg += 1;
+
+	return (SCF_SUCCESS);
+}
+
+/* Report services which didn't make it */
+int
+report_losers_cb(scf_handle_t *hdl, scf_instance_t *inst, void *arg)
+{
+	char instance_name[BUFSIZ];
+	char service_name[BUFSIZ];
+	scf_service_t *svc = NULL;
+
+	if (scf_instance_get_name(inst, instance_name, BUFSIZ) == SCF_FAILED) {
+		errx(1, "couldn't get instance name: %s\n",
+		    scf_strerror(scf_error()));
+	}
+
+	if ((svc = scf_service_create(hdl)) == NULL) {
+		errx(1, "couldn't allocate service: %s",
+		    scf_strerror(scf_error()));
+	}
+
+	if (scf_instance_get_parent(inst, svc) == SCF_FAILED) {
+		errx(1, "couldn't get service of instance: %s\n",
+		    scf_strerror(scf_error()));
+	}
+
+	if (scf_service_get_name(svc, service_name, BUFSIZ) == SCF_FAILED) {
+		errx(1, "couldn't get name of service of instance: %s\n",
+		    scf_strerror(scf_error()));
+	}
+
+	printf("svc:/%s:%s didn't make it\n", service_name, instance_name);
+
+	scf_service_destroy(svc);
+
+	return (SCF_SUCCESS);
+}
+
+/*
+ * The set of states which indicate the service is still on its way
+ * somewhere.
+ */
+const int CHUGGING_STATES = SCF_STATE_UNINIT | \
+    SCF_STATE_OFFLINE;
+
+/*
+ * The set of states that indicate problems.  A superset of `CHUGGING_STATES`
+ * since anyone in one of those when we think we're done is also problematic
+ */
+const int FAILED_STATES = CHUGGING_STATES | SCF_STATE_MAINT | \
+    SCF_STATE_DEGRADED;
+
+/*
+ * How many ticks we want to remain at 0 chugging services before we're done
+ */
+const int WAIT_TICKS = 3;
+
+/* How long to sleep between checks */
+const int SLEEP_FOR = 1;
+
+int
+main(int argc, char **argv)
+{
+	uint_t svccount;	/* Number of chugging services right now */
+	uint_t tickcount = WAIT_TICKS;
+
+	if (argc != 1)
+		errx(1, "usage: %s\n", __progname);
+
+	do {
+		svccount = 0;
+
+		if (scf_simple_walk_instances(CHUGGING_STATES,
+		    &svccount, count_instances_cb) == SCF_FAILED) {
+			errx(1, "couldn't walk instances: %s\n",
+			    scf_strerror(scf_error()));
+		}
+
+		if (svccount != 0) {
+			printf("\r%3d instances to wait for", svccount);
+			fflush(stdout);
+			tickcount = WAIT_TICKS;
+		} else {
+			tickcount--;
+		}
+
+		(void) sleep(SLEEP_FOR);
+	} while ((svccount > 0) && (tickcount > 0));
+
+	/*
+	 * There are better ways to do this, but this works even when $TERM is
+	 * incorrect, like on the console of a platform image.
+	 */
+	printf("\r                                      \r");
+	fflush(stdout);
+
+	/* Now report any services which aren't in a good state */
+	if (scf_simple_walk_instances(FAILED_STATES,
+	    NULL, report_losers_cb) == SCF_FAILED) {
+		errx(1, "couldn't walk instances: %s\n",
+		    scf_strerror(scf_error()));
+	}
+
+	return (EXIT_SUCCESS);
+}

--- a/usr/src/pkg/manifests/SUNWcs.p5m
+++ b/usr/src/pkg/manifests/SUNWcs.p5m
@@ -307,6 +307,7 @@ file path=lib/svc/bin/lsvcrun group=sys mode=0555
 file path=lib/svc/bin/mfstscan group=sys mode=0555
 file path=lib/svc/bin/restore_repository group=sys mode=0555
 file path=lib/svc/bin/rootisramdisk group=sys mode=0555
+file path=lib/svc/bin/settle group=sys mode=0555
 file path=lib/svc/bin/sqlite group=sys mode=0555
 file path=lib/svc/bin/svc.configd group=sys mode=0555
 file path=lib/svc/bin/svc.ipfd group=sys mode=0555


### PR DESCRIPTION
Wait for there to be no services in intermediate states for 5 seconds, reporting on our wait.  Afterwards, flag any services that didn't reach a successful terminal state.

This is inherently racey but is intended to support running automated tests and the like where it is useful to let the system finish booting and settle, contrary to SMF's goal to be available interactively as soon as possible.

@hadfl I did this for `testsuite.exp`, so the first few tests run in a more reliable environment