### PR TITLE
atomics correctness and ordering rework

### DIFF
--- a/usr/src/common/atomic/aarch64/atomic.c
+++ b/usr/src/common/atomic/aarch64/atomic.c
@@ -460,11 +460,11 @@ membar_exit(void)
 
 void
 membar_producer(void)
-{ __sync_synchronize(); }
+{ __asm__ __volatile__("dmb ishst" ::: "memory"); }
 
 void
 membar_consumer(void)
-{ __sync_synchronize(); }
+{ __asm__ __volatile__("dmb ishld" ::: "memory"); }
 
 void
 membar_sync(void)

--- a/usr/src/common/atomic/aarch64/atomic.c
+++ b/usr/src/common/atomic/aarch64/atomic.c
@@ -109,6 +109,10 @@ atomic_add_ushort(volatile ushort_t *target, short value)
 { (void)__sync_add_and_fetch(target, value); }
 
 void
+atomic_add_short(volatile short *target, short value)
+{ (void)__sync_add_and_fetch(target, value); }
+
+void
 atomic_add_32(volatile uint32_t *target, int32_t value)
 { (void)__sync_add_and_fetch(target, value); }
 
@@ -394,47 +398,43 @@ atomic_cas_ptr(volatile void *target, void *cmp, void *newval)
 
 uint8_t
 atomic_swap_8(volatile uint8_t *target, uint8_t newval)
-{ return __sync_lock_test_and_set(target, newval); }
+{ return __atomic_exchange_n(target, newval, __ATOMIC_SEQ_CST); }
 
 uchar_t
 atomic_swap_char(volatile uchar_t *target, uchar_t newval)
-{ return __sync_lock_test_and_set(target, newval); }
+{ return __atomic_exchange_n(target, newval, __ATOMIC_SEQ_CST); }
 
 uchar_t
 atomic_swap_uchar(volatile uchar_t *target, uchar_t newval)
-{ return __sync_lock_test_and_set(target, newval); }
+{ return __atomic_exchange_n(target, newval, __ATOMIC_SEQ_CST); }
 
 uint16_t
 atomic_swap_16(volatile uint16_t *target, uint16_t newval)
-{ return __sync_lock_test_and_set(target, newval); }
-
-void
-atomic_add_short(volatile short *target, short value)
-{ (void)__sync_add_and_fetch(target, value); }
+{ return __atomic_exchange_n(target, newval, __ATOMIC_SEQ_CST); }
 
 ushort_t
 atomic_swap_ushort(volatile ushort_t *target, ushort_t newval)
-{ return __sync_lock_test_and_set(target, newval); }
+{ return __atomic_exchange_n(target, newval, __ATOMIC_SEQ_CST); }
 
 uint32_t
 atomic_swap_32(volatile uint32_t *target, uint32_t newval)
-{ return __sync_lock_test_and_set(target, newval); }
+{ return __atomic_exchange_n(target, newval, __ATOMIC_SEQ_CST); }
 
 uint_t
 atomic_swap_uint(volatile uint_t *target, uint_t newval)
-{ return __sync_lock_test_and_set(target, newval); }
+{ return __atomic_exchange_n(target, newval, __ATOMIC_SEQ_CST); }
 
 uint64_t
 atomic_swap_64(volatile uint64_t *target, uint64_t newval)
-{ return __sync_lock_test_and_set(target, newval); }
+{ return __atomic_exchange_n(target, newval, __ATOMIC_SEQ_CST); }
 
 void *
 atomic_swap_ptr(volatile void *target, void *newval)
-{ return __sync_lock_test_and_set((void **)target, newval); }
+{ return __atomic_exchange_n((void **)target, newval, __ATOMIC_SEQ_CST); }
 
 ulong_t
 atomic_swap_ulong(volatile ulong_t *target, ulong_t newval)
-{ return __sync_lock_test_and_set(target, newval); }
+{ return __atomic_exchange_n(target, newval, __ATOMIC_SEQ_CST); }
 
 int
 atomic_set_long_excl(volatile ulong_t *target, uint_t value)

--- a/usr/src/common/atomic/aarch64/atomic.c
+++ b/usr/src/common/atomic/aarch64/atomic.c
@@ -26,375 +26,384 @@
 #include <sys/types.h>
 
 
-/* XXXARM: These just use the intrinsics right now, which may get messy later. */
+/* XXXARM: These just use the intrinsics right now, which may get messy later */
 
 void
 atomic_inc_8(volatile uint8_t *target)
-{ (void)__sync_add_and_fetch(target, 1); }
+{ (void)__atomic_add_fetch(target, 1, __ATOMIC_SEQ_CST); }
 
 void
 atomic_inc_uchar(volatile uchar_t *target)
-{ (void)__sync_add_and_fetch(target, 1); }
+{ (void)__atomic_add_fetch(target, 1, __ATOMIC_SEQ_CST); }
 
 void
 atomic_inc_16(volatile uint16_t *target)
-{ (void)__sync_add_and_fetch(target, 1); }
+{ (void)__atomic_add_fetch(target, 1, __ATOMIC_SEQ_CST); }
 
 void
 atomic_inc_ushort(volatile ushort_t *target)
-{ (void)__sync_add_and_fetch(target, 1); }
+{ (void)__atomic_add_fetch(target, 1, __ATOMIC_SEQ_CST); }
 
 void
 atomic_inc_32(volatile uint32_t *target)
-{ (void)__sync_add_and_fetch(target, 1); }
+{ (void)__atomic_add_fetch(target, 1, __ATOMIC_SEQ_CST); }
 
 void
 atomic_inc_uint(volatile uint_t *target)
-{ (void)__sync_add_and_fetch(target, 1); }
+{ (void)__atomic_add_fetch(target, 1, __ATOMIC_SEQ_CST); }
 
 void
 atomic_inc_ulong(volatile ulong_t *target)
-{ (void)__sync_add_and_fetch(target, 1); }
+{ (void)__atomic_add_fetch(target, 1, __ATOMIC_SEQ_CST); }
 
 void
 atomic_inc_64(volatile uint64_t *target)
-{ (void)__sync_add_and_fetch(target, 1); }
+{ (void)__atomic_add_fetch(target, 1, __ATOMIC_SEQ_CST); }
 
 void
 atomic_dec_8(volatile uint8_t *target)
-{ (void)__sync_sub_and_fetch(target, 1); }
+{ (void)__atomic_sub_fetch(target, 1, __ATOMIC_SEQ_CST); }
 
 void
 atomic_dec_uchar(volatile uchar_t *target)
-{ (void)__sync_sub_and_fetch(target, 1); }
+{ (void)__atomic_sub_fetch(target, 1, __ATOMIC_SEQ_CST); }
 
 void
 atomic_dec_16(volatile uint16_t *target)
-{ (void)__sync_sub_and_fetch(target, 1); }
+{ (void)__atomic_sub_fetch(target, 1, __ATOMIC_SEQ_CST); }
 
 void
 atomic_dec_ushort(volatile ushort_t *target)
-{ (void)__sync_sub_and_fetch(target, 1); }
+{ (void)__atomic_sub_fetch(target, 1, __ATOMIC_SEQ_CST); }
 
 void
 atomic_dec_32(volatile uint32_t *target)
-{ (void)__sync_sub_and_fetch(target, 1); }
+{ (void)__atomic_sub_fetch(target, 1, __ATOMIC_SEQ_CST); }
 
 void
 atomic_dec_uint(volatile uint_t *target)
