### PR TITLE
interrupt routing: accounting and redistribution

### DIFF
--- a/usr/src/cmd/pcitool/pcitool.c
+++ b/usr/src/cmd/pcitool/pcitool.c
@@ -1651,6 +1651,9 @@ get_interrupt_ctlr(int fd, pcitool_uiargs_t *input_args_p)
 		case PCITOOL_CTLR_TYPE_APIX:
 			ctlr_type = "APIX";
 			break;
+		case PCITOOL_CTLR_TYPE_GIC:
+			ctlr_type = "GIC";
+			break;
 
 		default:
 			break;

--- a/usr/src/uts/aarch64/Makefile.files
+++ b/usr/src/uts/aarch64/Makefile.files
@@ -146,6 +146,7 @@ DEVFDT_OBJS += devfdt.o
 PCIERC_OBJS +=		\
 	pci_boot.o	\
 	pci_common.o	\
+	pci_kstats.o	\
 	pci_tools.o	\
 	pcierc.o
 

--- a/usr/src/uts/aarch64/io/pci/pci_common.c
+++ b/usr/src/uts/aarch64/io/pci/pci_common.c
@@ -1037,6 +1037,37 @@ pci_intr_getpri(dev_info_t *pdip, dev_info_t *rdip,
 }
 
 static int
+pci_intr_addisr(dev_info_t *pdip, dev_info_t *rdip,
+    ddi_intr_op_t intr_op, ddi_intr_handle_impl_t *hdlp, void *result)
+{
+	ihdl_plat_t *ihdl_plat_datap;
+
+	ASSERT3P(hdlp->ih_private, !=, NULL);
+	ihdl_plat_datap = (ihdl_plat_t *)hdlp->ih_private;
+	pci_kstat_create(&ihdl_plat_datap->ip_ksp, pdip, hdlp);
+	return (i_ddi_intr_ops(pdip, rdip, intr_op, hdlp, result));
+}
+
+static int
+pci_intr_remisr(dev_info_t *pdip, dev_info_t *rdip,
+    ddi_intr_op_t intr_op, ddi_intr_handle_impl_t *hdlp, void *result)
+{
+	ihdl_plat_t *ihdl_plat_datap;
+	int ret;
+
+	ret = i_ddi_intr_ops(pdip, rdip, intr_op, hdlp, result);
+
+	ASSERT3P(hdlp->ih_private, !=, NULL);
+	ihdl_plat_datap = (ihdl_plat_t *)hdlp->ih_private;
+
+	if (ihdl_plat_datap->ip_ksp != NULL) {
+		pci_kstat_delete(ihdl_plat_datap->ip_ksp);
+	}
+
+	return (ret);
+}
+
+static int
 pci_intr_getcap(dev_info_t *pdip, dev_info_t *rdip,
     ddi_intr_op_t intr_op, ddi_intr_handle_impl_t *hdlp, void *result)
 {
@@ -1230,6 +1261,10 @@ pci_common_intr_ops(dev_info_t *pdip, dev_info_t *rdip, ddi_intr_op_t intr_op,
 		    hdlp, result));
 	case DDI_INTROP_GETPRI:
 		return (pci_intr_getpri(pdip, rdip, hdlp, result));
+	case DDI_INTROP_ADDISR:
+		return (pci_intr_addisr(pdip, rdip, intr_op, hdlp, result));
+	case DDI_INTROP_REMISR:
+		return (pci_intr_remisr(pdip, rdip, intr_op, hdlp, result));
 	case DDI_INTROP_GETCAP:
 		return (pci_intr_getcap(pdip, rdip, intr_op, hdlp, result));
 	case DDI_INTROP_SETMASK:	/* fallthrough */
@@ -1255,50 +1290,6 @@ pci_common_intr_ops(dev_info_t *pdip, dev_info_t *rdip, ddi_intr_op_t intr_op,
 		return (i_ddi_intr_ops(pdip, rdip, intr_op, hdlp, result));
 	}
 }
