### PR TITLE
pg/cmt and lgroup preparation

### DIFF
--- a/usr/src/uts/armv8/Makefile.files
+++ b/usr/src/uts/armv8/Makefile.files
@@ -56,6 +56,7 @@ CORE_OBJS +=			\
 	machdep.o		\
 	trap.o			\
 	mp_machdep.o		\
+	pg_plat.o		\
 	mp_startup.o		\
 	startup.o		\
 	hardclk.o		\

--- a/usr/src/uts/armv8/os/cpuinfo.c
+++ b/usr/src/uts/armv8/os/cpuinfo.c
@@ -94,6 +94,42 @@ cpuinfo_for_affinity(uint64_t affinity)
 	return (NULL);
 }
 
+/*
+ * Look up a CPU's processorid_t by its MPIDR affinity value.
+ *
+ * This supports both cpuinfo lifecycle phases:
+ *   - Before cpuinfo_init: walks the boot_ci array.
+ *   - After cpuinfo_init: walks the cpuinfo linked list.
+ *
+ * Returns the ci_id (processorid_t) on success, or -1 if not found.
+ */
+processorid_t
+cpuinfo_id_for_mpidr(uint64_t mpidr)
+{
+	struct cpuinfo *ci;
+	int idx;
+
+	if (boot_xbp != NULL && boot_ci != NULL) {
+		for (idx = 0; idx < boot_xbp->bi_cpuinfo_cnt; idx++) {
+			if (boot_ci[idx].xci_mpidr == mpidr) {
+				return ((processorid_t)idx);
+			}
+		}
+
+		return ((processorid_t)-1);
+	}
+
+	for (ci = cpuinfo_first();
+	    ci != cpuinfo_end();
+	    ci = cpuinfo_next(ci)) {
+		if (ci->ci_mpidr == mpidr) {
+			return (ci->ci_id);
+		}
+	}
+
+	return ((processorid_t)-1);
+}
+
 static int
 fill_cpuinfo(const struct xboot_cpu_info *xci, struct cpuinfo *ci)
 {

--- a/usr/src/uts/armv8/os/mp_machdep.c
+++ b/usr/src/uts/armv8/os/mp_machdep.c
@@ -32,7 +32,6 @@
 #define	PSMI_1_7
 #include <sys/smp_impldefs.h>
 #include <sys/cmn_err.h>
-#include <sys/strlog.h>
 #include <sys/clock.h>
 #include <sys/debug.h>
 #include <sys/cpupart.h>
@@ -40,16 +39,14 @@
 #include <sys/cpu_event.h>
 #include <sys/cmt.h>
 #include <sys/cpu.h>
-#include <sys/disp.h>
 #include <sys/archsystm.h>
 #include <sys/machsystm.h>
 #include <sys/sysmacros.h>
 #include <sys/memlist.h>
 #include <sys/param.h>
 #include <sys/promif.h>
-#include <sys/cpu_pm.h>
-#include <sys/controlregs.h>
-#include <sys/irq.h>
+#include <sys/sunddi.h>
+#include <sys/sunndi.h>
 #include <sys/cpuinfo.h>
 
 extern void return_instr(void);
@@ -71,101 +68,6 @@ mach_softlvl_to_vect(int ipl)
 	kdisetsoftint = kdi_av_set_softint_pending;
 
 	return (-1);
-}
-
-int
-pg_plat_hw_shared(cpu_t *cp, pghw_type_t hw)
-{
-	switch (hw) {
-	case PGHW_CHIP:
-		return (1);
-	case PGHW_CACHE:
-		return (1);
-	default:
-		return (0);
-	}
-}
-
-/*
- * Compare two CPUs and see if they have a pghw_type_t sharing relationship
- * If pghw_type_t is an unsupported hardware type, then return -1
- */
-int
-pg_plat_cpus_share(cpu_t *cpu_a, cpu_t *cpu_b, pghw_type_t hw)
-{
-	id_t pgp_a, pgp_b;
-
-	pgp_a = pg_plat_hw_instance_id(cpu_a, hw);
-	pgp_b = pg_plat_hw_instance_id(cpu_b, hw);
-
-	if (pgp_a == -1 || pgp_b == -1)
-		return (-1);
-
-	return (pgp_a == pgp_b);
-}
-
-
-/*
- * Return a physical instance identifier for known hardware sharing
- * relationships
- */
-id_t
-pg_plat_hw_instance_id(cpu_t *cpu, pghw_type_t hw)
-{
-	switch (hw) {
-	case PGHW_CACHE:
-		return (read_mpidr() & 0xFF);
-	case PGHW_CHIP:
-		return (((read_mpidr() >> 16) |
-		    (read_mpidr() >> 8)) & 0xFFFFFF);
-	default:
-		return (-1);
-	}
-}
-
-/*
- * Override the default CMT dispatcher policy for the specified
- * hardware sharing relationship
- */
-pg_cmt_policy_t
-pg_plat_cmt_policy(pghw_type_t hw)
-{
-	switch (hw) {
-	case PGHW_CACHE:
-		return (CMT_BALANCE|CMT_AFFINITY);
-	default:
-		return (CMT_NO_POLICY);
-	}
-}
-
-id_t
-pg_plat_get_core_id(cpu_t *cpu)
-{
-	return (read_mpidr() & 0xFF);
-}
-
-pghw_type_t
-pg_plat_hw_rank(pghw_type_t hw1, pghw_type_t hw2)
-{
-	int i, rank1, rank2;
-
-	static pghw_type_t hw_hier[] = {
-		PGHW_CACHE,
-		PGHW_CHIP,
-		PGHW_NUM_COMPONENTS
-	};
-
-	for (i = 0; hw_hier[i] != PGHW_NUM_COMPONENTS; i++) {
-		if (hw_hier[i] == hw1)
-			rank1 = i;
-		if (hw_hier[i] == hw2)
-			rank2 = i;
-	}
-
-	if (rank1 > rank2)
-		return (hw1);
-	else
-		return (hw2);
 }
 
 void

