### PR TITLE
Allow gicv2m under a gicv3 interrupt controller

### DIFF
--- a/usr/src/uts/armv8/gicv2m/Makefile
+++ b/usr/src/uts/armv8/gicv2m/Makefile
@@ -37,11 +37,6 @@ ALL_TARGET	= $(BINARY)
 INSTALL_TARGET	= $(BINARY) $(ROOTMODULE)
 
 #
-# depends on drv/gictwo
-#
-LDFLAGS         += -Ndrv/gictwo
-
-#
 #	Default build targets.
 #
 .KEEP_STATE:

--- a/usr/src/uts/armv8/gicv3_its/Makefile
+++ b/usr/src/uts/armv8/gicv3_its/Makefile
@@ -37,7 +37,7 @@ ALL_TARGET	= $(BINARY)
 INSTALL_TARGET	= $(BINARY) $(ROOTMODULE)
 
 #
-# depends on drv/gicthree
+# depends on drv/gicthree for gicv3_contig_alloc/free DMA utilities
 #
 LDFLAGS         += -Ndrv/gicthree
 

--- a/usr/src/uts/armv8/io/gicthree.c
+++ b/usr/src/uts/armv8/io/gicthree.c
@@ -97,6 +97,7 @@
 #include <sys/list.h>
 #include <sys/mach_intr.h>
 #include <sys/gic_v3.h>
+#include <sys/gic_ops.h>
 #include <sys/vmem.h>
 #include <vm/hat.h>
 #include <vm/hat_pte.h>
@@ -1528,6 +1529,171 @@ gicv3_init(dev_info_t *dip, gicv3_conf_t *gc)
 	return (DDI_SUCCESS);
 }
 
