### PR TITLE
interrupt routing: driver verbs

### DIFF
--- a/usr/src/uts/armv8/io/gicthree.c
+++ b/usr/src/uts/armv8/io/gicthree.c
@@ -1826,6 +1826,11 @@ gicv3_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 		break;
 	}
 
+	case DDI_INTROP_ADDISR:	/* fallthrough */
+	case DDI_INTROP_REMISR:
+		/* no-op in this implementation */
+		break;
+
 	case DDI_INTROP_ENABLE: {
 		gicv3_conf_t *gc =
 		    ddi_get_soft_state(gicv3_soft_state, ddi_get_instance(dip));

--- a/usr/src/uts/armv8/io/gicthree.c
+++ b/usr/src/uts/armv8/io/gicthree.c
@@ -88,6 +88,8 @@
 #include <sys/avintr.h>
 #include <sys/smp_impldefs.h>
 #include <sys/sunddi.h>
+#include <sys/sunndi.h>
+#include <sys/ddi_intr_impl.h>
 #include <sys/ddi_subrdefs.h>
 #include <sys/cpuinfo.h>
 #include <sys/sysmacros.h>
@@ -199,6 +201,7 @@ typedef struct gicv3_conf {
 	uint32_t		gc_lpi_max_intid; /* (1 << idbits) - 1 */
 	uint32_t		gc_lpi_count;	/* max_intid - 8191 */
 	vmem_t			*gc_lpi_arena;	/* LPI INTID allocator */
+	ddi_irm_pool_t		*gc_lpi_irm_pool; /* IRM pool for LPIs */
 	uint8_t			*gc_lpi_prop;	/* PROPBASER table VA */
 	uint64_t		gc_lpi_prop_pa;	/* PROPBASER table PA */
 	size_t			gc_lpi_prop_sz;	/* PROPBASER table bytes */
@@ -1156,6 +1159,11 @@ gicv3_init_lpis(gicv3_conf_t *gc)
 	uint32_t idbits;
 	uint32_t i;
 
+	ddi_irm_params_t params = {
+		.iparams_types = DDI_INTR_TYPE_MSI |
+		    DDI_INTR_TYPE_MSIX,
+	};
+
 	/* Check if LPIs are supported */
 	if ((gc->gc_gicd_typer & GICD_TYPER_LPIS) == 0)
 		return (DDI_SUCCESS);
@@ -1209,6 +1217,22 @@ gicv3_init_lpis(gicv3_conf_t *gc)
 	gc->gc_lpi_arena = vmem_create("lpi_intid",
 	    (void *)(uintptr_t)GIC_INTID_LPI_MIN,
 	    gc->gc_lpi_count, 1, NULL, NULL, NULL, 0, VM_SLEEP);
+
+	/*
+	 * Create an IRM pool for LPI-backed MSI/MSI-X interrupts.
+	 * The pool size is the total LPI INTID range; IRM uses this
+	 * to rebalance vector allocations across consumers.
+	 *
+	 * ITS instances return this pool via DDI_INTROP_GETPOOL.
+	 */
+	params.iparams_total = gc->gc_lpi_count;
+
+	if (ndi_irm_create(gc->gc_dip, &params,
+	    &gc->gc_lpi_irm_pool) != NDI_SUCCESS) {
+		dev_err(gc->gc_dip, CE_WARN,
+		    "failed to create LPI IRM pool");
+		gc->gc_lpi_irm_pool = NULL;
+	}
 
 	return (DDI_SUCCESS);
 
@@ -2292,6 +2316,16 @@ gicv3_lpi_navail(dev_info_t *gic_dip)
 	if (gc->gc_lpi_arena == NULL)
 		return (0);
 	return (vmem_size(gc->gc_lpi_arena, VMEM_FREE));
+}
+
+ddi_irm_pool_t *
+gicv3_get_lpi_irm_pool(dev_info_t *gic_dip)
+{
+	gicv3_conf_t *gc = ddi_get_soft_state(gicv3_soft_state,
+	    ddi_get_instance(gic_dip));
+
+	VERIFY3P(gc, !=, NULL);
+	return (gc->gc_lpi_irm_pool);
 }
 
 void

--- a/usr/src/uts/armv8/io/gicthree.c
+++ b/usr/src/uts/armv8/io/gicthree.c
@@ -70,11 +70,17 @@
  *   gc_lpi_prop_lock (mutex)
  *     Protects the LPI property table (gc_lpi_prop) reads and writes.
  *
+ *   gc_msi_lock (mutex, blockable - never held with gc_dist_lock)
+ *
  *   ih_rwlock --> syspic_intrs_lock --> gc_dist_lock --> av_lock
- *   gc_lpi_prop_lock is independent (no nesting with other locks).
+ *   gc_lpi_prop_lock and gc_msi_lock are each independent of all the
+ *   above (no nesting).  gc_msi_lock is only acquired from blockable
+ *   context (intr_ops, attach, detach) and must never be held when
+ *   acquiring gc_dist_lock.
  */
 
 #include <sys/types.h>
+#include <sys/stddef.h>
 #include <sys/syspic.h>
 #include <sys/syspic_impl.h>
 #include <sys/gic.h>
@@ -86,6 +92,7 @@
 #include <sys/cpuinfo.h>
 #include <sys/sysmacros.h>
 #include <sys/archsystm.h>
+#include <sys/list.h>
 #include <sys/mach_intr.h>
 #include <sys/gic_v3.h>
 #include <sys/vmem.h>
@@ -136,6 +143,16 @@ typedef struct {
 	ddi_dma_handle_t	gr_pend_dmah;
 	ddi_acc_handle_t	gr_pend_acch;
 } gicv3_redistributor_t;
+
+/*
+ * MSI SPI range - registered by SPI-backed child MSI controllers (v2m)
+ * so the parent can reject direct GETTARGET/SETTARGET for those INTIDs.
+ */
+typedef struct gicv3_msi_range {
+	list_node_t	mr_node;
+	uint32_t	mr_base;	/* first SPI in range */
+	uint32_t	mr_count;	/* number of SPIs */
+} gicv3_msi_range_t;
 
 typedef struct gicv3_conf {
 	/* Base address of, and handle to, the distributor */
@@ -196,6 +213,13 @@ typedef struct gicv3_conf {
 	 * A GICv3 is always the system PIC.
 	 */
 	syspic_ops_t		gc_syspic;
+
+	/*
+	 * MSI SPI ranges registered by child MSI controllers.
+	 * Protected by gc_msi_lock.
+	 */
+	kmutex_t		gc_msi_lock;
+	list_t			gc_msi_ranges;
 } gicv3_conf_t;
 
 #define	TO_CONF(__c)		((gicv3_conf_t *)(__c))
@@ -243,6 +267,13 @@ static inline void
 gicd_write4(gicv3_conf_t *gic, uint32_t reg, uint32_t val)
 {
 	ddi_put32(gic->gc_gicd_regh, (uint32_t *)(gic->gc_gicd + reg), val);
+}
+
+static inline uint64_t
+gicd_read8(gicv3_conf_t *gic, uint32_t reg)
+{
+	return (ddi_get64(gic->gc_gicd_regh,
+	    (uint64_t *)(gic->gc_gicd + reg)));
 }
 
 static inline void
@@ -1562,6 +1593,10 @@ gicv3_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 		    (uint64_t)i_ddi_pd_getreg(dip, 1 + i)->regspec_size;
 	}
 
+	mutex_init(&gc->gc_msi_lock, NULL, MUTEX_DRIVER, NULL);
+	list_create(&gc->gc_msi_ranges, sizeof (gicv3_msi_range_t),
+	    offsetof(gicv3_msi_range_t, mr_node));
+
 	if ((ret = gicv3_init(dip, gc)) != DDI_SUCCESS) {
 		if (gc->gc_num_redist && gc->gc_redist)
 			kmem_free(gc->gc_redist,
@@ -1667,6 +1702,140 @@ gicv3_irq_ispending(gicv3_conf_t *gc, uint32_t irq)
 
 	val = gicd_read4(gc, GICD_ISPENDRn(GICD_IPENDR_REGNUM(irq)));
 	return ((val & GICD_IPENDR_REGBIT(irq)) != 0);
+}
+
+
+/*
+ * Check whether an INTID falls within a registered MSI SPI range.
+ * Caller must hold gc_msi_lock.
+ */
+static boolean_t
+gicv3_is_msi_spi(gicv3_conf_t *gc, uint32_t intid)
+{
+	gicv3_msi_range_t *mr;
+
+	ASSERT(MUTEX_HELD(&gc->gc_msi_lock));
+
+	for (mr = list_head(&gc->gc_msi_ranges); mr != NULL;
+	    mr = list_next(&gc->gc_msi_ranges, mr)) {
+		if (intid >= mr->mr_base &&
+		    intid < mr->mr_base + mr->mr_count) {
+			return (B_TRUE);
+		}
+	}
+
+	return (B_FALSE);
+}
+
+/*
+ * Register an MSI SPI range owned by a child driver (v2m).
+ * Called from child attach.
+ */
+void
+gicv3_register_msi_range(dev_info_t *gic_dip, uint32_t base, uint32_t count)
+{
+	gicv3_conf_t *gc = ddi_get_soft_state(gicv3_soft_state,
+	    ddi_get_instance(gic_dip));
+	gicv3_msi_range_t *mr;
+
+	VERIFY3P(gc, !=, NULL);
+
+	mr = kmem_alloc(sizeof (*mr), KM_SLEEP);
+	mr->mr_base = base;
+	mr->mr_count = count;
+
+	mutex_enter(&gc->gc_msi_lock);
+	list_insert_tail(&gc->gc_msi_ranges, mr);
+	mutex_exit(&gc->gc_msi_lock);
+}
+
+/*
+ * Unregister an MSI SPI range.  Called from child detach.
+ */
+void
+gicv3_unregister_msi_range(dev_info_t *gic_dip, uint32_t base, uint32_t count)
+{
+	gicv3_conf_t *gc = ddi_get_soft_state(gicv3_soft_state,
+	    ddi_get_instance(gic_dip));
+	gicv3_msi_range_t *mr;
+
+	VERIFY3P(gc, !=, NULL);
+
+	mutex_enter(&gc->gc_msi_lock);
+	for (mr = list_head(&gc->gc_msi_ranges); mr != NULL;
+	    mr = list_next(&gc->gc_msi_ranges, mr)) {
+		if (mr->mr_base == base && mr->mr_count == count) {
+			list_remove(&gc->gc_msi_ranges, mr);
+			mutex_exit(&gc->gc_msi_lock);
+			kmem_free(mr, sizeof (*mr));
+			return;
+		}
+	}
+	mutex_exit(&gc->gc_msi_lock);
+	panic("gicv3_unregister_msi_range: range %u+%u not found", base,
+	    count);
+}
+
+/*
+ * Return the CPU targeted by GICD_IROUTERn for an SPI.
+ *
+ * If IRM=1 (any-of-N routing), returns CPU 0 by convention.
+ * Otherwise, extracts the affinity field and maps it to a
+ * processorid_t.  The GICD lock is held only for the register
+ * read; the cpuinfo lookup runs unlocked.
+ */
+processorid_t
+gicv3_get_target_spi(dev_info_t *gic_dip, uint32_t intid)
+{
+	gicv3_conf_t *gc = ddi_get_soft_state(gicv3_soft_state,
+	    ddi_get_instance(gic_dip));
+	uint64_t irouter;
+	struct cpuinfo *ci;
+
+	VERIFY3P(gc, !=, NULL);
+	ASSERT(GIC_INTID_IS_SPI(intid));
+
+	GICD_LOCK(gc);
+	irouter = gicd_read8(gc, GICD_IROUTERn(intid));
+	GICD_UNLOCK(gc);
+
+	if (irouter & GICD_IROUTER_Interrupt_Routing_Mode) {
+		return (0);
+	}
+
+	/*
+	 * The affinity field in IROUTER uses the same layout as MPIDR_EL1
+	 * (Aff3:Aff2:Aff1:Aff0 in bits 39:32, 23:16, 15:8, 7:0).
+	 * cpuinfo stores MPIDR values, so we can look up directly.
+	 * Mask off IRM (bit 31) before the lookup -- it is zero here,
+	 * but be explicit.
+	 */
+	ci = cpuinfo_for_affinity(
+	    irouter & ~GICD_IROUTER_Interrupt_Routing_Mode);
+	if (ci == NULL) {
+		return (0);
+	}
+
+	return (ci->ci_id);
+}
+
+/*
+ * Reprogram GICD_IROUTERn to target a single CPU for an SPI.
+ * Clears IRM (switches from any-of-N to explicit routing).
+ * Acquires and releases GICD lock internally.
+ */
+void
+gicv3_set_target_spi(dev_info_t *gic_dip, uint32_t intid, processorid_t cpuid)
+{
+	gicv3_conf_t *gc = ddi_get_soft_state(gicv3_soft_state,
+	    ddi_get_instance(gic_dip));
+
+	VERIFY3P(gc, !=, NULL);
+	ASSERT(GIC_INTID_IS_SPI(intid));
+
+	GICD_LOCK(gc);
+	gicd_write8(gc, GICD_IROUTERn(intid), cpu[cpuid]->cpu_m.affinity);
+	GICD_UNLOCK(gc);
 }
 
 static int
@@ -1957,13 +2126,90 @@ gicv3_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 		break;
 	}
 
-	case DDI_INTROP_GETTARGET:	/* fallthrough */
-	case DDI_INTROP_SETTARGET:
-		DDI_INTR_NEXDBG((CE_CONT, "gicv3_intr_ops: "
-		    "dip 0x%p, hdlp 0x%p, type 0x%x, inum 0x%x, op 0x%x "
-		    "unimplemented\n",
-		    rdip, hdlp, hdlp->ih_type, hdlp->ih_inum, intr_op));
-		return (DDI_FAILURE);
+	case DDI_INTROP_GETTARGET: {
+		gicv3_conf_t *gc;
+
+		if (gicv3_parse_unitintr(dip, rdip, hdlp,
+		    &cfg, &vector, &sense, &intid) != DDI_SUCCESS) {
+			return (DDI_FAILURE);
+		}
+
+		if (GIC_INTID_IS_PERCPU(intid)) {
+			*(processorid_t *)result = CPU->cpu_id;
+			return (DDI_SUCCESS);
+		}
+		if (GIC_INTID_IS_LPI(intid)) {
+			return (DDI_ENOTSUP);
+		}
+		if (!GIC_INTID_IS_SPI(intid)) {
+			return (DDI_ENOTSUP);
+		}
+
+		gc = ddi_get_soft_state(gicv3_soft_state,
+		    ddi_get_instance(dip));
+		VERIFY3P(gc, !=, NULL);
+
+		mutex_enter(&gc->gc_msi_lock);
+		if (gicv3_is_msi_spi(gc, intid)) {
+			mutex_exit(&gc->gc_msi_lock);
+			return (DDI_ENOTSUP);
+		}
+		mutex_exit(&gc->gc_msi_lock);
+
+		*(processorid_t *)result =
+		    gicv3_get_target_spi(dip, intid);
+		DDI_INTR_NEXDBG((CE_CONT, "gicv3_intr_ops: GETTARGET "
+		    "dip 0x%p, hdlp 0x%p, type 0x%x, inum 0x%x, op 0x%x, "
+		    "vector 0x%x, result 0x%x\n",
+		    rdip, hdlp, hdlp->ih_type, hdlp->ih_inum, intr_op,
+		    intid, *(int *)result));
+		return (DDI_SUCCESS);
+	}
+
+	case DDI_INTROP_SETTARGET: {
+		gicv3_conf_t *gc;
+		processorid_t new_cpu;
+
+		if (gicv3_parse_unitintr(dip, rdip, hdlp,
+		    &cfg, &vector, &sense, &intid) != DDI_SUCCESS) {
+			return (DDI_FAILURE);
+		}
+
+		new_cpu = *(processorid_t *)result;
+
+		if (GIC_INTID_IS_PERCPU(intid)) {
+			return (DDI_ENOTSUP);
+		}
+		if (GIC_INTID_IS_LPI(intid)) {
+			return (DDI_ENOTSUP);
+		}
+		if (!GIC_INTID_IS_SPI(intid)) {
+			return (DDI_ENOTSUP);
+		}
+
+		gc = ddi_get_soft_state(gicv3_soft_state,
+		    ddi_get_instance(dip));
+		VERIFY3P(gc, !=, NULL);
+
+		if (new_cpu < 0 || new_cpu >= (processorid_t)gc->gc_num_redist) {
+			return (DDI_EINVAL);
+		}
+
+		mutex_enter(&gc->gc_msi_lock);
+		if (gicv3_is_msi_spi(gc, intid)) {
+			mutex_exit(&gc->gc_msi_lock);
+			return (DDI_ENOTSUP);
+		}
+		mutex_exit(&gc->gc_msi_lock);
+
+		gicv3_set_target_spi(dip, intid, new_cpu);
+		DDI_INTR_NEXDBG((CE_CONT, "gicv3_intr_ops: SETTARGET "
+		    "dip 0x%p, hdlp 0x%p, type 0x%x, inum 0x%x, op 0x%x, "
+		    "vector 0x%x, new CPU 0x%x\n",
+		    rdip, hdlp, hdlp->ih_type, hdlp->ih_inum, intr_op,
+		    intid, (int)new_cpu));
+		return (DDI_SUCCESS);
+	}
 
 	/* Operations which should never have reached us */
 	default:

--- a/usr/src/uts/armv8/io/gicthree.c
+++ b/usr/src/uts/armv8/io/gicthree.c
@@ -1683,12 +1683,11 @@ gicv3_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 {
 	ASSERT(RW_WRITE_HELD(&hdlp->ih_rwlock));
 
-	switch (intr_op) {
-	case DDI_INTROP_ADDISR:
-		break;
-	case DDI_INTROP_REMISR:
-		break;
+	DDI_INTR_NEXDBG((CE_CONT, "gicv3_intr_ops: "
+	    "dip 0x%p, hdlp 0x%p, type 0x%x, inum 0x%x, op 0x%x\n",
+	    rdip, hdlp, hdlp->ih_type, hdlp->ih_inum, intr_op));
 
+	switch (intr_op) {
 	case DDI_INTROP_ENABLE: {
 		ihdl_plat_t *priv = hdlp->ih_private;
 		gicv3_conf_t *gc =
@@ -1728,17 +1727,32 @@ gicv3_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 		gicv3_config_irq(gc, hdlp->ih_vector, state->si_edge_triggered);
 		state->si_prio = hdlp->ih_pri;
 
+		DDI_INTR_NEXDBG((CE_CONT, "gicv3_intr_ops: ENABLE "
+		    "dip 0x%p, hdlp 0x%p, type 0x%x, inum 0x%x, op 0x%x, "
+		    "vector 0x%x, pri 0x%x, sense %s, devname %s, "
+		    "cbfunc 0x%p, arg1 0x%p, arg2 0x%p\n",
+		    rdip, hdlp, hdlp->ih_type, hdlp->ih_inum, intr_op,
+		    hdlp->ih_vector, hdlp->ih_pri,
+		    state->si_edge_triggered ? "EDGE" : "LEVEL",
+		    DEVI(rdip)->devi_name,
+		    hdlp->ih_cb_func, hdlp->ih_cb_arg1, hdlp->ih_cb_arg2));
+
 		/* Add the interrupt handler */
 		if (!add_avintr((void *)hdlp, hdlp->ih_pri,
 		    hdlp->ih_cb_func, DEVI(rdip)->devi_name, hdlp->ih_vector,
 		    hdlp->ih_cb_arg1, hdlp->ih_cb_arg2, NULL, rdip)) {
 			mutex_exit(&syspic_intrs_lock);
+			DDI_INTR_NEXDBG((CE_CONT, "gicv3_intr_ops: ENABLE "
+			    "dip 0x%p, hdlp 0x%p, type 0x%x, inum 0x%x: "
+			    "add_avintr failed\n",
+			    rdip, hdlp, hdlp->ih_type, hdlp->ih_inum));
 			return (DDI_FAILURE);
 		}
 
 		mutex_exit(&syspic_intrs_lock);
 		break;
 	}
+
 	case DDI_INTROP_DISABLE: {
 		ihdl_plat_t *priv = hdlp->ih_private;
 
@@ -1759,20 +1773,16 @@ gicv3_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 
 		hdlp->ih_vector = GIC_FDT_VEC_TO_IRQ(cfg, vector);
 
+		DDI_INTR_NEXDBG((CE_CONT, "gicv3_intr_ops: DISABLE "
+		    "dip 0x%p, hdlp 0x%p, type 0x%x, inum 0x%x, op 0x%x, "
+		    "vector 0x%x, pri 0x%x, devname %s, cbfunc 0x%p\n",
+		    rdip, hdlp, hdlp->ih_type, hdlp->ih_inum, intr_op,
+		    hdlp->ih_vector, hdlp->ih_pri, DEVI(rdip)->devi_name,
+		    hdlp->ih_cb_func));
+
 		/* Remove the interrupt handler */
 		rem_avintr((void *)hdlp, hdlp->ih_pri,
 		    hdlp->ih_cb_func, hdlp->ih_vector);
-		break;
-	}
-
-	case DDI_INTROP_GETPENDING: {
-		gicv3_conf_t *gc =
-		    ddi_get_soft_state(gicv3_soft_state,
-		    ddi_get_instance(dip));
-		uint32_t irq = hdlp->ih_vector;
-
-		VERIFY3P(gc, !=, NULL);
-		*(int *)result = gicv3_irq_ispending(gc, irq) ? 1 : 0;
 		break;
 	}
 
@@ -1780,31 +1790,49 @@ gicv3_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 		*(int *)result |= DDI_INTR_FLAG_PENDING;
 		*(int *)result |= DDI_INTR_FLAG_EDGE;
 		*(int *)result |= DDI_INTR_FLAG_LEVEL;
+		DDI_INTR_NEXDBG((CE_CONT, "gicv3_intr_ops: GETCAP "
+		    "dip 0x%p, hdlp 0x%p, type 0x%x, inum 0x%x, op 0x%x, "
+		    "result 0x%x\n",
+		    rdip, hdlp, hdlp->ih_type, hdlp->ih_inum, intr_op,
+		    *(int *)result));
 		break;
 
-	case DDI_INTROP_SETCAP:
+	case DDI_INTROP_SETCAP:		/* fallthrough */
+	case DDI_INTROP_SETMASK:	/* fallthrough */
+	case DDI_INTROP_CLRMASK:
+		/* SETCAP should have been filtered out by routing */
+		DDI_INTR_NEXDBG((CE_CONT, "gicv3_intr_ops: "
+		    "dip 0x%p, hdlp 0x%p, type 0x%x, inum 0x%x, op 0x%x "
+		    "unsupported\n",
+		    rdip, hdlp, hdlp->ih_type, hdlp->ih_inum, intr_op));
 		return (DDI_ENOTSUP);
 
-	/* Operations that are valid for us, but unimplemented */
-	case DDI_INTROP_BLOCKDISABLE:
-	case DDI_INTROP_BLOCKENABLE:
+	case DDI_INTROP_GETPENDING: {
+		gicv3_conf_t *gc =
+		    ddi_get_soft_state(gicv3_soft_state,
+		    ddi_get_instance(dip));
+		VERIFY3P(gc, !=, NULL);
+		*(int *)result =
+		    gicv3_irq_ispending(gc, hdlp->ih_vector) ? 1 : 0;
+		DDI_INTR_NEXDBG((CE_CONT, "gicv3_intr_ops: GETPENDING "
+		    "dip 0x%p, hdlp 0x%p, type 0x%x, inum 0x%x, op 0x%x, "
+		    "vector 0x%x, result 0x%x\n",
+		    rdip, hdlp, hdlp->ih_type, hdlp->ih_inum, intr_op,
+		    hdlp->ih_vector, *(int *)result));
+		break;
+	}
+
+	case DDI_INTROP_GETTARGET:	/* fallthrough */
+	case DDI_INTROP_SETTARGET:
+		DDI_INTR_NEXDBG((CE_CONT, "gicv3_intr_ops: "
+		    "dip 0x%p, hdlp 0x%p, type 0x%x, inum 0x%x, op 0x%x "
+		    "unimplemented\n",
+		    rdip, hdlp, hdlp->ih_type, hdlp->ih_inum, intr_op));
 		return (DDI_FAILURE);
 
 	/* Operations which should never have reached us */
-	case DDI_INTROP_ALLOC:
-	case DDI_INTROP_CLRMASK:
-	case DDI_INTROP_DUPVEC:
-	case DDI_INTROP_FREE:
-	case DDI_INTROP_GETPOOL:
-	case DDI_INTROP_GETPRI:
-	case DDI_INTROP_GETTARGET:
-	case DDI_INTROP_NAVAIL:
-	case DDI_INTROP_NINTRS:
-	case DDI_INTROP_SETMASK:
-	case DDI_INTROP_SETPRI:
-	case DDI_INTROP_SETTARGET:
-	case DDI_INTROP_SUPPORTED_TYPES:
-		dev_err(dip, CE_WARN, "unexpected introp %d for %s%d\n",
+	default:
+		dev_err(dip, CE_WARN, "unexpected introp %d for %s%d",
 		    intr_op, ddi_node_name(rdip), ddi_get_instance(rdip));
 		return (DDI_FAILURE);
 	}

--- a/usr/src/uts/armv8/io/gicthree.c
+++ b/usr/src/uts/armv8/io/gicthree.c
@@ -1742,6 +1742,19 @@ gicv3_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 	    rdip, hdlp, hdlp->ih_type, hdlp->ih_inum, intr_op));
 
 	switch (intr_op) {
+	case DDI_INTROP_ALLOC:
+		*(int *)result = hdlp->ih_scratch1;
+		DDI_INTR_NEXDBG((CE_CONT, "gicv3_intr_ops: ALLOC "
+		    "for rdip = 0x%p, inum = 0x%x, result is 0x%x for 0x%x\n",
+		    rdip, hdlp->ih_inum, *(int *)result, hdlp->ih_scratch1));
+		break;
+
+	case DDI_INTROP_FREE:
+		DDI_INTR_NEXDBG((CE_CONT, "gicv3_intr_ops: FREE "
+		    "for rdip = 0x%p, hdlp = 0x%p, inum = 0x%x\n",
+		    rdip, hdlp, hdlp->ih_inum));
+		break;
+
 	case DDI_INTROP_GETPRI: {
 		int shared;
 		uint_t curpri;

--- a/usr/src/uts/armv8/io/gicthree.c
+++ b/usr/src/uts/armv8/io/gicthree.c
@@ -82,6 +82,7 @@
 #include <sys/avintr.h>
 #include <sys/smp_impldefs.h>
 #include <sys/sunddi.h>
+#include <sys/ddi_subrdefs.h>
 #include <sys/cpuinfo.h>
 #include <sys/sysmacros.h>
 #include <sys/archsystm.h>
@@ -1668,6 +1669,54 @@ gicv3_irq_ispending(gicv3_conf_t *gc, uint32_t irq)
 	return ((val & GICD_IPENDR_REGBIT(irq)) != 0);
 }
 
+static int
+gicv3_parse_unitintr(dev_info_t *dip, dev_info_t *rdip,
+    ddi_intr_handle_impl_t *hdlp, uint32_t *pcfg, uint32_t *pvector,
+    uint32_t *psense, uint32_t *pintid)
+{
+	ihdl_plat_t *priv;
+	unit_intr_t *ui;
+	uint32_t *p;
+#if defined(DEBUG)
+	int i;
+#endif
+
+	if ((priv = hdlp->ih_private) == NULL) {
+		DDI_INTR_NEXDBG((CE_CONT, "gicv3_parse_unitintr: "
+		    "for rdip = 0x%p (%s%d), hdlp = 0x%p, inum = 0x%x: "
+		    "no ihdl_plat\n",
+		    rdip, ddi_node_name(rdip), ddi_get_instance(rdip),
+		    hdlp, hdlp->ih_inum));
+		return (DDI_FAILURE);
+	}
+
+	if ((ui = priv->ip_unitintr) == NULL) {
+		DDI_INTR_NEXDBG((CE_CONT, "gicv3_parse_unitintr: "
+		    "for rdip = 0x%p (%s%d), hdlp = 0x%p, inum = 0x%x: "
+		    "no unitintr\n",
+		    rdip, ddi_node_name(rdip), ddi_get_instance(rdip),
+		    hdlp, hdlp->ih_inum));
+		return (DDI_FAILURE);
+	}
+
+	/*
+	 * Always 3+ interrupt cells in the gicv3 binding.
+	 */
+	p = &ui->ui_v[ui->ui_addrcells];
+	*pcfg = *p++;
+	*pvector = *p++;
+	*psense = *p++;
+
+#if defined(DEBUG)
+	for (i = 3; i < priv->ip_unitintr->ui_intrcells; i++) {
+		ASSERT3U(*p++, ==, 0);
+	}
+#endif
+
+	*pintid = GIC_FDT_VEC_TO_IRQ(*pcfg, *pvector);
+	return (DDI_SUCCESS);
+}
+
 /*
  * Field interrupt operation requests to program this interrupt controller.
  *
@@ -1681,6 +1730,11 @@ static int
 gicv3_intr_ops(dev_info_t *dip, dev_info_t *rdip,
     ddi_intr_op_t intr_op, ddi_intr_handle_impl_t *hdlp, void *result)
 {
+	uint32_t cfg;
+	uint32_t vector;
+	uint32_t sense;
+	uint32_t intid;
+
 	ASSERT(RW_WRITE_HELD(&hdlp->ih_rwlock));
 
 	DDI_INTR_NEXDBG((CE_CONT, "gicv3_intr_ops: "
@@ -1688,32 +1742,92 @@ gicv3_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 	    rdip, hdlp, hdlp->ih_type, hdlp->ih_inum, intr_op));
 
 	switch (intr_op) {
+	case DDI_INTROP_GETPRI: {
+		int shared;
+		uint_t curpri;
+
+		if (gicv3_parse_unitintr(dip, rdip, hdlp,
+		    &cfg, &vector, &sense, &intid) != DDI_SUCCESS) {
+			DDI_INTR_NEXDBG((CE_CONT, "gicv3_intr_ops: GETPRI "
+			    "for rdip = 0x%p, hdlp = 0x%p, inum = 0x%x: "
+			    "gicv3_parse_unitintr failed\n",
+			    rdip, hdlp, hdlp->ih_inum));
+			return (DDI_FAILURE);
+		}
+
+		shared = av_get_shared(intid, &curpri);
+		if (shared > 0) {
+			hdlp->ih_pri = curpri;
+		} else if (hdlp->ih_pri == 0) {
+			hdlp->ih_pri = i_ddi_get_intr_pri(rdip, hdlp->ih_inum);
+		}
+
+		ASSERT3U(hdlp->ih_pri, !=, 0);
+		*(int *)result = hdlp->ih_pri;
+		DDI_INTR_NEXDBG((CE_CONT, "gicv3_intr_ops: GETPRI "
+		    "for rdip = 0x%p, hdlp = 0x%p, inum = 0x%x, "
+		    "shared = %d, result = 0x%x\n",
+		    rdip, hdlp, hdlp->ih_inum, shared, *(int *)result));
+		break;
+	}
+
+	case DDI_INTROP_SETPRI: {
+		int shared;
+		uint_t curpri;
+		uint_t newpri;
+
+		DDI_INTR_NEXDBG((CE_CONT, "gicv3_intr_ops: SETPRI "
+		    "for rdip = 0x%p, hdlp = 0x%p, inum = 0x%x, is 0x%x\n",
+		    rdip, hdlp, hdlp->ih_inum, *(int *)result));
+		if (*(int *)result > LOCK_LEVEL) {
+			DDI_INTR_NEXDBG((CE_CONT, "gicv3_intr_ops: SETPRI "
+			    "for rdip = 0x%p, hdlp = 0x%p, inum = 0x%x: "
+			    "new pri %d exceed LOCK_LEVEL %d\n",
+			    rdip, hdlp, hdlp->ih_inum,
+			    *(int *)result, LOCK_LEVEL));
+			return (DDI_FAILURE);
+		}
+
+		if (gicv3_parse_unitintr(dip, rdip, hdlp,
+		    &cfg, &vector, &sense, &intid) != DDI_SUCCESS) {
+			DDI_INTR_NEXDBG((CE_CONT, "gicv3_intr_ops: SETPRI "
+			    "for rdip = 0x%p, hdlp = 0x%p, inum = 0x%x: "
+			    "gicv3_parse_unitintr failed\n",
+			    rdip, hdlp, hdlp->ih_inum));
+			return (DDI_FAILURE);
+		}
+
+		shared = av_get_shared(intid, &curpri);
+		newpri = (uint_t)(*(int *)result);
+		if (shared > 0 && newpri != curpri) {
+			dev_err(dip, CE_NOTE,
+			    "!%s%d: refusing attempt to set pri 0x%x on "
+			    "shared INTID %u with pri 0x%x",
+			    ddi_node_name(rdip), ddi_get_instance(rdip),
+			    newpri, intid, curpri);
+			return (DDI_FAILURE);
+		}
+
+		ASSERT3U(*(int *)result, !=, 0);
+		hdlp->ih_pri = *(int *)result;
+		break;
+	}
+
 	case DDI_INTROP_ENABLE: {
-		ihdl_plat_t *priv = hdlp->ih_private;
 		gicv3_conf_t *gc =
 		    ddi_get_soft_state(gicv3_soft_state, ddi_get_instance(dip));
 		syspic_intr_state_t *state = NULL;
 
-		VERIFY3P(priv, !=, NULL);
-		VERIFY3P(priv->ip_unitintr, !=, NULL);
-		VERIFY3P(gc, !=, NULL);
-
-		/*
-		 * Always 3+ interrupt cells in the gicv3 binding (but this is
-		 * FDT specific, and needs to be better)
-		 */
-		unit_intr_t *ui = priv->ip_unitintr;
-		uint32_t *p = &ui->ui_v[ui->ui_addrcells];
-		const uint32_t cfg = *p++;
-		const uint32_t vector = *p++;
-		const uint32_t sense = *p++;
-
-		for (int i = 3; i < priv->ip_unitintr->ui_intrcells; i++) {
-			ASSERT3U(*p++, ==, 0);
+		if (gicv3_parse_unitintr(dip, rdip, hdlp,
+		    &cfg, &vector, &sense, &intid) != DDI_SUCCESS) {
+			DDI_INTR_NEXDBG((CE_CONT, "gicv3_intr_ops: ENABLE "
+			    "for rdip = 0x%p, hdlp = 0x%p, inum = 0x%x: "
+			    "gicv3_parse_unitintr failed\n",
+			    rdip, hdlp, hdlp->ih_inum));
+			return (DDI_FAILURE);
 		}
 
-		hdlp->ih_vector = GIC_FDT_VEC_TO_IRQ(cfg, vector);
-
+		hdlp->ih_vector = intid;
 		state = syspic_get_state(hdlp->ih_vector);
 		VERIFY3P(state, !=, NULL);
 
@@ -1724,7 +1838,9 @@ gicv3_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 		 */
 		state->si_edge_triggered =
 		    ((sense & 0xff) == 1) ? B_TRUE : B_FALSE;
+		VERIFY3P(gc, !=, NULL);
 		gicv3_config_irq(gc, hdlp->ih_vector, state->si_edge_triggered);
+		ASSERT3U(hdlp->ih_pri, !=, 0);
 		state->si_prio = hdlp->ih_pri;
 
 		DDI_INTR_NEXDBG((CE_CONT, "gicv3_intr_ops: ENABLE "
@@ -1754,24 +1870,17 @@ gicv3_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 	}
 
 	case DDI_INTROP_DISABLE: {
-		ihdl_plat_t *priv = hdlp->ih_private;
+		if (gicv3_parse_unitintr(dip, rdip, hdlp,
+		    &cfg, &vector, &sense, &intid) != DDI_SUCCESS) {
+			DDI_INTR_NEXDBG((CE_CONT, "gicv3_intr_ops: DISABLE "
+			    "for rdip = 0x%p, hdlp = 0x%p, inum = 0x%x: "
+			    "gicv3_parse_unitintr failed\n",
+			    rdip, hdlp, hdlp->ih_inum));
+			return (DDI_FAILURE);
+		}
 
-		VERIFY3P(priv, !=, NULL);
-		VERIFY3P(priv->ip_unitintr, !=, NULL);
-
-		/*
-		 * Always 3+ interrupt cells in the gicv3 binding (but this is
-		 * FDT specific, and needs to be better).
-		 *
-		 * Here we don't use the sense, we asserted in the enable path
-		 * that any fields present but not understood are 0.
-		 */
-		unit_intr_t *ui = priv->ip_unitintr;
-		uint32_t *p = &ui->ui_v[ui->ui_addrcells];
-		const uint32_t cfg = *p++;
-		const uint32_t vector = *p++;
-
-		hdlp->ih_vector = GIC_FDT_VEC_TO_IRQ(cfg, vector);
+		hdlp->ih_vector = intid;
+		ASSERT3U(hdlp->ih_pri, !=, 0);
 
 		DDI_INTR_NEXDBG((CE_CONT, "gicv3_intr_ops: DISABLE "
 		    "dip 0x%p, hdlp 0x%p, type 0x%x, inum 0x%x, op 0x%x, "
@@ -1812,13 +1921,21 @@ gicv3_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 		    ddi_get_soft_state(gicv3_soft_state,
 		    ddi_get_instance(dip));
 		VERIFY3P(gc, !=, NULL);
+		if (gicv3_parse_unitintr(dip, rdip, hdlp,
+		    &cfg, &vector, &sense, &intid) != DDI_SUCCESS) {
+			DDI_INTR_NEXDBG((CE_CONT, "gicv3_intr_ops: GETPENDING "
+			    "for rdip = 0x%p, hdlp = 0x%p, inum = 0x%x: "
+			    "gicv3_parse_unitintr failed\n",
+			    rdip, hdlp, hdlp->ih_inum));
+			return (DDI_FAILURE);
+		}
 		*(int *)result =
-		    gicv3_irq_ispending(gc, hdlp->ih_vector) ? 1 : 0;
+		    gicv3_irq_ispending(gc, intid) ? 1 : 0;
 		DDI_INTR_NEXDBG((CE_CONT, "gicv3_intr_ops: GETPENDING "
 		    "dip 0x%p, hdlp 0x%p, type 0x%x, inum 0x%x, op 0x%x, "
 		    "vector 0x%x, result 0x%x\n",
 		    rdip, hdlp, hdlp->ih_type, hdlp->ih_inum, intr_op,
-		    hdlp->ih_vector, *(int *)result));
+		    intid, *(int *)result));
 		break;
 	}
 

--- a/usr/src/uts/armv8/io/gicthree.c
+++ b/usr/src/uts/armv8/io/gicthree.c
@@ -1935,6 +1935,14 @@ gicv3_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 	    rdip, hdlp, hdlp->ih_type, hdlp->ih_inum, intr_op));
 
 	switch (intr_op) {
+	case DDI_INTROP_NINTRS:		/* fallthrough */
+	case DDI_INTROP_NAVAIL:
+		*(int *)result = i_ddi_get_intx_nintrs(rdip);
+		DDI_INTR_NEXDBG((CE_CONT, "gicv3_intr_ops: op 0x%x "
+		    "for rdip = 0x%p is 0x%x\n",
+		    intr_op, rdip, *(int *)result));
+		break;
+
 	case DDI_INTROP_ALLOC:
 		*(int *)result = hdlp->ih_scratch1;
 		DDI_INTR_NEXDBG((CE_CONT, "gicv3_intr_ops: ALLOC "

--- a/usr/src/uts/armv8/io/gictwo.c
+++ b/usr/src/uts/armv8/io/gictwo.c
@@ -66,10 +66,17 @@
  *     to maintain the invariant that at most one CPU touches the
  *     distributor at a time.
  *
+ *
+ *   gc_msi_lock (mutex, blockable - never held with gc_lock)
  *   ih_rwlock --> syspic_intrs_lock --> gc_lock --> av_lock
+ *
+ *   gc_msi_lock is independent of all the above (no nesting).  It is
+ *   only acquired from blockable context (intr_ops, attach, detach)
+ *   and must never be held when acquiring gc_lock.
  */
 
 #include <sys/types.h>
+#include <sys/stddef.h>
 #include <sys/syspic.h>
 #include <sys/syspic_impl.h>
 #include <sys/gic.h>
@@ -79,7 +86,18 @@
 #include <sys/sunddi.h>
 #include <sys/ddi_subrdefs.h>
 #include <sys/archsystm.h>
+#include <sys/list.h>
 #include <sys/mach_intr.h>
+
+/*
+ * MSI SPI range - registered by child MSI controllers (v2m) so the
+ * parent can reject direct GETTARGET/SETTARGET for those INTIDs.
+ */
+typedef struct gicv2_msi_range {
+	list_node_t	mr_node;
+	uint32_t	mr_base;	/* first SPI in range */
+	uint32_t	mr_count;	/* number of SPIs */
+} gicv2_msi_range_t;
 
 typedef struct {
 	/* Base address and access handle for the CPU interface */
@@ -127,6 +145,13 @@ typedef struct {
 	 * A GICv3 is always the system PIC.
 	 */
 	syspic_ops_t		gc_syspic;
+
+	/*
+	 * MSI SPI ranges registered by child MSI controllers.
+	 * Protected by gc_msi_lock.
+	 */
+	kmutex_t		gc_msi_lock;
+	list_t			gc_msi_ranges;
 } gicv2_conf_t;
 
 #define	TO_CONF(__c)		((gicv2_conf_t *)(__c))
@@ -378,6 +403,130 @@ gicv2_irq_ispending(dev_info_t *gic_dip, uint32_t irq)
 	val = gicd_read(sc, GICD_ISPENDRn(GICD_IPENDR_REGNUM(irq)));
 	GICV2_GICD_UNLOCK(sc);
 	return ((val & GICD_IPENDR_REGBIT(irq)) != 0);
+}
+
+/*
+ * Check whether an INTID falls within a registered MSI SPI range.
+ * Caller must hold gc_msi_lock.
+ */
+static boolean_t
+gicv2_is_msi_spi(gicv2_conf_t *sc, uint32_t intid)
+{
+	gicv2_msi_range_t *mr;
+
+	ASSERT(MUTEX_HELD(&sc->gc_msi_lock));
+
+	for (mr = list_head(&sc->gc_msi_ranges); mr != NULL;
+	    mr = list_next(&sc->gc_msi_ranges, mr)) {
+		if (intid >= mr->mr_base &&
+		    intid < mr->mr_base + mr->mr_count) {
+			return (B_TRUE);
+		}
+	}
+
+	return (B_FALSE);
+}
+
+/*
+ * Register an MSI SPI range owned by a child driver (v2m).
+ * Called from child attach.
+ */
+void
+gicv2_register_msi_range(dev_info_t *gic_dip, uint32_t base, uint32_t count)
+{
+	gicv2_conf_t *sc = ddi_get_soft_state(gicv2_soft_state,
+	    ddi_get_instance(gic_dip));
+	gicv2_msi_range_t *mr;
+
+	VERIFY3P(sc, !=, NULL);
+
+	mr = kmem_alloc(sizeof (*mr), KM_SLEEP);
+	mr->mr_base = base;
+	mr->mr_count = count;
+
+	mutex_enter(&sc->gc_msi_lock);
+	list_insert_tail(&sc->gc_msi_ranges, mr);
+	mutex_exit(&sc->gc_msi_lock);
+}
+
+/*
+ * Unregister an MSI SPI range.  Called from child detach.
+ */
+void
+gicv2_unregister_msi_range(dev_info_t *gic_dip, uint32_t base, uint32_t count)
+{
+	gicv2_conf_t *sc = ddi_get_soft_state(gicv2_soft_state,
+	    ddi_get_instance(gic_dip));
+	gicv2_msi_range_t *mr;
+
+	VERIFY3P(sc, !=, NULL);
+
+	mutex_enter(&sc->gc_msi_lock);
+	for (mr = list_head(&sc->gc_msi_ranges); mr != NULL;
+	    mr = list_next(&sc->gc_msi_ranges, mr)) {
+		if (mr->mr_base == base && mr->mr_count == count) {
+			list_remove(&sc->gc_msi_ranges, mr);
+			mutex_exit(&sc->gc_msi_lock);
+			kmem_free(mr, sizeof (*mr));
+			return;
+		}
+	}
+	mutex_exit(&sc->gc_msi_lock);
+	panic("gicv2_unregister_msi_range: range %u+%u not found", base,
+	    count);
+}
+
+/*
+ * Return the CPU targeted by GICD_ITARGETSRn for an SPI.
+ *
+ * The ITARGETS field is a bitmask of target CPUs; we return the
+ * lowest-numbered one.  Acquires and releases GICD lock internally.
+ */
+processorid_t
+gicv2_get_target_spi(dev_info_t *gic_dip, uint32_t intid)
+{
+	gicv2_conf_t *sc = ddi_get_soft_state(gicv2_soft_state,
+	    ddi_get_instance(gic_dip));
+	uint32_t reg;
+	uint8_t targets;
+
+	VERIFY3P(sc, !=, NULL);
+	ASSERT(GIC_INTID_IS_SPI(intid));
+
+	GICV2_GICD_LOCK(sc);
+	reg = gicd_read(sc, GICD_ITARGETSRn(GICD_ITARGETSR_REGNUM(intid)));
+	GICV2_GICD_UNLOCK(sc);
+
+	targets = GICD_ITARGETSR_GETTARGETS(reg, intid);
+
+	if (targets == 0) {
+		return (0);
+	}
+
+	/* Return lowest set bit (lowest-numbered targeted CPU) */
+	return ((processorid_t)(lowbit(targets) - 1));
+}
+
+/*
+ * Reprogram GICD_ITARGETSRn to target a single CPU for an SPI.
+ * Acquires and releases GICD lock internally.
+ */
+void
+gicv2_set_target_spi(dev_info_t *gic_dip, uint32_t intid, processorid_t cpuid)
+{
+	gicv2_conf_t *sc = ddi_get_soft_state(gicv2_soft_state,
+	    ddi_get_instance(gic_dip));
+
+	VERIFY3P(sc, !=, NULL);
+	ASSERT(GIC_INTID_IS_SPI(intid));
+	ASSERT3U(cpuid, <, 8);
+
+	GICV2_GICD_LOCK(sc);
+	(void) gicd_rmw(sc,
+	    GICD_ITARGETSRn(GICD_ITARGETSR_REGNUM(intid)),
+	    GICD_ITARGETSR_REGVAL(intid, GICD_ITARGETSR_REGMASK),
+	    GICD_ITARGETSR_REGVAL(intid, (1u << cpuid)));
+	GICV2_GICD_UNLOCK(sc);
 }
 
 /*
@@ -922,6 +1071,9 @@ gicv2_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 
 	GICV2_GICD_LOCK_INIT_HELD(xconf);
 
+	mutex_init(&xconf->gc_msi_lock, NULL, MUTEX_DRIVER, NULL);
+	list_create(&xconf->gc_msi_ranges, sizeof (gicv2_msi_range_t),
+	    offsetof(gicv2_msi_range_t, mr_node));
 	if ((ret = gicv2_init(xconf)) != DDI_SUCCESS) {
 		GICV2_GICD_UNLOCK(xconf);
 		ddi_regs_map_free(&xconf->gc_gicc_regh);
@@ -1274,13 +1426,82 @@ gicv2_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 		break;
 	}
 
-	case DDI_INTROP_GETTARGET:	/* fallthrough */
-	case DDI_INTROP_SETTARGET:
-		DDI_INTR_NEXDBG((CE_CONT, "gicv2_intr_ops: "
-		    "dip 0x%p, hdlp 0x%p, type 0x%x, inum 0x%x, op 0x%x "
-		    "unimplemented\n",
-		    rdip, hdlp, hdlp->ih_type, hdlp->ih_inum, intr_op));
-		return (DDI_FAILURE);
+	case DDI_INTROP_GETTARGET: {
+		gicv2_conf_t *sc;
+
+		if (gicv2_parse_unitintr(dip, rdip, hdlp,
+		    &cfg, &vector, &sense, &intid) != DDI_SUCCESS) {
+			return (DDI_FAILURE);
+		}
+
+		if (GIC_INTID_IS_PERCPU(intid)) {
+			*(processorid_t *)result = CPU->cpu_id;
+			return (DDI_SUCCESS);
+		}
+		if (!GIC_INTID_IS_SPI(intid)) {
+			return (DDI_ENOTSUP);
+		}
+
+		sc = ddi_get_soft_state(gicv2_soft_state,
+		    ddi_get_instance(dip));
+		VERIFY3P(sc, !=, NULL);
+
+		mutex_enter(&sc->gc_msi_lock);
+		if (gicv2_is_msi_spi(sc, intid)) {
+			mutex_exit(&sc->gc_msi_lock);
+			return (DDI_ENOTSUP);
+		}
+		mutex_exit(&sc->gc_msi_lock);
+
+		*(processorid_t *)result = gicv2_get_target_spi(dip, intid);
+		DDI_INTR_NEXDBG((CE_CONT, "gicv2_intr_ops: GETTARGET "
+		    "dip 0x%p, hdlp 0x%p, type 0x%x, inum 0x%x, op 0x%x, "
+		    "vector 0x%x, result 0x%x\n",
+		    rdip, hdlp, hdlp->ih_type, hdlp->ih_inum, intr_op,
+		    intid, *(int *)result));
+		return (DDI_SUCCESS);
+	}
+
+	case DDI_INTROP_SETTARGET: {
+		gicv2_conf_t *sc;
+		processorid_t new_cpu;
+
+		if (gicv2_parse_unitintr(dip, rdip, hdlp,
+		    &cfg, &vector, &sense, &intid) != DDI_SUCCESS) {
+			return (DDI_FAILURE);
+		}
+
+		new_cpu = *(processorid_t *)result;
+
+		if (GIC_INTID_IS_PERCPU(intid)) {
+			return (DDI_ENOTSUP);
+		}
+		if (!GIC_INTID_IS_SPI(intid)) {
+			return (DDI_ENOTSUP);
+		}
+		if (new_cpu < 0 || new_cpu >= 8) {
+			return (DDI_EINVAL);
+		}
+
+		sc = ddi_get_soft_state(gicv2_soft_state,
+		    ddi_get_instance(dip));
+		VERIFY3P(sc, !=, NULL);
+
+		mutex_enter(&sc->gc_msi_lock);
+		if (gicv2_is_msi_spi(sc, intid)) {
+			mutex_exit(&sc->gc_msi_lock);
+			return (DDI_ENOTSUP);
+		}
+		mutex_exit(&sc->gc_msi_lock);
+
+		gicv2_set_target_spi(dip, intid, new_cpu);
+		DDI_INTR_NEXDBG((CE_CONT, "gicv2_intr_ops: SETTARGET "
+		    "dip 0x%p, hdlp 0x%p, type 0x%x, inum 0x%x, op 0x%x, "
+		    "vector 0x%x, new CPU 0x%x\n",
+		    rdip, hdlp, hdlp->ih_type, hdlp->ih_inum, intr_op,
+		    intid, (int)new_cpu));
+		return (DDI_SUCCESS);
+	}
 
 	/* Operations which should never have reached us */
 	default:

--- a/usr/src/uts/armv8/io/gictwo.c
+++ b/usr/src/uts/armv8/io/gictwo.c
@@ -1057,6 +1057,19 @@ gicv2_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 	    rdip, hdlp, hdlp->ih_type, hdlp->ih_inum, intr_op));
 
 	switch (intr_op) {
+	case DDI_INTROP_ALLOC:
+		*(int *)result = hdlp->ih_scratch1;
+		DDI_INTR_NEXDBG((CE_CONT, "gicv2_intr_ops: ALLOC "
+		    "for rdip = 0x%p, inum = 0x%x, result is 0x%x for 0x%x\n",
+		    rdip, hdlp->ih_inum, *(int *)result, hdlp->ih_scratch1));
+		break;
+
+	case DDI_INTROP_FREE:
+		DDI_INTR_NEXDBG((CE_CONT, "gicv2_intr_ops: FREE "
+		    "for rdip = 0x%p, hdlp = 0x%p, inum = 0x%x\n",
+		    rdip, hdlp, hdlp->ih_inum));
+		break;
+
 	case DDI_INTROP_GETPRI: {
 		int shared;
 		uint_t curpri;

--- a/usr/src/uts/armv8/io/gictwo.c
+++ b/usr/src/uts/armv8/io/gictwo.c
@@ -77,7 +77,6 @@
 #include <sys/avintr.h>
 #include <sys/smp_impldefs.h>
 #include <sys/sunddi.h>
-#include <sys/smp_impldefs.h>
 #include <sys/archsystm.h>
 #include <sys/mach_intr.h>
 
@@ -1008,11 +1007,11 @@ gicv2_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 {
 	ASSERT(RW_WRITE_HELD(&hdlp->ih_rwlock));
 
+	DDI_INTR_NEXDBG((CE_CONT, "gicv2_intr_ops: "
+	    "dip 0x%p, hdlp 0x%p, type 0x%x, inum 0x%x, op 0x%x\n",
+	    rdip, hdlp, hdlp->ih_type, hdlp->ih_inum, intr_op));
+
 	switch (intr_op) {
-	case DDI_INTROP_ADDISR:
-		break;
-	case DDI_INTROP_REMISR:
-		break;
 	case DDI_INTROP_ENABLE: {
 		ihdl_plat_t *priv = hdlp->ih_private;
 		gicv2_conf_t *sc =
@@ -1051,17 +1050,32 @@ gicv2_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 		gicv2_config_irq(sc, hdlp->ih_vector, state->si_edge_triggered);
 		state->si_prio = hdlp->ih_pri;
 
+		DDI_INTR_NEXDBG((CE_CONT, "gicv2_intr_ops: ENABLE "
+		    "dip 0x%p, hdlp 0x%p, type 0x%x, inum 0x%x, op 0x%x, "
+		    "vector 0x%x, pri 0x%x, sense %s, devname %s, "
+		    "cbfunc 0x%p, arg1 0x%p, arg2 0x%p\n",
+		    rdip, hdlp, hdlp->ih_type, hdlp->ih_inum, intr_op,
+		    hdlp->ih_vector, hdlp->ih_pri,
+		    state->si_edge_triggered ? "EDGE" : "LEVEL",
+		    DEVI(rdip)->devi_name,
+		    hdlp->ih_cb_func, hdlp->ih_cb_arg1, hdlp->ih_cb_arg2));
+
 		/* Add the interrupt handler */
 		if (!add_avintr((void *)hdlp, hdlp->ih_pri,
 		    hdlp->ih_cb_func, DEVI(rdip)->devi_name, hdlp->ih_vector,
 		    hdlp->ih_cb_arg1, hdlp->ih_cb_arg2, NULL, rdip)) {
 			mutex_exit(&syspic_intrs_lock);
+			DDI_INTR_NEXDBG((CE_CONT, "gicv2_intr_ops: ENABLE "
+			    "dip 0x%p, hdlp 0x%p, type 0x%x, inum 0x%x: "
+			    "add_avintr failed\n",
+			    rdip, hdlp, hdlp->ih_type, hdlp->ih_inum));
 			return (DDI_FAILURE);
 		}
 
 		mutex_exit(&syspic_intrs_lock);
 		break;
 	}
+
 	case DDI_INTROP_DISABLE: {
 		ihdl_plat_t *priv = hdlp->ih_private;
 
@@ -1081,16 +1095,16 @@ gicv2_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 
 		hdlp->ih_vector = GIC_FDT_VEC_TO_IRQ(cfg, vector);
 
+		DDI_INTR_NEXDBG((CE_CONT, "gicv2_intr_ops: DISABLE "
+		    "dip 0x%p, hdlp 0x%p, type 0x%x, inum 0x%x, op 0x%x, "
+		    "vector 0x%x, pri 0x%x, devname %s, cbfunc 0x%p\n",
+		    rdip, hdlp, hdlp->ih_type, hdlp->ih_inum, intr_op,
+		    hdlp->ih_vector, hdlp->ih_pri, DEVI(rdip)->devi_name,
+		    hdlp->ih_cb_func));
+
 		/* Remove the interrupt handler */
 		rem_avintr((void *)hdlp, hdlp->ih_pri,
 		    hdlp->ih_cb_func, hdlp->ih_vector);
-		break;
-	}
-
-	case DDI_INTROP_GETPENDING: {
-		uint32_t irq = hdlp->ih_vector;
-
-		*(int *)result = gicv2_irq_ispending(dip, irq) ? 1 : 0;
 		break;
 	}
 
@@ -1098,31 +1112,46 @@ gicv2_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 		*(int *)result |= DDI_INTR_FLAG_PENDING;
 		*(int *)result |= DDI_INTR_FLAG_EDGE;
 		*(int *)result |= DDI_INTR_FLAG_LEVEL;
+		DDI_INTR_NEXDBG((CE_CONT, "gicv2_intr_ops: GETCAP "
+		    "dip 0x%p, hdlp 0x%p, type 0x%x, inum 0x%x, op 0x%x, "
+		    "result 0x%x\n",
+		    rdip, hdlp, hdlp->ih_type, hdlp->ih_inum, intr_op,
+		    *(int *)result));
 		break;
 
-	case DDI_INTROP_SETCAP:
+	case DDI_INTROP_SETCAP:		/* fallthrough */
+	case DDI_INTROP_SETMASK:	/* fallthrough */
+	case DDI_INTROP_CLRMASK:
+		/* SETCAP should have been filtered out by routing */
+		DDI_INTR_NEXDBG((CE_CONT, "gicv2_intr_ops: "
+		    "dip 0x%p, hdlp 0x%p, type 0x%x, inum 0x%x, op 0x%x "
+		    "unsupported\n",
+		    rdip, hdlp, hdlp->ih_type, hdlp->ih_inum, intr_op));
 		return (DDI_ENOTSUP);
 
-	/* Operations that are valid for us, but unimplemented */
-	case DDI_INTROP_BLOCKDISABLE:
-	case DDI_INTROP_BLOCKENABLE:
+	case DDI_INTROP_GETPENDING: {
+		*(int *)result =
+		    gicv2_irq_ispending(dip, hdlp->ih_vector) ? 1 : 0;
+		DDI_INTR_NEXDBG((CE_CONT, "gicv2_intr_ops: GETPENDING "
+		    "dip 0x%p, hdlp 0x%p, type 0x%x, inum 0x%x, op 0x%x, "
+		    "vector 0x%x, result 0x%x\n",
+		    rdip, hdlp, hdlp->ih_type, hdlp->ih_inum, intr_op,
+		    hdlp->ih_vector, *(int *)result));
+
+		break;
+	}
+
+	case DDI_INTROP_GETTARGET:	/* fallthrough */
+	case DDI_INTROP_SETTARGET:
+		DDI_INTR_NEXDBG((CE_CONT, "gicv2_intr_ops: "
+		    "dip 0x%p, hdlp 0x%p, type 0x%x, inum 0x%x, op 0x%x "
+		    "unimplemented\n",
+		    rdip, hdlp, hdlp->ih_type, hdlp->ih_inum, intr_op));
 		return (DDI_FAILURE);
 
 	/* Operations which should never have reached us */
-	case DDI_INTROP_ALLOC:
-	case DDI_INTROP_CLRMASK:
-	case DDI_INTROP_DUPVEC:
-	case DDI_INTROP_FREE:
-	case DDI_INTROP_GETPOOL:
-	case DDI_INTROP_GETPRI:
-	case DDI_INTROP_GETTARGET:
-	case DDI_INTROP_NAVAIL:
-	case DDI_INTROP_NINTRS:
-	case DDI_INTROP_SETMASK:
-	case DDI_INTROP_SETPRI:
-	case DDI_INTROP_SETTARGET:
-	case DDI_INTROP_SUPPORTED_TYPES:
-		dev_err(dip, CE_WARN, "unexpected introp %d for %s%d\n",
+	default:
+		dev_err(dip, CE_WARN, "unexpected introp %d for %s%d",
 		    intr_op, ddi_node_name(rdip), ddi_get_instance(rdip));
 		return (DDI_FAILURE);
 	}

--- a/usr/src/uts/armv8/io/gictwo.c
+++ b/usr/src/uts/armv8/io/gictwo.c
@@ -77,6 +77,7 @@
 #include <sys/avintr.h>
 #include <sys/smp_impldefs.h>
 #include <sys/sunddi.h>
+#include <sys/ddi_subrdefs.h>
 #include <sys/archsystm.h>
 #include <sys/mach_intr.h>
 
@@ -992,6 +993,45 @@ gicv2_bus_ctl(dev_info_t *dip, dev_info_t *rdip, ddi_ctl_enum_t ctlop,
 	return (ret);
 }
 
+static int
+gicv2_parse_unitintr(dev_info_t *dip, dev_info_t *rdip,
+    ddi_intr_handle_impl_t *hdlp, uint32_t *pcfg, uint32_t *pvector,
+    uint32_t *psense, uint32_t *pintid)
+{
+	ihdl_plat_t *priv;
+	unit_intr_t *ui;
+	uint32_t *p;
+
+	if ((priv = hdlp->ih_private) == NULL) {
+		DDI_INTR_NEXDBG((CE_CONT, "gicv2_parse_unitintr: "
+		    "for rdip = 0x%p (%s%d), hdlp = 0x%p, inum = 0x%x: "
+		    "no ihdl_plat\n",
+		    rdip, ddi_node_name(rdip), ddi_get_instance(rdip),
+		    hdlp, hdlp->ih_inum));
+		return (DDI_FAILURE);
+	}
+
+	if ((ui = priv->ip_unitintr) == NULL) {
+		DDI_INTR_NEXDBG((CE_CONT, "gicv2_parse_unitintr: "
+		    "for rdip = 0x%p (%s%d), hdlp = 0x%p, inum = 0x%x: "
+		    "no unitintr\n",
+		    rdip, ddi_node_name(rdip), ddi_get_instance(rdip),
+		    hdlp, hdlp->ih_inum));
+		return (DDI_FAILURE);
+	}
+
+	/*
+	 * Always 3 interrupt cells in the gicv2 binding.
+	 */
+	p = &ui->ui_v[ui->ui_addrcells];
+	*pcfg = *p++;
+	*pvector = *p++;
+	*psense = *p++;
+
+	*pintid = GIC_FDT_VEC_TO_IRQ(*pcfg, *pvector);
+	return (DDI_SUCCESS);
+}
+
 /*
  * Field interrupt operation requests to program this interrupt controller.
  *
@@ -1005,6 +1045,11 @@ static int
 gicv2_intr_ops(dev_info_t *dip, dev_info_t *rdip,
     ddi_intr_op_t intr_op, ddi_intr_handle_impl_t *hdlp, void *result)
 {
+	uint32_t cfg;
+	uint32_t vector;
+	uint32_t sense;
+	uint32_t intid;
+
 	ASSERT(RW_WRITE_HELD(&hdlp->ih_rwlock));
 
 	DDI_INTR_NEXDBG((CE_CONT, "gicv2_intr_ops: "
@@ -1012,27 +1057,92 @@ gicv2_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 	    rdip, hdlp, hdlp->ih_type, hdlp->ih_inum, intr_op));
 
 	switch (intr_op) {
+	case DDI_INTROP_GETPRI: {
+		int shared;
+		uint_t curpri;
+
+		if (gicv2_parse_unitintr(dip, rdip, hdlp,
+		    &cfg, &vector, &sense, &intid) != DDI_SUCCESS) {
+			DDI_INTR_NEXDBG((CE_CONT, "gicv2_intr_ops: GETPRI "
+			    "for rdip = 0x%p, hdlp = 0x%p, inum = 0x%x: "
+			    "gicv2_parse_unitintr failed\n",
+			    rdip, hdlp, hdlp->ih_inum));
+			return (DDI_FAILURE);
+		}
+
+		shared = av_get_shared(intid, &curpri);
+		if (shared > 0) {
+			hdlp->ih_pri = curpri;
+		} else if (hdlp->ih_pri == 0) {
+			hdlp->ih_pri = i_ddi_get_intr_pri(rdip, hdlp->ih_inum);
+		}
+
+		ASSERT3U(hdlp->ih_pri, !=, 0);
+		*(int *)result = hdlp->ih_pri;
+		DDI_INTR_NEXDBG((CE_CONT, "gicv2_intr_ops: GETPRI "
+		    "for rdip = 0x%p, hdlp = 0x%p, inum = 0x%x, "
+		    "shared = %d, result = 0x%x\n",
+		    rdip, hdlp, hdlp->ih_inum, shared, *(int *)result));
+		break;
+	}
+
+	case DDI_INTROP_SETPRI: {
+		int shared;
+		uint_t curpri;
+		uint_t newpri;
+
+		DDI_INTR_NEXDBG((CE_CONT, "gicv2_intr_ops: SETPRI "
+		    "for rdip = 0x%p, hdlp = 0x%p, inum = 0x%x, is 0x%x\n",
+		    rdip, hdlp, hdlp->ih_inum, *(int *)result));
+		if (*(int *)result > LOCK_LEVEL) {
+			DDI_INTR_NEXDBG((CE_CONT, "gicv2_intr_ops: SETPRI "
+			    "for rdip = 0x%p, hdlp = 0x%p, inum = 0x%x: "
+			    "new pri %d exceed LOCK_LEVEL %d\n",
+			    rdip, hdlp, hdlp->ih_inum,
+			    *(int *)result, LOCK_LEVEL));
+			return (DDI_FAILURE);
+		}
+
+		if (gicv2_parse_unitintr(dip, rdip, hdlp,
+		    &cfg, &vector, &sense, &intid) != DDI_SUCCESS) {
+			DDI_INTR_NEXDBG((CE_CONT, "gicv2_intr_ops: SETPRI "
+			    "for rdip = 0x%p, hdlp = 0x%p, inum = 0x%x: "
+			    "gicv2_parse_unitintr failed\n",
+			    rdip, hdlp, hdlp->ih_inum));
+			return (DDI_FAILURE);
+		}
+
+		shared = av_get_shared(intid, &curpri);
+		newpri = (uint_t)(*(int *)result);
+		if (shared > 0 && newpri != curpri) {
+			dev_err(dip, CE_NOTE,
+			    "!%s%d: refusing attempt to set pri 0x%x on "
+			    "shared INTID %u with pri 0x%x",
+			    ddi_node_name(rdip), ddi_get_instance(rdip),
+			    newpri, intid, curpri);
+			return (DDI_FAILURE);
+		}
+
+		ASSERT3U(*(int *)result, !=, 0);
+		hdlp->ih_pri = *(int *)result;
+		break;
+	}
+
 	case DDI_INTROP_ENABLE: {
-		ihdl_plat_t *priv = hdlp->ih_private;
 		gicv2_conf_t *sc =
 		    ddi_get_soft_state(gicv2_soft_state, ddi_get_instance(dip));
 		syspic_intr_state_t *state = NULL;
 
-		VERIFY3P(priv, !=, NULL);
-		VERIFY3P(priv->ip_unitintr, !=, NULL);
-		VERIFY3P(sc, !=, NULL);
+		if (gicv2_parse_unitintr(dip, rdip, hdlp,
+		    &cfg, &vector, &sense, &intid) != DDI_SUCCESS) {
+			DDI_INTR_NEXDBG((CE_CONT, "gicv2_intr_ops: ENABLE "
+			    "for rdip = 0x%p, hdlp = 0x%p, inum = 0x%x: "
+			    "gicv2_parse_unitintr failed\n",
+			    rdip, hdlp, hdlp->ih_inum));
+			return (DDI_FAILURE);
+		}
 
-		/*
-		 * Always 3 interrupt cells in the gicv2 binding (but this is
-		 * FDT specific, and needs to be better)
-		 */
-		unit_intr_t *ui = priv->ip_unitintr;
-		uint32_t *p = &ui->ui_v[ui->ui_addrcells];
-		const uint32_t cfg = *p++;
-		const uint32_t vector = *p++;
-		const uint32_t sense = *p++;
-
-		hdlp->ih_vector = GIC_FDT_VEC_TO_IRQ(cfg, vector);
+		hdlp->ih_vector = intid;
 
 		state = syspic_get_state(hdlp->ih_vector);
 		VERIFY3P(state, !=, NULL);
@@ -1047,7 +1157,9 @@ gicv2_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 		state->si_edge_triggered =
 		    ((sense & 0xf) == 1 || (sense & 0xf) == 2) ?
 		    B_TRUE : B_FALSE;
+		VERIFY3P(sc, !=, NULL);
 		gicv2_config_irq(sc, hdlp->ih_vector, state->si_edge_triggered);
+		ASSERT3U(hdlp->ih_pri, !=, 0);
 		state->si_prio = hdlp->ih_pri;
 
 		DDI_INTR_NEXDBG((CE_CONT, "gicv2_intr_ops: ENABLE "
@@ -1077,23 +1189,17 @@ gicv2_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 	}
 
 	case DDI_INTROP_DISABLE: {
-		ihdl_plat_t *priv = hdlp->ih_private;
+		if (gicv2_parse_unitintr(dip, rdip, hdlp,
+		    &cfg, &vector, &sense, &intid) != DDI_SUCCESS) {
+			DDI_INTR_NEXDBG((CE_CONT, "gicv2_intr_ops: DISABLE "
+			    "for rdip = 0x%p, hdlp = 0x%p, inum = 0x%x: "
+			    "gicv2_parse_unitintr failed\n",
+			    rdip, hdlp, hdlp->ih_inum));
+			return (DDI_FAILURE);
+		}
 
-		VERIFY3P(priv, !=, NULL);
-		VERIFY3P(priv->ip_unitintr, !=, NULL);
-
-		/*
-		 * Always 3 interrupt cells in the gicv2 binding (but this is
-		 * FDT specific, and needs to be better).
-		 *
-		 * Here we don't use the sense
-		 */
-		unit_intr_t *ui = priv->ip_unitintr;
-		uint32_t *p = &ui->ui_v[ui->ui_addrcells];
-		const uint32_t cfg = *p++;
-		const uint32_t vector = *p++;
-
-		hdlp->ih_vector = GIC_FDT_VEC_TO_IRQ(cfg, vector);
+		hdlp->ih_vector = intid;
+		ASSERT3U(hdlp->ih_pri, !=, 0);
 
 		DDI_INTR_NEXDBG((CE_CONT, "gicv2_intr_ops: DISABLE "
 		    "dip 0x%p, hdlp 0x%p, type 0x%x, inum 0x%x, op 0x%x, "
@@ -1130,13 +1236,22 @@ gicv2_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 		return (DDI_ENOTSUP);
 
 	case DDI_INTROP_GETPENDING: {
+		if (gicv2_parse_unitintr(dip, rdip, hdlp,
+		    &cfg, &vector, &sense, &intid) != DDI_SUCCESS) {
+			DDI_INTR_NEXDBG((CE_CONT, "gicv2_intr_ops: GETPENDING "
+			    "for rdip = 0x%p, hdlp = 0x%p, inum = 0x%x: "
+			    "gicv2_parse_unitintr failed\n",
+			    rdip, hdlp, hdlp->ih_inum));
+			return (DDI_FAILURE);
+		}
+
 		*(int *)result =
-		    gicv2_irq_ispending(dip, hdlp->ih_vector) ? 1 : 0;
+		    gicv2_irq_ispending(dip, intid) ? 1 : 0;
 		DDI_INTR_NEXDBG((CE_CONT, "gicv2_intr_ops: GETPENDING "
 		    "dip 0x%p, hdlp 0x%p, type 0x%x, inum 0x%x, op 0x%x, "
 		    "vector 0x%x, result 0x%x\n",
 		    rdip, hdlp, hdlp->ih_type, hdlp->ih_inum, intr_op,
-		    hdlp->ih_vector, *(int *)result));
+		    intid, *(int *)result));
 
 		break;
 	}

--- a/usr/src/uts/armv8/io/gictwo.c
+++ b/usr/src/uts/armv8/io/gictwo.c
@@ -1141,6 +1141,11 @@ gicv2_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 		break;
 	}
 
+	case DDI_INTROP_ADDISR:	/* fallthrough */
+	case DDI_INTROP_REMISR:
+		/* no-op in this implementation */
+		break;
+
 	case DDI_INTROP_ENABLE: {
 		gicv2_conf_t *sc =
 		    ddi_get_soft_state(gicv2_soft_state, ddi_get_instance(dip));

--- a/usr/src/uts/armv8/io/gictwo.c
+++ b/usr/src/uts/armv8/io/gictwo.c
@@ -1209,6 +1209,14 @@ gicv2_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 	    rdip, hdlp, hdlp->ih_type, hdlp->ih_inum, intr_op));
 
 	switch (intr_op) {
+	case DDI_INTROP_NINTRS:		/* fallthrough */
+	case DDI_INTROP_NAVAIL:
+		*(int *)result = i_ddi_get_intx_nintrs(rdip);
+		DDI_INTR_NEXDBG((CE_CONT, "gicv2_intr_ops: op 0x%x "
+		    "for rdip = 0x%p is 0x%x\n",
+		    intr_op, rdip, *(int *)result));
+		break;
+
 	case DDI_INTROP_ALLOC:
 		*(int *)result = hdlp->ih_scratch1;
 		DDI_INTR_NEXDBG((CE_CONT, "gicv2_intr_ops: ALLOC "

--- a/usr/src/uts/armv8/io/gicv2m.c
+++ b/usr/src/uts/armv8/io/gicv2m.c
@@ -602,6 +602,40 @@ gicv2m_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 		return (gicv2m_gettarget(sc, rdip, hdlp, result));
 	case DDI_INTROP_SETTARGET:
 		return (gicv2m_settarget(sc, rdip, hdlp, result));
+	case DDI_INTROP_SETPRI: {
+		int shared;
+		uint_t curpri;
+		uint_t newpri;
+		uint32_t spi = hdlp->ih_vector;
+
+		DDI_INTR_NEXDBG((CE_CONT, "gicv2m_intr_ops: SETPRI "
+		    "for rdip = 0x%p, hdlp = 0x%p, inum = 0x%x, "
+		    "is 0x%x\n",
+		    (void *)rdip, (void *)hdlp, hdlp->ih_inum,
+		    *(int *)result));
+		if (*(int *)result > LOCK_LEVEL) {
+			DDI_INTR_NEXDBG((CE_CONT, "gicv2m_intr_ops: SETPRI "
+			    "for rdip = 0x%p: new pri %d exceeds "
+			    "LOCK_LEVEL %d\n",
+			    (void *)rdip, *(int *)result, LOCK_LEVEL));
+			return (DDI_FAILURE);
+		}
+
+		shared = av_get_shared(spi, &curpri);
+		newpri = (uint_t)(*(int *)result);
+		if (shared > 0 && newpri != curpri) {
+			dev_err(rdip, CE_NOTE,
+			    "!%s%d: refusing to set pri 0x%x on "
+			    "shared SPI %u with pri 0x%x",
+			    ddi_node_name(rdip), ddi_get_instance(rdip),
+			    newpri, spi, curpri);
+			return (DDI_FAILURE);
+		}
+
+		ASSERT3U(*(int *)result, !=, 0);
+		hdlp->ih_pri = *(int *)result;
+		return (DDI_SUCCESS);
+	}
 	default:
 		return (DDI_ENOTSUP);
 	}

--- a/usr/src/uts/armv8/io/gicv2m.c
+++ b/usr/src/uts/armv8/io/gicv2m.c
@@ -118,6 +118,14 @@ typedef struct gicv2m_state {
 extern void gicv2_configure_irq(dev_info_t *gic_dip, uint32_t irq,
     boolean_t is_edge);
 extern boolean_t gicv2_irq_ispending(dev_info_t *gic_dip, uint32_t irq);
+extern processorid_t gicv2_get_target_spi(dev_info_t *gic_dip,
+    uint32_t intid);
+extern void gicv2_set_target_spi(dev_info_t *gic_dip, uint32_t intid,
+    processorid_t cpuid);
+extern void gicv2_register_msi_range(dev_info_t *gic_dip, uint32_t base,
+    uint32_t count);
+extern void gicv2_unregister_msi_range(dev_info_t *gic_dip, uint32_t base,
+    uint32_t count);
 
 static void *gicv2m_soft_state;
 
@@ -465,6 +473,86 @@ gicv2m_getpending(gicv2m_state_t *sc, dev_info_t *rdip,
 }
 
 /*
+ * GETTARGET: return the current CPU target for this device's SPI.
+ *
+ * v2m MSI SPIs live in the distributor just like any other SPI.
+ * Delegate to the parent GICv2's exported inner function, which
+ * acquires the GICD lock internally.
+ */
+static int
+gicv2m_gettarget(gicv2m_state_t *sc, dev_info_t *rdip,
+    ddi_intr_handle_impl_t *hdlp, void *result)
+{
+	gicv2m_dev_state_t *ds;
+	uint32_t spi;
+	uint32_t idx;
+
+	mutex_enter(&sc->v2m_dev_lock);
+	ds = gicv2m_find_dev(sc, rdip);
+	if (ds == NULL) {
+		mutex_exit(&sc->v2m_dev_lock);
+		return (DDI_FAILURE);
+	}
+
+	idx = hdlp->ih_inum - ds->ds_inum_base;
+	if (idx >= ds->ds_count) {
+		mutex_exit(&sc->v2m_dev_lock);
+		return (DDI_FAILURE);
+	}
+
+	if (ds->ds_type == DDI_INTR_TYPE_MSI) {
+		spi = ds->ds_base_spi + idx;
+	} else {
+		spi = ds->ds_spi_array[idx];
+	}
+	mutex_exit(&sc->v2m_dev_lock);
+
+	*(processorid_t *)result = gicv2_get_target_spi(sc->v2m_gic_dip, spi);
+	return (DDI_SUCCESS);
+}
+
+/*
+ * SETTARGET: retarget this device's SPI to a different CPU.
+ */
+static int
+gicv2m_settarget(gicv2m_state_t *sc, dev_info_t *rdip,
+    ddi_intr_handle_impl_t *hdlp, void *result)
+{
+	gicv2m_dev_state_t *ds;
+	processorid_t new_cpu = *(processorid_t *)result;
+	uint32_t spi;
+	uint32_t idx;
+
+	if (new_cpu < 0 || new_cpu >= 8) {
+		return (DDI_EINVAL);
+	}
+
+	mutex_enter(&sc->v2m_dev_lock);
+	ds = gicv2m_find_dev(sc, rdip);
+	if (ds == NULL) {
+		mutex_exit(&sc->v2m_dev_lock);
+		return (DDI_FAILURE);
+	}
+
+	idx = hdlp->ih_inum - ds->ds_inum_base;
+	if (idx >= ds->ds_count) {
+		mutex_exit(&sc->v2m_dev_lock);
+		return (DDI_FAILURE);
+	}
+
+	if (ds->ds_type == DDI_INTR_TYPE_MSI) {
+		spi = ds->ds_base_spi + idx;
+	} else {
+		spi = ds->ds_spi_array[idx];
+	}
+	mutex_exit(&sc->v2m_dev_lock);
+
+	gicv2_set_target_spi(sc->v2m_gic_dip, spi, new_cpu);
+	return (DDI_SUCCESS);
+}
+
+
+/*
  * bus_intr_op entry point - dispatches interrupt operations from the
  * MSI framework to per-operation handlers.
  */
@@ -510,6 +598,10 @@ gicv2m_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 		*(int *)result |= DDI_INTR_FLAG_EDGE;
 		*(int *)result &= ~DDI_INTR_FLAG_LEVEL;
 		return (DDI_SUCCESS);
+	case DDI_INTROP_GETTARGET:
+		return (gicv2m_gettarget(sc, rdip, hdlp, result));
+	case DDI_INTROP_SETTARGET:
+		return (gicv2m_settarget(sc, rdip, hdlp, result));
 	default:
 		return (DDI_ENOTSUP);
 	}
@@ -674,6 +766,14 @@ gicv2m_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 	    sc->v2m_spi_base,
 	    sc->v2m_spi_base + sc->v2m_spi_count - 1,
 	    sc->v2m_doorbell_pa);
+
+	/*
+	 * Register our SPI range with the parent GICv2 so it rejects
+	 * direct GETTARGET/SETTARGET for our INTIDs -- only we can
+	 * issue targeting operations for our SPIs.
+	 */
+	gicv2_register_msi_range(sc->v2m_gic_dip, sc->v2m_spi_base,
+	    sc->v2m_spi_count);
 
 	ddi_report_dev(dip);
 	return (DDI_SUCCESS);

--- a/usr/src/uts/armv8/io/gicv2m.c
+++ b/usr/src/uts/armv8/io/gicv2m.c
@@ -55,6 +55,7 @@
 #include <sys/syspic_impl.h>
 #include <sys/mach_intr.h>
 #include <sys/gic_reg.h>
+#include <sys/ddi_intr_impl.h>
 
 /*
  * Device tree properties for SPI base/count override.
@@ -101,6 +102,7 @@ typedef struct gicv2m_state {
 	uint32_t		v2m_spi_base;		/* first SPI (TYPER) */
 	uint32_t		v2m_spi_count;		/* SPI count (TYPER) */
 	vmem_t			*v2m_spi_arena;		/* SPI allocator */
+	ddi_irm_pool_t		*v2m_irm_pool;		/* IRM pool for SPIs */
 	list_t			v2m_devs;		/* gicv2m_dev_state_t */
 	kmutex_t		v2m_dev_lock;		/* protects v2m_devs */
 } gicv2m_state_t;
@@ -636,6 +638,12 @@ gicv2m_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 		hdlp->ih_pri = *(int *)result;
 		return (DDI_SUCCESS);
 	}
+	case DDI_INTROP_GETPOOL:
+		if (sc->v2m_irm_pool == NULL) {
+			return (DDI_ENOTSUP);
+		}
+		*(ddi_irm_pool_t **)result = sc->v2m_irm_pool;
+		return (DDI_SUCCESS);
 	default:
 		return (DDI_ENOTSUP);
 	}
@@ -654,6 +662,9 @@ gicv2m_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 		.devacc_attr_version		= DDI_DEVICE_ATTR_V0,
 		.devacc_attr_endian_flags	= DDI_STRUCTURE_LE_ACC,
 		.devacc_attr_dataorder		= DDI_STRICTORDER_ACC
+	};
+	ddi_irm_params_t params = {
+		.iparams_types = DDI_INTR_TYPE_MSI | DDI_INTR_TYPE_MSIX,
 	};
 
 	switch (cmd) {
@@ -794,6 +805,20 @@ gicv2m_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 	    (void *)(uintptr_t)sc->v2m_spi_base,
 	    sc->v2m_spi_count, 1 /* quantum */,
 	    NULL, NULL, NULL, 0, VM_SLEEP);
+
+	/*
+	 * Create an IRM pool for this v2m frame's SPI range.
+	 * Each v2m frame has its own disjoint SPI allocation domain,
+	 * so each gets its own pool for IRM rebalancing.
+	 */
+	params.iparams_total = sc->v2m_spi_count;
+
+	if (ndi_irm_create(dip, &params,
+	    &sc->v2m_irm_pool) != NDI_SUCCESS) {
+		dev_err(dip, CE_WARN,
+		    "failed to create IRM pool");
+		sc->v2m_irm_pool = NULL;
+	}
 
 	dev_err(dip, CE_CONT, "?GICv2m: %u MSI SPIs [%u-%u], "
 	    "doorbell PA 0x%" PRIx64 "\n", sc->v2m_spi_count,

--- a/usr/src/uts/armv8/io/gicv3_its.c
+++ b/usr/src/uts/armv8/io/gicv3_its.c
@@ -1266,6 +1266,16 @@ gicv3_its_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 		*(int *)result |= DDI_INTR_FLAG_EDGE;
 		*(int *)result &= ~DDI_INTR_FLAG_LEVEL;
 		return (DDI_SUCCESS);
+	case DDI_INTROP_GETPOOL: {
+		ddi_irm_pool_t *pool;
+
+		pool = gicv3_get_lpi_irm_pool(sc->its_gic_dip);
+		if (pool == NULL) {
+			return (DDI_ENOTSUP);
+		}
+		*(ddi_irm_pool_t **)result = pool;
+		return (DDI_SUCCESS);
+	}
 	default:
 		return (DDI_ENOTSUP);
 	}

--- a/usr/src/uts/armv8/io/gicv3_its.c
+++ b/usr/src/uts/armv8/io/gicv3_its.c
@@ -1213,6 +1213,41 @@ gicv3_its_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 		return (gicv3_its_settarget(sc, rdip, hdlp, result));
 	case DDI_INTROP_GETTARGET:
 		return (gicv3_its_gettarget(sc, rdip, hdlp, result));
+	case DDI_INTROP_SETPRI: {
+		int shared;
+		uint_t curpri;
+		uint_t newpri;
+		uint32_t lpi = hdlp->ih_vector;
+
+		DDI_INTR_NEXDBG((CE_CONT, "gicv3_its_intr_ops: SETPRI "
+		    "for rdip = 0x%p, hdlp = 0x%p, inum = 0x%x, "
+		    "is 0x%x\n",
+		    (void *)rdip, (void *)hdlp, hdlp->ih_inum,
+		    *(int *)result));
+		if (*(int *)result > LOCK_LEVEL) {
+			DDI_INTR_NEXDBG((CE_CONT,
+			    "gicv3_its_intr_ops: SETPRI "
+			    "for rdip = 0x%p: new pri %d exceeds "
+			    "LOCK_LEVEL %d\n",
+			    (void *)rdip, *(int *)result, LOCK_LEVEL));
+			return (DDI_FAILURE);
+		}
+
+		shared = av_get_shared(lpi, &curpri);
+		newpri = (uint_t)(*(int *)result);
+		if (shared > 0 && newpri != curpri) {
+			dev_err(rdip, CE_NOTE,
+			    "!%s%d: refusing to set pri 0x%x on "
+			    "shared LPI %u with pri 0x%x",
+			    ddi_node_name(rdip), ddi_get_instance(rdip),
+			    newpri, lpi, curpri);
+			return (DDI_FAILURE);
+		}
+
+		ASSERT3U(*(int *)result, !=, 0);
+		hdlp->ih_pri = *(int *)result;
+		return (DDI_SUCCESS);
+	}
 	case DDI_INTROP_ADDISR:
 	case DDI_INTROP_REMISR:
 		return (DDI_SUCCESS);

--- a/usr/src/uts/armv8/sys/gic_reg.h
+++ b/usr/src/uts/armv8/sys/gic_reg.h
@@ -249,6 +249,9 @@ extern "C" {
 #define	GICD_ITARGETSR_REGNUM(n)		((n) >> 2)
 #define	GICD_ITARGETSR_REGVAL(n, v)		(((v) & 0xff) << \
 						(((n) & 0x3) << 3))
+#define	GICD_ITARGETSR_GETTARGETS(val, n)	(((val) >> \
+						(((n) & 0x3) << 3)) & \
+						GICD_ITARGETSR_REGMASK)
 #define	GICD_ITARGETSR_SETTARGETS(val, n, v)	(((val) & \
 						~(GICD_ITARGETSR_REGVAL((n), \
 						0xFF))) | \

--- a/usr/src/uts/armv8/sys/gic_v3.h
+++ b/usr/src/uts/armv8/sys/gic_v3.h
@@ -60,6 +60,14 @@ extern uint32_t	gicv3_redist_procnum(dev_info_t *, processorid_t);
 extern uint32_t	gicv3_num_redists(dev_info_t *);
 extern uint32_t	gicv3_lpi_idbits(dev_info_t *);
 
+/* SPI targeting - inner functions for use by child MSI controllers */
+extern processorid_t	gicv3_get_target_spi(dev_info_t *, uint32_t);
+extern void		gicv3_set_target_spi(dev_info_t *, uint32_t, processorid_t);
+
+/* MSI SPI range registration for child MSI controllers */
+extern void	gicv3_register_msi_range(dev_info_t *, uint32_t, uint32_t);
+extern void	gicv3_unregister_msi_range(dev_info_t *, uint32_t, uint32_t);
+
 #ifdef __cplusplus
 }
 #endif

--- a/usr/src/uts/armv8/sys/gic_v3.h
+++ b/usr/src/uts/armv8/sys/gic_v3.h
@@ -18,6 +18,7 @@
 
 #include <sys/types.h>
 #include <sys/sunddi.h>
+#include <sys/ddi_intr_impl.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -47,6 +48,9 @@ extern int	gicv3_alloc_lpi_block(dev_info_t *, uint32_t, uint32_t,
 extern void	gicv3_free_lpi(dev_info_t *, uint32_t);
 extern void	gicv3_free_lpi_block(dev_info_t *, uint32_t, uint32_t);
 extern size_t	gicv3_lpi_navail(dev_info_t *);
+
+/* LPI IRM pool */
+extern ddi_irm_pool_t	*gicv3_get_lpi_irm_pool(dev_info_t *);
 
 /* LPI configuration (PROPBASER table access) */
 extern void	gicv3_lpi_set_config(dev_info_t *, uint32_t, uint8_t,


### PR DESCRIPTION
_This is the second of five PRs that flesh out the verbs handled by our interrupt controllers, clean up interrupt routing for both FIXED interrupts and those managed through a root complex, implement interrupt redistribution and update documentation._

Seventeen commits that teach the GIC interrupt controllers the full set of DDI interrupt operations needed for interrupt redistribution and `pcitool(8)` support. Each verb is implemented in the FIXED controllers (gictwo, gicthree) and, where applicable, the MSI controllers (gicv2m, gicv3 ITS). The gictwo and gicthree implementations mirror each other throughout: differences are called out where they exist.

The underlying design point here is to have the framework and platform not impose limitations on what an interrupt controller or nexus may or may not do - all verbs should be hit either the root complex or the controller (or both), allowing future controllers to participate in the full interrupt lifecycle.

PR #256 makes all of these verb implementations reachable.

## gictwo/gicthree: restructure interrupt op switch and add debug logging

Restructure the `intr_ops` switch in both FIXED controllers to better reflect the operations they are expected to handle.  Add debug logging via `DDI_INTR_NEXDBG`.

This is preparatory scaffolding for the verb implementations that follow.

## gictwo/gicthree: implement GETPRI and SETPRI with shared vector enforcement

Implement `GETPRI` and `SETPRI` as controller operations. Both need access to the interrupt vector to determine sharing state via `autovect`, which is only available at the controller level.

`GETPRI` resolves the vector via the new `gicv2_parse_unitintr`/`gicv3_parse_unitintr` helper, checks whether the vector is shared, and if so returns the existing shared priority. Otherwise falls back to the device tree (driver.conf) `interrupt-priorities` property via `i_ddi_get_intr_pri` when the handle has no priority set.

`SETPRI` validates the requested priority against `LOCK_LEVEL` and refuses to change the priority on a shared vector where another consumer has already established a different priority.

As a consequence of introducing the `parse_unitintr` helpers, `ENABLE`, `DISABLE`, and `GETPENDING` are refactored to use them rather than inlining the `unitintr` cell parsing.

## gictwo/gicthree: handle ALLOC and FREE in the controller

Handle the `ALLOC` and `FREE` interrupt operations in the controller. As is existing practice, `ALLOC` echoes `ih_scratch1` into the result (the allocated count) and `FREE` is a no-op. Both have debug logging added. These are currently lightweight, but provide a natural point at which a more advanced controller could maintain internal state for interrupts.

## gictwo/gicthree: handle ADDISR and REMISR in the controller

Handle `ADDISR` and `REMISR` in the controller. These are no-ops - we use `autovect` and the DDI already populates `ih_cb_func`, `ih_cb_arg1`, and `ih_cb_arg2` for us. Handling them allows future controllers to take more complex actions, such as maintaining controller-private state.

## gictwo: implement GETTARGET/SETTARGET for SPIs

Replace the `GETTARGET`/`SETTARGET` stubs in gictwo with full implementations that read and write the `GICD_ITARGETSRn` registers.

`GETTARGET` resolves the INTID, returns the current CPU for per-CPU interrupts (SGI/PPI), rejects non-SPI and MSI-owned SPIs with `DDI_ENOTSUP`, and reads the target CPU from the distributor for FIXED SPIs (the lowest bit set is returned as the target).

`SETTARGET` follows the same validation path and reprograms the distributor to target a single CPU.

Supporting infrastructure added:

* `gc_msi_lock` and `gc_msi_ranges` list to track SPI ranges owned by child MSI controllers (v2m), so `GETTARGET`/`SETTARGET` rejects direct targeting of MSI-owned SPIs.
* `gicv2_is_msi_spi`, `gicv2_register_msi_range`, `gicv2_unregister_msi_range` for MSI range management.
* `gicv2_get_target_spi` / `gicv2_set_target_spi` exported helpers that the v2m driver also calls.
* `GICD_ITARGETSR_GETTARGETS` macro in `gic_reg.h` to extract the per-interrupt target byte.

## gicthree: implement GETTARGET/SETTARGET for SPIs

The same operation for gicthree, reading and writing `GICD_IROUTERn` instead of `GICD_ITARGETSRn`. Key differences from gictwo:

* LPIs are explicitly rejected (targeting is managed by the ITS via `MOVI` commands, not the distributor).
* For `IRM=1` (any-of-N routing), `GETTARGET` returns CPU 0 by convention.
* `SETTARGET` clears `IRM` and maps the target `processorid_t` to an MPIDR affinity via `cpuinfo_for_affinity`.
* Adds `gicd_read8` accessor for 64-bit distributor register reads.

The same `gc_msi_lock`/`gc_msi_ranges` infrastructure is added, with `gicv3_get_target_spi`/`gicv3_set_target_spi` exported via `gic_v3.h`.

## gicv2m: wire GETTARGET/SETTARGET via parent GICv2

Add `GETTARGET` and `SETTARGET` to the GICv2m MSI driver by delegating to the parent GICv2's exported targeting functions. The v2m driver resolves the device's SPI for the given `inum` and calls through to the parent.

During attach, the v2m frame's SPI range is registered with the parent GICv2 via `gicv2_register_msi_range`, so the parent rejects direct `GETTARGET`/`SETTARGET` for MSI-owned INTIDs - these _must_ be controlled via v2m.

## gic: msi: implement SETPRI with shared vector enforcement

Add `SETPRI` handling to both MSI controllers (gicv2m for MSI SPIs, gicv3 ITS for MSI LPIs). Both enforce the same shared-vector priority consistency as the FIXED controllers: reject priorities above `LOCK_LEVEL`, query `av_get_shared` for current sharing state, and refuse to change priority on a shared vector if the new priority differs from the existing one.

While MSI/MSI-X should never be shared, we check anyway.

## gicthree: add IRM pool for LPIs to GICv3

Create a `ddi_irm_pool_t` for LPI-backed MSI/MSI-X interrupts in `gicv3_init_lpis`. The pool size equals the total LPI INTID range, giving IRM the information it needs to rebalance vector allocations across consumers. The LPI number-space is shared across ITS children of a GICv3, so the pool lives in the parent and ITS instances return it via `GETPOOL`.

## gicv3_its: add GETPOOL to GICv3 ITS

Wire `DDI_INTROP_GETPOOL` to return the LPI IRM pool from the parent GICv3. Returns `DDI_ENOTSUP` if the pool was not created.

## gicv2m: add IRM pool and GETPOOL to GICv2m

Create a per-frame `ddi_irm_pool_t` for each GICv2m MSI frame and wire `DDI_INTROP_GETPOOL` to return it. Each v2m frame manages a disjoint SPI allocation domain, so each gets its own pool sized to its SPI count.

## gictwo/gicthree: handle NINTRS and NAVAIL in the controller

Move `NINTRS` and `NAVAIL` handling from rootnex into the FIXED controllers. Same effect as before - `i_ddi_get_intx_nintrs` - but simplifies routing and allows future controllers to do something different if needed.

## Testing
Tested in the full stack for FDT platforms, grafted into my combined-everything stack for ACPI platforms.

* QEMU virt ([FDT](https://gist.github.com/r1mikey/8cb562753e9e49acb1ae49913b2af526), GICv3+ITS)
* RPi4/FDT (GICv2): [FIXED path through pci_common → gictwo](https://gist.github.com/r1mikey/460c7c350054e037523d69eca696f848)
* QEMU virt ([ACPI](https://gist.github.com/r1mikey/da627300ae2156473d5e31c2e43d3285), GICv3+ITS)
* [Ampere Altra Max](https://gist.github.com/r1mikey/edd1c2a6c73ccd0280551dacc309f94c): [full MSI-X + FIXED bridges](https://gist.github.com/r1mikey/8c7ce3faa1378c532e246e51678784f5)