-{ (void)__sync_sub_and_fetch(target, 1); }
+{ (void)__atomic_sub_fetch(target, 1, __ATOMIC_SEQ_CST); }
 
 void
 atomic_dec_ulong(volatile ulong_t *target)
-{ (void)__sync_sub_and_fetch(target, 1); }
+{ (void)__atomic_sub_fetch(target, 1, __ATOMIC_SEQ_CST); }
 
 void
 atomic_dec_64(volatile uint64_t *target)
-{ (void)__sync_sub_and_fetch(target, 1); }
+{ (void)__atomic_sub_fetch(target, 1, __ATOMIC_SEQ_CST); }
 
 void
 atomic_add_8(volatile uint8_t *target, int8_t value)
-{ (void)__sync_add_and_fetch(target, value); }
+{ (void)__atomic_add_fetch(target, value, __ATOMIC_SEQ_CST); }
 
 void
 atomic_add_char(volatile uchar_t *target, signed char value)
-{ (void)__sync_add_and_fetch(target, value); }
+{ (void)__atomic_add_fetch(target, value, __ATOMIC_SEQ_CST); }
 
 void
 atomic_add_16(volatile uint16_t *target, int16_t value)
-{ (void)__sync_add_and_fetch(target, value); }
+{ (void)__atomic_add_fetch(target, value, __ATOMIC_SEQ_CST); }
 
 void
 atomic_add_ushort(volatile ushort_t *target, short value)
-{ (void)__sync_add_and_fetch(target, value); }
+{ (void)__atomic_add_fetch(target, value, __ATOMIC_SEQ_CST); }
 
 void
 atomic_add_short(volatile short *target, short value)
-{ (void)__sync_add_and_fetch(target, value); }
+{ (void)__atomic_add_fetch(target, value, __ATOMIC_SEQ_CST); }
 
 void
 atomic_add_32(volatile uint32_t *target, int32_t value)
-{ (void)__sync_add_and_fetch(target, value); }
+{ (void)__atomic_add_fetch(target, value, __ATOMIC_SEQ_CST); }
 
 void
 atomic_add_int(volatile uint32_t *target, int32_t value)
-{ (void)__sync_add_and_fetch(target, value); }
+{ (void)__atomic_add_fetch(target, value, __ATOMIC_SEQ_CST); }
 
 void
 atomic_add_ptr(volatile void *target, ssize_t value)
-{ (void)__sync_add_and_fetch((caddr_t *)target, value); }
+{ (void)__atomic_add_fetch((caddr_t *)target, value, __ATOMIC_SEQ_CST); }
 
 void
 atomic_add_long(volatile ulong_t *target, long value)
-{ (void)__sync_add_and_fetch(target, value); }
+{ (void)__atomic_add_fetch(target, value, __ATOMIC_SEQ_CST); }
 
 void
 atomic_add_64(volatile uint64_t *target, int64_t value)
-{ (void)__sync_add_and_fetch(target, value); }
+{ (void)__atomic_add_fetch(target, value, __ATOMIC_SEQ_CST); }
 
 void
 atomic_or_8(volatile uint8_t *target, uint8_t bits)
-{ (void)__sync_or_and_fetch(target, bits); }
+{ (void)__atomic_or_fetch(target, bits, __ATOMIC_SEQ_CST); }
 
 void
 atomic_or_uchar(volatile uchar_t *target, uchar_t bits)
-{ (void)__sync_or_and_fetch(target, bits); }
+{ (void)__atomic_or_fetch(target, bits, __ATOMIC_SEQ_CST); }
 
 void
 atomic_or_16(volatile uint16_t *target, uint16_t bits)
-{ (void)__sync_or_and_fetch(target, bits); }
+{ (void)__atomic_or_fetch(target, bits, __ATOMIC_SEQ_CST); }
 
 void
 atomic_or_ushort(volatile ushort_t *target, ushort_t bits)
-{ (void)__sync_or_and_fetch(target, bits); }
+{ (void)__atomic_or_fetch(target, bits, __ATOMIC_SEQ_CST); }
 
 void
 atomic_or_32(volatile uint32_t *target, uint32_t bits)
-{ (void)__sync_or_and_fetch(target, bits); }
+{ (void)__atomic_or_fetch(target, bits, __ATOMIC_SEQ_CST); }
 
 void
 atomic_or_uint(volatile uint_t *target, uint_t bits)
-{ (void)__sync_or_and_fetch(target, bits); }
+{ (void)__atomic_or_fetch(target, bits, __ATOMIC_SEQ_CST); }
 
 void
 atomic_or_ulong(volatile ulong_t *target, ulong_t bits)
-{ (void)__sync_or_and_fetch(target, bits); }
+{ (void)__atomic_or_fetch(target, bits, __ATOMIC_SEQ_CST); }
 
 void
 atomic_or_64(volatile uint64_t *target, uint64_t bits)
-{ (void)__sync_or_and_fetch(target, bits); }
+{ (void)__atomic_or_fetch(target, bits, __ATOMIC_SEQ_CST); }
 
 void
 atomic_and_8(volatile uint8_t *target, uint8_t bits)
-{ (void)__sync_and_and_fetch(target, bits); }
+{ (void)__atomic_and_fetch(target, bits, __ATOMIC_SEQ_CST); }
 
 void
 atomic_and_uchar(volatile uchar_t *target, uchar_t bits)
-{ (void)__sync_and_and_fetch(target, bits); }
+{ (void)__atomic_and_fetch(target, bits, __ATOMIC_SEQ_CST); }
 
 void
 atomic_and_16(volatile uint16_t *target, uint16_t bits)
-{ (void)__sync_and_and_fetch(target, bits); }
+{ (void)__atomic_and_fetch(target, bits, __ATOMIC_SEQ_CST); }
 
 void
 atomic_and_ushort(volatile ushort_t *target, ushort_t bits)
-{ (void)__sync_and_and_fetch(target, bits); }
+{ (void)__atomic_and_fetch(target, bits, __ATOMIC_SEQ_CST); }
 
 void
 atomic_and_32(volatile uint32_t *target, uint32_t bits)
-{ (void)__sync_and_and_fetch(target, bits); }
+{ (void)__atomic_and_fetch(target, bits, __ATOMIC_SEQ_CST); }
 
 void
 atomic_and_uint(volatile uint_t *target, uint_t bits)
-{ (void)__sync_and_and_fetch(target, bits); }
+{ (void)__atomic_and_fetch(target, bits, __ATOMIC_SEQ_CST); }
 
 void
 atomic_and_ulong(volatile ulong_t *target, ulong_t bits)
-{ (void)__sync_and_and_fetch(target, bits); }
+{ (void)__atomic_and_fetch(target, bits, __ATOMIC_SEQ_CST); }
 
 void
 atomic_and_64(volatile uint64_t *target, uint64_t bits)
-{ (void)__sync_and_and_fetch(target, bits); }
+{ (void)__atomic_and_fetch(target, bits, __ATOMIC_SEQ_CST); }
 
 uint8_t
 atomic_inc_8_nv(volatile uint8_t *target)
-{ return __sync_add_and_fetch(target, 1); }
+{ return __atomic_add_fetch(target, 1, __ATOMIC_SEQ_CST); }
 
 uchar_t
 atomic_inc_uchar_nv(volatile uchar_t *target)