+/*
+ * Child ops wrappers - v2m parent operations.
+ *
+ * gicv3_config_irq_spi() and gicv3_irq_ispending() are file-local and
+ * take gicv3_conf_t; the wrappers do the soft-state lookup.  The
+ * remaining four functions already take dev_info_t and are called
+ * through.
+ */
+static void
+gicthree_v2m_configure_irq(void *ctx, uint32_t intid, boolean_t is_edge)
+{
+	dev_info_t *dip = (dev_info_t *)ctx;
+	gicv3_conf_t *gc = ddi_get_soft_state(gicv3_soft_state,
+	    ddi_get_instance(dip));
+
+	VERIFY3P(gc, !=, NULL);
+	ASSERT(GIC_INTID_IS_ANY_SPI(intid));
+	gicv3_config_irq_spi(gc, intid, is_edge ?
+	    GICD_ICFGR_INT_CONFIG_EDGE : GICD_ICFGR_INT_CONFIG_LEVEL);
+}
+
+/*
+ * Return the pending state of an SGI, PPI, or SPI from the GICv3 hardware.
+ *
+ * SGIs and PPIs (INTIDs 0-31) are per-CPU: their pending state lives in
+ * GICR_ISPENDR0 on the current CPU's redistributor.  SPIs (INTIDs 32-1019)
+ * are shared: their pending state lives in GICD_ISPENDRn on the distributor.
+ *
+ * This is inherently racy: the pending bit can change at any instant.
+ * The result is a best-effort snapshot for diagnostic use.
+ */
+static boolean_t
+gicv3_irq_ispending(gicv3_conf_t *gc, uint32_t irq)
+{
+	uint32_t val;
+
+	ASSERT(GIC_INTID_IS_SGI(irq) || GIC_INTID_IS_PPI(irq) ||
+	    GIC_INTID_IS_SPI(irq));
+
+	if (GIC_INTID_IS_PERCPU(irq)) {
+		gicv3_redistributor_t *r;
+
+		VERIFY3U(CPU->cpu_id, <, gc->gc_num_redist);
+		r = &gc->gc_redist[CPU->cpu_id];
+
+		val = gicr_sgi_read4(r, GICR_ISPENDR0);
+		return ((val & GICD_IPENDR_REGBIT(irq)) != 0);
+	}
+
+	val = gicd_read4(gc, GICD_ISPENDRn(GICD_IPENDR_REGNUM(irq)));
+	return ((val & GICD_IPENDR_REGBIT(irq)) != 0);
+}
+
+static boolean_t
+gicthree_v2m_irq_ispending(void *ctx, uint32_t intid)
+{
+	dev_info_t *dip = (dev_info_t *)ctx;
+	gicv3_conf_t *gc = ddi_get_soft_state(gicv3_soft_state,
+	    ddi_get_instance(dip));
+
+	VERIFY3P(gc, !=, NULL);
+	return (gicv3_irq_ispending(gc, intid));
+}
+
+static processorid_t
+gicthree_v2m_get_target_spi(void *ctx, uint32_t intid)
+{
+	return (gicv3_get_target_spi((dev_info_t *)ctx, intid));
+}
+
+static void
+gicthree_v2m_set_target_spi(void *ctx, uint32_t intid, processorid_t cpu)
+{
+	gicv3_set_target_spi((dev_info_t *)ctx, intid, cpu);
+}
+
+static void
+gicthree_v2m_register_msi_range(void *ctx, uint32_t base, uint32_t count)
+{
+	gicv3_register_msi_range((dev_info_t *)ctx, base, count);
+}
+
+static void
+gicthree_v2m_unregister_msi_range(void *ctx, uint32_t base, uint32_t count)
+{
+	gicv3_unregister_msi_range((dev_info_t *)ctx, base, count);
+}
+
+static gicv2m_parent_ops_t gicthree_v2m_ops = {
+	.gpo_configure_irq = gicthree_v2m_configure_irq,
+	.gpo_irq_ispending = gicthree_v2m_irq_ispending,
+	.gpo_get_target_spi = gicthree_v2m_get_target_spi,
+	.gpo_set_target_spi = gicthree_v2m_set_target_spi,
+	.gpo_register_msi_range = gicthree_v2m_register_msi_range,
+	.gpo_unregister_msi_range = gicthree_v2m_unregister_msi_range,
+};
+
+/*
+ * Child ops wrappers - ITS parent operations.
+ */
+static int
+gicthree_its_alloc_lpi(void *ctx, uint32_t *lpip)
+{
+	return (gicv3_alloc_lpi((dev_info_t *)ctx, lpip));
+}
+
+static void
+gicthree_its_free_lpi(void *ctx, uint32_t lpi)
+{
+	gicv3_free_lpi((dev_info_t *)ctx, lpi);
+}
+
+static void
+gicthree_its_lpi_set_config(void *ctx, uint32_t lpi, uint8_t prio,
+    boolean_t enable)
+{
+	gicv3_lpi_set_config((dev_info_t *)ctx, lpi, prio, enable);
+}
+
+static boolean_t
+gicthree_its_lpi_ispending(void *ctx, uint32_t lpi, processorid_t cpuid)
+{
+	return (gicv3_lpi_ispending((dev_info_t *)ctx, lpi, cpuid));
+}
+
+static size_t
+gicthree_its_lpi_navail(void *ctx)
+{
+	return (gicv3_lpi_navail((dev_info_t *)ctx));
+}
+
+static ddi_irm_pool_t *
+gicthree_its_get_lpi_irm_pool(void *ctx)
+{
+	return (gicv3_get_lpi_irm_pool((dev_info_t *)ctx));
+}
+
+static uint64_t
+gicthree_its_redist_pa(void *ctx, processorid_t cpuid)
+{
+	return (gicv3_redist_pa((dev_info_t *)ctx, cpuid));
+}
+
+static uint32_t
+gicthree_its_redist_procnum(void *ctx, processorid_t cpuid)
+{
+	return (gicv3_redist_procnum((dev_info_t *)ctx, cpuid));
+}
+
+static gicv3its_parent_ops_t gicthree_its_ops = {
+	.ipo_alloc_lpi = gicthree_its_alloc_lpi,
+	.ipo_free_lpi = gicthree_its_free_lpi,
+	.ipo_lpi_set_config = gicthree_its_lpi_set_config,
+	.ipo_lpi_ispending = gicthree_its_lpi_ispending,
+	.ipo_lpi_navail = gicthree_its_lpi_navail,
+	.ipo_get_lpi_irm_pool = gicthree_its_get_lpi_irm_pool,
+	.ipo_redist_pa = gicthree_its_redist_pa,
+	.ipo_redist_procnum = gicthree_its_redist_procnum,
+};
+
+static gic_child_ops_t gicthree_child_ops = {
+	.gco_v2m_ops = &gicthree_v2m_ops,
+	.gco_its_ops = &gicthree_its_ops,
+};
+
 static int
 gicv3_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 {
@@ -1652,6 +1818,9 @@ gicv3_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 		    "system programmable interrupt controller.");
 	}
 
+	gicthree_child_ops.gco_ctx = (void *)dip;
+	syspic_register_child_ops(&gicthree_child_ops);
+
 	ddi_report_dev(dip);
 	return (DDI_SUCCESS);
 }
@@ -1695,39 +1864,6 @@ gicv3_bus_ctl(dev_info_t *dip, dev_info_t *rdip, ddi_ctl_enum_t ctlop,
 
 	return (ret);
 }