-
-#if XXXARM
-int
-pci_get_intr_from_vecirq(apic_get_intr_t *intrinfo_p,
-    int vecirq, boolean_t is_irq)
-{
-	ddi_intr_handle_impl_t	get_info_ii_hdl;
-
-	if (is_irq)
-		intrinfo_p->avgi_req_flags |= PSMGI_INTRBY_IRQ;
-
-	/*
-	 * For this locally-declared and used handle, ih_private will contain a
-	 * pointer to apic_get_intr_t, not an ihdl_plat_t as used for
-	 * global interrupt handling.
-	 */
-	get_info_ii_hdl.ih_private = intrinfo_p;
-	get_info_ii_hdl.ih_vector = vecirq;
-
-	panic("XXXARM: PSM_INTR_OP_GET_INTR");
-
-	if ((*psm_intr_ops)(NULL, &get_info_ii_hdl,
-	    PSM_INTR_OP_GET_INTR, NULL) == PSM_FAILURE)
-		return (DDI_FAILURE);
-
-	return (DDI_SUCCESS);
-}
-
-
-int
-pci_get_cpu_from_vecirq(int vecirq, boolean_t is_irq)
-{
-	int rval;
-	apic_get_intr_t	intrinfo;
-
-	intrinfo.avgi_req_flags = PSMGI_REQ_CPUID;
-	rval = pci_get_intr_from_vecirq(&intrinfo, vecirq, is_irq);
-
-	if (rval == DDI_SUCCESS)
-		return (intrinfo.avgi_cpu_id);
-	else
-		return (-1);
-}
-#endif
 
 /*
  * Miscellaneous library function

--- a/usr/src/uts/aarch64/io/pci/pci_common.h
+++ b/usr/src/uts/aarch64/io/pci/pci_common.h
@@ -78,6 +78,13 @@ int	pci_common_peekpoke(dev_info_t *dip, dev_info_t *rdip,
 	ddi_ctl_enum_t ctlop, void *arg, void *result);
 int	pci_fm_acc_setup(ddi_acc_hdl_t *hp, off_t offset, off_t len);
 
+/*
+ * Functions exported from pci_kstats.c
+ */
+extern void pci_kstat_create(kstat_t **kspp, dev_info_t *nexus_dip,
+    ddi_intr_handle_impl_t *hdlp);
+extern void pci_kstat_delete(kstat_t *kspp);
+
 #ifdef	__cplusplus
 }
 #endif