-{ return __sync_add_and_fetch(target, 1); }
+{ return __atomic_add_fetch(target, 1, __ATOMIC_SEQ_CST); }
 
 uint16_t
 atomic_inc_16_nv(volatile uint16_t *target)
-{ return __sync_add_and_fetch(target, 1); }
+{ return __atomic_add_fetch(target, 1, __ATOMIC_SEQ_CST); }
 
 ushort_t
 atomic_inc_ushort_nv(volatile ushort_t *target)
-{ return __sync_add_and_fetch(target, 1); }
+{ return __atomic_add_fetch(target, 1, __ATOMIC_SEQ_CST); }
 
 uint32_t
 atomic_inc_32_nv(volatile uint32_t *target)
-{ return __sync_add_and_fetch(target, 1); }
+{ return __atomic_add_fetch(target, 1, __ATOMIC_SEQ_CST); }
 
 uint_t
 atomic_inc_uint_nv(volatile uint_t *target)
-{ return __sync_add_and_fetch(target, 1); }
+{ return __atomic_add_fetch(target, 1, __ATOMIC_SEQ_CST); }
 
 ulong_t
 atomic_inc_ulong_nv(volatile ulong_t *target)
-{ return __sync_add_and_fetch(target, 1); }
+{ return __atomic_add_fetch(target, 1, __ATOMIC_SEQ_CST); }
 
 uint64_t
 atomic_inc_64_nv(volatile uint64_t *target)
-{ return __sync_add_and_fetch(target, 1); }
+{ return __atomic_add_fetch(target, 1, __ATOMIC_SEQ_CST); }
 
 uint8_t
 atomic_dec_8_nv(volatile uint8_t *target)
-{ return __sync_sub_and_fetch(target, 1); }
+{ return __atomic_sub_fetch(target, 1, __ATOMIC_SEQ_CST); }
 
 uchar_t
 atomic_dec_uchar_nv(volatile uchar_t *target)
-{ return __sync_sub_and_fetch(target, 1); }
+{ return __atomic_sub_fetch(target, 1, __ATOMIC_SEQ_CST); }
 
 uint16_t
 atomic_dec_16_nv(volatile uint16_t *target)
-{ return __sync_sub_and_fetch(target, 1); }
+{ return __atomic_sub_fetch(target, 1, __ATOMIC_SEQ_CST); }
 
 ushort_t
 atomic_dec_ushort_nv(volatile ushort_t *target)
-{ return __sync_sub_and_fetch(target, 1); }
+{ return __atomic_sub_fetch(target, 1, __ATOMIC_SEQ_CST); }
 
 uint32_t
 atomic_dec_32_nv(volatile uint32_t *target)
-{ return __sync_sub_and_fetch(target, 1); }
+{ return __atomic_sub_fetch(target, 1, __ATOMIC_SEQ_CST); }
 
 uint_t
 atomic_dec_uint_nv(volatile uint_t *target)
-{ return __sync_sub_and_fetch(target, 1); }
+{ return __atomic_sub_fetch(target, 1, __ATOMIC_SEQ_CST); }
 
 ulong_t
 atomic_dec_ulong_nv(volatile ulong_t *target)
-{ return __sync_sub_and_fetch(target, 1); }
+{ return __atomic_sub_fetch(target, 1, __ATOMIC_SEQ_CST); }
 
 uint64_t
 atomic_dec_64_nv(volatile uint64_t *target)
-{ return __sync_sub_and_fetch(target, 1); }
+{ return __atomic_sub_fetch(target, 1, __ATOMIC_SEQ_CST); }
 
 uint8_t
 atomic_add_8_nv(volatile uint8_t *target, int8_t value)
-{ return __sync_add_and_fetch(target, value); }
+{ return __atomic_add_fetch(target, value, __ATOMIC_SEQ_CST); }
 
 uchar_t
 atomic_add_char_nv(volatile uchar_t *target, signed char value)
-{ return __sync_add_and_fetch(target, value); }
+{ return __atomic_add_fetch(target, value, __ATOMIC_SEQ_CST); }
 
 uint16_t
 atomic_add_16_nv(volatile uint16_t *target, int16_t value)
-{ return __sync_add_and_fetch(target, value); }
+{ return __atomic_add_fetch(target, value, __ATOMIC_SEQ_CST); }
 
 ushort_t
 atomic_add_short_nv(volatile ushort_t *target, short value)
-{ return __sync_add_and_fetch(target, value); }
+{ return __atomic_add_fetch(target, value, __ATOMIC_SEQ_CST); }
 
 uint32_t
 atomic_add_32_nv(volatile uint32_t *target, int32_t value)
-{ return __sync_add_and_fetch(target, value); }
+{ return __atomic_add_fetch(target, value, __ATOMIC_SEQ_CST); }
 
 uint_t
 atomic_add_int_nv(volatile uint_t *target, int value)
-{ return __sync_add_and_fetch(target, value); }
+{ return __atomic_add_fetch(target, value, __ATOMIC_SEQ_CST); }
 
 void *
 atomic_add_ptr_nv(volatile void *target, ssize_t value)
-{ return __sync_add_and_fetch((caddr_t *)target, value); }
+{ return __atomic_add_fetch((caddr_t *)target, value, __ATOMIC_SEQ_CST); }
 
 ulong_t
 atomic_add_long_nv(volatile ulong_t *target, long value)
-{ return __sync_add_and_fetch(target, value); }
+{ return __atomic_add_fetch(target, value, __ATOMIC_SEQ_CST); }
 
 uint64_t
 atomic_add_64_nv(volatile uint64_t *target, int64_t value)
-{ return __sync_add_and_fetch(target, value); }
+{ return __atomic_add_fetch(target, value, __ATOMIC_SEQ_CST); }
 
 uint8_t
 atomic_or_8_nv(volatile uint8_t *target, uint8_t value)
-{ return __sync_or_and_fetch(target, value); }
+{ return __atomic_or_fetch(target, value, __ATOMIC_SEQ_CST); }
 
 uchar_t
 atomic_or_uchar_nv(volatile uchar_t *target, uchar_t value)
-{ return __sync_or_and_fetch(target, value); }
+{ return __atomic_or_fetch(target, value, __ATOMIC_SEQ_CST); }
 
 uint16_t
 atomic_or_16_nv(volatile uint16_t *target, uint16_t value)
-{ return __sync_or_and_fetch(target, value); }
+{ return __atomic_or_fetch(target, value, __ATOMIC_SEQ_CST); }
 
 ushort_t
 atomic_or_ushort_nv(volatile ushort_t *target, ushort_t value)
-{ return __sync_or_and_fetch(target, value); }
+{ return __atomic_or_fetch(target, value, __ATOMIC_SEQ_CST); }
 
 uint32_t
 atomic_or_32_nv(volatile uint32_t *target, uint32_t value)
-{ return __sync_or_and_fetch(target, value); }
+{ return __atomic_or_fetch(target, value, __ATOMIC_SEQ_CST); }
 
 uint_t
 atomic_or_uint_nv(volatile uint_t *target, uint_t value)
-{ return __sync_or_and_fetch(target, value); }
+{ return __atomic_or_fetch(target, value, __ATOMIC_SEQ_CST); }
 
 ulong_t
 atomic_or_ulong_nv(volatile ulong_t *target, ulong_t value)
-{ return __sync_or_and_fetch(target, value); }
+{ return __atomic_or_fetch(target, value, __ATOMIC_SEQ_CST); }
 
 uint64_t
 atomic_or_64_nv(volatile uint64_t *target, uint64_t value)
