### PR TITLE
arm64 should treat pages like x86

### DIFF
--- a/usr/src/uts/common/vm/page.h
+++ b/usr/src/uts/common/vm/page.h
@@ -736,7 +736,7 @@ page_t	*page_get_freelist(struct vnode *, u_offset_t, struct seg *,
 
 page_t	*page_get_cachelist(struct vnode *, u_offset_t, struct seg *,
 		caddr_t, uint_t, struct lgrp *);
-#if defined(__i386) || defined(__amd64)
+#if defined(__x86) || defined(__aarch64__)
 int	page_chk_freelist(uint_t);
 #endif
 void	page_list_add(page_t *, int);

--- a/usr/src/uts/common/vm/seg_kmem.c
+++ b/usr/src/uts/common/vm/seg_kmem.c
@@ -64,9 +64,9 @@
  * They must never be paged out since segkmem_fault() is a no-op to
  * prevent recursive faults.
  *
- * Currently, seg_kmem pages are sharelocked (p_sharelock == 1) on
- * __x86 and are unlocked (p_sharelock == 0) on __sparc.  Once __x86
- * supports relocation the #ifdef kludges can be removed.
+ * Currently, seg_kmem pages are sharelocked (p_selock == 1) on x86 and
+ * aarch64 and are unlocked (p_selock == 0) on SPARC.  Once the other
+ * platforms support relocation the #ifdef kludges can be removed.
  *
  * seg_kmem pages may be subject to relocation by page_relocate(),
  * provided that the HAT supports it; if this is so, segkmem_reloc
@@ -404,7 +404,7 @@ boot_mapin(caddr_t addr, size_t size)
 
 		(void) page_hashin(pp, &kvp, (u_offset_t)(uintptr_t)addr, NULL);
 		pp->p_lckcnt = 1;
-#if defined(__x86)
+#if defined(__x86) || defined(__aarch64__)
 		page_downgrade(pp);
 #else
 		page_unlock(pp);
@@ -903,10 +903,13 @@ segkmem_xalloc(vmem_t *vmp, void *inaddr, size_t size, int vmflag, uint_t attr,
 	 * In addition, the x86 hat cannot safely do memory
 	 * allocations while in vmem_populate(), because there
 	 * is no simple bound on its usage.
+	 *
+	 * The aarch64 HAT is derived from the x86 hat and is assumed to have
+	 * the same limitation.
 	 */
 	if (vmflag & VM_MEMLOAD)
 		allocflag = HAT_NO_KALLOC;
-#if defined(__x86)
+#if defined(__x86) || defined(__aarch64__)
 	else if (vmem_is_populator())
 		allocflag = HAT_NO_KALLOC;
 #endif
@@ -923,7 +926,7 @@ segkmem_xalloc(vmem_t *vmp, void *inaddr, size_t size, int vmflag, uint_t attr,
 		    (PROT_ALL & ~PROT_USER) | HAT_NOSYNC | attr,
 		    HAT_LOAD_LOCK | allocflag);
 		pp->p_lckcnt = 1;
-#if defined(__x86)
+#if defined(__x86) || defined(__aarch64__)
 		page_downgrade(pp);
 #else
 		if (vmflag & SEGKMEM_SHARELOCKED)
@@ -1014,7 +1017,7 @@ segkmem_xfree(vmem_t *vmp, void *inaddr, size_t size, struct vnode *vp,
 	hat_unload(kas.a_hat, addr, size, HAT_UNLOAD_UNLOCK);
 
 	for (eaddr = addr + size; addr < eaddr; addr += PAGESIZE) {
-#if defined(__x86)
+#if defined(__x86) || defined(__aarch64__)
 		pp = page_find(vp, (u_offset_t)(uintptr_t)addr);
 		if (pp == NULL)
 			panic("segkmem_free: page not found");

--- a/usr/src/uts/common/vm/seg_kpm.h
+++ b/usr/src/uts/common/vm/seg_kpm.h
@@ -82,13 +82,13 @@ extern int	segmap_kpm;
 #define	IS_KPM_ADDR(addr) \
 	((addr) >= segkpm->s_base && (addr) < (segkpm->s_base + segkpm->s_size))
 
-#ifdef	__x86
+#if defined(__x86) || defined(__aarch64__)
 /* x86 systems use neither kpm_page_t nor kpm_spage_t when supporting kpm. */
 #define	KPMPAGE_T_SZ	(0)
-#else	/* __x86 */
+#else	/* __x86 || __aarch64__ */
 #define	KPMPAGE_T_SZ \
 	((kpm_smallpages == 0) ? sizeof (kpm_page_t) : sizeof (kpm_spage_t))
-#endif	/* __x86 */
+#endif	/* __x86 || __aarch64__ */
 
 #else	/* SEGKPM_SUPPORT */
 

--- a/usr/src/uts/common/vm/vm_page.c
+++ b/usr/src/uts/common/vm/vm_page.c
@@ -1860,7 +1860,7 @@ page_create_get_something(vnode_t *vp, u_offset_t off, struct seg *seg,
 
 	flags &= ~PG_MATCH_COLOR;
 	locked = 0;
-#if defined(__x86)
+#if defined(__x86)		/* x86 should retry with fewer limitations */
 	flags = page_create_update_flags_x86(flags);
 #endif
 
@@ -2038,7 +2038,7 @@ page_alloc_pages(struct vnode *vp, struct seg *seg, caddr_t addr,
 	ASSERT(basepp != NULL || ppa != NULL);
 	ASSERT(basepp == NULL || ppa == NULL);
 
-#if defined(__x86)
+#if defined(__x86) || defined(__aarch64__)
 	while (page_chk_freelist(szc) == 0) {
 		VM_STAT_ADD(alloc_pages[8]);
 		if (anypgsz == 0 || --szc == 0)

--- a/usr/src/uts/common/vm/vm_pagelist.c
+++ b/usr/src/uts/common/vm/vm_pagelist.c
@@ -3645,7 +3645,7 @@ page_get_contig_pages(int mnode, uint_t bin, int mtype, uchar_t szc,
 	return (NULL);
 }
 
-#if defined(__x86)
+#if defined(__x86) || defined(__aarch64__)
 /*
  * Determine the likelihood of finding/coalescing a szc page.
  * Return 0 if the likelihood is small otherwise return 1.


### PR DESCRIPTION
This corrects ifdefs so that our pages know they don't support relocation in the hat (like x86, not like sparc), and that kpm doesn't need meta-pages.

long-term relocation would be good (on x86 too) as part of attempts to avoid exhausting large pages, but those attempts don't exist or work right now...