--- a/usr/src/uts/aarch64/io/pci/pci_kstats.c
+++ b/usr/src/uts/aarch64/io/pci/pci_kstats.c
@@ -1,0 +1,211 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Copyright 2026 Michael van der Westhuizen
+ */
+
+/*
+ * Kstat support for aarch64 PCI interrupts.
+ *
+ * Creates per-interrupt "pci_intrs" kstats consumed by intrd(8) for
+ * interrupt load balancing.  Each kstat instance reports the device
+ * name, interrupt type, target CPU, priority, cumulative service
+ * time, interrupt number (ino), and device/bus paths.
+ *
+ * The target CPU is obtained by walking the DDI interrupt tree via
+ * GETTARGET.  This is more expensive than the x86 PSM direct-read
+ * path but preserves the clean DDI abstraction; caching may be
+ * added if this proves to be a bottleneck.
+ */
+
+#include <sys/conf.h>
+#include <sys/mach_intr.h>
+#include <sys/clock.h>
+#include <sys/ddi_intr_impl.h>
+#include <sys/sunddi.h>
+#include <sys/sunndi.h>
+
+typedef struct pci_kstat_private {
+	ddi_intr_handle_impl_t	*hdlp;
+	dev_info_t		*nexus_dip;
+} pci_kstat_private_t;
+
+static struct {
+	kstat_named_t ihks_name;
+	kstat_named_t ihks_type;
+	kstat_named_t ihks_cpu;
+	kstat_named_t ihks_pil;
+	kstat_named_t ihks_time;
+	kstat_named_t ihks_ino;
+	kstat_named_t ihks_cookie;
+	kstat_named_t ihks_devpath;
+	kstat_named_t ihks_buspath;
+} pci_ks_template = {
+	{ "name",	KSTAT_DATA_CHAR },
+	{ "type",	KSTAT_DATA_CHAR },
+	{ "cpu",	KSTAT_DATA_UINT64 },
+	{ "pil",	KSTAT_DATA_UINT64 },
+	{ "time",	KSTAT_DATA_UINT64 },
+	{ "ino",	KSTAT_DATA_UINT64 },
+	{ "cookie",	KSTAT_DATA_UINT64 },
+	{ "devpath",	KSTAT_DATA_STRING },
+	{ "buspath",	KSTAT_DATA_STRING },
+};
+
+static char ih_devpath[MAXPATHLEN];
+static char ih_buspath[MAXPATHLEN];
+static uint32_t pci_ks_inst;
+static kmutex_t pci_ks_template_lock;
+
+static int
+pci_ih_ks_update(kstat_t *ksp, int rw __unused)
+{
+	pci_kstat_private_t *private_data =
+	    (pci_kstat_private_t *)ksp->ks_private;
+	dev_info_t *nexus_dip = private_data->nexus_dip;
+	ddi_intr_handle_impl_t *ih_p = private_data->hdlp;
+	dev_info_t *dip = ih_p->ih_dip;
+	const size_t maxlen = sizeof (pci_ks_template.ihks_name.value.c);
+	processorid_t cpu_id = 0;
+
+	(void) snprintf(pci_ks_template.ihks_name.value.c, maxlen, "%s%d",
+	    ddi_driver_name(dip), ddi_get_instance(dip));
+	(void) ddi_pathname(dip, ih_devpath);
+	(void) ddi_pathname(nexus_dip, ih_buspath);
+	kstat_named_setstr(&pci_ks_template.ihks_devpath, ih_devpath);
+	kstat_named_setstr(&pci_ks_template.ihks_buspath, ih_buspath);
+
+	/*
+	 * Only populate live fields when the interrupt is enabled.
+	 * ADDISR fires before ENABLE, so there is a window where the
+	 * kstat exists but the interrupt is not yet active.
+	 */
+	if (ih_p->ih_state != DDI_IHDL_STATE_ENABLE) {
+		(void) strcpy(pci_ks_template.ihks_type.value.c, "disabled");
+		pci_ks_template.ihks_pil.value.ui64 = 0;
+		pci_ks_template.ihks_time.value.ui64 = 0;
+		pci_ks_template.ihks_cookie.value.ui64 = 0;
+		pci_ks_template.ihks_cpu.value.ui64 = 0;
+		pci_ks_template.ihks_ino.value.ui64 = 0;
+		return (0);
+	}
+
+	/*
+	 * Interrupt type.
+	 */
+	switch (ih_p->ih_type) {
+	case DDI_INTR_TYPE_MSI:
+		(void) strcpy(pci_ks_template.ihks_type.value.c, "msi");
+		break;
+	case DDI_INTR_TYPE_MSIX:
+		(void) strcpy(pci_ks_template.ihks_type.value.c, "msix");
+		break;
+	default:
+		(void) strcpy(pci_ks_template.ihks_type.value.c, "fixed");
+		break;
+	}
+
+	/*
+	 * Priority and cumulative interrupt service time.
+	 */
+	pci_ks_template.ihks_pil.value.ui64 = ih_p->ih_pri;
+	pci_ks_template.ihks_time.value.ui64 =
+	    ((ihdl_plat_t *)ih_p->ih_private)->ip_ticks;
+	scalehrtime((hrtime_t *)&pci_ks_template.ihks_time.value.ui64);
+
+	/*
+	 * Interrupt number and cookie: both ih_vector (the GIC INTID).
+	 */
+	pci_ks_template.ihks_ino.value.ui64 = ih_p->ih_vector;
+	pci_ks_template.ihks_cookie.value.ui64 = ih_p->ih_vector;
+
+	/*
+	 * Target CPU: walk the DDI interrupt tree via GETTARGET.
+	 * This is more expensive than x86's direct PSM register read,
+	 * but keeps the DDI abstraction clean.
+	 */
+	if (get_intr_affinity(
+	    (ddi_intr_handle_t)ih_p, &cpu_id) == DDI_SUCCESS) {
+		pci_ks_template.ihks_cpu.value.ui64 = cpu_id;
+	} else {
+		pci_ks_template.ihks_cpu.value.ui64 = 0;
+	}
+
+	return (0);
+}
+
+
+void
+pci_kstat_create(kstat_t **kspp, dev_info_t *nexus_dip,
+    ddi_intr_handle_impl_t *hdlp)
+{
+	pci_kstat_private_t *private_data;
+
+	*kspp = kstat_create("pci_intrs", atomic_inc_32_nv(&pci_ks_inst),
+	    _MODULE_NAME, "interrupts", KSTAT_TYPE_NAMED,
+	    sizeof (pci_ks_template) / sizeof (kstat_named_t),
+	    KSTAT_FLAG_VIRTUAL);
+	if (*kspp != NULL) {
+		private_data =
+		    kmem_zalloc(sizeof (pci_kstat_private_t), KM_SLEEP);
+		private_data->hdlp = hdlp;
+		private_data->nexus_dip = nexus_dip;
+
+		(*kspp)->ks_private = private_data;
+		(*kspp)->ks_data_size += MAXPATHLEN * 2;
+		(*kspp)->ks_lock = &pci_ks_template_lock;
+		(*kspp)->ks_data = &pci_ks_template;
+		(*kspp)->ks_update = pci_ih_ks_update;
+		kstat_install(*kspp);
+	}
+}
+
+
+/*
+ * This function is invoked in two ways:
+ * 1. From the REMISR introp when an interrupt handler is being removed.
+ * 2. Potentially from a taskq if user-bound interrupt kstat removal is
+ *    added in the future (matching the x86 pattern).
+ */
+void
+pci_kstat_delete(kstat_t *ksp)
+{
+	pci_kstat_private_t *kstat_private;
+	ddi_intr_handle_impl_t *hdlp;
+
+	if (ksp != NULL) {
+		kstat_private = ksp->ks_private;
+		hdlp = kstat_private->hdlp;
+		((ihdl_plat_t *)hdlp->ih_private)->ip_ksp = NULL;
+
+		/*
+		 * Delete the kstat before freeing the private data, to
+		 * prevent an update callback from running after private
+		 * is freed.
+		 */
+		kstat_delete(ksp);
+
+		kmem_free(kstat_private, sizeof (pci_kstat_private_t));
+	}
+}