-{ return __sync_or_and_fetch(target, value); }
+{ return __atomic_or_fetch(target, value, __ATOMIC_SEQ_CST); }
 
 uint8_t
 atomic_and_8_nv(volatile uint8_t *target, uint8_t value)
-{ return __sync_and_and_fetch(target, value); }
+{ return __atomic_and_fetch(target, value, __ATOMIC_SEQ_CST); }
 
 uchar_t
 atomic_and_uchar_nv(volatile uchar_t *target, uchar_t value)
-{ return __sync_and_and_fetch(target, value); }
+{ return __atomic_and_fetch(target, value, __ATOMIC_SEQ_CST); }
 
 uint16_t
 atomic_and_16_nv(volatile uint16_t *target, uint16_t value)
-{ return __sync_and_and_fetch(target, value); }
+{ return __atomic_and_fetch(target, value, __ATOMIC_SEQ_CST); }
 
 ushort_t
 atomic_and_ushort_nv(volatile ushort_t *target, ushort_t value)
-{ return __sync_and_and_fetch(target, value); }
+{ return __atomic_and_fetch(target, value, __ATOMIC_SEQ_CST); }
 
 uint32_t
 atomic_and_32_nv(volatile uint32_t *target, uint32_t value)
-{ return __sync_and_and_fetch(target, value); }
+{ return __atomic_and_fetch(target, value, __ATOMIC_SEQ_CST); }
 
 uint_t
 atomic_and_uint_nv(volatile uint_t *target, uint_t value)
-{ return __sync_and_and_fetch(target, value); }
+{ return __atomic_and_fetch(target, value, __ATOMIC_SEQ_CST); }
 
 ulong_t
 atomic_and_ulong_nv(volatile ulong_t *target, ulong_t value)
-{ return __sync_and_and_fetch(target, value); }
+{ return __atomic_and_fetch(target, value, __ATOMIC_SEQ_CST); }
 
 uint64_t
 atomic_and_64_nv(volatile uint64_t *target, uint64_t value)
-{ return __sync_and_and_fetch(target, value); }
+{ return __atomic_and_fetch(target, value, __ATOMIC_SEQ_CST); }
 
 uint8_t
 atomic_cas_8(volatile uint8_t *target, uint8_t cmp, uint8_t newval)
-{ return __sync_val_compare_and_swap(target, cmp, newval); }
+{ { (void)__atomic_compare_exchange_n(target, &cmp, newval,
+    0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST); return cmp; } }
 
 uchar_t
 atomic_cas_uchar(volatile uchar_t *target, uchar_t cmp, uchar_t newval)
-{ return __sync_val_compare_and_swap(target, cmp, newval); }
+{ { (void)__atomic_compare_exchange_n(target, &cmp, newval,
+    0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST); return cmp; } }
 
 uint16_t
 atomic_cas_16(volatile uint16_t *target, uint16_t cmp, uint16_t newval)
-{ return __sync_val_compare_and_swap(target, cmp, newval); }
+{ { (void)__atomic_compare_exchange_n(target, &cmp, newval,
+    0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST); return cmp; } }
 
 ushort_t
 atomic_cas_ushort(volatile ushort_t *target, ushort_t cmp, ushort_t newval)
-{ return __sync_val_compare_and_swap(target, cmp, newval); }
+{ { (void)__atomic_compare_exchange_n(target, &cmp, newval,
+    0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST); return cmp; } }
 
 uint32_t
 atomic_cas_32(volatile uint32_t *target, uint32_t cmp, uint32_t newval)
-{ return __sync_val_compare_and_swap(target, cmp, newval); }
+{ { (void)__atomic_compare_exchange_n(target, &cmp, newval,
+    0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST); return cmp; } }
 
 uint_t
 atomic_cas_uint(volatile uint_t *target, uint_t cmp, uint_t newval)
-{ return __sync_val_compare_and_swap(target, cmp, newval); }
+{ { (void)__atomic_compare_exchange_n(target, &cmp, newval,
+    0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST); return cmp; } }
 
 ulong_t
 atomic_cas_ulong(volatile ulong_t *target, ulong_t cmp, ulong_t newval)
-{ return __sync_val_compare_and_swap(target, cmp, newval); }
+{ { (void)__atomic_compare_exchange_n(target, &cmp, newval,
+    0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST); return cmp; } }
 
 uint64_t
 atomic_cas_64(volatile uint64_t *target, uint64_t cmp, uint64_t newval)
-{ return __sync_val_compare_and_swap(target, cmp, newval); }
+{ { (void)__atomic_compare_exchange_n(target, &cmp, newval,
+    0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST); return cmp; } }
 
 void *
 atomic_cas_ptr(volatile void *target, void *cmp, void *newval)
-{ return __sync_val_compare_and_swap((void **)target, cmp, newval); }
+{ { (void)__atomic_compare_exchange_n((void **)target, &cmp, newval,
+    0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST); return cmp; } }
 
 uint8_t
 atomic_swap_8(volatile uint8_t *target, uint8_t newval)
@@ -440,23 +449,24 @@ int
 atomic_set_long_excl(volatile ulong_t *target, uint_t value)
 {
 	ulong_t bit = (1UL << value);
-	return (__sync_fetch_and_or(target, bit) & bit ? -1: 0);
+	return (__atomic_fetch_or(target, bit, __ATOMIC_SEQ_CST) & bit ? -1: 0);
 }
 
 int
 atomic_clear_long_excl(volatile ulong_t *target, uint_t value)
 {
 	ulong_t bit = (1UL << value);
-	return (__sync_fetch_and_and(target, ~bit) & bit ? 0: -1);
+	return (__atomic_fetch_and(
+	    target, ~bit, __ATOMIC_SEQ_CST) & bit ? 0: -1);
 }
 
 void
 membar_enter(void)
-{ __sync_synchronize(); }
+{ __atomic_thread_fence(__ATOMIC_SEQ_CST); }
 
 void
 membar_exit(void)
-{ __sync_synchronize(); }
+{ __atomic_thread_fence(__ATOMIC_SEQ_CST); }
 
 void
 membar_producer(void)
@@ -468,7 +478,7 @@ membar_consumer(void)
 
 void
 membar_sync(void)
-{ __sync_synchronize(); }
+{ __atomic_thread_fence(__ATOMIC_SEQ_CST); }
 
 #if defined(_KERNEL)
 /*
@@ -476,29 +486,34 @@ membar_sync(void)
  */
 uint8_t
 cas8(uint8_t *target, uint8_t cmp, uint8_t newval)
-{ return __sync_val_compare_and_swap(target, cmp, newval); }
+{ { (void)__atomic_compare_exchange_n(target, &cmp, newval,
+    0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST); return cmp; } }
 
 uint32_t
 cas32(uint32_t *target, uint32_t cmp, uint32_t newval)
-{ return __sync_val_compare_and_swap(target, cmp, newval); }
+{ { (void)__atomic_compare_exchange_n(target, &cmp, newval,
+    0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST); return cmp; } }
 
 uint64_t
 cas64(uint64_t *target, uint64_t cmp, uint64_t newval)
-{ return __sync_val_compare_and_swap(target, cmp, newval); }
+{ { (void)__atomic_compare_exchange_n(target, &cmp, newval,
+    0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST); return cmp; } }
 
 ulong_t
 caslong(ulong_t *target, ulong_t cmp, ulong_t newval)
