### PR TITLE
ksensor: guard ksensor_cb_remove against NULL in unbind taskq

### DIFF
--- a/usr/src/uts/common/os/ksensor.c
+++ b/usr/src/uts/common/os/ksensor.c
@@ -399,8 +399,10 @@ ksensor_dip_unbind_taskq(void *arg)
 	    sensor = list_next(&k->ksdip_sensors, sensor)) {
 		mutex_enter(&sensor->ksensor_mutex);
 		if (sensor->ksensor_flags & KSENSOR_F_NOTIFIED) {
-			ksensor_cb_remove(sensor->ksensor_id,
-			    sensor->ksensor_name);
+			if (ksensor_cb_remove != NULL) {
+				ksensor_cb_remove(sensor->ksensor_id,
+				    sensor->ksensor_name);
+			}
 			sensor->ksensor_flags &= ~KSENSOR_F_NOTIFIED;
 		}
 		mutex_exit(&sensor->ksensor_mutex);


### PR DESCRIPTION
_A minor potential panic that I came across while soak testing on Altra Max._

`ksensor_dip_unbind_taskq` calls `ksensor_cb_remove` for sensors with `KSENSOR_F_NOTIFIED` set, but does not check whether the callback is NULL.  If `ksensor_dip_unbind_cb` removes a sensor from the AVL before `ksensor_unregister` runs, the sensor's `KSENSOR_F_NOTIFIED` flag is not cleared (`ksensor_unregister` iterates the AVL, which no longer contains the sensor), but `ksensor_cb_remove` is set to NULL.  When the taskq fires, the first loop sees the flag set and calls through a NULL function pointer.

Guard the call with a NULL check on `ksensor_cb_remove`.  The taskq already holds `ksensor_g_mutex`, which serializes against `ksensor_unregister`, so `ksensor_cb_remove` cannot go NULL between the check and the call.  If the callback is NULL, just clear the flag; `ksensor_detach`'s subsequent `ddi_remove_minor_node` will clean up the minor node.