### PR TITLE
ddi: move ddm_node_type to kernel heap

### DIFF
--- a/usr/src/uts/common/os/sunddi.c
+++ b/usr/src/uts/common/os/sunddi.c
@@ -5690,10 +5690,16 @@ ddi_create_minor_common(dev_info_t *dip, const char *name, int spec_type,
 		kmem_free(dmdp, sizeof (struct ddi_minor_data));
 		return (DDI_FAILURE);
 	}
+	if (node_type != NULL &&
+	    (dmdp->ddm_node_type = i_ddi_strdup(node_type,
+	    KM_NOSLEEP)) == NULL) {
+		kmem_free(dmdp->ddm_name, strlen(dmdp->ddm_name) + 1);
+		kmem_free(dmdp, sizeof (struct ddi_minor_data));
+		return (DDI_FAILURE);
+	}
 	dmdp->dip = dip;
 	dmdp->ddm_dev = makedevice(major, minor_num);
 	dmdp->ddm_spec_type = spec_type;
-	dmdp->ddm_node_type = node_type;
 	dmdp->type = mtype;
 	if (flag & CLONE_DEV) {
 		dmdp->type = DDM_ALIAS;
@@ -5783,6 +5789,10 @@ ddi_remove_minor_node(dev_info_t *dip, const char *name)
 					    dmdp->ddm_name);
 				kmem_free(dmdp->ddm_name,
 				    strlen(dmdp->ddm_name) + 1);
+			}
+			if (dmdp->ddm_node_type != NULL) {
+				kmem_free(dmdp->ddm_node_type,
+				    strlen(dmdp->ddm_node_type) + 1);
 			}
 			/*
 			 * Release device privilege, if any.

--- a/usr/src/uts/common/sys/ddi_impldefs.h
+++ b/usr/src/uts/common/sys/ddi_impldefs.h
@@ -732,7 +732,7 @@ struct ddi_minor {
 	dev_t		dev;		/* device number */
 	int		spec_type;	/* block or char */
 	int		flags;		/* access flags */
-	const char	*node_type;	/* block, byte, serial, network */
+	char		*node_type;	/* block, byte, serial, network */
 	struct devplcy	*node_priv;	/* privilege for this minor */
 	mode_t		priv_mode;	/* default apparent privilege mode */
 };


### PR DESCRIPTION
`ddi_create_minor_common` stores the caller-supplied `node_type` pointer directly in `ddm_node_type` without copying it, assuming the string is a static constant (e.g. `DDI_NT_BLOCK`, `DDI_PSEUDO`).  However, at least one consumer, `ksensor(4D)`, passes a heap-allocated string (`sensor->ksensor_class` via `ddi_strdup`) which can be freed while the minor node is still live.

This creates a use-after-free: `di_getmdata` walks the minor list under `ndi_devi_enter` and calls `strlen(ddm_node_type)` on the dangling pointer. The freed slab page is unmapped and the kmem deadbeef poison (no null bytes) causes `strlen` to walk into an unmapped page, producing a data abort.

The race window in ksensor: `ksensor_unregister` clears `KSENSOR_F_NOTIFIED` under `ksensor_g_mutex` for sensors still in the AVL.  If a sensor's dip unbinds after the flag is cleared but _before_ `ksensor_detach` calls `ddi_remove_minor_node`, the unbind taskq's first loop skips the sensor (flag clear) and the second loop frees the sensor - including `strfree(ksensor_class)` - while the minor node referencing that string is still on the list.

Fix this in the DDI framework: copy `node_type` with `i_ddi_strdup` in `ddi_create_minor_common` and free the copy in `ddi_remove_minor_node`, matching the existing `ddm_name` lifetime management.  This makes DDI immune to callers' string lifetime decisions.