### PR TITLE
interrupt routing: infrastructure preparation and fixes

### DIFF
--- a/usr/src/uts/armv8/os/ddi_impl.c
+++ b/usr/src/uts/armv8/os/ddi_impl.c
@@ -2144,18 +2144,7 @@ done:
 	 * The unit interrupt descriptor in the platform private data is
 	 * specific to a single pass of FIXED interrupt mapping and must
 	 * be cleared on the way back down the tree.
-	 *
-	 * For FIXED interrupts, ih_vector is also transient (re-derived
-	 * each call via map_interrupt/unitintr).
-	 *
-	 * For MSI/MSI-X, ih_vector is the LPI INTID set during ENABLE
-	 * and must persist for DISABLE/FREE.  The ip_msi_* fields in
-	 * the platform private data are persistent for the handle's
-	 * lifetime - do not clear them here.
 	 */
-	if (!DDI_INTR_IS_MSI_OR_MSIX(hdlp->ih_type))
-		hdlp->ih_vector = 0;
-
 	ihdl_plat_t *priv = hdlp->ih_private;
 	if (priv != NULL) {
 		i_ddi_free_unitintr(priv->ip_unitintr);

--- a/usr/src/uts/armv8/os/ddi_impl.c
+++ b/usr/src/uts/armv8/os/ddi_impl.c
@@ -1946,6 +1946,7 @@ map_interrupt_map(dev_info_t *dip, ddi_intr_handle_impl_t *hdlp)
 			return (parent);
 		}
 
+		ndi_rele_devi(parent);
 		effective_stride += par_addr_cells + par_intr_cells;
 	}
 

--- a/usr/src/uts/armv8/os/intr.c
+++ b/usr/src/uts/armv8/os/intr.c
@@ -367,10 +367,11 @@ intr_thread_epilog(struct cpu *cpu, intr_cookie_t ack, uint_t oldpil)
 		(void) splhigh();
 		(void) enable_interrupts();
 
-		it->t_state = TS_FREE;
 		/*
 		 * Return interrupt thread to pool
 		 */
+		it->t_lwp = NULL;
+		it->t_state = TS_FREE;
 		it->t_link = cpu->cpu_intr_thread;
 		cpu->cpu_intr_thread = it;
 		swtch();
@@ -381,9 +382,10 @@ intr_thread_epilog(struct cpu *cpu, intr_cookie_t ack, uint_t oldpil)
 	/*
 	 * Return interrupt thread to the pool
 	 */
+	it->t_lwp = NULL;
+	it->t_state = TS_FREE;
 	it->t_link = cpu->cpu_intr_thread;
 	cpu->cpu_intr_thread = it;
-	it->t_state = TS_FREE;
 
 	basespl = cpu->cpu_base_spl;
 	pil = MAX(oldpil, basespl);
@@ -624,6 +626,7 @@ dosoftint_epilog(struct cpu *cpu, uint_t oldpil)
 		 * This was an interrupt thread, so set CPU's base SPL.
 		 */
 		set_base_spl();
+		it->t_lwp = NULL;
 		it->t_state = TS_FREE;
 		it->t_link = cpu->cpu_intr_thread;
 		cpu->cpu_intr_thread = it;
@@ -633,9 +636,10 @@ dosoftint_epilog(struct cpu *cpu, uint_t oldpil)
 		/*NOTREACHED*/
 		panic("dosoftint_epilog: swtch returned");
 	}
+	it->t_lwp = NULL;
+	it->t_state = TS_FREE;
 	it->t_link = cpu->cpu_intr_thread;
 	cpu->cpu_intr_thread = it;
-	it->t_state = TS_FREE;
 	write_tpidr_el1((uintptr_t)t);
 	cpu->cpu_thread = t;
 	if (t->t_flag & T_INTR_THREAD)

--- a/usr/src/uts/armv8/sys/gic_reg.h
+++ b/usr/src/uts/armv8/sys/gic_reg.h
@@ -348,7 +348,7 @@ extern "C" {
 #define	GICD_NSACRnE(n)				(0x3600+(4*(n)))
 #define	GICD_INMIRnE(n)				(0x3b00+(4*(n)))
 
-#define	GICD_IROUTERn(n)			(0x6100+(8*(n)))
+#define	GICD_IROUTERn(n)			(0x6000+(8*(n)))
 #define	GICD_IROUTERnE(n)			(0x8000+(8*(n)))
 #define	GICD_IROUTER_Interrupt_Routing_Mode	0x0000000080000000
 

--- a/usr/src/uts/common/io/avintr.c
+++ b/usr/src/uts/common/io/avintr.c
@@ -346,6 +346,42 @@ av_get_vec_lvl(uint_t vect, int *lvl)
 	return (0);
 }
 
