### PR TITLE
Processor group topology for FDT systems

### DIFF
--- a/usr/src/uts/aarch64/sys/prom_plat.h
+++ b/usr/src/uts/aarch64/sys/prom_plat.h
@@ -24,11 +24,13 @@
  * All rights reserved.
  */
 /*
- * Copyright 2025 Michael van der Westhuizen
+ * Copyright 2026 Michael van der Westhuizen
  */
 
 #ifndef	_SYS_PROM_PLAT_H
 #define	_SYS_PROM_PLAT_H
+
+#include <sys/types.h>
 
 #ifdef	__cplusplus
 extern "C" {
@@ -50,6 +52,33 @@ extern pnode_t prom_fdt_find_compatible(pnode_t node, const char *compatible);
 extern void prom_fdt_walk(void(*func)(pnode_t, void*), void *arg);
 extern int prom_fdt_get_reg_address(pnode_t node, int index, uint64_t *reg);
 extern int prom_fdt_get_reg_size(pnode_t node, int index, uint64_t *regsize);
+
+/*
+ * Per-CPU topology extracted from the FDT by prom_fdt_get_cpu_topology.
+ *
+ * pft_mpidr       MPIDR affinity value from the cpu node's reg property.
+ * pft_llc_id      Last-level cache group identity, derived by following the
+ *                 next-level-cache phandle chain to its terminal node.  Two
+ *                 CPUs with the same pft_llc_id share an LLC.  Set to -1 if
+ *                 the cpu node has no next-level-cache property.
+ * pft_chip_id     Socket/package identity from the cpu-map node.  Set to 0
+ *                 (single socket) if cpu-map is absent or has no socket
+ *                 nodes.
+ * pft_cluster_id  Cluster identity from the cpu-map node.  Set to 0 (single
+ *                 cluster) if cpu-map is absent or has no cluster nodes.
+ * pft_core_id     Core identity from the cpu-map node.  Set to the CPU's
+ *                 ordinal index if cpu-map is absent or lacks a core/thread
+ *                 hierarchy (one core per CPU, no SMT).
+ */
+typedef struct prom_fdt_cpu_topo {
+	uint64_t	pft_mpidr;
+	id_t		pft_llc_id;
+	id_t		pft_chip_id;
+	id_t		pft_cluster_id;
+	id_t		pft_core_id;
+} prom_fdt_cpu_topo_t;
+
+extern int prom_fdt_get_cpu_topology(prom_fdt_cpu_topo_t *topo, int max_cpus);
 
 #ifdef	__cplusplus
 }

--- a/usr/src/uts/armv8/os/mlsetup.c
+++ b/usr/src/uts/armv8/os/mlsetup.c
@@ -217,8 +217,6 @@ mlsetup(struct regs *rp, struct xboot_info *xbp)
 
 	cpu_vm_data_init(CPU);
 
-	pg_cpu_bootstrap(CPU);
-
 	/* Get value of boot_ncpus. */
 	boot_ncpus = NCPU;
 	max_ncpus = boot_max_ncpus = boot_ncpus;
@@ -228,6 +226,14 @@ mlsetup(struct regs *rp, struct xboot_info *xbp)
 	 * values for boot_ncpus, boot_max_ncpus and max_ncpus.
 	 */
 	cpuinfo_bootstrap(CPU, xbp);