-
-/*
- * Return the pending state of an SGI, PPI, or SPI from the GICv3 hardware.
- *
- * SGIs and PPIs (INTIDs 0-31) are per-CPU: their pending state lives in
- * GICR_ISPENDR0 on the current CPU's redistributor.  SPIs (INTIDs 32-1019)
- * are shared: their pending state lives in GICD_ISPENDRn on the distributor.
- *
- * This is inherently racy: the pending bit can change at any instant.
- * The result is a best-effort snapshot for diagnostic use.
- */
-static boolean_t
-gicv3_irq_ispending(gicv3_conf_t *gc, uint32_t irq)
-{
-	uint32_t val;
-
-	ASSERT(GIC_INTID_IS_SGI(irq) || GIC_INTID_IS_PPI(irq) ||
-	    GIC_INTID_IS_SPI(irq));
-
-	if (GIC_INTID_IS_PERCPU(irq)) {
-		gicv3_redistributor_t *r;
-
-		VERIFY3U(CPU->cpu_id, <, gc->gc_num_redist);
-		r = &gc->gc_redist[CPU->cpu_id];
-
-		val = gicr_sgi_read4(r, GICR_ISPENDR0);
-		return ((val & GICD_IPENDR_REGBIT(irq)) != 0);
-	}
-
-	val = gicd_read4(gc, GICD_ISPENDRn(GICD_IPENDR_REGNUM(irq)));
-	return ((val & GICD_IPENDR_REGBIT(irq)) != 0);
-}
-
 
 /*
  * Check whether an INTID falls within a registered MSI SPI range.

--- a/usr/src/uts/armv8/io/gictwo.c
+++ b/usr/src/uts/armv8/io/gictwo.c
@@ -88,6 +88,7 @@
 #include <sys/archsystm.h>
 #include <sys/list.h>
 #include <sys/mach_intr.h>
+#include <sys/gic_ops.h>
 
 /*
  * MSI SPI range - registered by child MSI controllers (v2m) so the
@@ -1012,6 +1013,63 @@ gicv2_init(gicv2_conf_t *sc)
 	return (DDI_SUCCESS);
 }
 
+/*
+ * Child ops wrappers for GICv2m parent operations.
+ *
+ * These thin wrappers adapt the existing gictwo functions (which take
+ * dev_info_t *) to the gicv2m_parent_ops_t interface (which takes an
+ * opaque void *ctx).
+ */
+static void
+gictwo_v2m_configure_irq(void *ctx, uint32_t intid, boolean_t is_edge)
+{
+	gicv2_configure_irq((dev_info_t *)ctx, intid, is_edge);
+}
+
+static boolean_t
+gictwo_v2m_irq_ispending(void *ctx, uint32_t intid)
+{
+	return (gicv2_irq_ispending((dev_info_t *)ctx, intid));
+}
+
+static processorid_t
+gictwo_v2m_get_target_spi(void *ctx, uint32_t intid)
+{
+	return (gicv2_get_target_spi((dev_info_t *)ctx, intid));
+}
+
+static void
+gictwo_v2m_set_target_spi(void *ctx, uint32_t intid, processorid_t cpu)
+{
+	gicv2_set_target_spi((dev_info_t *)ctx, intid, cpu);
+}
+
+static void
+gictwo_v2m_register_msi_range(void *ctx, uint32_t base, uint32_t count)
+{
+	gicv2_register_msi_range((dev_info_t *)ctx, base, count);
+}
+
+static void
+gictwo_v2m_unregister_msi_range(void *ctx, uint32_t base, uint32_t count)
+{
+	gicv2_unregister_msi_range((dev_info_t *)ctx, base, count);
+}
+
+static gicv2m_parent_ops_t gictwo_v2m_ops = {
+	.gpo_configure_irq = gictwo_v2m_configure_irq,
+	.gpo_irq_ispending = gictwo_v2m_irq_ispending,
+	.gpo_get_target_spi = gictwo_v2m_get_target_spi,
+	.gpo_set_target_spi = gictwo_v2m_set_target_spi,
+	.gpo_register_msi_range = gictwo_v2m_register_msi_range,
+	.gpo_unregister_msi_range = gictwo_v2m_unregister_msi_range,
+};
+
+static gic_child_ops_t gictwo_child_ops = {
+	.gco_v2m_ops = &gictwo_v2m_ops,
+	.gco_its_ops = NULL,
+};
+
 static int
 gicv2_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 {
@@ -1100,6 +1158,9 @@ gicv2_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 		dev_err(dip, CE_PANIC, "Failed to register GIC as the "
 		    "system programmable interrupt controller.");
 	}
+
+	gictwo_child_ops.gco_ctx = (void *)dip;
+	syspic_register_child_ops(&gictwo_child_ops);
 
 	ddi_report_dev(dip);
 	return (DDI_SUCCESS);

