### PR TITLE
armv8: clean up references static references segkpm

### DIFF
--- a/usr/src/uts/armv8/os/efirt_machdep.c
+++ b/usr/src/uts/armv8/os/efirt_machdep.c
@@ -236,7 +236,7 @@ efirt_map_page(pte_t *root, uint64_t pa, pte_t pte_attr)
 			    kas.a_hat, (caddr_t)next), level, 1);
 			table = next;
 		} else {
-			table = (pte_t *)pfn_to_kseg(
+			table = (pte_t *)hat_kpm_pfn2va(
 			    PTE2PFN(table[idx], level));
 		}
 	}

--- a/usr/src/uts/armv8/os/mp_startup.c
+++ b/usr/src/uts/armv8/os/mp_startup.c
@@ -303,8 +303,8 @@ wakeup_cpu_spin_table_simple(cpu_t *cp)
 	 * XXXARM: This is sketchy.  We're far enough along that we should use
 	 * the VM subsystem properly.
 	 */
-	*(uint64_t *)(SEGKPM_BASE + addr) = pa;
-	flush_data_cache(SEGKPM_BASE + addr);
+	*(uint64_t *)(kpm_vbase + addr) = pa;
+	flush_data_cache((uintptr_t)kpm_vbase + addr);
 	dsb(ish);
 
 	__asm__ volatile("sev":::"memory");

--- a/usr/src/uts/armv8/os/startup.c
+++ b/usr/src/uts/armv8/os/startup.c
@@ -440,18 +440,26 @@ startup_init(void)
 	PRM_POINT("startup_init() done");
 }
 