+
+	/*
+	 * Initialise the PG platform layer before pg_cpu_bootstrap runs.
+	 */
+	extern void pg_plat_set_fw(uint64_t);
+	pg_plat_set_fw(0);
+
+	pg_cpu_bootstrap(CPU);
 
 	/*
 	 * lgroup framework initialization. This must be done prior

--- a/usr/src/uts/armv8/os/pg_plat.c
+++ b/usr/src/uts/armv8/os/pg_plat.c
@@ -27,35 +27,171 @@
  */
 
 /*
- * Processor Group platform support for aarch64.
+ * Processor Group platform support for FDT-based aarch64 systems.
  *
- * This is the base (FDT) implementation.  It derives processor topology
- * (badly) from MPIDR affinity fields, which is a rough heuristic -- MPIDR
- * encoding is implementation-defined and may not accurately reflect cache
- * sharing or physical package boundaries.
+ * Topology is derived from two DT mechanisms:
+ *
+ *   next-level-cache (DTSpec s3.9)
+ *     Each cpu node may contain a "next-level-cache" phandle pointing to a
+ *     cache node.  Cache nodes may themselves chain via next-level-cache.
+ *     We follow each chain to its terminal node; two CPUs whose chains
+ *     converge at the same terminal node share an LLC (PGHW_CACHE).
+ *
+ *   cpu-map (DTSpec cpu-topology binding)
+ *     The cpu-map node, when present, describes a socket/cluster/core/thread
+ *     hierarchy.  The full walk classifies nodes by their DTSpec-mandated
+ *     name prefixes ("socketN", "clusterN", "coreN", "threadN"):
+ *       - socketN  -> PGHW_CHIP   (package)
+ *       - clusterN -> PGHW_PROCNODE (AMD CCX/CCD analogue)
+ *       - coreN    -> PGHW_IPIPE  (threads sharing a pipeline, i.e. SMT)
+ *       - threadN  -> leaf CPU
+ *     Socket is optional (clusters may appear directly under cpu-map).
+ *     Clusters may nest; the innermost cluster determines PROCNODE identity.
+ *     When cpu-map is absent or structurally invalid, a flat fallback is
+ *     applied: all CPUs in socket 0, cluster 0, one core per CPU, no SMT.
+ *
+ * MPIDR is NOT used - its encoding is implementation-defined and unreliable
+ * for topology inference without a-priori platform knowledge.
+ *
+ * Initialisation:
+ *   pg_plat_set_fw is called from mlsetup after cpuinfo_bootstrap
+ *   and before pg_cpu_bootstrap.  On some platforms this could receive a
+ *   firmware table physical address.  On FDT platforms the argument is unused
+ *   and we perform the FDT walk here instead.
  */
 
 #include <sys/types.h>
+#include <sys/param.h>
 #include <sys/cpuvar.h>
 #include <sys/cmt.h>
 #include <sys/pghw.h>
-#include <sys/controlregs.h>
+#include <sys/cmn_err.h>
+#include <sys/debug.h>
+#include <sys/promif.h>
+#include <sys/prom_plat.h>
+#include <sys/cpuinfo.h>
+
+/*
+ * Per-CPU topology information derived from the FDT.
+ */
+typedef struct fdt_cpu_info {
+	id_t		fci_chip_id;	/* socket from cpu-map */
+	id_t		fci_cluster_id;	/* cluster from cpu-map */
+	id_t		fci_llc_id;	/* LLC group from next-level-cache */
+	id_t		fci_core_id;	/* core group from cpu-map */
+	boolean_t	fci_valid;	/* entry populated */
+} fdt_cpu_info_t;
+
+static fdt_cpu_info_t fdt_info[NCPU];
+static boolean_t fdt_parsed = B_FALSE;
+
+/*
+ * Parse the FDT and populate fdt_info.
+ */
+static void
+fdt_parse_topology(void)
+{
+	prom_fdt_cpu_topo_t raw_topo[NCPU];
+	int ncpus;
+	int i;
+
+	ncpus = prom_fdt_get_cpu_topology(raw_topo, NCPU);
+	if (ncpus <= 0) {
+		/*
+		 * No FDT or no cpu nodes found.  Leave fdt_parsed false;
+		 * all lookups will use the flat fallback.
+		 */
+		return;
+	}
+
+	for (i = 0; i < ncpus; i++) {
+		processorid_t cpu_id;
+
+		cpu_id = cpuinfo_id_for_mpidr(raw_topo[i].pft_mpidr);
+		if (cpu_id == (processorid_t)-1) {
+			continue;
+		}
+
+		ASSERT3S(cpu_id, >=, 0);
+		ASSERT3S(cpu_id, <, NCPU);
+
+		fdt_info[cpu_id].fci_chip_id = raw_topo[i].pft_chip_id;
+		fdt_info[cpu_id].fci_cluster_id = raw_topo[i].pft_cluster_id;
+		fdt_info[cpu_id].fci_llc_id = raw_topo[i].pft_llc_id;
+		fdt_info[cpu_id].fci_core_id = raw_topo[i].pft_core_id;
+		fdt_info[cpu_id].fci_valid = B_TRUE;
+	}
+
+	/*
+	 * Normalise LLC IDs.  If a CPU has no next-level-cache
+	 * (llc_id == -1), give it a unique llc_id based on cpu_id so
+	 * it forms a singleton cache group rather than false-sharing
+	 * with other CPUs that also lack cache data.
+	 *
+	 * Use a negative offset from -1 so synthetic IDs can never
+	 * collide with real phandle values (which are positive).
+	 */
+	for (i = 0; i < NCPU; i++) {
+		if (!fdt_info[i].fci_valid) {
+			continue;
+		}
+
+		if (fdt_info[i].fci_llc_id == -1) {
+			fdt_info[i].fci_llc_id = -(i + 2);
+		}
+	}
+
+	fdt_parsed = B_TRUE;
+}
+
+static id_t
+fdt_instance_id(processorid_t id, pghw_type_t hw)
+{
+	switch (hw) {
+	case PGHW_IPIPE:
+		return (fdt_info[id].fci_core_id);
+	case PGHW_CACHE:
+		return (fdt_info[id].fci_llc_id);
+	case PGHW_PROCNODE:
+		return (fdt_info[id].fci_cluster_id);
+	case PGHW_CHIP:
+		return (fdt_info[id].fci_chip_id);
+	default:
+		return ((id_t)-1);
+	}
+}
 
 int
 pg_plat_hw_shared(cpu_t *cp, pghw_type_t hw)
 {
-	switch (hw) {
-	case PGHW_CHIP:
-		return (1);
-	case PGHW_CACHE:
-		return (1);
-	default:
+	id_t my_id;
+	int i;
+	processorid_t id = cp->cpu_id;
+
+	if (!fdt_parsed || id < 0 || id >= NCPU || !fdt_info[id].fci_valid) {
 		return (0);
 	}
+
+	if ((my_id = fdt_instance_id(id, hw)) == (id_t)-1) {
+		return (0);
+	}
+
+	for (i = 0; i < NCPU; i++) {
+		if (i == id || !fdt_info[i].fci_valid) {
+			continue;
+		}
+
+		if (fdt_instance_id(i, hw) == my_id) {
+			return (1);
+		}
+	}
+
+	return (0);
 }
 
 /*
  * Compare two CPUs and see if they have a pghw_type_t sharing relationship.
+ *
  * If pghw_type_t is an unsupported hardware type, then return -1.
  */
 int
@@ -66,8 +202,9 @@ pg_plat_cpus_share(cpu_t *cpu_a, cpu_t *cpu_b, pghw_type_t hw)
 	pgp_a = pg_plat_hw_instance_id(cpu_a, hw);
 	pgp_b = pg_plat_hw_instance_id(cpu_b, hw);
 
-	if (pgp_a == -1 || pgp_b == -1)
+	if (pgp_a == -1 || pgp_b == -1) {
 		return (-1);
+	}
 
 	return (pgp_a == pgp_b);
 }