--- a/usr/src/uts/aarch64/io/pci/pci_tools.c
+++ b/usr/src/uts/aarch64/io/pci/pci_tools.c
@@ -24,6 +24,7 @@
 
 /*
  * Copyright 2023 Oxide Computer Company
+ * Copyright 2026 Michael van der Westhuizen
  */
 
 /*
@@ -37,8 +38,8 @@
 #include <sys/mkdev.h>
 #include <sys/stat.h>
 #include <sys/sunddi.h>
-#include <vm/seg_kmem.h>
 #include <sys/sunndi.h>
+#include <vm/seg_kmem.h>
 #include <sys/ontrap.h>
 #include <sys/pcie.h>
 #include <sys/pci_tools.h>
@@ -47,6 +48,8 @@
 #include <sys/promif.h>
 #include <sys/cpuvar.h>
 #include <sys/pci_cfgacc.h>
+#include <sys/ddi_intr_impl.h>
+#include <sys/avintr.h>
 
 #define	PCIEX_BDF_OFFSET_DELTA	4
 #define	PCIEX_REG_FUNC_SHIFT	(PCI_REG_FUNC_SHIFT + PCIEX_BDF_OFFSET_DELTA)
@@ -113,27 +116,266 @@ pcitool_uninit(dev_info_t *dip)
 	ddi_remove_minor_node(dip, PCI_MINOR_REG);
 }
 
-static int
-pcitool_set_intr(dev_info_t *dip, void *arg, int mode)
+/*
+ * Fill in a pcitool_intr_dev_t from a dev_info_t.
+ */
+static void
+pcitool_get_intr_dev_info(dev_info_t *dip, pcitool_intr_dev_t *devs)
 {
-	return (ENOTSUP);
-}
+	if (dip == NULL) {
+		(void) strlcpy(devs->driver_name,
+		    "(unknown)", sizeof (devs->driver_name));
+		devs->path[0] = '/';
+		devs->path[1] = '\0';
+		devs->dev_inst = 0;
+		return;
+	}
 
