### PR TITLE
Remove SMPEN/CPUECTLR startup code

### DIFF
--- a/usr/src/uts/aarch64/sys/controlregs.h
+++ b/usr/src/uts/aarch64/sys/controlregs.h
@@ -305,8 +305,6 @@
 #define	CPTR_EL2_NO_E2H_RES1	(0x22fful)
 #define	INIT_CPTR_EL2_NO_E2H	(CPTR_EL2_NO_E2H_RES1)
 
-#define	CPUECTLR_SMP	(1<<6)
-
 #define	TCR_AS		(1ul<<36)
 #define	TCR_IPS_4G	(0ul<<32)
 #define	TCR_IPS_64G	(1ul<<32)

--- a/usr/src/uts/armv8/dboot/dboot_srt0.S
+++ b/usr/src/uts/armv8/dboot/dboot_srt0.S
@@ -230,39 +230,6 @@
 
 3:
 	/*
-	 * Apply known errata applicable at EL2.
-	 */
-	mrs	x0, midr_el1
-	/* examine implementer, must be Arm (0x41) */
-	ubfx	x1, x0, #24, #8
-	cmp	x1, #(MIDR_IMPL_ARM)
-	b.ne	.Lnot_cortex_a5x_0
-	/* examine the architecture, must be 0xf */
-	ubfx	x1, x0, #15, #4
-	cmp	x1, #0xF
-	b.ne	.Lnot_cortex_a5x_0
-	/* examine the part */
-	ubfx	x1, x0, #4, #12
-	cmp	x1, #(MIDR_PART_ARM_CORTEX_A72)
-	b.eq	.Lcortex_a72_0
-	cmp	x1, #(MIDR_PART_ARM_CORTEX_A57)
-	b.eq	.Lcortex_a57_0
-	/* Explicitly _not_ Cortex-A55 */
-	cmp	x1, #(MIDR_PART_ARM_CORTEX_A53)
-	b.eq	.Lcortex_a53_0
-	b	.Lnot_cortex_a5x_0
-
-.Lcortex_a72_0:
-.Lcortex_a57_0:
-.Lcortex_a53_0:
-	// access L2ACTLR L2ECTLR L2CTLR CPUECTLR CPUACTLR
-	mrs	x0, actlr_el2
-	orr	x0, x0, #0x70
-	orr	x0, x0, #0x3
-	msr	actlr_el2, x0
-.Lnot_cortex_a5x_0:
-
-	/*
 	 * Set up and execute an exception return to our target exception
 	 * level, which is either EL1 or EL2. This also synchronises PSTATE.
 	 */
@@ -271,41 +238,6 @@
 	eret
 
 .Lrun_dboot:
-	/*
-	 * Apply known errata applicable at EL1 or unified EL1/EL2.
-	 */
-	mrs	x0, midr_el1
-	/* examine implementer, must be Arm (0x41) */
-	ubfx	x1, x0, #24, #8
-	cmp	x1, #(MIDR_IMPL_ARM)
-	b.ne	.Lnot_cortex_a5x_1
-	/* examine the architecture, must be 0xf */
-	ubfx	x1, x0, #15, #4
-	cmp	x1, #0xF
-	b.ne	.Lnot_cortex_a5x_1
-	/* examine the part */
-	ubfx	x1, x0, #4, #12
-	cmp	x1, #(MIDR_PART_ARM_CORTEX_A72)
-	b.eq	.Lcortex_a72_1
-	cmp	x1, #(MIDR_PART_ARM_CORTEX_A57)
-	b.eq	.Lcortex_a57_1
-	/* explicitly _not_ Cortex-A55 */
-	cmp	x1, #(MIDR_PART_ARM_CORTEX_A53)
-	b.eq	.Lcortex_a53_1
-	b	.Lnot_cortex_a5x_1
-
-.Lcortex_a72_1:
-.Lcortex_a57_1:
-.Lcortex_a53_1:
-	/* CPUECTLR_EL1.SMPEN -> 1 (enable cache coherence) */
-	mrs	x0, s3_1_c15_c2_1
-	tbnz	x0, #6, .Lnot_cortex_a5x_1
-	orr	x0, x0, #(1<<6)
-	msr	s3_1_c15_c2_1, x0
-	dsb	sy
-	isb
-.Lnot_cortex_a5x_1:
-
 	mrs	x0, cpacr_el1
 	bic	x0, x0, #CPACR_FPEN_MASK
 	msr	cpacr_el1, x0