@@ -75,20 +212,39 @@ pg_plat_cpus_share(cpu_t *cpu_a, cpu_t *cpu_b, pghw_type_t hw)
 /*
  * Return a physical instance identifier for known hardware sharing
  * relationships.
- *
- * NOTE: This MPIDR-based implementation reads the *current* CPU's MPIDR
- * rather than the target cpu's.  It serves as a placeholder until PPTT-based
- * topology is available on ACPI platforms.
  */
 id_t
 pg_plat_hw_instance_id(cpu_t *cpu, pghw_type_t hw)
 {
+	processorid_t id = cpu->cpu_id;
+
+	if (!fdt_parsed || id < 0 || id >= NCPU || !fdt_info[id].fci_valid) {
+		/*
+		 * Flat fallback: unique core, single cluster, single chip.
+		 */
+		switch (hw) {
+		case PGHW_IPIPE:
+			return (id);
+		case PGHW_CACHE:
+			return (id);
+		case PGHW_PROCNODE:
+			return (0);
+		case PGHW_CHIP:
+			return (0);
+		default:
+			return (-1);
+		}
+	}
+
 	switch (hw) {
+	case PGHW_IPIPE:
+		return (fdt_info[id].fci_core_id);
 	case PGHW_CACHE:
-		return (read_mpidr() & 0xFF);
+		return (fdt_info[id].fci_llc_id);
+	case PGHW_PROCNODE:
+		return (fdt_info[id].fci_cluster_id);
 	case PGHW_CHIP:
-		return (((read_mpidr() >> 16) |
-		    (read_mpidr() >> 8)) & 0xFFFFFF);
+		return (fdt_info[id].fci_chip_id);
 	default:
 		return (-1);
 	}
@@ -97,6 +253,9 @@ pg_plat_hw_instance_id(cpu_t *cpu, pghw_type_t hw)
 /*
  * Override the default CMT dispatcher policy for the specified
  * hardware sharing relationship.
+ *
+ * This follows the i86pc implementation, with the exception being that we
+ * don't recognise FPU sharing (nothing in FDT can provide this information).
  */
 pg_cmt_policy_t
 pg_plat_cmt_policy(pghw_type_t hw)
@@ -104,6 +263,8 @@ pg_plat_cmt_policy(pghw_type_t hw)
 	switch (hw) {
 	case PGHW_CACHE:
 		return (CMT_BALANCE|CMT_AFFINITY);
+	case PGHW_IPIPE:
+	case PGHW_PROCNODE:
 	default:
 		return (CMT_NO_POLICY);
 	}
@@ -112,29 +273,52 @@ pg_plat_cmt_policy(pghw_type_t hw)
 id_t
 pg_plat_get_core_id(cpu_t *cpu)
 {
-	return (read_mpidr() & 0xFF);
+	processorid_t id = cpu->cpu_id;
+
+	if (fdt_parsed && id >= 0 && id < NCPU && fdt_info[id].fci_valid) {
+		return (fdt_info[id].fci_core_id);
+	}
+
+	return ((id_t)id);
 }
 
 pghw_type_t
 pg_plat_hw_rank(pghw_type_t hw1, pghw_type_t hw2)
 {
-	int i, rank1, rank2;
+	int i;
+	int rank1 = 0;
+	int rank2 = 0;
 
 	static pghw_type_t hw_hier[] = {
+		PGHW_IPIPE,
 		PGHW_CACHE,
+		PGHW_PROCNODE,
 		PGHW_CHIP,
 		PGHW_NUM_COMPONENTS
 	};
 
 	for (i = 0; hw_hier[i] != PGHW_NUM_COMPONENTS; i++) {
-		if (hw_hier[i] == hw1)
+		if (hw_hier[i] == hw1) {
 			rank1 = i;
-		if (hw_hier[i] == hw2)
+		}
+
+		if (hw_hier[i] == hw2) {
 			rank2 = i;
+		}
 	}
 
-	if (rank1 > rank2)
+	if (rank1 > rank2) {
 		return (hw1);
-	else
+	} else {
 		return (hw2);
+	}
+}
+
+/*
+ * Called from mlsetup after cpuinfo_bootstrap and before pg_cpu_bootstrap.
+ */
+void
+pg_plat_set_fw(uint64_t arg0 __unused)
+{
+	fdt_parse_topology();
 }

--- a/usr/src/uts/armv8/promif/prom_emul_fdt.c
+++ b/usr/src/uts/armv8/promif/prom_emul_fdt.c
@@ -33,6 +33,9 @@
 #include <sys/systm.h>
 #include <sys/ddi.h>
 #include <sys/sunddi.h>
+#include <sys/param.h>
+#include <sys/prom_plat.h>
+#include <sys/cmn_err.h>
 #include <libfdt.h>
 
 static const struct fdt_header *fdtp = NULL;
@@ -765,4 +768,396 @@ promif_setup(void)
 {
 	if (prom_propname_warn == -1)
 		prom_propname_warn = 1;
+}
+
+/*
+ * Classification of cpu-map node types per DTSpec cpu-topology binding.
+ *
+ * Node names must be "socketN", "clusterN", "coreN", or "threadN".
+ */
+typedef enum cpumap_level {
+	CML_SOCKET,
+	CML_CLUSTER,
+	CML_CORE,
+	CML_THREAD,
+	CML_UNKNOWN
+} cpumap_level_t;
+
+static cpumap_level_t
+cpumap_classify(const char *name)
+{
+	if (name == NULL) {
+		return (CML_UNKNOWN);
+	} else if (strncmp(name, "socket", 6) == 0) {
+		return (CML_SOCKET);
+	} else if (strncmp(name, "cluster", 7) == 0) {
+		return (CML_CLUSTER);
+	} else if (strncmp(name, "core", 4) == 0) {
+		return (CML_CORE);
+	} else if (strncmp(name, "thread", 6) == 0) {
+		return (CML_THREAD);
+	}
+
+	return (CML_UNKNOWN);
+}
+
+/*
+ * Check that all children of a cpu-map container node share a single
+ * classification.  Returns the common type, or CML_UNKNOWN if the node
+ * has no children, any child has an unrecognised name, or children have
+ * mixed types.
+ */
+static cpumap_level_t
+cpumap_children_type(int parent_off)
+{
+	cpumap_level_t common = CML_UNKNOWN;
+	int child;
+
+	fdt_for_each_subnode(child, fdtp, parent_off) {
+		const char *name = fdt_get_name(fdtp, child, NULL);
+		cpumap_level_t t = cpumap_classify(name);
+
+		if (t == CML_UNKNOWN) {
+			return (CML_UNKNOWN);
+		}
+
+		if (common == CML_UNKNOWN) {
+			common = t;
+		} else if (t != common) {
+			return (CML_UNKNOWN);
+		}
+	}
+
+	return (common);
+}
+
+/*
+ * Walk the /cpus node of the FDT and extract per-CPU topology information.
+ *
+ * For each cpu node (device_type = "cpu"):
+ * - Read the MPIDR affinity value from the reg property.
+ * - Follow the next-level-cache phandle chain to its terminal node.
+ *   The terminal node's phandle becomes the LLC group identity. CPUs
+ *   sharing the same terminal cache phandle share an LLC.
+ * - If /cpus/cpu-map exists, walk its full hierarchy per the DTSpec
+ *   cpu-topology binding:
+ *     cpu-map -> socketN -> clusterN [-> clusterN] -> coreN [-> threadN]
+ *   Socket is optional: clusters may appear directly under cpu-map.
+ *   Clusters may nest.  Cores are leaves (no SMT) or contain threads.
+ *   Node names are validated against "socketN", "clusterN", "coreN",
+ *   "threadN" conventions.
+ *
+ * When cpu-map is absent or structurally invalid, the flat fallback is
+ * applied: all CPUs in socket 0, cluster 0, one core per CPU, no SMT.
+ *
+ * Returns the number of CPUs found (written to topo[0..n-1]), or -1
+ * on error.  max_cpus limits the output array size.
+ */
+int
+prom_fdt_get_cpu_topology(prom_fdt_cpu_topo_t *topo, int max_cpus)
+{
+	int cpus_off;
+	int cpu_off;
+	int count = 0;
+	int ac;
+
+	if (fdtp == NULL) {
+		return (-1);
+	}
+
+	cpus_off = fdt_path_offset(fdtp, "/cpus");
+	if (cpus_off < 0) {
+		return (-1);
+	}
+
+	ac = fdt_address_cells(fdtp, cpus_off);
+	if (ac != 1 && ac != 2) {
+		return (-1);
+	}
+
+	/*
+	 * We need to match cpu-map leaf "cpu" phandles back to the
+	 * enumerated cpu nodes.  Store phandles alongside the topo
+	 * entries.  Static because this runs exactly once at boot and
+	 * NCPU may be large enough to stress early boot stacks.
+	 */
+	static uint32_t cpu_phandles[NCPU];
+
+	fdt_for_each_subnode(cpu_off, fdtp, cpus_off) {
+		const char *devtype;
+		const void *prop;
+		int plen;
+
+		devtype = fdt_getprop(fdtp, cpu_off, "device_type", &plen);
+		if (devtype == NULL || strcmp(devtype, "cpu") != 0) {
+			continue;
+		}
+
+		if (count >= max_cpus) {
+			break;
+		}
+
+		/* MPIDR from reg property */
+		prop = fdt_getprop(fdtp, cpu_off, "reg", &plen);
+		if (prop == NULL) {
+			continue;
+		}
+
+		uint64_t mpidr = 0;
+		if (ac == 1 && plen >= (int)sizeof (uint32_t)) {
+			uint32_t v;
+			memcpy(&v, prop, sizeof (v));
+			mpidr = fdt32_to_cpu(v);
+		} else if (ac == 2 && plen >= (int)(sizeof (uint32_t) * 2)) {
+			uint32_t parts[2];
+			memcpy(parts, prop, sizeof (parts));
+			mpidr = ((uint64_t)fdt32_to_cpu(parts[0]) << 32) |
+			    fdt32_to_cpu(parts[1]);
+		} else {
+			continue;
+		}
+
+		topo[count].pft_mpidr = mpidr;
+
+		/*
+		 * Follow next-level-cache phandle chain to the terminal
+		 * cache node (the one without its own next-level-cache).
+		 */
+		id_t llc_id = -1;
+		int cur_off = cpu_off;
+		int depth = 0;
+#define	MAX_CACHE_DEPTH	8
+		for (;;) {
+			if (++depth > MAX_CACHE_DEPTH) {
+				cmn_err(CE_WARN, "prom_fdt: invalid "
+				    "next-level-cache chain");
+				return (-1);
+			}
+
+			prop = fdt_getprop(fdtp, cur_off,
+			    "next-level-cache", &plen);
+			if (prop == NULL || plen != (int)sizeof (uint32_t)) {
+				break;
+			}
+
+			uint32_t ph;
+			memcpy(&ph, prop, sizeof (ph));
+			ph = fdt32_to_cpu(ph);
+			llc_id = (id_t)ph;
+			int cache_off =
+			    fdt_node_offset_by_phandle(fdtp, ph);
+			if (cache_off < 0) {
+				break;
+			}
+
+			cur_off = cache_off;
+		}
+		topo[count].pft_llc_id = llc_id;
+
+		/* Default: single socket, single cluster, unique core */
+		topo[count].pft_chip_id = 0;
+		topo[count].pft_cluster_id = 0;
+		topo[count].pft_core_id = (id_t)count;
+
+		/* Record cpu node phandle for cpu-map matching */
+		prop = fdt_getprop(fdtp, cpu_off, "phandle", &plen);
+		if (prop != NULL && plen == (int)sizeof (uint32_t)) {
+			uint32_t ph;
+			memcpy(&ph, prop, sizeof (ph));
+			cpu_phandles[count] = fdt32_to_cpu(ph);
+		} else {
+			cpu_phandles[count] = 0;
+		}
+
+		count++;
+	}
+
+	/*
+	 * Parse cpu-map if present.
+	 *
+	 * The DTSpec cpu-topology binding defines a strict hierarchy:
+	 *   cpu-map -> socketN -> clusterN [-> clusterN] -> coreN [-> threadN]
+	 *
+	 * Socket is optional (clusters may appear directly under cpu-map).
+	 * Clusters may nest (inner clusters group cores within outer ones).
+	 * Cores are leaves when there is no SMT, or contain thread nodes.
+	 * Node names are mandated: "socketN", "clusterN", "coreN", "threadN".
+	 *
+	 * We walk depth-first with an explicit stack, classifying each node
+	 * by name prefix and validating children at each container level.
+	 * Any structural violation causes a bail to the flat fallback
+	 * (chip=0, cluster=0, core=cpu ordinal).
+	 */
+	int cpumap_off = fdt_subnode_offset(fdtp, cpus_off, "cpu-map");
+	if (cpumap_off < 0) {
+		goto done;
+	}
+
+	cpumap_level_t top_type = cpumap_children_type(cpumap_off);
+	if (top_type != CML_SOCKET && top_type != CML_CLUSTER) {
+		cmn_err(CE_WARN, "prom_fdt: invalid cpu-map structure, "
+		    "ignoring");
+		goto done;
+	}
+
+	id_t next_chip = 0, next_cluster = 0, next_core = 0;
+	id_t cur_chip = 0, cur_cluster = 0, cur_core = 0;
+
+#define	CPUMAP_MAX_DEPTH	8
+	int wstack[CPUMAP_MAX_DEPTH];
+	int wsp = 0;
+	int wnode;
+
+	wnode = fdt_first_subnode(fdtp, cpumap_off);
+	if (wnode < 0) {
+		goto done;
+	}
+
+	for (;;) {
+		const char *nname;
+		cpumap_level_t level;
+		boolean_t is_leaf = B_FALSE;
+
+		nname = fdt_get_name(fdtp, wnode, NULL);
+		level = cpumap_classify(nname);
+
+		if (level == CML_UNKNOWN) {
+			cmn_err(CE_WARN, "prom_fdt: unrecognised cpu-map "
+			    "node '%s', ignoring cpu-map",
+			    nname != NULL ? nname : "<null>");
+			goto cpumap_bail;
+		}
+
+		/* Update hierarchy context */
+		switch (level) {
+		case CML_SOCKET:
+			cur_chip = next_chip++;
+			break;
+		case CML_CLUSTER:
+			cur_cluster = next_cluster++;
+			break;
+		case CML_CORE:
+			cur_core = next_core++;
+			break;
+		default:
+			break;
+		}
+
+		/* Validate structure and handle leaves */
+		switch (level) {
+		case CML_SOCKET: {
+			cpumap_level_t ct = cpumap_children_type(wnode);
+			if (ct != CML_CLUSTER) {
+				cmn_err(CE_WARN, "prom_fdt: socket children "
+				    "must be clusters, ignoring cpu-map");
+				goto cpumap_bail;
+			}
+			break;
+		}
+		case CML_CLUSTER: {
+			cpumap_level_t ct = cpumap_children_type(wnode);
+			if (ct != CML_CLUSTER && ct != CML_CORE) {
+				cmn_err(CE_WARN, "prom_fdt: cluster children "
+				    "must be clusters or cores, ignoring "
+				    "cpu-map");
+				goto cpumap_bail;
+			}
+			break;
+		}
+		case CML_CORE: {
+			int fc = fdt_first_subnode(fdtp, wnode);
+			if (fc >= 0) {
+				cpumap_level_t ct =
+				    cpumap_children_type(wnode);
+				if (ct != CML_THREAD) {
+					cmn_err(CE_WARN, "prom_fdt: core "
+					    "children must be threads, "
+					    "ignoring cpu-map");
+					goto cpumap_bail;
+				}
+			} else {
+				is_leaf = B_TRUE;
+			}
+			break;
+		}
+		case CML_THREAD:
+			if (fdt_first_subnode(fdtp, wnode) >= 0) {
+				cmn_err(CE_WARN, "prom_fdt: thread node "
+				    "must be a leaf, ignoring cpu-map");
+				goto cpumap_bail;
+			}
+			is_leaf = B_TRUE;
+			break;
+		default:
+			goto cpumap_bail;
+		}
+
+		/* Match cpu phandle at leaf nodes */
+		if (is_leaf) {
+			const void *cpuprop;
+			int cpulen;
+
+			cpuprop = fdt_getprop(fdtp, wnode, "cpu", &cpulen);
+			if (cpuprop == NULL ||
+			    cpulen != (int)sizeof (uint32_t)) {
+				cmn_err(CE_WARN, "prom_fdt: cpu-map leaf "
+				    "'%s' missing cpu phandle, ignoring "
+				    "cpu-map",
+				    nname != NULL ? nname : "<null>");
+				goto cpumap_bail;
+			}
+
+			uint32_t cpu_ph;
+			memcpy(&cpu_ph, cpuprop, sizeof (cpu_ph));
+			cpu_ph = fdt32_to_cpu(cpu_ph);
+
+			for (int i = 0; i < count; i++) {
+				if (cpu_phandles[i] == cpu_ph) {
+					topo[i].pft_chip_id = cur_chip;
+					topo[i].pft_cluster_id = cur_cluster;
+					topo[i].pft_core_id = cur_core;
+					break;
+				}
+			}
+		}
+
+		/* Descend to first child for container nodes */
+		if (!is_leaf) {
+			int child = fdt_first_subnode(fdtp, wnode);
+			if (child >= 0 && wsp < CPUMAP_MAX_DEPTH) {
+				wstack[wsp++] = wnode;
+				wnode = child;
+				continue;
+			}
+
+			if (wsp >= CPUMAP_MAX_DEPTH) {
+				cmn_err(CE_WARN,
+				    "prom_fdt: cpu-map hierarchy too deep");
+				goto cpumap_bail;
+			}
+		}
+
+		/* Move to next sibling or pop up */
+		for (;;) {
+			int sib = fdt_next_subnode(fdtp, wnode);
+			if (sib >= 0) {
+				wnode = sib;
+				break;
+			}
+			if (wsp == 0) {
+				goto done;
+			}
+			wnode = wstack[--wsp];
+		}
+	}
+
+cpumap_bail:
+	for (int i = 0; i < count; i++) {
+		topo[i].pft_chip_id = 0;
+		topo[i].pft_cluster_id = 0;
+		topo[i].pft_core_id = (id_t)i;
+	}
+
+done:
+	return (count);
 }


### PR DESCRIPTION
_This is the second of three PRs that flesh out processor group (PG/CMT) topology and NUMA lgroup support for FDT platforms._

Replace the MPIDR-based topology heuristics with proper PG/CMT topology derived from the devicetree. MPIDR encoding is implementation-defined (ARMv8 ARM D17.2.99) and cannot reliably convey cache sharing or package boundaries without a-priori platform knowledge.

**An important difference**: this code will reproduce what I can divine as the behaviour that we'd see on UPPC and UP SPARC systems:
```
root@braich:~# /usr/bin/pginfo
pginfo: can not obtain Processor Group information: Operation not supported
root@braich:~# 
```

This looks a bit odd, but is technically correct and _should_ match existing UP systems.

Two DTSpec mechanisms drive the topology discovery:

**next-level-cache** (DTSpec §3.9) drives `PGHW_CACHE`: each cpu node's phandle chain is followed to its terminal cache node, and CPUs whose chains converge share an LLC.

**cpu-map** (DTSpec cpu-topology binding) drives three PG types:

| DT level | PG type | Meaning |
|---|---|---|
| `socketN` | `PGHW_CHIP` | Package |
| `clusterN` | `PGHW_PROCNODE` | e.g. AMD CCX/CCD analogue |
| `coreN` | `PGHW_IPIPE` | SMT threads sharing a pipeline |

Socket is optional per DTSpec; clusters may nest (innermost wins for `PROCNODE` identity). Absent hierarchy levels are assigned ID 0, meaning "there is one".

Hierarchy ranking follows the i86pc model: `IPIPE < CACHE < PROCNODE < CHIP`. `IPIPE` and `PROCNODE` use `CMT_NO_POLICY`; `CACHE` retains `CMT_BALANCE|CMT_AFFINITY`.

Any structural violation of the binding produces a `CE_WARN` and falls back to flat topology: all CPUs in socket 0, cluster 0, one core per CPU.

The FDT walk lives in `promif` (which has raw `libfdt` access). `pg_plat.c` consumes a processed per-CPU array and answers sharing queries by scanning per-CPU topology IDs at init time.

## Testing

Tested in the full series.

**UMA: basic topology (QEMU)**

|   | Topology | Exercises |
|---|----------|-----------|
| 1 | [Single CPU](https://gist.github.com/r1mikey/5907bac039ba735477f738e60991a66a) | Degenerate case, no sharing |
| 2 | [1 socket, 1 cluster, 2 cores, 1 thread each](https://gist.github.com/r1mikey/c34280a9dcfee3d806dfeed4dbad2657) | CHIP/PROCNODE grouping, distinct IPIPE |
| 3 | [1 socket, 1 cluster, 1 core, 2 threads](https://gist.github.com/r1mikey/7b9dd03a403a4dee7031697404ac9e72) | IPIPE sharing (SMT) |
| 4 | [1 socket, 2 clusters, 1 core each, 1 thread each](https://gist.github.com/r1mikey/6528ea9b8816c9813514ce157836967b) | PROCNODE differentiation |
| 5 | [1 socket, 2 clusters, 2 cores each, 1 thread each](https://gist.github.com/r1mikey/d13c327e459cd58c184c11c432a6ca42) | Multi-level: CHIP+PROCNODE+IPIPE |
| 6 | [2 sockets, 1 cluster each, 2 cores each, 1 thread each](https://gist.github.com/r1mikey/35c242bec611d2db6e8c72aa7d324a8f) | CHIP differentiation |

**UMA: cache sharing variants (QEMU)**

|   | Base | Cache topology | Exercises |
|---|------|----------------|-----------|
| 7 | 5 | [Shared within each cluster](https://gist.github.com/r1mikey/efdc438627ec0f9ee404a2f1b349e39c) | PGHW_CACHE groups within PROCNODE |
| 8 | 6 | [Shared within each socket](https://gist.github.com/r1mikey/cd6a93bc7ee97c27e7fe537568260656) | PGHW_CACHE groups within CHIP |
| 9 | 6 | [Single shared cache across all CPUs](https://gist.github.com/r1mikey/589c54e897958a3bd4a09c3f57165507) | PGHW_CACHE collapses to one group |

**UMA: fallback (QEMU)**

|   | Topology | Exercises |
|---|----------|-----------|
| 10 | [4 CPUs, no cpu-map, shared l2 cache explicitly present](https://gist.github.com/r1mikey/ed2f458027523cf2b69cdc90de29883d) | Flat fallback: socket 0, cluster 0, one core per CPU |

**NUMA: lgroups (QEMU)**

|   | Topology | Exercises |
|---|----------|-----------|
| 11 | [Two NUMA nodes, two memory banks](https://gist.github.com/r1mikey/f2bb25058c3d95ab578e0d8b76f7d4ee) | Full lgroup path: node discovery, distance matrix, memnode mapping, NUMA-aware page_get_anylist |

**Bare metal**

|   | Platform | Exercises |
|---|----------|-----------|
| 12 | [RPi4](https://gist.github.com/r1mikey/9714abc6af7be137a60c4a21b34b9364) | Real hardware, GICv2, single-socket single-cluster |