--- a/usr/src/uts/armv8/io/gicv2m.c
+++ b/usr/src/uts/armv8/io/gicv2m.c
@@ -32,7 +32,7 @@
  *     Protects the per-device state list (v2m_devs).
  *
  *   v2m_dev_lock --> syspic_intrs_lock --> av_lock
- *   gc_lock is acquired independently via gicv2_configure_irq()
+ *   gc_lock is acquired independently via gpo_configure_irq()
  *   cross-driver call, and is held only for the duration of that
  *   call.  The base GICv2 driver does not call into the v2m driver.
  */
@@ -56,6 +56,7 @@
 #include <sys/mach_intr.h>
 #include <sys/gic_reg.h>
 #include <sys/ddi_intr_impl.h>
+#include <sys/gic_ops.h>
 
 /*
  * Device tree properties for SPI base/count override.
@@ -105,29 +106,9 @@ typedef struct gicv2m_state {
 	ddi_irm_pool_t		*v2m_irm_pool;		/* IRM pool for SPIs */
 	list_t			v2m_devs;		/* gicv2m_dev_state_t */
 	kmutex_t		v2m_dev_lock;		/* protects v2m_devs */
+	gicv2m_parent_ops_t	*v2m_ops;		/* parent GIC ops */
+	void			*v2m_ops_ctx;		/* parent GIC ctx */
 } gicv2m_state_t;
-
-/*
- * Configure an SPI as edge-triggered or level-sensitive on the GICv2
- * distributor.  Takes the distributor lock internally.
- *
- * gic_dip: dev_info_t of the parent GICv2 instance
- * irq:     SPI INTID (32-1019)
- * is_edge: B_TRUE for edge-triggered, B_FALSE for level-sensitive
- *
- * This is a private interface, implemented by the GICv2 driver.
- */
-extern void gicv2_configure_irq(dev_info_t *gic_dip, uint32_t irq,
-    boolean_t is_edge);
-extern boolean_t gicv2_irq_ispending(dev_info_t *gic_dip, uint32_t irq);
-extern processorid_t gicv2_get_target_spi(dev_info_t *gic_dip,
-    uint32_t intid);
-extern void gicv2_set_target_spi(dev_info_t *gic_dip, uint32_t intid,
-    processorid_t cpuid);
-extern void gicv2_register_msi_range(dev_info_t *gic_dip, uint32_t base,
-    uint32_t count);
-extern void gicv2_unregister_msi_range(dev_info_t *gic_dip, uint32_t base,
-    uint32_t count);
 
 static void *gicv2m_soft_state;
 