--- a/usr/src/uts/armv8/ml/locore.S
+++ b/usr/src/uts/armv8/ml/locore.S
@@ -268,41 +268,6 @@ t0:
 1:
 
 	/*
-	 * Enable SMP cache coherence.
-	 */
-	mrs	x0, midr_el1
-	/* examine implementer, must be Arm (0x41) */
-	ubfx	x1, x0, #24, #8
-	cmp	x1, #(MIDR_IMPL_ARM)
-	b.ne	.Lnot_cortex_a5x_1
-	/* examine the architecture, must be 0xf */
-	ubfx	x1, x0, #15, #4
-	cmp	x1, #0xF
-	b.ne	.Lnot_cortex_a5x_1
-	/* examine the part */
-	ubfx	x1, x0, #4, #12
-	cmp	x1, #(MIDR_PART_ARM_CORTEX_A72)
-	b.eq	.Lcortex_a72_1
-	cmp	x1, #(MIDR_PART_ARM_CORTEX_A57)
-	b.eq	.Lcortex_a57_1
-	/* explicitly _not_ Cortex-A55 */
-	cmp	x1, #(MIDR_PART_ARM_CORTEX_A53)
-	b.eq	.Lcortex_a53_1
-	b	.Lnot_cortex_a5x_1
-
-.Lcortex_a72_1:
-.Lcortex_a57_1:
-.Lcortex_a53_1:
-	/* CPUECTLR_EL1.SMPEN -> 1 (enable cache coherence) */
-	mrs	x0, s3_1_c15_c2_1
-	tbnz	x0, #6, .Lnot_cortex_a5x_1
-	orr	x0, x0, #(1<<6)
-	msr	s3_1_c15_c2_1, x0
-	dsb	sy
-	isb
-.Lnot_cortex_a5x_1:
-
-	/*
 	 * Have the core trap when attempting to execute FPU
 	 * instructions - mirrors what dboot has done for the
 	 * boot processor.


### PR DESCRIPTION
Remove the `CPUECTLR_EL1.SMPEN` initialisation from dboot (boot processor) and locore (secondary CPUs), along with the `ACTLR_EL2` access grant that existed solely to make the `SMPEN` write reachable from EL1.

This code set bit 6 (`SMPEN`) of the implementation-defined `CPUECTLR_EL1` register (`S3_1_C15_C2_1`) on Cortex-A53, A57, and A72 cores to enable participation in broadcast cache/TLB maintenance operations.  On all supported platforms this is dead code:
* RPi4: the VideoCore firmware's armstub8.S sets `SMPEN` at EL3 for every core before dropping to EL2.  By the time illumos runs, the `tbnz` guard sees bit 6 already set and skips the write.
* QEMU virt: does not model `CPUECTLR`.  Emulated CPUs are always coherent regardless of this register.
- Others: `MIDR` dispatch would skip the entire block anyway.

Additionally, the locore (secondary) path never set `ACTLR_EL2` to grant EL1 access to `CPUECTLR`, so the `SMPEN` write would have trapped on any platform where firmware had not already set it - making it not just redundant but broken as a safety net.

The dboot EL2 block that set `ACTLR_EL2` bits 0-1,4-6 (granting EL1 access to `CPUACTLR`, `CPUECTLR`, `L2CTLR`, `L2ECTLR`, `L2ACTLR`) has no remaining consumers and is removed as well.

Also remove the unused `CPUECTLR_SMP` define from `controlregs.h`.

## Why this is safe

On virtualised platforms the CPU is always coherent, so no action is needed. On other platforms we run with TF-A (Arm's Trusted Firmware) - this includes rpi4:

### Per-CPU reset functions (EL3)

Each CPU type has a `cpu_reset_func` called by TF-A's BL31 cold/warm boot path at EL3. For the cores we care about, every one of them sets `SMPEN`:

| CPU | Register | Action |
|---|---|---|
| Cortex-A35 | S3_1_C15_C2_1 bit 6 | sysreg_bit_set in cpu_reset_func |
| Cortex-A53 | S3_1_C15_C2_1 bit 6 | sysreg_bit_set in cpu_reset_func |
| Cortex-A57 | S3_1_C15_C2_1 bit 6 | sysreg_bit_set in cpu_reset_func |
| Cortex-A72 | S3_1_C15_C2_1 bit 6 | sysreg_bit_set in cpu_reset_func |
| Cortex-A73 | S3_1_C15_C2_1 bit 6 | sysreg_bit_set in cpu_reset_func |

This runs at EL3, so no `ACTLR_EL2` grant is needed as EL3 has direct access.

### Power-down path

Each of those CPUs also has a `disable_smp` function that clears `SMPEN` as part of `core_pwr_dwn`/`cluster_pwr_dwn`. The sequence is: flush caches -> disable coherency (clear `SMPEN`) -> `WFI`. On warm boot, `cpu_reset_func` re-enables it.

### RPi4 specifically

* `platform.mk` links `lib/cpus/aarch64/cortex_a72.S`
* `cortex_a72_reset_func` sets `SMPEN` at EL3 for both cold and warm boot
* `plat_reset_handler` just configures L2 cache latency - nothing to do with `SMPEN`
* `rpi3_pm.c` handles PSCI; the core/cluster power-down calls `cortex_a72_disable_smp` (via the `cpu_ops` table)

So on RPi4 with TF-A, `SMPEN` is set at EL3 on every boot path (cold and warm/PSCI). With the VideoCore `armstub8.S`, same story - set at EL3 before dropping to EL2. Either way, the OS never needs to touch it.

Notable: `SMPEN` in `S3_1_C15_C2_1` is purely an A35/A53/A57/A72/A73 thing. Newer cores (A55, A75, A76+, Neoverse) moved `CPUECTLR` to `S3_0_C15_C1_4` with a completely different bit layout - no `SMPEN` bit. Coherency is either always-on or managed differently (and this is a firmware concern, so we don't need to worry about it).

## Testing

* Qemu virt (u-boot/FDT): successfully boots, runs, reboots, shuts down
* rpi4: successfully boots, runs, reboots, shuts down