### PR TITLE
syscall: shmsys sysent must use SE_64RVAL on LP64

### DIFF
--- a/usr/src/uts/common/os/shm.c
+++ b/usr/src/uts/common/os/shm.c
@@ -180,11 +180,11 @@ static uintptr_t shmsys(int, uintptr_t, uintptr_t, uintptr_t);
 
 static struct sysent ipcshm_sysent = {
 	4,
-#ifdef	_SYSCALL32_IMPL
+#ifdef	_LP64
 	SE_ARGC | SE_NOUNLOAD | SE_64RVAL,
-#else	/* _SYSCALL32_IMPL */
+#else	/* _LP64 */
 	SE_ARGC | SE_NOUNLOAD | SE_32RVAL1,
-#endif	/* _SYSCALL32_IMPL */
+#endif	/* _LP64 */
 	(int (*)())(uintptr_t)shmsys
 };
 


### PR DESCRIPTION
The ipcshm_sysent entry uses _SYSCALL32_IMPL as the guard for choosing SE_64RVAL vs SE_32RVAL1.  On LP64 kernels without _SYSCALL32_IMPL (such as aarch64), this selects SE_32RVAL1, causing the syscall return path to truncate the 64-bit return value to 32 bits.

shmsys returns uintptr_t (the virtual address from shmat), so on LP64 a shared memory segment mapped above 4GB returns a truncated pointer to userspace - silent memory corruption.

Use _LP64 as the guard instead, matching the pattern already used by msgsys in msg.c.  The 32-bit compat sysent (ipcshm_sysent32) is unchanged - it is already correctly guarded by _SYSCALL32_IMPL.