-
 static void
 kpm_init(void)
 {
 	struct segkpm_crargs b;
 
+	/*
+	 * These variables were all designed for the SPARC "spitfire" MMU,
+	 * sfmmu, in which segkpm is mapped using a single pagesize - either
+	 * 8KB or 4MB.  On ARM, we might use 2+ page sizes, so none of these
+	 * variables have a single correct value.  They are set up as if we
+	 * always use the base pagesize, which should do no harm.  In the long
+	 * run, we should get rid of KPM's assumption that only a single
+	 * pagesize is used.
+	 */
 	kpm_pgshft = MMU_PAGESHIFT;
 	kpm_pgsz =  MMU_PAGESIZE;
 	kpm_pgoff = MMU_PAGEOFFSET;
 	kpmp2pshft = 0;
 	kpmpnpgs = 1;
-	ASSERT(((uintptr_t)kpm_vbase & (kpm_pgsz - 1)) == 0);
+	ASSERT(IS_P2ALIGNED(kpm_vbase, kpm_pgsz));
 
 	PRM_POINT("about to create segkpm");
 	rw_enter(&kas.a_lock, RW_WRITER);

--- a/usr/src/uts/armv8/vm/aarch64_mmu.c
+++ b/usr/src/uts/armv8/vm/aarch64_mmu.c
@@ -127,6 +127,9 @@ hat_kmap_init(uintptr_t base, size_t len)
 /*
  * Routine to pre-allocate data structures for hat_kern_setup(). It computes
  * how many pagetables it needs by walking the boot loader's page tables.
+ *
+ * NB: This runs while memory is still identity mapped and uses physical
+ * addresses
  */
 void
 hat_kern_alloc(
@@ -136,8 +139,15 @@ hat_kern_alloc(
 {
 	uint_t		table_cnt = 1;
 	uint_t		mapping_cnt;
+	extern size_t	kpm_size;
 
-	pte_t *l3_ptbl = (pte_t *)pa_to_kseg(TTBR_BADDR48(read_ttbr1()));
+	/* After khat is running, we can't access physical memory in this way */
+	VERIFY3U(khat_running, ==, 0);
+
+	/* KPM is not optional on ARM */
+	VERIFY3U(kpm_size, >, 0);
+
+	pte_t *l3_ptbl = (pte_t *)TTBR_BADDR48(read_ttbr1());
 
 	for (int i = 0; i < NPTEPERPT; i++) {
 		if (!PTE_ISTABLE(l3_ptbl[i], 3)) {
@@ -145,15 +155,14 @@ hat_kern_alloc(
 		}
 		++table_cnt;
 
-		pte_t *l2_ptbl = (pte_t *)pa_to_kseg(l3_ptbl[i] & PTE_PFN_MASK);
+		pte_t *l2_ptbl = (pte_t *)(l3_ptbl[i] & PTE_PFN_MASK);
 		for (int j = 0; j < NPTEPERPT; j++) {
 			if (!PTE_ISTABLE(l2_ptbl[j], 2)) {
 				continue;
 			}
 			++table_cnt;
 
-			pte_t *l1_ptbl = (pte_t *)pa_to_kseg(l2_ptbl[j] &
-			    PTE_PFN_MASK);
+			pte_t *l1_ptbl = (pte_t *)(l2_ptbl[j] & PTE_PFN_MASK);
 			for (int k = 0; k < NPTEPERPT; k++) {
 				if (!PTE_ISTABLE(l1_ptbl[k], 1)) {
 					continue;
@@ -335,6 +344,10 @@ is_reserved_memory(paddr_t pa)
 	return (B_TRUE);
 }
 
+/*
+ * NB: This runs while memory is still identity mapped and uses physical
+ * addresses
+ */
 void
 boot_reserve(void)
 {
@@ -354,8 +367,10 @@ boot_reserve(void)
 	uintptr_t va = KERNELBASE;
 	pte_t *ptbl[MMU_PAGE_LEVELS] = {0};
 
-	ptbl[MMU_PAGE_LEVELS - 1] =
-	    (pte_t *)pa_to_kseg(TTBR_BADDR48(read_ttbr1()));
+	/* After khat is running, we can't access physical memory in this way */
+	VERIFY3U(khat_running, ==, 0);
+
+	ptbl[MMU_PAGE_LEVELS - 1] = (pte_t *)TTBR_BADDR48(read_ttbr1());
 
 	ASSERT(MMFR0_PARANGE(read_id_aa64mmfr0()) < ARRAY_SIZE(pa_size_array));
 
@@ -387,8 +402,7 @@ boot_reserve(void)
 
 		if (PTE_ISTABLE(*ptbl[l], l)) {
 			ASSERT(ptbl[l - 1] == NULL);
-			ptbl[l - 1] = (pte_t *)pa_to_kseg(*ptbl[l] &
-			    PTE_PFN_MASK);
+			ptbl[l - 1] = (pte_t *)(*ptbl[l] & PTE_PFN_MASK);
 
 			ASSERT(is_reserved_memory(*ptbl[l] & PTE_PFN_MASK));
 

--- a/usr/src/uts/armv8/vm/hat_kdi.c
+++ b/usr/src/uts/armv8/vm/hat_kdi.c
@@ -67,8 +67,7 @@ kdi_vtop(uintptr_t vaddr, uint64_t *pap)
 int
 kdi_pread(caddr_t buf, size_t nbytes, uint64_t addr, size_t *ncopiedp)
 {
-	caddr_t va = (caddr_t)(addr + SEGKPM_BASE);
-	bcopy(va, buf, nbytes);
+	bcopy(kpm_vbase + addr, buf, nbytes);
 	*ncopiedp = nbytes;
 	return (0);
 }
@@ -76,8 +75,7 @@ kdi_pread(caddr_t buf, size_t nbytes, uint64_t addr, size_t *ncopiedp)
 int
 kdi_pwrite(caddr_t buf, size_t nbytes, uint64_t addr, size_t *ncopiedp)
 {
-	caddr_t va = (caddr_t)(addr + SEGKPM_BASE);
-	bcopy(buf, va, nbytes);
+	bcopy(buf, kpm_vbase + addr, nbytes);
 	*ncopiedp = nbytes;
 	return (0);
 }

--- a/usr/src/uts/armv8/vm/hat_kpm.c
+++ b/usr/src/uts/armv8/vm/hat_kpm.c
@@ -22,11 +22,14 @@
  * Copyright 2017 Hayashi Naoyuki
  */
 
+#include <sys/cmn_err.h>
 #include <sys/machparam.h>
+#include <sys/machsystm.h>
+
 #include <vm/hat.h>
 #include <vm/hat_aarch64.h>
 #include <vm/seg_kpm.h>
-#include <sys/cmn_err.h>
+
 
 /*
  * Kernel Physical Mapping (segkpm) hat interface routines.
@@ -37,7 +40,7 @@
 caddr_t
 hat_kpm_pfn2va(pfn_t pfn)
 {
-	return (caddr_t)(SEGKPM_BASE + (pfn<<MMU_PAGESHIFT));
+	return (kpm_vbase + ptob(pfn));
 }
 
 
@@ -45,7 +48,7 @@ pfn_t
 hat_kpm_va2pfn(caddr_t vaddr)
 {
 	ASSERT(IS_KPM_ADDR(vaddr));
-	return (mmu_btop((uintptr_t)vaddr - SEGKPM_BASE));
+	return ((pfn_t)btop(vaddr - kpm_vbase));
 }
 
 caddr_t

--- a/usr/src/uts/armv8/vm/hat_pte.h
+++ b/usr/src/uts/armv8/vm/hat_pte.h
@@ -125,8 +125,6 @@ extern struct hat_mmu_info mmu;
 	((index) * sizeof (pte_t))))
 
 #define	pfn_to_pa(pfn)		mmu_ptob((paddr_t)(pfn))
-#define	pa_to_kseg(pa)		((void *)((paddr_t)SEGKPM_BASE|(paddr_t)(pa)))
-#define	pfn_to_kseg(pfn)	pa_to_kseg(pfn_to_pa(pfn))
 
 #define	IN_VA_HOLE(va)		(HOLE_START <= (va) && (va) < HOLE_END)
 #define	FMT_PTE			"0x%lx"


### PR DESCRIPTION
_more from arm64/dynahat_

We should refer to segkpm via the dynamic `kpm_vbase`, and/or calculate addresses via the `hat_kpm_*` interfaces.  This will allow, in future, kpm to transparently change address or size.

While here, also assert that kpm exists.  It is not optional on arm (as it used to be optional, or at least missing, on 32bit platforms).

@r1mikey this doesn't change the BOOT_VEC thing, even though arguable it should at least call into the hat_kpm bits, because it didn't seem worth fixing when we want it gone.  Seem ok?