-static int
-pcitool_get_intr(dev_info_t *dip, void *arg, int mode)
-{
-	return (ENOTSUP);
-}
-
-static int
-pcitool_intr_info(dev_info_t *dip, void *arg, int mode)
-{
-	return (ENOTSUP);
+	(void) strlcpy(devs->driver_name,
+	    ddi_driver_name(dip), sizeof (devs->driver_name));
+	(void) ddi_pathname(dip, devs->path);
+	devs->dev_inst = ddi_get_instance(dip);
 }
 
 /*
- * Main function for handling interrupt CPU binding requests and queries.
- * Need to implement later
+ * PCITOOL_DEVICE_SET_INTR: retarget an interrupt to a different CPU.
+ */
+static int
+pcitool_set_intr(dev_info_t *dip, void *arg, int mode)
+{
+	pcitool_intr_set_t iset;
+	ddi_intr_handle_impl_t *hdlp = NULL;
+	processorid_t old_cpu;
+	processorid_t new_cpu;
+	int rval = SUCCESS;
+	size_t copyinout_size = sizeof (pcitool_intr_set_t);
+
+	if (ddi_copyin(arg, &iset, copyinout_size, mode) != DDI_SUCCESS) {
+		return (EFAULT);
+	}
+
+	switch (iset.user_version) {
+	case PCITOOL_V2:
+		break;
+
+	default:
+		iset.status = PCITOOL_OUT_OF_RANGE;
+		rval = ENOTSUP;
+		goto done_set_intr;
+	}
+
+	/*
+	 * i86pc only retargets MSI/MSI-X, but we can retarget FIXED as well.
+	 */
+
+	ndi_devi_enter(dip);
+
+	/* Look up the autovect chain for a representative handle */
+	if (av_get_vector_info(iset.ino, &hdlp, NULL, 0) == 0 ||
+	    hdlp == NULL) {
+		ndi_devi_exit(dip);
+		iset.status = PCITOOL_INVALID_INO;
+		rval = EINVAL;
+		goto done_set_intr;
+	}
+
+	/* Read current CPU assignment */
+	if (hdlp->ih_dip == NULL) {
+		old_cpu = (processorid_t)-1;
+	} else {
+		if (get_intr_affinity(
+		    (ddi_intr_handle_t)hdlp, &old_cpu) != DDI_SUCCESS) {
+			ndi_devi_exit(dip);
+			iset.status = PCITOOL_IO_ERROR;
+			rval = EIO;
+			goto done_set_intr;
+		}
+	}
+
+	/* Validate target CPU. */
+	if (iset.cpu_id >= (uint32_t)ncpus) {
+		ndi_devi_exit(dip);
+		rval = EINVAL;
+		iset.status = PCITOOL_INVALID_CPUID;
+		goto done_set_intr;
+	}
+
+	iset.status = PCITOOL_SUCCESS;
+
+	/* Retarget the interrupt via the GIC driver. */
+	new_cpu = (processorid_t)iset.cpu_id;
+	if (set_intr_affinity(
+	    (ddi_intr_handle_t)hdlp, new_cpu) != DDI_SUCCESS) {
+		rval = EIO;
+		iset.status = PCITOOL_IO_ERROR;
+	}
+
+	ndi_devi_exit(dip);
+
+	/* Return original CPU */
+	iset.cpu_id = (uint32_t)old_cpu;
+
+done_set_intr:
+	iset.drvr_version = PCITOOL_VERSION;
+	if (ddi_copyout(&iset, arg, copyinout_size, mode) != DDI_SUCCESS) {
+		rval = EFAULT;
+	}
+
+	return (rval);
+}
+
+/*
+ * PCITOOL_DEVICE_GET_INTR: return device and CPU information for a
+ * given interrupt vector.
+ */
+static int
+pcitool_get_intr(dev_info_t *dip, void *arg, int mode)
+{
+	pcitool_intr_get_t partial_iget;
+	pcitool_intr_get_t *iget = &partial_iget;
+	size_t iget_kmem_alloc_size = 0;
+	uint8_t num_devs_ret = 0;
+	int copyout_rval;
+	int rval = SUCCESS;
+	uint_t i;
+	ddi_intr_handle_impl_t *hdlp = NULL;
+	uint_t num_devs;
+	processorid_t cpu_id;
+	dev_info_t **dip_list = NULL;
+	uint32_t saved_ino;
+
+	/* Read in just the header part, no variable-length array section. */
+	if (ddi_copyin(arg, &partial_iget, PCITOOL_IGET_SIZE(0), mode) !=
+	    DDI_SUCCESS) {
+		return (EFAULT);
+	}
+
+	num_devs_ret = partial_iget.num_devs_ret;
+
+	/*
+	 * If caller wants device information, allocate the full response
+	 * buffer and the dip collection array.
+	 *
+	 * NOTE: we are allocating memory based on user-supplied values here,
+	 * both via PCITOOL_IGET_SIZE and directly for the dip list.  This
+	 * is not an attack vector, as both num_devs_ret and the user-supplied
+	 * iget.num_devs_ret are uint8_t.  For the dip list the maximum
+	 * allocation size is 2040 bytes, and for iget the maximum allocation
+	 * size is 327447 bytes (modulo struct padding).  This is nowhere near
+	 * integer overflow territory.
+	 */
+	if (num_devs_ret > 0) {
+		iget_kmem_alloc_size = PCITOOL_IGET_SIZE(num_devs_ret);
+		iget = kmem_zalloc(iget_kmem_alloc_size, KM_SLEEP);
+
+		/* Read in whole structure to verify there's room. */
+		if (ddi_copyin(arg, iget, iget_kmem_alloc_size, mode) !=
+		    SUCCESS) {
+			kmem_free(iget, iget_kmem_alloc_size);
+			return (EFAULT);
+		}
+
+		dip_list = kmem_zalloc(
+		    num_devs_ret * sizeof (dev_info_t *), KM_SLEEP);
+	}
+
+	/*
+	 * Hold the device tree to stabilise dip pointers returned by
+	 * av_get_vector_info() while we extract device information.
+	 */
+	if (num_devs_ret > 0) {
+		ndi_devi_enter(dip);
+	}
+
+	/*
+	 * Walk the autovect chain.  Returns total handler count and
+	 * fills dip_list up to num_devs_ret entries.  hdlp receives a
+	 * representative handle for GETTARGET.
+	 */
+	num_devs = av_get_vector_info(partial_iget.ino, &hdlp,
+	    dip_list, num_devs_ret);
+
+	/* Get current CPU via the interrupt controller driver */
+	if (num_devs != 0 && hdlp != NULL && hdlp->ih_dip != NULL) {
+		if (get_intr_affinity(
+		    (ddi_intr_handle_t)hdlp, &cpu_id) != DDI_SUCCESS) {
+			cpu_id = (processorid_t)-1;
+		}
+	} else {
+		cpu_id = (processorid_t)-1;
+	}
+
+	saved_ino = partial_iget.ino;
+	bzero(iget, PCITOOL_IGET_SIZE(num_devs_ret));
+	iget->ino = saved_ino;
+	iget->cpu_id = (uint32_t)cpu_id;
+	iget->num_devs = (uint8_t)num_devs;
+	iget->num_devs_ret = (uint8_t)MIN(num_devs_ret, num_devs);
+
+	/* Fill in device information for each handler */
+	for (i = 0; i < iget->num_devs_ret; i++) {
+		pcitool_get_intr_dev_info(dip_list[i], &iget->dev[i]);
+	}
+
+	if (num_devs_ret > 0) {
+		ndi_devi_exit(dip);
+	}
+
+	if (dip_list != NULL) {
+		kmem_free(dip_list, num_devs_ret * sizeof (dev_info_t *));
+	}
+
+	iget->drvr_version = PCITOOL_VERSION;
+	copyout_rval = ddi_copyout(iget, arg,
+	    PCITOOL_IGET_SIZE(num_devs_ret), mode);
+
+	if (iget_kmem_alloc_size > 0) {
+		kmem_free(iget, iget_kmem_alloc_size);
+	}
+
+	if (copyout_rval != DDI_SUCCESS) {
+		rval = EFAULT;
+	}
+
+	return (rval);
+}
+
+/*
+ * PCITOOL_SYSTEM_INTR_INFO: return interrupt controller type and
+ * configuration.
+ *
+ * num_intr is set to MAX_VECT, the autovect hash table size.  This
+ * bounds pcitool's brute-force 0..num_intr-1 iteration.  A future
+ * ioctl will provide proper active-vector enumeration.
+ */
+static int
+pcitool_intr_info(dev_info_t *dip, void *arg, int mode)
+{
+	pcitool_intr_info_t intr_info;
+	int rval = SUCCESS;
+
+	if (ddi_copyin(arg, &intr_info, sizeof (pcitool_intr_info_t),
+	    mode) != DDI_SUCCESS) {
+		return (EFAULT);
+	}
+
+	intr_info.ctlr_type = PCITOOL_CTLR_TYPE_GIC;
+	intr_info.ctlr_version = 0;
+	intr_info.num_intr = 1020;	/* maximum SPI, for now */
+	intr_info.num_cpu = ncpus;
+	intr_info.drvr_version = PCITOOL_VERSION;
+
+	if (ddi_copyout(&intr_info, arg, sizeof (pcitool_intr_info_t),
+	    mode) != DDI_SUCCESS) {
+		rval = EFAULT;
+	}
+
+	return (rval);
+}
+
+/*
+ * Main function for handling interrupt CPU binding requests and queries
+ * from pcitool(8) and intrd(8).
  */
 int
 pcitool_intr_admn(dev_info_t *dip, void *arg, int cmd, int mode)