+#if defined(__aarch64__)
+/*
+ * Return the number of active handlers registered for the given
+ * vector.
+ *
+ * This walks the autovect hash chain and counts entries with a
+ * matching av_vecnum and non-NULL av_vector.  Because MAX_VECT is
+ * smaller than the INTID space on aarch64, multiple vectors hash to
+ * the same bucket; av_vector_match() disambiguates.
+ *
+ * av_lock is acquired internally; callers must not already hold it.
+ */
+int
+av_get_shared(uint_t vecnum, uint_t *prip)
+{
+	struct av_head *vecp;
+	struct autovec *p;
+	int count = 0;
+
+	vecp = &autovect[vecnum % MAX_VECT];
+
+	mutex_enter(&av_lock);
+	for (p = vecp->avh_link; p != NULL; p = p->av_link) {
+		if (p->av_vector != NULL && av_vector_match(p, vecnum)) {
+			if (count == 0 && prip != NULL) {
+				*prip = p->av_prilevel;
+			}
+
+			count++;
+		}
+	}
+	mutex_exit(&av_lock);
+	return (count);
+}
+#endif /* __aarch64__ */
+
 void
 update_avsoftintr_args(void *intr_id, int lvl, caddr_t arg2)
 {

--- a/usr/src/uts/common/io/avintr.c
+++ b/usr/src/uts/common/io/avintr.c
@@ -46,6 +46,9 @@
 #ifdef __xpv
 #include <sys/evtchn_impl.h>
 #endif
+#if defined(__aarch64__)
+#include <sys/ddi_intr_impl.h>
+#endif
 
 #define	NO_VECT	((uint_t)-1)
 
@@ -378,6 +381,65 @@ av_get_shared(uint_t vecnum, uint_t *prip)
 		}
 	}
 	mutex_exit(&av_lock);
+	return (count);
+}
+
+/*
+ * Retrieve information about all handlers registered on a given interrupt
+ * vector.  Returns the total number of active handlers (which may exceed
+ * dips_max if the caller-provided array is too small).
+ *
+ * If hdlpp is non-NULL, a representative ddi_intr_handle_impl_t pointer
+ * is stored there.  For a shared vector all handles resolve to the same
+ * underlying interrupt, so any one is suitable for GETTARGET/SETTARGET
+ * via i_ddi_intr_ops.
+ *
+ * If dips is non-NULL, up to dips_max dev_info_t pointers are copied out.
+ * The caller owns the buffer; no memory is allocated.
+ *
+ * The walk is performed under av_lock.  The returned pointers (dips and
+ * handle) remain valid as long as the interrupt has not been removed;
+ * callers that require stability across the lookup should hold the
+ * nexus devinfo tree lock (ndi_devi_enter) around the call and any
+ * subsequent use of the returned pointers.
+ */
+uint_t
+av_get_vector_info(uint_t vecnum, ddi_intr_handle_impl_t **hdlpp,
+    dev_info_t **dips, uint_t dips_max)
+{
+	struct av_head *vecp;
+	struct autovec *p;
+	uint_t count = 0;
+
+	if (hdlpp != NULL) {
+		*hdlpp = NULL;
+	}
+
+	vecp = &autovect[vecnum % MAX_VECT];
+
+	mutex_enter(&av_lock);
+	for (p = vecp->avh_link; p != NULL; p = p->av_link) {
+		if (p->av_vector == NULL || !av_vector_match(p, vecnum)) {
+			continue;
+		}
+
+		/*
+		 * Store the first valid handle as representative.
+		 * All handles on a shared vector are equivalent for
+		 * GETTARGET/SETTARGET since they resolve to the same INTID.
+		 */
+		if (count == 0 && hdlpp != NULL) {
+			*hdlpp = (ddi_intr_handle_impl_t *)p->av_intr_id;
+		}
+
+		if (dips != NULL && count < dips_max) {
+			dips[count] = p->av_dip;
+		}
+
+		count++;
+	}
+	mutex_exit(&av_lock);
+
 	return (count);
 }
 #endif /* __aarch64__ */

--- a/usr/src/uts/common/sys/avintr.h
+++ b/usr/src/uts/common/sys/avintr.h
@@ -112,7 +112,13 @@ extern uint_t softlevel1(caddr_t, caddr_t);
 extern int av_get_vec_lvl(uint_t vect, int *lvl);
 
 #if defined(__aarch64__)
+
+struct ddi_intr_handle_impl;	/* <sys/ddi_intr_impl.h> */
+
 extern int av_get_shared(uint_t vecnum, uint_t *prip);
+extern uint_t av_get_vector_info(uint_t vecnum,
+    struct ddi_intr_handle_impl **hdlpp, dev_info_t **dips, uint_t dips_max);
+
 #endif
 
 #endif	/* _KERNEL */

--- a/usr/src/uts/common/sys/avintr.h
+++ b/usr/src/uts/common/sys/avintr.h
@@ -111,6 +111,10 @@ extern void wait_till_seen(int ipl);
 extern uint_t softlevel1(caddr_t, caddr_t);
 extern int av_get_vec_lvl(uint_t vect, int *lvl);
 