@@ -367,7 +348,7 @@ gicv2m_enable(gicv2m_state_t *sc, dev_info_t *rdip,
 	hdlp->ih_vector = spi;
 
 	/* Configure SPI as edge-triggered; MSI is always edge */
-	gicv2_configure_irq(sc->v2m_gic_dip, spi, B_TRUE);
+	sc->v2m_ops->gpo_configure_irq(sc->v2m_ops_ctx, spi, B_TRUE);
 
 	/*
 	 * syspic_get_state() acquires syspic_intrs_lock; we must release
@@ -470,7 +451,8 @@ gicv2m_getpending(gicv2m_state_t *sc, dev_info_t *rdip,
 	}
 	mutex_exit(&sc->v2m_dev_lock);
 
-	*(int *)result = gicv2_irq_ispending(sc->v2m_gic_dip, spi) ? 1 : 0;
+	*(int *)result = sc->v2m_ops->gpo_irq_ispending(sc->v2m_ops_ctx,
+	    spi) ? 1 : 0;
 	return (DDI_SUCCESS);
 }
 
@@ -509,7 +491,8 @@ gicv2m_gettarget(gicv2m_state_t *sc, dev_info_t *rdip,
 	}
 	mutex_exit(&sc->v2m_dev_lock);
 
-	*(processorid_t *)result = gicv2_get_target_spi(sc->v2m_gic_dip, spi);
+	*(processorid_t *)result = sc->v2m_ops->gpo_get_target_spi(
+	    sc->v2m_ops_ctx, spi);
 	return (DDI_SUCCESS);
 }
 
@@ -549,7 +532,7 @@ gicv2m_settarget(gicv2m_state_t *sc, dev_info_t *rdip,
 	}
 	mutex_exit(&sc->v2m_dev_lock);
 
-	gicv2_set_target_spi(sc->v2m_gic_dip, spi, new_cpu);
+	sc->v2m_ops->gpo_set_target_spi(sc->v2m_ops_ctx, spi, new_cpu);
 	return (DDI_SUCCESS);
 }
 
@@ -658,6 +641,7 @@ gicv2m_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 	int instance;
 	int nregs;
 	gicv2m_state_t *sc;
+	gic_child_ops_t *gco;
 	ddi_device_acc_attr_t reg_acc_attr = {
 		.devacc_attr_version		= DDI_DEVICE_ATTR_V0,
 		.devacc_attr_endian_flags	= DDI_STRUCTURE_LE_ACC,
@@ -708,6 +692,12 @@ gicv2m_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 	sc->v2m_gic_dip = ddi_get_parent(dip);
 	VERIFY3P(sc->v2m_gic_dip, !=, NULL);
 	VERIFY3P(sc->v2m_gic_dip, ==, syspic_get_dip());
+
+	gco = (gic_child_ops_t *)syspic_get_child_ops();
+	VERIFY3P(gco, !=, NULL);
+	VERIFY3P(gco->gco_v2m_ops, !=, NULL);
+	sc->v2m_ops = gco->gco_v2m_ops;
+	sc->v2m_ops_ctx = gco->gco_ctx;
 
 	/*
 	 * Initialise per-device state list.
@@ -831,8 +821,8 @@ gicv2m_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 	 * direct GETTARGET/SETTARGET for our INTIDs -- only we can
 	 * issue targeting operations for our SPIs.
 	 */
-	gicv2_register_msi_range(sc->v2m_gic_dip, sc->v2m_spi_base,
-	    sc->v2m_spi_count);
+	sc->v2m_ops->gpo_register_msi_range(sc->v2m_ops_ctx,
+	    sc->v2m_spi_base, sc->v2m_spi_count);
 
 	ddi_report_dev(dip);
 	return (DDI_SUCCESS);

--- a/usr/src/uts/armv8/io/gicv3_its.c
+++ b/usr/src/uts/armv8/io/gicv3_its.c
@@ -82,7 +82,7 @@
  * It must not be held when calling ITS command functions.
  *
  * gc_lpi_prop_lock (in gicthree.c) is acquired independently via
- * gicv3_lpi_set_config() - it is not nested with any ITS lock.
+ * ipo_lpi_set_config() - it is not nested with any ITS lock.
  *
  * Stall recovery
  * ==============
@@ -113,6 +113,7 @@
 #include <sys/syspic.h>
 #include <sys/syspic_impl.h>
 #include <sys/gic_v3.h>
+#include <sys/gic_ops.h>
 #include <sys/gic_reg.h>
 #include <sys/byteorder.h>
 #include <sys/cpu.h>
@@ -249,6 +250,10 @@ typedef struct gicv3_its_state {
 
 	/* Global list linkage (in parent GICv3's its_list) */
 	list_node_t		its_node;
+
+	/* Parent GIC ops (from syspic child ops) */
+	gicv3its_parent_ops_t	*its_ops;
+	void			*its_ops_ctx;
 } gicv3_its_state_t;
 
 static void *gicv3_its_soft_state;
@@ -596,10 +601,11 @@ static uint64_t
 gicv3_its_sync_target(gicv3_its_state_t *sc, processorid_t cpuid)
 {
 	if (sc->its_pta)
-		return (gicv3_redist_pa(sc->its_gic_dip, cpuid) >> 16);
+		return (sc->its_ops->ipo_redist_pa(sc->its_ops_ctx,
+		    cpuid) >> 16);
 	else
-		return ((uint64_t)gicv3_redist_procnum(sc->its_gic_dip,
-		    cpuid));
+		return ((uint64_t)sc->its_ops->ipo_redist_procnum(
+		    sc->its_ops_ctx, cpuid));
 }
 
 static int
@@ -777,7 +783,7 @@ gicv3_its_alloc(gicv3_its_state_t *sc, dev_info_t *rdip,
 	for (actual = 0; actual < count; actual++) {
 		uint32_t lpi;
 
-		if (gicv3_alloc_lpi(sc->its_gic_dip, &lpi) != 0)
+		if (sc->its_ops->ipo_alloc_lpi(sc->its_ops_ctx, &lpi) != 0)
 			break;
 		ds->ds_vecs[actual].gv_lpi = lpi;
 		ds->ds_vecs[actual].gv_eventid = actual;
@@ -817,7 +823,7 @@ gicv3_its_alloc(gicv3_its_state_t *sc, dev_info_t *rdip,
 	    PAGESIZE, &ds->ds_itt, &ds->ds_itt_pa,
 	    &ds->ds_itt_dmah, &ds->ds_itt_acch) != DDI_SUCCESS) {
 		for (i = 0; i < actual; i++)
-			gicv3_free_lpi(sc->its_gic_dip,
+			sc->its_ops->ipo_free_lpi(sc->its_ops_ctx,
 			    ds->ds_vecs[i].gv_lpi);
 		kmem_free(ds->ds_vecs, ds->ds_vecs_sz);
 		kmem_free(ds, sizeof (*ds));
@@ -829,7 +835,7 @@ gicv3_its_alloc(gicv3_its_state_t *sc, dev_info_t *rdip,
 	    ds->ds_itt_pa, B_TRUE) != 0) {
 		gicv3_contig_free(&ds->ds_itt_dmah, &ds->ds_itt_acch);
 		for (i = 0; i < actual; i++)
-			gicv3_free_lpi(sc->its_gic_dip,
+			sc->its_ops->ipo_free_lpi(sc->its_ops_ctx,
 			    ds->ds_vecs[i].gv_lpi);
 		kmem_free(ds->ds_vecs, ds->ds_vecs_sz);
 		kmem_free(ds, sizeof (*ds));
@@ -884,9 +890,10 @@ gicv3_its_free(gicv3_its_state_t *sc, dev_info_t *rdip,
 	 */
 	for (i = 0; i < ds->ds_nalloc; i++) {
 		ASSERT3S(ds->ds_vecs[i].gv_enabled, ==, B_FALSE);
-		gicv3_lpi_set_config(sc->its_gic_dip,
+		sc->its_ops->ipo_lpi_set_config(sc->its_ops_ctx,
 		    ds->ds_vecs[i].gv_lpi, 0, B_FALSE);
-		gicv3_free_lpi(sc->its_gic_dip, ds->ds_vecs[i].gv_lpi);
+		sc->its_ops->ipo_free_lpi(sc->its_ops_ctx,
+		    ds->ds_vecs[i].gv_lpi);
 	}
 
 	kmem_free(ds->ds_vecs, ds->ds_vecs_sz);
@@ -977,13 +984,13 @@ gicv3_its_enable(gicv3_its_state_t *sc, dev_info_t *rdip,
 	mutex_exit(&syspic_intrs_lock);
 
 	/* Enable LPI in PROPBASER: set priority and enable */
-	gicv3_lpi_set_config(sc->its_gic_dip, lpi,
+	sc->its_ops->ipo_lpi_set_config(sc->its_ops_ctx, lpi,
 	    GIC_IPL_TO_PRIO(hdlp->ih_pri), B_TRUE);
 
 	/* Program ITS translation: EventID -> (LPI, Collection) */
 	if (gicv3_its_do_mapti(sc, devid, eventid, lpi,
 	    (uint16_t)target_cpu, target_cpu) != 0) {
-		gicv3_lpi_set_config(sc->its_gic_dip, lpi,
+		sc->its_ops->ipo_lpi_set_config(sc->its_ops_ctx, lpi,
 		    GIC_IPL_TO_PRIO(hdlp->ih_pri), B_FALSE);
 		rem_avintr((void *)hdlp, hdlp->ih_pri,
 		    hdlp->ih_cb_func, lpi);
@@ -1060,7 +1067,7 @@ gicv3_its_disable(gicv3_its_state_t *sc, dev_info_t *rdip,
 	rem_avintr((void *)hdlp, hdlp->ih_pri, hdlp->ih_cb_func, lpi);
 
 	/* Disable LPI in PROPBASER */
-	gicv3_lpi_set_config(sc->its_gic_dip, lpi,
+	sc->its_ops->ipo_lpi_set_config(sc->its_ops_ctx, lpi,
 	    GIC_IPL_TO_PRIO(hdlp->ih_pri), B_FALSE);
 
 	/*
@@ -1155,7 +1162,7 @@ gicv3_its_gettarget(gicv3_its_state_t *sc, dev_info_t *rdip,
  *
  * The LPI INTID and target CPU are looked up from the per-device
  * vector state, then the pending bit is read from the target
- * redistributor's pending table via gicv3_lpi_ispending().
+ * redistributor's pending table via ipo_lpi_ispending().
  */
 static int
 gicv3_its_getpending(gicv3_its_state_t *sc, dev_info_t *rdip,
@@ -1179,7 +1186,7 @@ gicv3_its_getpending(gicv3_its_state_t *sc, dev_info_t *rdip,
 	target_cpu = ds->ds_vecs[idx].gv_target_cpu;
 	mutex_exit(&sc->its_dev_lock);
 
-	*(int *)result = gicv3_lpi_ispending(sc->its_gic_dip,
+	*(int *)result = sc->its_ops->ipo_lpi_ispending(sc->its_ops_ctx,
 	    lpi, target_cpu) ? 1 : 0;
 	return (DDI_SUCCESS);
 }
@@ -1256,7 +1263,7 @@ gicv3_its_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 		return (DDI_SUCCESS);
 	case DDI_INTROP_NAVAIL:
 		*(int *)result =
-		    (int)gicv3_lpi_navail(sc->its_gic_dip);
+		    (int)sc->its_ops->ipo_lpi_navail(sc->its_ops_ctx);
 		return (DDI_SUCCESS);
 	case DDI_INTROP_GETPENDING:
 		return (gicv3_its_getpending(sc, rdip, hdlp, result));
@@ -1269,7 +1276,7 @@ gicv3_its_intr_ops(dev_info_t *dip, dev_info_t *rdip,
 	case DDI_INTROP_GETPOOL: {
 		ddi_irm_pool_t *pool;
 
-		pool = gicv3_get_lpi_irm_pool(sc->its_gic_dip);
+		pool = sc->its_ops->ipo_get_lpi_irm_pool(sc->its_ops_ctx);
 		if (pool == NULL) {
 			return (DDI_ENOTSUP);
 		}
@@ -1652,6 +1659,7 @@ gicv3_its_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 	int instance;
 	int nregs;
 	gicv3_its_state_t *sc;
+	gic_child_ops_t *gco;
 	uint32_t ctlr;
 	int timeout_us;
 	cpu_t *cp;
@@ -1711,6 +1719,12 @@ gicv3_its_attach(dev_info_t *dip, ddi_attach_cmd_t cmd)
 	sc->its_dip = dip;
 	sc->its_gic_dip = ddi_get_parent(dip);
 	VERIFY3P(sc->its_gic_dip, !=, NULL);
+
+	gco = (gic_child_ops_t *)syspic_get_child_ops();
+	VERIFY3P(gco, !=, NULL);
+	VERIFY3P(gco->gco_its_ops, !=, NULL);
+	sc->its_ops = gco->gco_its_ops;
+	sc->its_ops_ctx = gco->gco_ctx;
 
 	/* Initialise locks */
 	mutex_init(&sc->its_cmd_lock, NULL, MUTEX_DRIVER, NULL);

--- a/usr/src/uts/armv8/os/syspic.c
+++ b/usr/src/uts/armv8/os/syspic.c
@@ -54,6 +54,7 @@ static syspic_ops_t spo_default_ops = {
 static spo_ctx_t spo_ctx = &spo_default_ops;
 static syspic_ops_t *spo_ops = &spo_default_ops;
 static dev_info_t *syspic_dip;
+static void *syspic_child_ops;
 
 static void
 stub_not_config(void)
@@ -162,6 +163,19 @@ dev_info_t *
 syspic_get_dip(void)
 {
 	return (syspic_dip);
+}
+
+void
+syspic_register_child_ops(void *ops)
+{
+	VERIFY3P(syspic_child_ops, ==, NULL);
+	syspic_child_ops = ops;
+}
+
+void *
+syspic_get_child_ops(void)
+{
+	return (syspic_child_ops);
 }
 
 void

--- a/usr/src/uts/armv8/sys/gic_ops.h
+++ b/usr/src/uts/armv8/sys/gic_ops.h
@@ -1,0 +1,114 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2026 Michael van der Westhuizen
+ */
+
+#ifndef _SYS_GIC_OPS_H
+#define	_SYS_GIC_OPS_H
+
+/*
+ * GIC parent-child operations
+ *
+ * Function pointer interfaces between the system interrupt controller
+ * (a GICv2 or GICv3 driver) and its subordinate MSI controllers
+ * (GICv2m frame drivers and GICv3 ITS drivers).
+ *
+ * The parent GIC driver populates and registers a gic_child_ops_t
+ * structure during attach. Subordinate drivers retrieve it via
+ * syspic_get_child_ops() and call the parent through the appropriate
+ * ops pointer, eliminating direct symbol dependencies between the
+ * drivers.
+ *
+ * Two ops structures are defined, named after the consumers rather
+ * than the providers, since the interfaces are shaped by what each
+ * consumer needs:
+ *
+ *   gicv2m_parent_ops_t   SPI-level operations needed by GICv2m
+ *                         frame drivers (provided by gictwo or
+ *                         gicthree)
+ *
+ *   gicv3its_parent_ops_t LPI and redistributor operations needed
+ *                         by GICv3 ITS drivers (provided by
+ *                         gicthree only)
+ */
+
+#include <sys/types.h>
+#include <sys/sunddi.h>
+#include <sys/ddi_intr_impl.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef	_KERNEL
+
+/*
+ * Operations a GICv2m frame driver needs from its parent GIC.
+ *
+ * Both gictwo and gicthree provide these; the context pointer
+ * passed to each function is the opaque value from gco_ctx.
+ */
+typedef struct gicv2m_parent_ops {
+	void (*gpo_configure_irq)(void *ctx, uint32_t intid,
+	    boolean_t is_edge);
+	boolean_t (*gpo_irq_ispending)(void *ctx, uint32_t intid);
+	processorid_t (*gpo_get_target_spi)(void *ctx, uint32_t intid);
+	void (*gpo_set_target_spi)(void *ctx, uint32_t intid,
+	    processorid_t cpu);
+	void (*gpo_register_msi_range)(void *ctx, uint32_t base,
+	    uint32_t count);
+	void (*gpo_unregister_msi_range)(void *ctx, uint32_t base,
+	    uint32_t count);
+} gicv2m_parent_ops_t;
+
+/*
+ * Operations a GICv3 ITS driver needs from its parent GIC.
+ *
+ * Only gicthree provides these; the context pointer passed to each
+ * function is the opaque value from gco_ctx.
+ */
+typedef struct gicv3its_parent_ops {
+	int (*ipo_alloc_lpi)(void *ctx, uint32_t *lpip);
+	void (*ipo_free_lpi)(void *ctx, uint32_t lpi);
+	void (*ipo_lpi_set_config)(void *ctx, uint32_t lpi, uint8_t prio,
+	    boolean_t enable);
+	boolean_t (*ipo_lpi_ispending)(void *ctx, uint32_t lpi,
+	    processorid_t cpuid);
+	size_t (*ipo_lpi_navail)(void *ctx);
+	ddi_irm_pool_t *(*ipo_get_lpi_irm_pool)(void *ctx);
+	uint64_t (*ipo_redist_pa)(void *ctx, processorid_t cpuid);
+	uint32_t (*ipo_redist_procnum)(void *ctx, processorid_t cpuid);
+} gicv3its_parent_ops_t;
+
+/*
+ * Container registered by the parent GIC with syspic.
+ *
+ * gco_ctx is the opaque context passed as the first argument to every
+ * ops function (typically the parent GIC's dev_info_t pointer).
+ *
+ * A GICv2 parent fills in gco_v2m_ops only (gco_its_ops == NULL).
+ * A GICv3 parent fills in both.
+ */
+typedef struct gic_child_ops {
+	void			*gco_ctx;
+	gicv2m_parent_ops_t	*gco_v2m_ops;
+	gicv3its_parent_ops_t	*gco_its_ops;
+} gic_child_ops_t;
+
+#endif	/* _KERNEL */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _SYS_GIC_OPS_H */

--- a/usr/src/uts/armv8/sys/syspic_impl.h
+++ b/usr/src/uts/armv8/sys/syspic_impl.h
@@ -162,6 +162,21 @@ extern int syspic_register_syspic(spo_ctx_t ctx, syspic_ops_t *ops,
  */
 extern dev_info_t *syspic_get_dip(void);
 
+/*
+ * Register and retrieve an opaque child-ops pointer.
+ *
+ * The system interrupt controller registers a pointer to a
+ * controller-specific child operations structure during attach.
+ * Subordinate interrupt controllers (such as MSI controllers)
+ * retrieve this pointer during their own attach to obtain indirect
+ * access to their parent's operations.
+ *
+ * The syspic facility stores this pointer opaquely and does not
+ * interpret its contents.
+ */
+extern void syspic_register_child_ops(void *ops);
+extern void *syspic_get_child_ops(void);
+
 #endif	/* _KERNEL */
 
 #ifdef __cplusplus


### PR DESCRIPTION
Per https://github.com/richlowe/illumos-gate/pull/238#issuecomment-4395508553 we can expect to find a GICv2m frame under a GICv3 controller.

Handle this by breaking the ELF-level dependency between the GIC child and parent drivers (note that this remains for code-sharing in the `gicv3_its` case, which has no impact here). The interface called by children is extracted into two ops structures (gicv2 ops and gicv3 ops) and bundled into a holding ops structure, a pointer to which is registered with `syspic` as an opaque pointer.

The GICv2 parent driver registers only the GICv2 ops, while the GICv3 driver populates both GICv2 ops and GICv3 ops.

Child GIC drivers then retrieve the GIC parent ops structure pointer and call into the parent via the ops. Lifetime-wise, this works due to the parent/child relationship in the device tree.

No impact on `gicv2m` when a child of `gictwo` or `gicv3_its` when a child of `gicthree`.

We can now attach a GICv2 under `gicthree` using `QEMU_SCRIPT_MACHINE="virt,gic-version=3,msi=gicv2m"`.

Testing:
* Qemu, [GICv2/GICv2m](https://gist.github.com/r1mikey/d8d9a75e80f03b6ede9f36d7b561c4cb) (unchanged)
* Qemu, [GICv3, ITS](https://gist.github.com/r1mikey/426d58bf04346fc74993c49843f04b69) (unchanged)
* Qemu, [GICv3, GICv2m](https://gist.github.com/r1mikey/9c9d4306fe9578e88a7f1452dd3df508) (new)