--- a/usr/src/uts/aarch64/pcierc/Makefile
+++ b/usr/src/uts/aarch64/pcierc/Makefile
@@ -40,8 +40,6 @@ ROOTMODULE	= $(ROOT_MISC_DIR)/$(MODULE)
 
 INC_PATH += -I$(SRC)/uts/aarch64/io/pciex/pcierc/
 
-LDFLAGS += -Nmisc/pcie -Nmisc/pci_prd
-
 #
 #	Include common rules.
 #
@@ -54,13 +52,14 @@ ALL_TARGET	= $(BINARY)
 INSTALL_TARGET	= $(BINARY) $(ROOTMODULE)
 
 #
-# depends on misc/pcie
+# depends on misc/pcie and misc/pci_prd
 #
 # pcie supplies PCI Express fabric error support
+# pci_prd provides platform choices and implementations
 #
-LDFLAGS	+= -Nmisc/pcie
+LDFLAGS	+= -Nmisc/pcie -Nmisc/pci_prd
 
-CPPFLAGS += -I$(UTSBASE)/armv8
+CPPFLAGS += -I$(UTSBASE)/armv8 -D_MODULE_NAME="\"$(MODULE)\""
 
 #
 # For now, disable these checks; maintainers should endeavor

--- a/usr/src/uts/armv8/io/gicthree.c
+++ b/usr/src/uts/armv8/io/gicthree.c
@@ -2035,6 +2035,7 @@ gicv3_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 	case DDI_INTROP_ENABLE: {
 		gicv3_conf_t *gc =
 		    ddi_get_soft_state(gicv3_soft_state, ddi_get_instance(dip));
+		ihdl_plat_t *priv = hdlp->ih_private;
 		syspic_intr_state_t *state = NULL;
 
 		if (gicv3_parse_unitintr(dip, rdip, hdlp,
@@ -2075,7 +2076,8 @@ gicv3_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 		/* Add the interrupt handler */
 		if (!add_avintr((void *)hdlp, hdlp->ih_pri,
 		    hdlp->ih_cb_func, DEVI(rdip)->devi_name, hdlp->ih_vector,
-		    hdlp->ih_cb_arg1, hdlp->ih_cb_arg2, NULL, rdip)) {
+		    hdlp->ih_cb_arg1, hdlp->ih_cb_arg2,
+		    &priv->ip_ticks, rdip)) {
 			mutex_exit(&syspic_intrs_lock);
 			DDI_INTR_NEXDBG((CE_CONT, "gicv3_intr_ops: ENABLE "
 			    "dip 0x%p, hdlp 0x%p, type 0x%x, inum 0x%x: "

--- a/usr/src/uts/armv8/io/gictwo.c
+++ b/usr/src/uts/armv8/io/gictwo.c
@@ -1309,6 +1309,7 @@ gicv2_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 	case DDI_INTROP_ENABLE: {
 		gicv2_conf_t *sc =
 		    ddi_get_soft_state(gicv2_soft_state, ddi_get_instance(dip));
+		ihdl_plat_t *priv = hdlp->ih_private;
 		syspic_intr_state_t *state = NULL;
 
 		if (gicv2_parse_unitintr(dip, rdip, hdlp,
@@ -1353,7 +1354,8 @@ gicv2_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 		/* Add the interrupt handler */
 		if (!add_avintr((void *)hdlp, hdlp->ih_pri,
 		    hdlp->ih_cb_func, DEVI(rdip)->devi_name, hdlp->ih_vector,
-		    hdlp->ih_cb_arg1, hdlp->ih_cb_arg2, NULL, rdip)) {
+		    hdlp->ih_cb_arg1, hdlp->ih_cb_arg2,
+		    &priv->ip_ticks, rdip)) {
 			mutex_exit(&syspic_intrs_lock);
 			DDI_INTR_NEXDBG((CE_CONT, "gicv2_intr_ops: ENABLE "
 			    "dip 0x%p, hdlp 0x%p, type 0x%x, inum 0x%x: "

--- a/usr/src/uts/armv8/io/gicv2m.c
+++ b/usr/src/uts/armv8/io/gicv2m.c
@@ -382,7 +382,7 @@ gicv2m_enable(gicv2m_state_t *sc, dev_info_t *rdip,
 	if (!add_avintr((void *)hdlp, hdlp->ih_pri,
 	    hdlp->ih_cb_func, DEVI(rdip)->devi_name,
 	    spi, hdlp->ih_cb_arg1, hdlp->ih_cb_arg2,
-	    NULL, rdip)) {
+	    &priv->ip_ticks, rdip)) {
 		syspic_remove_state(spi);
 		mutex_exit(&syspic_intrs_lock);
 		return (DDI_FAILURE);

--- a/usr/src/uts/armv8/io/gicv3_its.c
+++ b/usr/src/uts/armv8/io/gicv3_its.c
@@ -969,7 +969,7 @@ gicv3_its_enable(gicv3_its_state_t *sc, dev_info_t *rdip,
 	if (!add_avintr((void *)hdlp, hdlp->ih_pri,
 	    hdlp->ih_cb_func, DEVI(rdip)->devi_name,
 	    lpi, hdlp->ih_cb_arg1, hdlp->ih_cb_arg2,
-	    NULL, rdip)) {
+	    &priv->ip_ticks, rdip)) {
 		syspic_remove_state(lpi);
 		mutex_exit(&syspic_intrs_lock);
 		return (DDI_FAILURE);

--- a/usr/src/uts/common/os/ddi_intr_impl.c
+++ b/usr/src/uts/common/os/ddi_intr_impl.c
@@ -554,11 +554,21 @@ set_intr_affinity(ddi_intr_handle_t h, processorid_t tgt)
 		return (DDI_EINVAL);
 
 	rw_enter(&hdlp->ih_rwlock, RW_WRITER);
-	if ((hdlp->ih_state != DDI_IHDL_STATE_ENABLE) ||
-	    (hdlp->ih_type != DDI_INTR_TYPE_MSIX)) {
+	if (hdlp->ih_state != DDI_IHDL_STATE_ENABLE) {
 		rw_exit(&hdlp->ih_rwlock);
 		return (DDI_EINVAL);
 	}
+
+#if !defined(__aarch64__)
+	/*
+	 * This is a really odd place to enforce this restriction, and it's
+	 * a restriction that does not exist on Arm.
+	 */
+	if (hdlp->ih_type != DDI_INTR_TYPE_MSIX) {
+		rw_exit(&hdlp->ih_rwlock);
+		return (DDI_EINVAL);
+	}
+#endif
 
 	ret = i_ddi_intr_ops(hdlp->ih_dip, hdlp->ih_dip,
 	    DDI_INTROP_SETTARGET, hdlp, &tgt);

--- a/usr/src/uts/common/sys/pci_tools.h
+++ b/usr/src/uts/common/sys/pci_tools.h
@@ -197,6 +197,7 @@ typedef struct pcitool_intr_info {
 #define	PCITOOL_CTLR_TYPE_UPPC		2
 #define	PCITOOL_CTLR_TYPE_PCPLUSMP	3
 #define	PCITOOL_CTLR_TYPE_APIX		4
+#define	PCITOOL_CTLR_TYPE_GIC		5
 
 /*
  * Size and endian fields for acc_attr bitmask.


### PR DESCRIPTION
_This is the fourth of five PRs that flesh out the verbs handled by our interrupt controllers, clean up interrupt routing for both FIXED interrupts and those managed through a root complex, implement interrupt redistribution and update documentation._

Four commits that wire up the interrupt accounting and redistribution infrastructure on aarch64. With the driver verbs in place (PR #255) and the routing rework landed (PR #256), the GIC controllers can now answer GETTARGET/SETTARGET queries and the DDI framework routes them correctly. This PR connects the consumers: `intrd(8)` needs per-interrupt tick accounting and kstats to make load-balancing decisions, and `pcitool(8)` needs ioctls to query and retarget interrupts. After this PR, `intrd` and `pcitool -i` work on aarch64.

## ddi_intr: allow non-MSI-X interrupts to be affinitised

`set_intr_affinity` has always rejected anything that isn't MSI-X. On x86 this made some sense - FIXED interrupts are managed through the IOAPIC and MSI vectors share a group address, so per-vector retargeting only worked cleanly for MSI-X. On aarch64, GIC SPIs (FIXED) are independently targetable via `GICD_IROUTERn`, and MSI SPIs/LPIs are independently targetable via `GICD_IROUTERn` or ITS `MOVI`. There is no architectural reason to restrict affinity to MSI-X.

The fix splits the state check (handle must be enabled) from the type check (must be MSI-X), and makes the type check `#if !defined(__aarch64__)`. The controller is the right place to enforce any type-specific restrictions, not this common-code gate.

## intr: wire up `ip_ticks` in all GIC drivers

Pass `&priv->ip_ticks` instead of `NULL` as the `ticksp` argument to `add_avintr` in the ENABLE path of all four GIC interrupt controllers:

* gictwo: FIXED SPIs
* gicthree: FIXED SPIs
* gicv2m: MSI SPIs
* gicv3_its: MSI LPIs

Without this, `ip_ticks` stays zero and `intrd` sees every interrupt as consuming no CPU time. One-line change per driver, but it's the difference between `intrd` having data to work with and having nothing.

## pci: add pci_intrs kstats for interrupt time accounting

New file `aarch64/io/pci/pci_kstats.c`. Creates per-interrupt `pci_intrs` kstats consumed by `intrd(8)` for interrupt load balancing. Each kstat instance reports:

* device name and instance
* interrupt type (fixed/msi/msix)
* target CPU (via GETTARGET through the DDI interrupt tree)
* priority
* cumulative service time (from `ip_ticks`)
* interrupt number (the GIC INTID)
* device and bus paths

The template is intended to be compatible with i86pc's `pci_intrs` kstats so that `intrd` and `Intrs.xs` can consume them without modification.

Kstats are created at ADDISR time and deleted at REMISR time - `pci_common_intr_ops` now intercepts these two verbs to call `pci_kstat_create`/`pci_kstat_delete` before forwarding to the controller. Note that ADDISR fires before ENABLE, so there is a window where the kstat exists but the interrupt is not yet active; the update callback handles this by reporting "disabled" with zeroed fields.

The target CPU is obtained by calling `get_intr_affinity`, which walks the DDI interrupt tree via GETTARGET. This is more expensive than x86's direct PSM register read, but preserves the clean DDI abstraction. The comment notes that caching may be added if this proves to be a bottleneck.

Also: the old `pci_get_intr_from_vecirq` and `pci_get_cpu_from_vecirq` XXXARM stubs are deleted - the kstat path replaces what they were placeholder for.

Build integration: `_MODULE_NAME` defined via `CPPFLAGS` for the kstat module name - this is `pcierc` in our case, not a specific root complex driver (`ecam`).

## pci: implement pcitool interrupt ioctls and add GIC controller type

Implements the three `pcitool` interrupt ioctl handlers that were returning `ENOTSUP`:

* **`PCITOOL_SYSTEM_INTR_INFO`** (`pcitool_intr_info`): returns `PCITOOL_CTLR_TYPE_GIC` (value 5, new constant in `pci_tools.h`) and `num_intr = 1020` (maximum SPI INTID - bounds `pcitool`'s brute-force iteration). A future ioctl should provide proper active-vector enumeration - or userspace could just use kstats.

* **`PCITOOL_DEVICE_GET_INTR`** (`pcitool_get_intr`): uses `av_get_vector_info` (from PR #254) to walk the autovect chain for a given vector number, returns handler count, per-handler device info (driver name, instance, path), and the current target CPU via `get_intr_affinity`. Supports the variable-length `pcitool_intr_get_t` response with caller-specified `num_devs_ret`.

* **`PCITOOL_DEVICE_SET_INTR`** (`pcitool_set_intr`): looks up the vector via `av_get_vector_info`, reads the current CPU via `get_intr_affinity`, retargets via `set_intr_affinity`, and returns the original CPU. Supports both `PCITOOL_V1` and `PCITOOL_V2` request formats (though it feels weird to keep the legacy interface). Unlike i86pc, this can retarget FIXED interrupts as well as MSI/MSI-X (the affinity restriction was lifted in the first commit of this PR).

The `pcitool(8)` CLI gets a `"GIC"` display case for the new controller type.

No changes to `intrd` or `Intrs.xs` were needed: `is_apic()` in `Intrs.xs` already returns `XSRETURN_NO` for any controller type other than `PCPLUSMP` or `APIX`, which correctly skips APIC-style MSI grouping for GIC where MSI vectors are independently targetable.

## Testing

Tested in the full stack for FDT platforms, grafted into my combined-everything stack for ACPI platforms.

* QEMU virt ([FDT](https://gist.github.com/r1mikey/8cb562753e9e49acb1ae49913b2af526), GICv3+ITS)
* RPi4/FDT (GICv2): [FIXED path through pci_common → gictwo](https://gist.github.com/r1mikey/460c7c350054e037523d69eca696f848)
* QEMU virt ([ACPI](https://gist.github.com/r1mikey/da627300ae2156473d5e31c2e43d3285), GICv3+ITS)
* [Ampere Altra Max](https://gist.github.com/r1mikey/edd1c2a6c73ccd0280551dacc309f94c): [full MSI-X + FIXED bridges](https://gist.github.com/r1mikey/8c7ce3faa1378c532e246e51678784f5)