+#if defined(__aarch64__)
+extern int av_get_shared(uint_t vecnum, uint_t *prip);
+#endif
+
 #endif	/* _KERNEL */
 
 #ifdef	__cplusplus


### PR DESCRIPTION
_This is the first of five PRs that flesh out the verbs handled by our interrupt controllers, clean up interrupt routing for both FIXED interrupts and those managed through a root complex, implement interrupt redistribution and update documentation._

Six preparatory commits that fix existing bugs and add infrastructure needed by the interrupt routing rework. These are independently correct and introduce no behavioural change to the current interrupt path.

## intr: clear stale lwp from interrupt threads

Clear `t_lwp` before returning interrupt threads to the free pool in all four epilogue paths (hard interrupt return-via-swtch, hard interrupt direct return, soft interrupt return-via-swtch, soft interrupt direct return). Interrupt threads borrow `t_lwp` from the pinned thread; leaving it set after the interrupt completes means a recycled interrupt thread can carry a stale LWP pointer, confusing humans doing debugging (ask me how I know...). Also reorders the cleanup sequence to be consistent across all epilogues: `t_lwp = NULL`, `t_state = TS_FREE`, then link to pool.

Debugging quality-of-life improvement and consistency: not a functional change.

## avintr: add helper to determine if a vector is shared

Add `av_get_shared`, which walks the `autovect` hash chain for a given vector number and returns the number of active handlers registered on it, optionally returning the priority of the first handler via an out parameter.

Protected by `#if defined(__aarch64__)` to avoid affecting other platforms, though we're really the only user.

Will be used by the GIC drivers to determine whether a vector has shared handlers when implementing `SETPRI` with priority enforcement.

## `map_interrupt_map`: plug a hold leak

Add missing `ndi_rele_devi` for intermediate parent nodes skipped during `interrupt-map` traversal. These dips are acquired via `e_ddi_nodeid_to_dip`, which returns them held. Without the release, their hold counts grow monotonically on each interrupt mapping call.

Simple one-line fix.

## gic_reg: fix `GICD_IROUTERn` offset to use raw INTID indexing

The `GICD_IROUTERn` macro was defined as `0x6100 + 8*n`, which is correct only if `n` is the SPI number (INTID − 32). All callers pass the raw INTID, so the macro must be `0x6000 + 8*n` — matching both the GIC spec (IHI0069H §12.9.22: offset 0x6100 + 8*(n−32) simplifies to 0x6000 + 8*n for raw INTID) and the convention used by Linux.

The bug was masked because without `intrd` no active rebalancing occurs, and the `IROUTER` reset state provides functional routing regardless.

## ddi: preserve `ih_vector` for FIXED interrupts

Remove the conditional zeroing of `ih_vector` for FIXED interrupts on the way back down the interrupt mapping tree. The vector is always re-derived from the unit interrupt descriptor on the next mapping call, so stale data is not a concern. Preserving it will allow kstats and the interrupt balancer to identify which vector a FIXED interrupt handle refers to without requiring an additional mapping round-trip.

The `ih_vector` for MSI/MSI-X (LPI INTID set during ENABLE) was already preserved - this makes the behaviour uniform across all interrupt types.

## avintr: add `av_get_vector_info` for interrupt retargeting

Add `av_get_vector_info`, the aarch64 equivalent of the x86 `PSM_INTR_OP_GET_INTR` path. Given a vector number, it walks the autovect chain and returns:

* The total number of active handlers (may exceed the caller's array size).
* A representative `ddi_intr_handle_impl_t` pointer suitable for `GETTARGET`/`SETTARGET` operations - on a shared vector all handles resolve to the same INTID, so any representative is equivalent.
* Up to `dips_max` device `dev_info_t` pointers, for kstat and pcitool consumer identification.

Uses the same `av_lock` + `av_vector_match` pattern as `av_get_shared`. Protected by `#if defined(__aarch64__)` to avoid affecting other platforms, though we're really the only user.

## Testing
Tested in the full stack for FDT platforms, grafted into my combined-everything stack for ACPI platforms.

* QEMU virt ([FDT](https://gist.github.com/r1mikey/8cb562753e9e49acb1ae49913b2af526), GICv3+ITS)
* RPi4/FDT (GICv2): [FIXED path through pci_common -> gictwo](https://gist.github.com/r1mikey/460c7c350054e037523d69eca696f848)
* QEMU virt ([ACPI](https://gist.github.com/r1mikey/da627300ae2156473d5e31c2e43d3285), GICv3+ITS)
* [Ampere Altra Max](https://gist.github.com/r1mikey/edd1c2a6c73ccd0280551dacc309f94c): [full MSI-X + FIXED bridges](https://gist.github.com/r1mikey/8c7ce3faa1378c532e246e51678784f5)