--- a/usr/src/uts/armv8/os/mp_startup.c
+++ b/usr/src/uts/armv8/os/mp_startup.c
@@ -384,7 +384,7 @@ mp_startup_boot(void)
 
 	init_cpu_info(cp);
 
-	cp->cpu_flags |= CPU_RUNNING | CPU_READY | CPU_EXISTS;
+	cp->cpu_flags |= CPU_RUNNING | CPU_EXISTS;
 
 	cpu_event_init_cpu(cp);
 
@@ -415,6 +415,7 @@ mp_startup_boot(void)
 
 	mutex_enter(&cpu_lock);
 	cp->cpu_flags &= ~CPU_OFFLINE;
+	cp->cpu_flags |= CPU_READY;
 	cpu_enable_intr(cp);
 	cpu_add_active(cp);
 	mutex_exit(&cpu_lock);

--- a/usr/src/uts/armv8/os/pg_plat.c
+++ b/usr/src/uts/armv8/os/pg_plat.c
@@ -1,0 +1,140 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright (c) 1992, 2010, Oracle and/or its affiliates. All rights reserved.
+ */
+/*
+ * Copyright 2017 Hayashi Naoyuki
+ * Copyright 2026 Michael van der Westhuizen
+ */
+
+/*
+ * Processor Group platform support for aarch64.
+ *
+ * This is the base (FDT) implementation.  It derives processor topology
+ * (badly) from MPIDR affinity fields, which is a rough heuristic -- MPIDR
+ * encoding is implementation-defined and may not accurately reflect cache
+ * sharing or physical package boundaries.
+ */
+
+#include <sys/types.h>
+#include <sys/cpuvar.h>
+#include <sys/cmt.h>
+#include <sys/pghw.h>
+#include <sys/controlregs.h>
+
+int
+pg_plat_hw_shared(cpu_t *cp, pghw_type_t hw)
+{
+	switch (hw) {
+	case PGHW_CHIP:
+		return (1);
+	case PGHW_CACHE:
+		return (1);
+	default:
+		return (0);
+	}
+}
+
+/*
+ * Compare two CPUs and see if they have a pghw_type_t sharing relationship.
+ * If pghw_type_t is an unsupported hardware type, then return -1.
+ */
+int
+pg_plat_cpus_share(cpu_t *cpu_a, cpu_t *cpu_b, pghw_type_t hw)
+{
+	id_t pgp_a, pgp_b;
+
+	pgp_a = pg_plat_hw_instance_id(cpu_a, hw);
+	pgp_b = pg_plat_hw_instance_id(cpu_b, hw);
+
+	if (pgp_a == -1 || pgp_b == -1)
+		return (-1);
+
+	return (pgp_a == pgp_b);
+}
+
+/*
+ * Return a physical instance identifier for known hardware sharing
+ * relationships.
+ *
+ * NOTE: This MPIDR-based implementation reads the *current* CPU's MPIDR
+ * rather than the target cpu's.  It serves as a placeholder until PPTT-based
+ * topology is available on ACPI platforms.
+ */
+id_t
+pg_plat_hw_instance_id(cpu_t *cpu, pghw_type_t hw)
+{
+	switch (hw) {
+	case PGHW_CACHE:
+		return (read_mpidr() & 0xFF);
+	case PGHW_CHIP:
+		return (((read_mpidr() >> 16) |
+		    (read_mpidr() >> 8)) & 0xFFFFFF);
+	default:
+		return (-1);
+	}
+}
+
+/*
+ * Override the default CMT dispatcher policy for the specified
+ * hardware sharing relationship.
+ */
+pg_cmt_policy_t
+pg_plat_cmt_policy(pghw_type_t hw)
+{
+	switch (hw) {
+	case PGHW_CACHE:
+		return (CMT_BALANCE|CMT_AFFINITY);
+	default:
+		return (CMT_NO_POLICY);
+	}
+}
+
+id_t
+pg_plat_get_core_id(cpu_t *cpu)
+{
+	return (read_mpidr() & 0xFF);
+}
+
+pghw_type_t
+pg_plat_hw_rank(pghw_type_t hw1, pghw_type_t hw2)
+{
+	int i, rank1, rank2;
+
+	static pghw_type_t hw_hier[] = {
+		PGHW_CACHE,
+		PGHW_CHIP,
+		PGHW_NUM_COMPONENTS
+	};
+
+	for (i = 0; hw_hier[i] != PGHW_NUM_COMPONENTS; i++) {
+		if (hw_hier[i] == hw1)
+			rank1 = i;
+		if (hw_hier[i] == hw2)
+			rank2 = i;
+	}
+
+	if (rank1 > rank2)
+		return (hw1);
+	else
+		return (hw2);
+}

