### PR TITLE
uts/inet: OK_32PTR need only check for 16-byte alignment on aarch64, …

### DIFF
--- a/usr/src/cmd/mdb/common/modules/idm/idm.c
+++ b/usr/src/cmd/mdb/common/modules/idm/idm.c
@@ -3518,7 +3518,7 @@ iscsi_ini_hba_step(mdb_walk_state_t *wsp)
 /* ARGSUSED */
 
 #define	OK_16PTR(p)	(!((uintptr_t)(p) & 0x1))
-#if defined(__x86)
+#if defined(__x86) || defined(__aarch64__)
 #define	OK_32PTR(p)	OK_16PTR(p)
 #else
 #define	OK_32PTR(p)	(!((uintptr_t)(p) & 0x3))

--- a/usr/src/uts/common/inet/led.h
+++ b/usr/src/uts/common/inet/led.h
@@ -47,7 +47,7 @@ extern "C" {
  * that packet headers are 16 bit aligned.
  */
 #define	OK_16PTR(p)	(!((uintptr_t)(p) & 0x1))
-#if defined(__x86)
+#if defined(__x86) || defined(__aarch64__)
 #define	OK_32PTR(p)	OK_16PTR(p)
 #else
 #define	OK_32PTR(p)	(!((uintptr_t)(p) & 0x3))


### PR DESCRIPTION
…like x86

This is the ultimate cause of mac_ktest failures as packet data fails the alignment check, looking like:

```
/opt/os-tests/tests/mac/mac_cksum -4 -f -e -s 8 /opt/os-tests/tests/mac/data/ipv4_sctp.snoop
   0    FAIL    (len: 86)
MSG: (!((uintptr_t)(curr->b_rptr + meoi.meoi_l2hlen) & 0x3)) == B_TRUE (0x0 == 0x1)
```

You can see the overly restrictive alignment check in the assertion.

@r1mikey this is one you'd mentioned, I didnt expect it to be this simple when I looked though.  Assuming there's no objects to the lower alignment?