### PR TITLE
aarch64: remove 2GB file offset cap from pread/pwrite/sendfile

### DIFF
--- a/usr/src/uts/common/syscall/rw.c
+++ b/usr/src/uts/common/syscall/rw.c
@@ -349,6 +349,8 @@ pread(int fdes, void *cbuf, size_t count, off_t offset)
 #ifdef _SYSCALL32_IMPL
 	u_offset_t maxoff = get_udatamodel() == DATAMODEL_ILP32 ?
 	    MAXOFF32_T : MAXOFFSET_T;
+#elif defined(_LP64) && !defined(_MULTI_DATAMODEL)
+	const u_offset_t maxoff = MAXOFFSET_T;
 #else
 	const u_offset_t maxoff = MAXOFF32_T;
 #endif
@@ -489,6 +491,8 @@ pwrite(int fdes, void *cbuf, size_t count, off_t offset)
 #ifdef _SYSCALL32_IMPL
 	u_offset_t maxoff = get_udatamodel() == DATAMODEL_ILP32 ?
 	    MAXOFF32_T : MAXOFFSET_T;
+#elif defined(_LP64) && !defined(_MULTI_DATAMODEL)
+	const u_offset_t maxoff = MAXOFFSET_T;
 #else
 	const u_offset_t maxoff = MAXOFF32_T;
 #endif

--- a/usr/src/uts/common/syscall/sendfile.c
+++ b/usr/src/uts/common/syscall/sendfile.c
@@ -408,6 +408,8 @@ sendvec_small_chunk(file_t *fp, u_offset_t *fileoff, struct sendfilevec *sfv,
 	model_t model = get_udatamodel();
 	u_offset_t maxoff = (model == DATAMODEL_ILP32) ?
 	    MAXOFF32_T : MAXOFFSET_T;
+#elif defined(_LP64) && !defined(_MULTI_DATAMODEL)
+	const u_offset_t maxoff = MAXOFFSET_T;
 #else
 	const u_offset_t maxoff = MAXOFF32_T;
 #endif
@@ -698,6 +700,8 @@ sendvec_chunk(file_t *fp, u_offset_t *fileoff, struct sendfilevec *sfv,
 	model_t model = get_udatamodel();
 	u_offset_t maxoff = (model == DATAMODEL_ILP32) ?
 	    MAXOFF32_T : MAXOFFSET_T;
+#elif defined(_LP64) && !defined(_MULTI_DATAMODEL)
+	const u_offset_t maxoff = MAXOFFSET_T;
 #else
 	const u_offset_t maxoff = MAXOFF32_T;
 #endif


### PR DESCRIPTION
_This is one of the bugs I uncovered while developing kernel FPU support._

On platforms without `_SYSCALL32_IMPL` (64-bit kernels that do not support 32-bit userland), the `pread`, `pwrite`, and `sendfile` syscalls unconditionally set `maxoff` to `MAXOFF32_T` (0x7fffffff).  This caps all file I/O at 2 GB, causing short writes (and eventually `EINVAL`) for any operation beyond that offset.

This breaks `savecore` on aarch64: compressed crash dumps larger than 2GiB cannot be written, making post-mortem debugging impossible on Altra Max.

The existing `#else` clause assumed that `!_SYSCALL32_IMPL` implies a 32-bit kernel, but aarch64 is LP64 without `_MULTI_DATAMODEL` (no 32-bit userland support).

Add a `#elif` for `_LP64 && !_MULTI_DATAMODEL` to use `MAXOFFSET_T`.  This is a compile-time constant with no runtime cost and does not alter any existing platform's code path.

Affected syscalls: `pread`, `pwrite`, `sendvec_small_chunk`, `sendvec_chunk`.

## Testing
* Before: https://gist.github.com/r1mikey/06476817d81c89832ab18916bc4fb6fb
* After: https://gist.github.com/r1mikey/49a016b103c9cba655abc24f0a6b4d45