--- a/usr/src/uts/armv8/sys/cpuinfo.h
+++ b/usr/src/uts/armv8/sys/cpuinfo.h
@@ -134,6 +134,7 @@ extern struct cpuinfo *cpuinfo_next_enabled(struct cpuinfo *ci);
 extern struct cpuinfo *cpuinfo_end(void);
 
 extern struct cpuinfo *cpuinfo_for_affinity(uint64_t affinity);
+extern processorid_t cpuinfo_id_for_mpidr(uint64_t mpidr);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
_This is the first of three PRs that flesh out processor group (PG/CMT) topology and NUMA lgroup support for FDT platforms._

Three preparatory commits that provide infrastructure for the PG/CMT and lgroup work. These are independent and introduce no new behaviour.

## pg/cmt: move `pg_plat_*` to a new implementation file

Move the `pg_plat_*` functions out of `mp_machdep.c` into a dedicated `pg_plat.c`. On aarch64 these are firmware-derived rather than architectural, so they don't belong in the machdep grab-bag. SBBR platforms will eventually need a different implementation, and this separation makes that clean.

Pure code motion, no functional change.

## startup: move `CPU_READY` after `pg_cmt_cpu_startup`

Move the `CPU_READY` flag after `pg_cmt_cpu_startup` completes. The PG/CMT startup path may pause CPUs, which deadlocks if the target CPU is still spinning on its startup handoff bit. Reordering removes the window.