-{ return __sync_val_compare_and_swap(target, cmp, newval); }
+{ { (void)__atomic_compare_exchange_n(target, &cmp, newval,
+    0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST); return cmp; } }
 
 void *
 casptr(void *target, void *cmp, void *newval)
-{ return __sync_val_compare_and_swap((void **)target, cmp, newval); }
+{ { (void)__atomic_compare_exchange_n((void **)target, &cmp, newval,
+    0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST); return cmp; } }
 
 void
 atomic_or_long(ulong_t *target, ulong_t bits)
-{ (void)__sync_or_and_fetch(target, bits); }
+{ (void)__atomic_or_fetch(target, bits, __ATOMIC_SEQ_CST); }
 
 void
 atomic_and_long(ulong_t *target, ulong_t bits)
-{ (void)__sync_and_and_fetch(target, bits); }
+{ (void)__atomic_and_fetch(target, bits, __ATOMIC_SEQ_CST); }
 #endif

--- a/usr/src/uts/aarch64/asm/atomic.h
+++ b/usr/src/uts/aarch64/asm/atomic.h
@@ -36,547 +36,565 @@ extern "C" {
 extern __GNU_INLINE void
 atomic_inc_8(volatile uint8_t *target)
 {
-	(void) __sync_add_and_fetch(target, 1);
+	(void) __atomic_add_fetch(target, 1, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_inc_uchar(volatile uchar_t *target)
 {
-	(void) __sync_add_and_fetch(target, 1);
+	(void) __atomic_add_fetch(target, 1, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_inc_16(volatile uint16_t *target)
 {
-	(void) __sync_add_and_fetch(target, 1);
+	(void) __atomic_add_fetch(target, 1, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_inc_ushort(volatile ushort_t *target)
 {
-	(void) __sync_add_and_fetch(target, 1);
+	(void) __atomic_add_fetch(target, 1, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_inc_32(volatile uint32_t *target)
 {
-	(void) __sync_add_and_fetch(target, 1);
+	(void) __atomic_add_fetch(target, 1, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_inc_uint(volatile uint_t *target)
 {
-	(void) __sync_add_and_fetch(target, 1);
+	(void) __atomic_add_fetch(target, 1, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_inc_ulong(volatile ulong_t *target)
 {
-	(void) __sync_add_and_fetch(target, 1);
+	(void) __atomic_add_fetch(target, 1, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_inc_64(volatile uint64_t *target)
 {
-	(void) __sync_add_and_fetch(target, 1);
+	(void) __atomic_add_fetch(target, 1, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_dec_8(volatile uint8_t *target)
 {
-	(void) __sync_sub_and_fetch(target, 1);
+	(void) __atomic_sub_fetch(target, 1, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_dec_uchar(volatile uchar_t *target)
 {
-	(void) __sync_sub_and_fetch(target, 1);
+	(void) __atomic_sub_fetch(target, 1, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_dec_16(volatile uint16_t *target)
 {
-	(void) __sync_sub_and_fetch(target, 1);
+	(void) __atomic_sub_fetch(target, 1, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_dec_ushort(volatile ushort_t *target)
 {
-	(void) __sync_sub_and_fetch(target, 1);
+	(void) __atomic_sub_fetch(target, 1, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_dec_32(volatile uint32_t *target)
 {
-	(void) __sync_sub_and_fetch(target, 1);
+	(void) __atomic_sub_fetch(target, 1, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_dec_uint(volatile uint_t *target)
 {
-	(void) __sync_sub_and_fetch(target, 1);
+	(void) __atomic_sub_fetch(target, 1, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_dec_ulong(volatile ulong_t *target)
 {
-	(void) __sync_sub_and_fetch(target, 1);
+	(void) __atomic_sub_fetch(target, 1, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_dec_64(volatile uint64_t *target)
 {
-	(void) __sync_sub_and_fetch(target, 1);
+	(void) __atomic_sub_fetch(target, 1, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_add_8(volatile uint8_t *target, int8_t value)
 {
-	(void) __sync_add_and_fetch(target, value);
+	(void) __atomic_add_fetch(target, value, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_add_char(volatile uchar_t *target, signed char value)
 {
-	(void) __sync_add_and_fetch(target, value);
+	(void) __atomic_add_fetch(target, value, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_add_16(volatile uint16_t *target, int16_t value)
 {
-	(void) __sync_add_and_fetch(target, value);
+	(void) __atomic_add_fetch(target, value, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_add_ushort(volatile ushort_t *target, short value)
 {
-	(void) __sync_add_and_fetch(target, value);
+	(void) __atomic_add_fetch(target, value, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_add_32(volatile uint32_t *target, int32_t value)
 {
-	(void) __sync_add_and_fetch(target, value);
+	(void) __atomic_add_fetch(target, value, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_add_int(volatile uint32_t *target, int32_t value)
 {
-	(void) __sync_add_and_fetch(target, value);
+	(void) __atomic_add_fetch(target, value, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_add_ptr(volatile void *target, ssize_t value)
 {
-	(void) __sync_add_and_fetch((caddr_t *)target, value);
+	(void) __atomic_add_fetch((caddr_t *)target, value, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_add_long(volatile ulong_t *target, long value)
 {
-	(void) __sync_add_and_fetch(target, value);
+	(void) __atomic_add_fetch(target, value, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_add_64(volatile uint64_t *target, int64_t value)
 {
-	(void) __sync_add_and_fetch(target, value);
+	(void) __atomic_add_fetch(target, value, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_or_8(volatile uint8_t *target, uint8_t bits)
 {
-	(void) __sync_or_and_fetch(target, bits);
+	(void) __atomic_or_fetch(target, bits, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_or_uchar(volatile uchar_t *target, uchar_t bits)
 {
-	(void) __sync_or_and_fetch(target, bits);
+	(void) __atomic_or_fetch(target, bits, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_or_16(volatile uint16_t *target, uint16_t bits)
 {
-	(void) __sync_or_and_fetch(target, bits);
+	(void) __atomic_or_fetch(target, bits, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_or_ushort(volatile ushort_t *target, ushort_t bits)
 {
-	(void) __sync_or_and_fetch(target, bits);
+	(void) __atomic_or_fetch(target, bits, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_or_32(volatile uint32_t *target, uint32_t bits)
 {
-	(void) __sync_or_and_fetch(target, bits);
+	(void) __atomic_or_fetch(target, bits, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_or_uint(volatile uint_t *target, uint_t bits)
 {
-	(void) __sync_or_and_fetch(target, bits);
+	(void) __atomic_or_fetch(target, bits, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_or_ulong(volatile ulong_t *target, ulong_t bits)
 {
-	(void) __sync_or_and_fetch(target, bits);
+	(void) __atomic_or_fetch(target, bits, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_or_64(volatile uint64_t *target, uint64_t bits)
 {
-	(void) __sync_or_and_fetch(target, bits);
+	(void) __atomic_or_fetch(target, bits, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_and_8(volatile uint8_t *target, uint8_t bits)
 {
-	(void) __sync_and_and_fetch(target, bits);
+	(void) __atomic_and_fetch(target, bits, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_and_uchar(volatile uchar_t *target, uchar_t bits)
 {
-	(void) __sync_and_and_fetch(target, bits);
+	(void) __atomic_and_fetch(target, bits, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_and_16(volatile uint16_t *target, uint16_t bits)
 {
-	(void) __sync_and_and_fetch(target, bits);
+	(void) __atomic_and_fetch(target, bits, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_and_ushort(volatile ushort_t *target, ushort_t bits)
 {
-	(void) __sync_and_and_fetch(target, bits);
+	(void) __atomic_and_fetch(target, bits, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_and_32(volatile uint32_t *target, uint32_t bits)
 {
-	(void) __sync_and_and_fetch(target, bits);
+	(void) __atomic_and_fetch(target, bits, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_and_uint(volatile uint_t *target, uint_t bits)
 {
-	(void) __sync_and_and_fetch(target, bits);
+	(void) __atomic_and_fetch(target, bits, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_and_ulong(volatile ulong_t *target, ulong_t bits)
 {
-	(void) __sync_and_and_fetch(target, bits);
+	(void) __atomic_and_fetch(target, bits, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_and_64(volatile uint64_t *target, uint64_t bits)
 {
-	(void) __sync_and_and_fetch(target, bits);
+	(void) __atomic_and_fetch(target, bits, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE uint8_t
 atomic_inc_8_nv(volatile uint8_t *target)
 {
-	return (__sync_add_and_fetch(target, 1));
+	return (__atomic_add_fetch(target, 1, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE uchar_t
 atomic_inc_uchar_nv(volatile uchar_t *target)
 {
-	return (__sync_add_and_fetch(target, 1));
+	return (__atomic_add_fetch(target, 1, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE uint16_t
 atomic_inc_16_nv(volatile uint16_t *target)
 {
-	return (__sync_add_and_fetch(target, 1));
+	return (__atomic_add_fetch(target, 1, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE ushort_t
 atomic_inc_ushort_nv(volatile ushort_t *target)
 {
-	return (__sync_add_and_fetch(target, 1));
+	return (__atomic_add_fetch(target, 1, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE uint32_t
 atomic_inc_32_nv(volatile uint32_t *target)
 {
-	return (__sync_add_and_fetch(target, 1));
+	return (__atomic_add_fetch(target, 1, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE uint_t
 atomic_inc_uint_nv(volatile uint_t *target)
 {
-	return (__sync_add_and_fetch(target, 1));
+	return (__atomic_add_fetch(target, 1, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE ulong_t
 atomic_inc_ulong_nv(volatile ulong_t *target)
 {
-	return (__sync_add_and_fetch(target, 1));
+	return (__atomic_add_fetch(target, 1, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE uint64_t
 atomic_inc_64_nv(volatile uint64_t *target)
 {
-	return (__sync_add_and_fetch(target, 1));
+	return (__atomic_add_fetch(target, 1, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE uint8_t
 atomic_dec_8_nv(volatile uint8_t *target)
 {
-	return (__sync_sub_and_fetch(target, 1));
+	return (__atomic_sub_fetch(target, 1, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE uchar_t
 atomic_dec_uchar_nv(volatile uchar_t *target)
 {
-	return (__sync_sub_and_fetch(target, 1));
+	return (__atomic_sub_fetch(target, 1, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE uint16_t
 atomic_dec_16_nv(volatile uint16_t *target)
 {
-	return (__sync_sub_and_fetch(target, 1));
+	return (__atomic_sub_fetch(target, 1, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE ushort_t
 atomic_dec_ushort_nv(volatile ushort_t *target)
 {
-	return (__sync_sub_and_fetch(target, 1));
+	return (__atomic_sub_fetch(target, 1, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE uint32_t
 atomic_dec_32_nv(volatile uint32_t *target)
 {
-	return (__sync_sub_and_fetch(target, 1));
+	return (__atomic_sub_fetch(target, 1, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE uint_t
 atomic_dec_uint_nv(volatile uint_t *target)
 {
-	return (__sync_sub_and_fetch(target, 1));
+	return (__atomic_sub_fetch(target, 1, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE ulong_t
 atomic_dec_ulong_nv(volatile ulong_t *target)
 {
-	return (__sync_sub_and_fetch(target, 1));
+	return (__atomic_sub_fetch(target, 1, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE uint64_t
 atomic_dec_64_nv(volatile uint64_t *target)
 {
-	return (__sync_sub_and_fetch(target, 1));
+	return (__atomic_sub_fetch(target, 1, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE uint8_t
 atomic_add_8_nv(volatile uint8_t *target, int8_t value)
 {
-	return (__sync_add_and_fetch(target, value));
+	return (__atomic_add_fetch(target, value, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE uchar_t
 atomic_add_char_nv(volatile uchar_t *target, signed char value)
 {
-	return (__sync_add_and_fetch(target, value));
+	return (__atomic_add_fetch(target, value, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE uint16_t
 atomic_add_16_nv(volatile uint16_t *target, int16_t value)
 {
-	return (__sync_add_and_fetch(target, value));
+	return (__atomic_add_fetch(target, value, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE ushort_t
 atomic_add_short_nv(volatile ushort_t *target, short value)
 {
-	return (__sync_add_and_fetch(target, value));
+	return (__atomic_add_fetch(target, value, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE uint32_t
 atomic_add_32_nv(volatile uint32_t *target, int32_t value)
 {
-	return (__sync_add_and_fetch(target, value));
+	return (__atomic_add_fetch(target, value, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE uint_t
 atomic_add_int_nv(volatile uint_t *target, int value)
 {
-	return (__sync_add_and_fetch(target, value));
+	return (__atomic_add_fetch(target, value, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE void *
 atomic_add_ptr_nv(volatile void *target, ssize_t value)
 {
-	return (__sync_add_and_fetch((caddr_t *)target, value));
+	return (__atomic_add_fetch((caddr_t *)target, value, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE ulong_t
 atomic_add_long_nv(volatile ulong_t *target, long value)
 {
-	return (__sync_add_and_fetch(target, value));
+	return (__atomic_add_fetch(target, value, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE uint64_t
 atomic_add_64_nv(volatile uint64_t *target, int64_t value)
 {
-	return (__sync_add_and_fetch(target, value));
+	return (__atomic_add_fetch(target, value, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE uint8_t
 atomic_or_8_nv(volatile uint8_t *target, uint8_t value)
 {
-	return (__sync_or_and_fetch(target, value));
+	return (__atomic_or_fetch(target, value, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE uchar_t
 atomic_or_uchar_nv(volatile uchar_t *target, uchar_t value)
 {
-	return (__sync_or_and_fetch(target, value));
+	return (__atomic_or_fetch(target, value, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE uint16_t
 atomic_or_16_nv(volatile uint16_t *target, uint16_t value)
 {
-	return (__sync_or_and_fetch(target, value));
+	return (__atomic_or_fetch(target, value, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE ushort_t
 atomic_or_ushort_nv(volatile ushort_t *target, ushort_t value)
 {
-	return (__sync_or_and_fetch(target, value));
+	return (__atomic_or_fetch(target, value, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE uint32_t
 atomic_or_32_nv(volatile uint32_t *target, uint32_t value)
 {
-	return (__sync_or_and_fetch(target, value));
+	return (__atomic_or_fetch(target, value, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE uint_t
 atomic_or_uint_nv(volatile uint_t *target, uint_t value)
 {
-	return (__sync_or_and_fetch(target, value));
+	return (__atomic_or_fetch(target, value, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE ulong_t
 atomic_or_ulong_nv(volatile ulong_t *target, ulong_t value)
 {
-	return (__sync_or_and_fetch(target, value));
+	return (__atomic_or_fetch(target, value, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE uint64_t
 atomic_or_64_nv(volatile uint64_t *target, uint64_t value)
 {
-	return (__sync_or_and_fetch(target, value));
+	return (__atomic_or_fetch(target, value, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE uint8_t
 atomic_and_8_nv(volatile uint8_t *target, uint8_t value)
 {
-	return (__sync_and_and_fetch(target, value));
+	return (__atomic_and_fetch(target, value, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE uchar_t
 atomic_and_uchar_nv(volatile uchar_t *target, uchar_t value)
 {
-	return (__sync_and_and_fetch(target, value));
+	return (__atomic_and_fetch(target, value, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE uint16_t
 atomic_and_16_nv(volatile uint16_t *target, uint16_t value)
 {
-	return (__sync_and_and_fetch(target, value));
+	return (__atomic_and_fetch(target, value, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE ushort_t
 atomic_and_ushort_nv(volatile ushort_t *target, ushort_t value)
 {
-	return (__sync_and_and_fetch(target, value));
+	return (__atomic_and_fetch(target, value, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE uint32_t
 atomic_and_32_nv(volatile uint32_t *target, uint32_t value)
 {
-	return (__sync_and_and_fetch(target, value));
+	return (__atomic_and_fetch(target, value, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE uint_t
 atomic_and_uint_nv(volatile uint_t *target, uint_t value)
 {
-	return (__sync_and_and_fetch(target, value));
+	return (__atomic_and_fetch(target, value, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE ulong_t
 atomic_and_ulong_nv(volatile ulong_t *target, ulong_t value)
 {
-	return (__sync_and_and_fetch(target, value));
+	return (__atomic_and_fetch(target, value, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE uint64_t
 atomic_and_64_nv(volatile uint64_t *target, uint64_t value)
 {
-	return (__sync_and_and_fetch(target, value));
+	return (__atomic_and_fetch(target, value, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE uint8_t
 atomic_cas_8(volatile uint8_t *target, uint8_t cmp, uint8_t newval)
 {
-	return (__sync_val_compare_and_swap(target, cmp, newval));
+	(void) __atomic_compare_exchange_n(target, &cmp, newval,
+	    0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+	return (cmp);
 }
 
 extern __GNU_INLINE uchar_t
 atomic_cas_uchar(volatile uchar_t *target, uchar_t cmp, uchar_t newval)
 {
-	return (__sync_val_compare_and_swap(target, cmp, newval));
+	(void) __atomic_compare_exchange_n(target, &cmp, newval,
+	    0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+	return (cmp);
 }
 
 extern __GNU_INLINE uint16_t
 atomic_cas_16(volatile uint16_t *target, uint16_t cmp, uint16_t newval)
 {
-	return (__sync_val_compare_and_swap(target, cmp, newval));
+	(void) __atomic_compare_exchange_n(target, &cmp, newval,
+	    0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+	return (cmp);
 }
 
 extern __GNU_INLINE ushort_t
 atomic_cas_ushort(volatile ushort_t *target, ushort_t cmp, ushort_t newval)
 {
-	return (__sync_val_compare_and_swap(target, cmp, newval));
+	(void) __atomic_compare_exchange_n(target, &cmp, newval,
+	    0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+	return (cmp);
 }
 
 extern __GNU_INLINE uint32_t
 atomic_cas_32(volatile uint32_t *target, uint32_t cmp, uint32_t newval)
 {
-	return (__sync_val_compare_and_swap(target, cmp, newval));
+	(void) __atomic_compare_exchange_n(target, &cmp, newval,
+	    0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+	return (cmp);
 }
 
 extern __GNU_INLINE uint_t
 atomic_cas_uint(volatile uint_t *target, uint_t cmp, uint_t newval)
 {
-	return (__sync_val_compare_and_swap(target, cmp, newval));
+	(void) __atomic_compare_exchange_n(target, &cmp, newval,
+	    0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+	return (cmp);
 }
 
 extern __GNU_INLINE ulong_t
 atomic_cas_ulong(volatile ulong_t *target, ulong_t cmp, ulong_t newval)
 {
-	return (__sync_val_compare_and_swap(target, cmp, newval));
+	(void) __atomic_compare_exchange_n(target, &cmp, newval,
+	    0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+	return (cmp);
 }
 
 extern __GNU_INLINE uint64_t
 atomic_cas_64(volatile uint64_t *target, uint64_t cmp, uint64_t newval)
 {
-	return (__sync_val_compare_and_swap(target, cmp, newval));
+	(void) __atomic_compare_exchange_n(target, &cmp, newval,
+	    0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+	return (cmp);
 }
 
 extern __GNU_INLINE void *
 atomic_cas_ptr(volatile void *target, void *cmp, void *newval)
 {
-	return (__sync_val_compare_and_swap((void **)target, cmp, newval));
+	(void) __atomic_compare_exchange_n((void **)target, &cmp, newval,
+	    0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+	return (cmp);
 }
 
 extern __GNU_INLINE uint8_t
@@ -638,26 +656,27 @@ atomic_set_long_excl(volatile ulong_t *target, uint_t value)
 {
 
 	ulong_t bit = (1UL << value);
-	return (__sync_fetch_and_or(target, bit) & bit ? -1: 0);
+	return (__atomic_fetch_or(target, bit, __ATOMIC_SEQ_CST) & bit ? -1: 0);
 }
 
 extern __GNU_INLINE int
 atomic_clear_long_excl(volatile ulong_t *target, uint_t value)
 {
 	ulong_t bit = (1UL << value);
-	return (__sync_fetch_and_and(target, ~bit) & bit ? 0: -1);
+	return (__atomic_fetch_and(
+	    target, ~bit, __ATOMIC_SEQ_CST) & bit ? 0: -1);
 }
 
 extern __GNU_INLINE void
 membar_enter(void)
 {
-	__sync_synchronize();
+	__atomic_thread_fence(__ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 membar_exit(void)
 {
-	__sync_synchronize();
+	__atomic_thread_fence(__ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
@@ -675,7 +694,7 @@ membar_consumer(void)
 extern __GNU_INLINE void
 membar_sync(void)
 {
-	__sync_synchronize();
+	__atomic_thread_fence(__ATOMIC_SEQ_CST);
 }
 
 #if defined(_KERNEL)
@@ -685,43 +704,53 @@ membar_sync(void)
 extern __GNU_INLINE uint8_t
 cas8(uint8_t *target, uint8_t cmp, uint8_t newval)
 {
-	return (__sync_val_compare_and_swap(target, cmp, newval));
+	(void) __atomic_compare_exchange_n(target, &cmp, newval,
+	    0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+	return (cmp);
 }
 
 extern __GNU_INLINE uint32_t
 cas32(uint32_t *target, uint32_t cmp, uint32_t newval)
 {
-	return (__sync_val_compare_and_swap(target, cmp, newval));
+	(void) __atomic_compare_exchange_n(target, &cmp, newval,
+	    0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+	return (cmp);
 }
 
 extern __GNU_INLINE uint64_t
 cas64(uint64_t *target, uint64_t cmp, uint64_t newval)
 {
-	return (__sync_val_compare_and_swap(target, cmp, newval));
+	(void) __atomic_compare_exchange_n(target, &cmp, newval,
+	    0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+	return (cmp);
 }
 
 extern __GNU_INLINE ulong_t
 caslong(ulong_t *target, ulong_t cmp, ulong_t newval)
 {
-	return (__sync_val_compare_and_swap(target, cmp, newval));
+	(void) __atomic_compare_exchange_n(target, &cmp, newval,
+	    0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+	return (cmp);
 }
 
 extern __GNU_INLINE void *
 casptr(void *target, void *cmp, void *newval)
 {
-	return (__sync_val_compare_and_swap((void **)target, cmp, newval));
+	(void) __atomic_compare_exchange_n((void **)target, &cmp, newval,
+	    0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+	return (cmp);
 }
 
 extern __GNU_INLINE void
 atomic_or_long(ulong_t *target, ulong_t bits)
 {
-	(void) __sync_or_and_fetch(target, bits);
+	(void) __atomic_or_fetch(target, bits, __ATOMIC_SEQ_CST);
 }
 
 extern __GNU_INLINE void
 atomic_and_long(ulong_t *target, ulong_t bits)
 {
-	(void) __sync_and_and_fetch(target, bits);
+	(void) __atomic_and_fetch(target, bits, __ATOMIC_SEQ_CST);
 }
 #endif
 

--- a/usr/src/uts/aarch64/asm/atomic.h
+++ b/usr/src/uts/aarch64/asm/atomic.h
@@ -663,13 +663,13 @@ membar_exit(void)
 extern __GNU_INLINE void
 membar_producer(void)
 {
-	__sync_synchronize();
+	__asm__ __volatile__("dmb ishst" ::: "memory");
 }
 
 extern __GNU_INLINE void
 membar_consumer(void)
 {
-	__sync_synchronize();
+	__asm__ __volatile__("dmb ishld" ::: "memory");
 }
 
 extern __GNU_INLINE void

--- a/usr/src/uts/aarch64/asm/atomic.h
+++ b/usr/src/uts/aarch64/asm/atomic.h
@@ -582,55 +582,55 @@ atomic_cas_ptr(volatile void *target, void *cmp, void *newval)
 extern __GNU_INLINE uint8_t
 atomic_swap_8(volatile uint8_t *target, uint8_t newval)
 {
-	return (__sync_lock_test_and_set(target, newval));
+	return (__atomic_exchange_n(target, newval, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE uchar_t
 atomic_swap_char(volatile uchar_t *target, uchar_t newval)
 {
-	return (__sync_lock_test_and_set(target, newval));
+	return (__atomic_exchange_n(target, newval, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE uint16_t
 atomic_swap_16(volatile uint16_t *target, uint16_t newval)
 {
-	return (__sync_lock_test_and_set(target, newval));
+	return (__atomic_exchange_n(target, newval, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE ushort_t
 atomic_swap_ushort(volatile ushort_t *target, ushort_t newval)
 {
-	return (__sync_lock_test_and_set(target, newval));
+	return (__atomic_exchange_n(target, newval, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE uint32_t
 atomic_swap_32(volatile uint32_t *target, uint32_t newval)
 {
-	return (__sync_lock_test_and_set(target, newval));
+	return (__atomic_exchange_n(target, newval, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE uint_t
 atomic_swap_uint(volatile uint_t *target, uint_t newval)
 {
-	return (__sync_lock_test_and_set(target, newval));
+	return (__atomic_exchange_n(target, newval, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE uint64_t
 atomic_swap_64(volatile uint64_t *target, uint64_t newval)
 {
-	return (__sync_lock_test_and_set(target, newval));
+	return (__atomic_exchange_n(target, newval, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE void *
 atomic_swap_ptr(volatile void *target, void *newval)
 {
-	return (__sync_lock_test_and_set((void **)target, newval));
+	return (__atomic_exchange_n((void **)target, newval, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE ulong_t
 atomic_swap_ulong(volatile ulong_t *target, ulong_t newval)
 {
-	return (__sync_lock_test_and_set(target, newval));
+	return (__atomic_exchange_n(target, newval, __ATOMIC_SEQ_CST));
 }
 
 extern __GNU_INLINE int

--- a/usr/src/uts/aarch64/ml/lock_prim.S
+++ b/usr/src/uts/aarch64/ml/lock_prim.S
@@ -601,7 +601,8 @@ thread_onproc(kthread_id_t t, cpu_t *cp)
 	mov	w2, #TS_ONPROC
 	str	w2, [x0, #T_STATE]
 	add	x3, x1, #CPU_THREAD_LOCK
-	str	x3, [x0, #T_LOCKP]
+	add	x4, x0, #T_LOCKP
+	stlr	x3, [x4]
 	ret
 	SET_SIZE(thread_onproc)
 


### PR DESCRIPTION
This series reworks the aarch64 atomic operations in both the kernel (`uts/aarch64/asm/atomic.h`) and libc (`common/atomic/aarch64/atomic.c`), fixing correctness bugs and aligning the memory ordering with the de facto illumos contract established by the SPARC implementations.

## Bug fixes

* **`atomic_swap` acquire-only barrier:** The `__sync_lock_test_and_set` builtin used for `atomic_swap_*` only provides acquire semantics on aarch64 (`LDAXR`/`STXR` — no store barrier). illumos callers expect full-barrier semantics matching x86 `XCHG`. Any code using `atomic_swap` for lock handoffs or state transitions has a missing store barrier. On many-core systems under contention this is a correctness hazard.
* **`thread_onproc` `t_lockp` store**: The write to `t_lockp` in `thread_onproc` must be a store-release (`STLR`) so that prior stores to thread state are visible to other CPUs before the lock pointer becomes visible.

## Migration to `__atomic` builtins

All `__sync_*` builtins are replaced with their `__atomic_*` equivalents. The `__sync_*` family is deprecated by GCC and does not accept an explicit memory order parameter, making it impossible to express anything other than sequentially consistent ordering. This migration is a prerequisite for the ordering refinements that follow.

## Barrier refinements

`membar_producer` and `membar_consumer` both emitted `DMB ISH` (full inner-shareable barrier) via `__sync_synchronize`. `membar_producer` needs only store-before-store (`DMB ISHST`) and `membar_consumer` needs only load-before-load (`DMB ISHLD`). Not a correctness issue, as over-fencing is safe, but reduces unnecessary ordering overhead.

## Relaxation from `SEQ_CST` to `ACQ_REL`

The illumos atomic operation man pages specify only atomicity, not memory ordering. The de facto ordering contract is set by the platform implementations. SPARC, uses bare `CAS`/`CASX` in retry loops with no `MEMBAR` instructions - under TSO this provides LoadLoad + StoreStore + LoadStore ordering but _not_ StoreLoad. StoreLoad is provided separately by `membar_enter` when needed (e.g. after lock acquisition). Any code relying on StoreLoad ordering from atomics alone (without an explicit membar_enter) is already broken on SPARC.

On aarch64, `__ATOMIC_ACQ_REL` maps to `LDAXR`/`STLXR` (acquire-release), which matches SPARC TSO and is strictly weaker than `SEQ_CST`. The explicit barrier operations (`membar_enter`, `membar_exit`, `membar_sync`) retain `__ATOMIC_SEQ_CST`/`DMB ISH`.

This is a higher-risk change, as SPARC is effectively abandoned and implicit reliance on x86 `SEQ_CST` semantics may have crept into the codebase.

## Testing

Heavily and repeatedly tested on Altra Max and rpi4 with high concurrency under load and contention in #219.