## cpuinfo: add a helper to find a CPU id by MPIDR

Add a helper that returns the `processorid_t` for a given MPIDR value, or −1 if not found. Supports both cpuinfo lifecycle phases: walks the `boot_ci` array before `cpuinfo_init`, the linked list after.

Used by the PG/CMT layer to map FDT cpu nodes (which carry MPIDR via the `reg` property) back to illumos CPU IDs.

## Testing

Tested in the full series.

**UMA: basic topology (QEMU)**

|   | Topology | Exercises |
|---|----------|-----------|
| 1 | [Single CPU](https://gist.github.com/r1mikey/5907bac039ba735477f738e60991a66a) | Degenerate case, no sharing |
| 2 | [1 socket, 1 cluster, 2 cores, 1 thread each](https://gist.github.com/r1mikey/c34280a9dcfee3d806dfeed4dbad2657) | CHIP/PROCNODE grouping, distinct IPIPE |
| 3 | [1 socket, 1 cluster, 1 core, 2 threads](https://gist.github.com/r1mikey/7b9dd03a403a4dee7031697404ac9e72) | IPIPE sharing (SMT) |
| 4 | [1 socket, 2 clusters, 1 core each, 1 thread each](https://gist.github.com/r1mikey/6528ea9b8816c9813514ce157836967b) | PROCNODE differentiation |
| 5 | [1 socket, 2 clusters, 2 cores each, 1 thread each](https://gist.github.com/r1mikey/d13c327e459cd58c184c11c432a6ca42) | Multi-level: CHIP+PROCNODE+IPIPE |
| 6 | [2 sockets, 1 cluster each, 2 cores each, 1 thread each](https://gist.github.com/r1mikey/35c242bec611d2db6e8c72aa7d324a8f) | CHIP differentiation |

**UMA: cache sharing variants (QEMU)**

|   | Base | Cache topology | Exercises |
|---|------|----------------|-----------|
| 7 | 5 | [Shared within each cluster](https://gist.github.com/r1mikey/efdc438627ec0f9ee404a2f1b349e39c) | PGHW_CACHE groups within PROCNODE |
| 8 | 6 | [Shared within each socket](https://gist.github.com/r1mikey/cd6a93bc7ee97c27e7fe537568260656) | PGHW_CACHE groups within CHIP |
| 9 | 6 | [Single shared cache across all CPUs](https://gist.github.com/r1mikey/589c54e897958a3bd4a09c3f57165507) | PGHW_CACHE collapses to one group |

**UMA: fallback (QEMU)**

|   | Topology | Exercises |
|---|----------|-----------|
| 10 | [4 CPUs, no cpu-map, shared l2 cache explicitly present](https://gist.github.com/r1mikey/ed2f458027523cf2b69cdc90de29883d) | Flat fallback: socket 0, cluster 0, one core per CPU |

**NUMA: lgroups (QEMU)**

|   | Topology | Exercises |
|---|----------|-----------|
| 11 | [Two NUMA nodes, two memory banks](https://gist.github.com/r1mikey/f2bb25058c3d95ab578e0d8b76f7d4ee) | Full lgroup path: node discovery, distance matrix, memnode mapping, NUMA-aware page_get_anylist |

**Bare metal**

|   | Platform | Exercises |
|---|----------|-----------|
| 12 | [RPi4](https://gist.github.com/r1mikey/9714abc6af7be137a60c4a21b34b9364) | Real hardware, GICv2, single-socket single-cluster |