### PR TITLE
armv8: replace xcall with the i86pc implementation

### DIFF
--- a/usr/src/uts/aarch64/sys/mutex_impl.h
+++ b/usr/src/uts/aarch64/sys/mutex_impl.h
@@ -105,7 +105,7 @@ extern void null_xcall(void);
 #define	MUTEX_SYNC()	{	\
 			cpuset_t set;   \
 			CPUSET_ALL(set);        \
-			xc_call(0, 0, 0, (set),	\
+			xc_call(0, 0, 0, CPUSET2BV(set),	\
 			    (xc_func_t)null_xcall); \
 		}
 

--- a/usr/src/uts/armv8/os/dtrace_subr.c
+++ b/usr/src/uts/armv8/os/dtrace_subr.c
@@ -136,7 +136,7 @@ dtrace_xcall(processorid_t cpu, dtrace_xcall_t func, void *arg)
 	}
 
 	kpreempt_disable();
-	xc_sync((xc_arg_t)func, (xc_arg_t)arg, 0, (set),
+	xc_sync((xc_arg_t)func, (xc_arg_t)arg, 0, CPUSET2BV(set),
 	    (xc_func_t)(uintptr_t)dtrace_xcall_func); /* XXXARM */
 	kpreempt_enable();
 }

--- a/usr/src/uts/armv8/os/machdep.c
+++ b/usr/src/uts/armv8/os/machdep.c
@@ -452,17 +452,6 @@ panic_idle(void)
 
 	(void) setjmp(&curthread->t_pcb);
 
-	/*
-	 * XXXARM: This is a hack because our xcalls are not great right now.
-	 * If we kick a cpu into a function which spins (like this), we never
-	 * get chance to ack the xcall, and the caller waits for us forever.
-	 *
-	 * To break free of this, for right now, we ack the xcall ourselves as
-	 * we know this will always happen to us.
-	 */
-	CPU->cpu_m.xc_ack = 1;
-	dsb(ish);
-
 	dumpsys_helper();
 
 	/*
@@ -487,7 +476,7 @@ panic_stopcpus(cpu_t *cp, kthread_t *t, int spl)
 	(void) splzs();
 
 	CPUSET_ALL_BUT(xcset, cp->cpu_id);
-	xc_call(0, 0, 0, CPUSET2BV(xcset), (xc_func_t)panic_idle);
+	xc_priority(0, 0, 0, CPUSET2BV(xcset), (xc_func_t)panic_idle);
 
 	for (i = 0; i < NCPU; i++) {
 		if (i != cp->cpu_id && cpu[i] != NULL &&
@@ -549,19 +538,9 @@ static int
 mach_cpu_halt(xc_arg_t arg1 __unused, xc_arg_t arg2 __unused,
     xc_arg_t arg3 __unused)
 {
-	/*
-	 * XXXARM: As in panic_idle is a hack because our xcalls are not great
-	 * right now.  If we kick a cpu into a function which spins (like
-	 * this), we never get chance to ack the xcall, and the caller waits
-	 * for us forever.
-	 *
-	 * To break free of this, for right now, we ack the xcall ourselves as
-	 * we know this will always happen to us.
-	 */
-	CPU->cpu_m.xc_ack = 1;
-
-	for (;;)
+	for (;;) {
 		__asm__ volatile("wfe":::"memory");
+	}
 
 	return (0);
 }
@@ -572,7 +551,7 @@ stop_other_cpus(void)
 	cpuset_t xcset;
 
 	CPUSET_ALL_BUT(xcset, CPU->cpu_id);
-	xc_call_nowait(0, 0, 0, xcset, mach_cpu_halt);
+	xc_priority(0, 0, 0, CPUSET2BV(xcset), mach_cpu_halt);
 }
 
 /*
@@ -845,4 +824,13 @@ impl_obmem_pfnum(pfn_t pf)
 void
 do_hotinlines(struct module *mp)
 {
+}
+
+/*
+ * CPU Dynamic Reconfiguration is not currently supported on aarch64.
+ */
+boolean_t
+plat_dr_support_cpu(void)
+{
+	return (B_FALSE);
 }

--- a/usr/src/uts/armv8/os/mp_call.c
+++ b/usr/src/uts/armv8/os/mp_call.c
@@ -60,7 +60,7 @@ cpu_call(cpu_t *cp, cpu_call_func_t func, uintptr_t arg1, uintptr_t arg2)
 	} else {
 		CPUSET_ONLY(set, cp->cpu_id);
 		/* XXXARM */
-		xc_call((xc_arg_t)arg1, (xc_arg_t)arg2, 0, set,
+		xc_call((xc_arg_t)arg1, (xc_arg_t)arg2, 0, CPUSET2BV(set),
 		    (xc_func_t)(uintptr_t)func);
 	}
 

--- a/usr/src/uts/armv8/os/mp_startup.c
+++ b/usr/src/uts/armv8/os/mp_startup.c
@@ -621,6 +621,7 @@ mp_start_cpu_common(cpu_t *cp)
 
 	mp_startup_wait(&procset_slave, cpuid);
 
+	xc_init_cpu(cp);
 	(void) pg_cpu_init(cp, B_FALSE);
 	cpu_set_state(cp);
 	mp_startup_signal(&procset_master, cpuid);
@@ -679,7 +680,7 @@ start_other_cpus(int flag __unused)
 
 	cpu_pause_init();
 
-	xc_init();
+	xc_init_cpu(CPU);
 
 	if (mach_cpucontext_init() != 0)
 		prom_panic("mach_cpucontext_init fail");

--- a/usr/src/uts/armv8/os/x_call.c
+++ b/usr/src/uts/armv8/os/x_call.c
@@ -21,9 +21,15 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
- *
- * Copyright 2017 Hayashi Naoyuki
  */
+/*
+ * Copyright (c) 2010, Intel Corporation.
+ * All rights reserved.
+ * Copyright 2017 Hayashi Naoyuki
+ * Copyright 2018 Joyent, Inc.
+ * Copyright 2026 Michael van der Westhuizen
+ */
+
 #include <sys/types.h>
 #include <sys/param.h>
 #include <sys/t_lock.h>
@@ -32,7 +38,6 @@
 #include <sys/x_call.h>
 #include <sys/xc_levels.h>
 #include <sys/cpu.h>
-#include <sys/psw.h>
 #include <sys/sunddi.h>
 #include <sys/debug.h>
 #include <sys/systm.h>
@@ -43,301 +48,613 @@
 #include <sys/promif.h>
 #include <sys/spl.h>
 #include <sys/irq.h>
-#include <sys/syspic.h>
-#include <sys/smp_impldefs.h>
 
-struct	xc_mbox {
-	xc_func_t	func;
-	xc_arg_t	arg0;
-	xc_arg_t	arg1;
-	xc_arg_t	arg2;
-	cpuset_t	set;
-};
 
-enum {
-	XC_DONE,	/* x-call session done */
-	XC_HOLD,	/* spin doing nothing */
-	XC_SYNC_OP,	/* perform a synchronous operation */
-	XC_CALL_OP,	/* perform a call operation */
-	XC_WAIT,	/* capture/release. callee has seen wait */
-	XC_ASYNC_OP,
-};
+/*
+ * Implementation for cross-processor calls via interprocessor interrupts
+ *
+ * This implementation uses a message passing architecture to allow multiple
+ * concurrent cross calls to be in flight at any given time. We use
+ * compare/exchange instruction sequences, aka atomic_cas_ptr(), to implement
+ * simple, efficient, work queues for message passing between CPUs with almost
+ * no need for regular locking.  See xc_extract() and xc_insert() below.
+ *
+ * The general idea is that initiating a cross call means putting a message
+ * on a target(s) CPU's work queue. Any synchronization is handled by passing
+ * the message back and forth between initiator and target(s).
+ *
+ * Every CPU has xc_work_cnt, which indicates it has messages to process.
+ * This value is incremented as message traffic is initiated and decremented
+ * with every message that finishes all processing.
+ *
+ * The code needs minimal memory barriers.  The uses of atomic_cas_ptr(),
+ * atomic_cas_32() and atomic_dec_32() for the message passing are implemented
+ * with acquire/release semantics sufficient to ensure correctness.
+ *
+ * One interesting aspect of this implementation is that it allows 2 or more
+ * CPUs to initiate cross calls to intersecting sets of CPUs at the same time.
+ * The cross call processing by the CPUs will happen in any order with only
+ * a guarantee, for xc_call() and xc_sync(), that an initiator won't return
+ * from cross calls before all slaves have invoked the function.
+ *
+ * The reason for this asynchronous approach is to allow for fast global
+ * TLB shootdowns. If all CPUs, say N, tried to do a global TLB invalidation
+ * on a different Virtual Address at the same time. The old code required
+ * N squared IPIs. With this method, depending on timing, it could happen
+ * with just N IPIs.
+ *
+ * Here are the normal transitions for XC_MSG_* values in ->xc_command. A
+ * transition of "->" happens in the slave cpu and "=>" happens in the master
+ * cpu as the messages are passed back and forth.
+ *
+ * FREE => ASYNC ->                       DONE => FREE
+ * FREE => CALL ->                        DONE => FREE
+ * FREE => SYNC -> WAITING => RELEASED -> DONE => FREE
+ *
+ * The interesting one above is ASYNC. You might ask, why not go directly
+ * to FREE, instead of DONE? If it did that, it might be possible to exhaust
+ * the master's xc_free list if a master can generate ASYNC messages faster
+ * then the slave can process them. That could be handled with more complicated
+ * handling. However since nothing important uses ASYNC, I've not bothered.
+ */
 
-static int	xc_initialized = 0;
-extern cpuset_t	cpu_ready_set;
+/*
+ * The default is to not enable collecting counts of IPI information, since
+ * the updating of shared cachelines could cause excess bus traffic.
+ */
+uint_t xc_collect_enable = 0;
+uint64_t xc_total_cnt = 0;	/* total #IPIs sent for cross calls */
+uint64_t xc_multi_cnt = 0;	/* # times we piggy backed on another IPI */
 
-static kmutex_t	xc_mbox_lock;
-static struct	xc_mbox xc_mbox;
-static uint_t	xc_serv(caddr_t, caddr_t);
-static uint_t	xc_poke(caddr_t, caddr_t);
+/*
+ * We allow for one high priority message at a time to happen in the system.
+ * This is used for panic, kmdb, etc., so no locking is done.
+ */
+static volatile cpuset_t xc_priority_set_store;
+static volatile ulong_t *xc_priority_set = CPUSET2BV(xc_priority_set_store);
+static xc_data_t xc_priority_data;
 
-void
-xc_init()
-{
-	ASSERT(xc_initialized == 0);
-	mutex_init(&xc_mbox_lock, NULL,  MUTEX_SPIN,
-	    (void *)ipltospl(XC_HI_PIL));
+uint_t xc_serv(caddr_t arg1, caddr_t arg2);
 
-	add_avintr((void *)NULL, XC_HI_PIL, xc_serv, "xc_intr", IRQ_IPI_HI,
-	    NULL, NULL, NULL, NULL);
-	add_avintr((void *)NULL, XC_CPUPOKE_PIL, xc_poke, "xc_poke",
-	    IRQ_IPI_CPUPOKE, NULL, NULL, NULL, NULL);
-
-	xc_initialized = 1;
-}
-
-/* We do nothing except be poked */
+/*
+ * Poke is extremely lightweight: just ack the interrupt.
+ *
+ * This is used to force a CPU to re-evaluate its idle state.
+ */
 static uint_t
 xc_poke(caddr_t arg0, caddr_t arg1)
 {
 	return (DDI_INTR_CLAIMED);
 }
 
-static uint_t
-xc_serv(caddr_t arg0, caddr_t arg1)
+/*
+ * Decrement a CPU's work count
+ */
+static void
+xc_decrement(struct machcpu *mcpu)
 {
-	struct cpu *cpup = CPU;
-
-	int xc_pend = cpup->cpu_m.xc_pend;
-	dsb(ish);
-
-	/*
-	 * XXXARM: If there are no pending calls, it's not clear how we got
-	 * here.
-	 */
-	if (xc_pend == 0) {
-		return (DDI_INTR_UNCLAIMED);
-	}
-
-	int op = cpup->cpu_m.xc_state;
-
-	xc_func_t func = xc_mbox.func;
-	xc_arg_t a0 = xc_mbox.arg0;
-	xc_arg_t a1 = xc_mbox.arg1;
-	xc_arg_t a2 = xc_mbox.arg2;
-	int ret;
-
-	dsb(ish);
-	cpup->cpu_m.xc_pend = 0;
-
-	if (func != NULL)
-		ret = (*func)(a0, a1, a2);
-	else
-		ret = 0;
-
-	if (op == XC_ASYNC_OP)
-		return (DDI_INTR_CLAIMED);
-
-	cpup->cpu_m.xc_retval = ret;
-
-	/*
-	 * Acknowledge that we have completed the x-call operation.
-	 */
-	dsb(ish);
-	cpup->cpu_m.xc_ack = 1;
-
-	if (op == XC_CALL_OP) {
-		return (DDI_INTR_CLAIMED);
-	}
-
-	dsb(ish);
-	/*
-	 * for (op == XC_SYNC_OP)
-	 * Wait for the initiator of the x-call to indicate
-	 * that all CPUs involved can proceed.
-	 *
-	 * XXXARM: It feels like there's much better things to do here, but
-	 * likely not in high-level interrupt context.
-	 */
-	while (cpup->cpu_m.xc_wait) {
-	}
-
-	dsb(ish);
-
-	/*
-	 * Acknowledge that we have received the directive to continue.
-	 */
-	ASSERT(cpup->cpu_m.xc_ack == 0);
-	dsb(ish);
-	cpup->cpu_m.xc_ack = 1;
-
-	return (DDI_INTR_CLAIMED);
+	atomic_dec_32(&mcpu->xc_work_cnt);
 }
 
+/*
+ * Increment a CPU's work count and return the old value
+ */
+static int
+xc_increment(struct machcpu *mcpu)
+{
+	int old;
+	do {
+		old = mcpu->xc_work_cnt;
+	} while (atomic_cas_32(&mcpu->xc_work_cnt, old, old + 1) != old);
+	return (old);
+}
+
+/*
+ * Put a message into a queue. The insertion is atomic no matter
+ * how many different inserts/extracts to the same queue happen.
+ */
+static void
+xc_insert(void *queue, xc_msg_t *msg)
+{
+	xc_msg_t *old_head;
+
+	/*
+	 * FREE messages should only ever be getting inserted into
+	 * the xc_master CPUs xc_free queue.
+	 */
+	ASSERT(msg->xc_command != XC_MSG_FREE ||
+	    cpu[msg->xc_master] == NULL || /* possible only during init */
+	    queue == &cpu[msg->xc_master]->cpu_m.xc_free);
+
+	do {
+		old_head = (xc_msg_t *)*(volatile xc_msg_t **)queue;
+		msg->xc_next = old_head;
+	} while (atomic_cas_ptr(queue, old_head, msg) != old_head);
+}
+
+/*
+ * Extract a message from a queue. The extraction is atomic only
+ * when just one thread does extractions from the queue.
+ * If the queue is empty, NULL is returned.
+ */
+static xc_msg_t *
+xc_extract(xc_msg_t **queue)
+{
+	xc_msg_t *old_head;
+
+	do {
+		old_head = (xc_msg_t *)*(volatile xc_msg_t **)queue;
+		if (old_head == NULL)
+			return (old_head);
+	} while (atomic_cas_ptr(queue, old_head, old_head->xc_next) !=
+	    old_head);
+	old_head->xc_next = NULL;
+	return (old_head);
+}
+
+/*
+ * Extract the next message from the CPU's queue, and place the message in
+ * .xc_curmsg.  The latter is solely to make debugging (and ::xcall) more
+ * useful.
+ */
+static xc_msg_t *
+xc_get(void)
+{
+	struct machcpu *mcpup = &CPU->cpu_m;
+	xc_msg_t *msg = xc_extract(&mcpup->xc_msgbox);
+	mcpup->xc_curmsg = msg;
+	return (msg);
+}
+
+/*
+ * Initialize the machcpu fields used for cross calls
+ */
+static uint_t xc_initialized = 0;
+
+void
+xc_init_cpu(struct cpu *cpup)
+{
+	xc_msg_t *msg;
+	int c;
+
+	/*
+	 * Allocate message buffers for the new CPU.
+	 */
+	for (c = 0; c < max_ncpus; ++c) {
+		if (plat_dr_support_cpu()) {
+			/*
+			 * Allocate a message buffer for every CPU possible
+			 * in system, including our own, and add them to our xc
+			 * message queue.
+			 */
+			msg = kmem_zalloc(sizeof (*msg), KM_SLEEP);
+			msg->xc_command = XC_MSG_FREE;
+			msg->xc_master = cpup->cpu_id;
+			xc_insert(&cpup->cpu_m.xc_free, msg);
+		} else if (cpu[c] != NULL && cpu[c] != cpup) {
+			/*
+			 * Add a new message buffer to each existing CPU's free
+			 * list, as well as one for my list for each of them.
+			 * Note: cpu0 is statically inserted into cpu[] array,
+			 * so need to check cpu[c] isn't cpup itself to avoid
+			 * allocating extra message buffers for cpu0.
+			 */
+			msg = kmem_zalloc(sizeof (*msg), KM_SLEEP);
+			msg->xc_command = XC_MSG_FREE;
+			msg->xc_master = c;
+			xc_insert(&cpu[c]->cpu_m.xc_free, msg);
+
+			msg = kmem_zalloc(sizeof (*msg), KM_SLEEP);
+			msg->xc_command = XC_MSG_FREE;
+			msg->xc_master = cpup->cpu_id;
+			xc_insert(&cpup->cpu_m.xc_free, msg);
+		}
+	}
+
+	if (!plat_dr_support_cpu()) {
+		/*
+		 * Add one for self messages if CPU hotplug is disabled.
+		 */
+		msg = kmem_zalloc(sizeof (*msg), KM_SLEEP);
+		msg->xc_command = XC_MSG_FREE;
+		msg->xc_master = cpup->cpu_id;
+		xc_insert(&cpup->cpu_m.xc_free, msg);
+	}
+
+	if (!xc_initialized) {
+		add_avintr(NULL, XC_HI_PIL, xc_serv, "xc_intr",
+		    IRQ_IPI_HI, NULL, NULL, NULL, NULL);
+		add_avintr(NULL, XC_CPUPOKE_PIL, xc_poke, "xc_poke",
+		    IRQ_IPI_CPUPOKE, NULL, NULL, NULL, NULL);
+		xc_initialized = 1;
+	}
+}
+
+void
+xc_fini_cpu(struct cpu *cpup)
+{
+	xc_msg_t *msg;
+
+	ASSERT((cpup->cpu_flags & CPU_READY) == 0);
+	ASSERT(cpup->cpu_m.xc_msgbox == NULL);
+	ASSERT(cpup->cpu_m.xc_work_cnt == 0);
+
+	while ((msg = xc_extract(&cpup->cpu_m.xc_free)) != NULL) {
+		kmem_free(msg, sizeof (*msg));
+	}
+}
+
+#define	XC_FLUSH_MAX_WAITS		1000
+
+/* Flush inflight message buffers. */
+int
+xc_flush_cpu(struct cpu *cpup)
+{
+	int i;
+
+	ASSERT((cpup->cpu_flags & CPU_READY) == 0);
+
+	/*
+	 * Pause all working CPUs, which ensures that there's no CPU in
+	 * function xc_common().
+	 * This is used to work around a race condition window in xc_common()
+	 * between checking CPU_READY flag and increasing working item count.
+	 */
+	pause_cpus(cpup, NULL);
+	start_cpus();
+
+	for (i = 0; i < XC_FLUSH_MAX_WAITS; i++) {
+		if (cpup->cpu_m.xc_work_cnt == 0) {
+			break;
+		}
+		DELAY(1);
+	}
+	for (; i < XC_FLUSH_MAX_WAITS; i++) {
+		if (!BT_TEST(xc_priority_set, cpup->cpu_id)) {
+			break;
+		}
+		DELAY(1);
+	}
+
+	return (i >= XC_FLUSH_MAX_WAITS ? ETIME : 0);
+}
+
+/*
+ * X-call message processing routine. Note that this is used by both
+ * senders and recipients of messages.
+ *
+ * We're protected against changing CPUs by either being in a high-priority
+ * interrupt, having preemption disabled or by having a raised SPL.
+ */
+/*ARGSUSED*/
+uint_t
+xc_serv(caddr_t arg1, caddr_t arg2)
+{
+	struct machcpu *mcpup = &(CPU->cpu_m);
+	xc_msg_t *msg;
+	xc_data_t *data;
+	xc_msg_t *xc_waiters = NULL;
+	uint32_t num_waiting = 0;
+	xc_func_t func;
+	xc_arg_t a1;
+	xc_arg_t a2;
+	xc_arg_t a3;
+	uint_t rc = DDI_INTR_UNCLAIMED;
+
+	while (mcpup->xc_work_cnt != 0) {
+		rc = DDI_INTR_CLAIMED;
+
+		/*
+		 * We may have to wait for a message to arrive.
+		 */
+		for (msg = NULL; msg == NULL; msg = xc_get()) {
+
+			/*
+			 * Always check for and handle a priority message.
+			 */
+			if (BT_TEST(xc_priority_set, CPU->cpu_id)) {
+				membar_consumer();
+				func = xc_priority_data.xc_func;
+				a1 = xc_priority_data.xc_a1;
+				a2 = xc_priority_data.xc_a2;
+				a3 = xc_priority_data.xc_a3;
+				BT_ATOMIC_CLEAR(xc_priority_set, CPU->cpu_id);
+				xc_decrement(mcpup);
+				func(a1, a2, a3);
+				if (mcpup->xc_work_cnt == 0)
+					return (rc);
+			}
+
+			/*
+			 * wait for a message to arrive
+			 */
+			SMT_PAUSE();
+		}
+
+
+		/*
+		 * process the message
+		 */
+		switch (msg->xc_command) {
+
+		/*
+		 * ASYNC gives back the message immediately, then we do the
+		 * function and return with no more waiting.
+		 */
+		case XC_MSG_ASYNC:
+			data = &cpu[msg->xc_master]->cpu_m.xc_data;
+			func = data->xc_func;
+			a1 = data->xc_a1;
+			a2 = data->xc_a2;
+			a3 = data->xc_a3;
+			msg->xc_command = XC_MSG_DONE;
+			xc_insert(&cpu[msg->xc_master]->cpu_m.xc_msgbox, msg);
+			if (func != NULL)
+				(void) (*func)(a1, a2, a3);
+			xc_decrement(mcpup);
+			break;
+
+		/*
+		 * SYNC messages do the call, then send it back to the master
+		 * in WAITING mode
+		 */
+		case XC_MSG_SYNC:
+			data = &cpu[msg->xc_master]->cpu_m.xc_data;
+			if (data->xc_func != NULL)
+				(void) (*data->xc_func)(data->xc_a1,
+				    data->xc_a2, data->xc_a3);
+			msg->xc_command = XC_MSG_WAITING;
+			xc_insert(&cpu[msg->xc_master]->cpu_m.xc_msgbox, msg);
+			break;
+
+		/*
+		 * WAITING messsages are collected by the master until all
+		 * have arrived. Once all arrive, we release them back to
+		 * the slaves
+		 */
+		case XC_MSG_WAITING:
+			xc_insert(&xc_waiters, msg);
+			if (++num_waiting < mcpup->xc_wait_cnt)
+				break;
+			while ((msg = xc_extract(&xc_waiters)) != NULL) {
+				msg->xc_command = XC_MSG_RELEASED;
+				xc_insert(&cpu[msg->xc_slave]->cpu_m.xc_msgbox,
+				    msg);
+				--num_waiting;
+			}
+			if (num_waiting != 0)
+				panic("wrong number waiting");
+			mcpup->xc_wait_cnt = 0;
+			break;
+
+		/*
+		 * CALL messages do the function and then, like RELEASE,
+		 * send the message back to master as DONE.
+		 */
+		case XC_MSG_CALL:
+			data = &cpu[msg->xc_master]->cpu_m.xc_data;
+			if (data->xc_func != NULL)
+				(void) (*data->xc_func)(data->xc_a1,
+				    data->xc_a2, data->xc_a3);
+			/*FALLTHROUGH*/
+		case XC_MSG_RELEASED:
+			msg->xc_command = XC_MSG_DONE;
+			xc_insert(&cpu[msg->xc_master]->cpu_m.xc_msgbox, msg);
+			xc_decrement(mcpup);
+			break;
+
+		/*
+		 * DONE means a slave has completely finished up.
+		 * Once we collect all the DONE messages, we'll exit
+		 * processing too.
+		 */
+		case XC_MSG_DONE:
+			msg->xc_command = XC_MSG_FREE;
+			xc_insert(&mcpup->xc_free, msg);
+			xc_decrement(mcpup);
+			break;
+
+		case XC_MSG_FREE:
+			panic("free message 0x%p in msgbox", (void *)msg);
+			break;
+
+		default:
+			panic("bad message 0x%p in msgbox", (void *)msg);
+			break;
+		}
+
+		CPU->cpu_m.xc_curmsg = NULL;
+	}
+	return (rc);
+}
+
+/*
+ * Initiate cross call processing.
+ */
 static void
 xc_common(
 	xc_func_t func,
-	xc_arg_t arg0,
 	xc_arg_t arg1,
 	xc_arg_t arg2,
-	cpuset_t set,
-	int op)
+	xc_arg_t arg3,
+	ulong_t *set,
+	uint_t command)
 {
-	int cix;
-	int lcx = (int)(CPU->cpu_id);
-	cpuset_t cpuset;
+	int c;
+	struct cpu *cpup;
+	xc_msg_t *msg;
+	xc_data_t *data;
+	int cnt;
+	int save_spl;
 
-	/*
-	 * Assert we haven't panicked and stopped the other CPUs.
-	 *
-	 * XXXARM: I'm deeply unhappy about using `panicstr` for this, but
-	 * seemingly that's the done thing.
-	 */
-	ASSERT(panicstr == NULL);
-
-	ASSERT(MUTEX_HELD(&xc_mbox_lock));
-
-	/*
-	 * XXXARM: I don't know what this guards against.  Us trying to to
-	 * cross call when we ourselves aren't ready to get it?  There must be
-	 * a story here at the very least.
-	 */
-	ASSERT(CPU->cpu_flags & CPU_READY);
-
-	CPUSET_ZERO(cpuset);
-
-	/*
-	 * Set up the service definition mailbox.
-	 */
-	xc_mbox.func = func;
-	xc_mbox.arg0 = arg0;
-	xc_mbox.arg1 = arg1;
-	xc_mbox.arg2 = arg2;
-
-	/*
-	 * Request service on all remote processors.
-	 */
-	cpuset = set;
-	while (!CPUSET_ISNULL(cpuset)) {
-		CPUSET_FIND(cpuset, cix);
-		struct cpu *cpup = cpu[cix];
-		if (cpup == NULL || (cpup->cpu_flags & CPU_READY) == 0) {
-			CPUSET_DEL(set, cix);
-		} else if (cix != lcx) {
-			CPU_STATS_ADDQ(CPU, sys, xcalls, 1);
-
-			ASSERT(cpup->cpu_m.xc_ack == 0);
-			ASSERT(cpup->cpu_m.xc_wait == 0);
-			ASSERT(cpup->cpu_m.xc_pend == 0);
-			cpup->cpu_m.xc_wait = (op == XC_SYNC_OP);
-			cpup->cpu_m.xc_state = op;
-			cpup->cpu_m.xc_pend = 1;
-		}
-		CPUSET_DEL(cpuset, cix);
-	}
-
-	/*
-	 * Send IPI to requested remote cpus in selected set.
-	 */
-	cpuset = set;
-	CPUSET_DEL(cpuset, lcx);
-	if (!CPUSET_ISNULL(cpuset)) {
-		syspic_send_ipi(cpuset, IRQ_IPI_HI);
-	}
-
-	/*
-	 * Run service locally if we're in the set
-	 */
-	if (CPU_IN_SET(set, lcx) && func != NULL)
-		CPU->cpu_m.xc_retval = (*func)(arg0, arg1, arg2);
-
-	/*
-	 * Wait here until all remote calls acknowledge.
-	 *
-	 * XXXARM: Should we check if the cpu is quiesced as well, rather than
-	 * forcing the ack in panic_idle?
-	 */
-	dsb(ish);
-	cpuset = set;
-	while (!CPUSET_ISNULL(cpuset)) {
-		CPUSET_FIND(cpuset, cix);
-		struct cpu *cpup = cpu[cix];
-		if (cix != lcx) {
-			for (;;) {
-				if ((cpup->cpu_flags & CPU_READY) == 0 ||
-				    cpup->cpu_m.xc_ack != 0 ||
-				    (op == XC_ASYNC_OP &&
-				    cpup->cpu_m.xc_pend == 0)) {
-					cpup->cpu_m.xc_ack = 0;
-					break;
-				}
-			}
-		}
-		CPUSET_DEL(cpuset, cix);
-	}
-
-	if (op == XC_ASYNC_OP || op == XC_CALL_OP)
+	if (!xc_initialized) {
+		if (BT_TEST(set, CPU->cpu_id) && (CPU->cpu_flags & CPU_READY) &&
+		    func != NULL)
+			(void) (*func)(arg1, arg2, arg3);
 		return;
+	}
 
-	dsb(ish);
-	cpuset = set;
-	while (!CPUSET_ISNULL(cpuset)) {
-		CPUSET_FIND(cpuset, cix);
-		struct cpu *cpup = cpu[cix];
-		if (cix != lcx) {
-			cpup->cpu_m.xc_wait = 0;
+	save_spl = splr(ipltospl(XC_HI_PIL));
+
+	/*
+	 * fill in cross call data
+	 */
+	data = &CPU->cpu_m.xc_data;
+	data->xc_func = func;
+	data->xc_a1 = arg1;
+	data->xc_a2 = arg2;
+	data->xc_a3 = arg3;
+
+	/*
+	 * Post messages to all CPUs involved that are CPU_READY
+	 */
+	CPU->cpu_m.xc_wait_cnt = 0;
+	for (c = 0; c < max_ncpus; ++c) {
+		if (!BT_TEST(set, c))
+			continue;
+		cpup = cpu[c];
+		if (cpup == NULL || !(cpup->cpu_flags & CPU_READY))
+			continue;
+
+		/*
+		 * Fill out a new message.
+		 */
+		msg = xc_extract(&CPU->cpu_m.xc_free);
+		if (msg == NULL)
+			panic("Ran out of free xc_msg_t's");
+		msg->xc_command = command;
+		if (msg->xc_master != CPU->cpu_id)
+			panic("msg %p has wrong xc_master", (void *)msg);
+		msg->xc_slave = c;
+
+		/*
+		 * Increment my work count for all messages that I'll
+		 * transition from DONE to FREE.
+		 * Also remember how many XC_MSG_WAITINGs to look for
+		 */
+		(void) xc_increment(&CPU->cpu_m);
+		if (command == XC_MSG_SYNC)
+			++CPU->cpu_m.xc_wait_cnt;
+
+		/*
+		 * Increment the target CPU work count then insert the message
+		 * in the target msgbox. If I post the first bit of work
+		 * for the target to do, send an IPI to the target CPU.
+		 */
+		cnt = xc_increment(&cpup->cpu_m);
+		xc_insert(&cpup->cpu_m.xc_msgbox, msg);
+		if (cpup != CPU) {
+			if (cnt == 0) {
+				CPU_STATS_ADDQ(CPU, sys, xcalls, 1);
+				send_dirint(c, IRQ_IPI_HI);
+				if (xc_collect_enable)
+					++xc_total_cnt;
+			} else if (xc_collect_enable) {
+				++xc_multi_cnt;
+			}
 		}
-		CPUSET_DEL(cpuset, cix);
 	}
 
 	/*
-	 * Wait here until all remote calls acknowledge.
+	 * Now drop into the message handler until all work is done
 	 */
-	dsb(ish);
-	cpuset = set;
-	while (!CPUSET_ISNULL(cpuset)) {
-		CPUSET_FIND(cpuset, cix);
-		struct cpu *cpup = cpu[cix];
-		if (cix != lcx) {
-			for (;;) {
-				if ((cpup->cpu_flags & CPU_READY) == 0 ||
-				    cpup->cpu_m.xc_ack != 0) {
-					cpup->cpu_m.xc_ack = 0;
-					break;
-				}
-			}
+	(void) xc_serv(NULL, NULL);
+	splx(save_spl);
+}
+
+/*
+ * Push out a priority cross call.
+ */
+static void
+xc_priority_common(
+	xc_func_t func,
+	xc_arg_t arg1,
+	xc_arg_t arg2,
+	xc_arg_t arg3,
+	ulong_t *set)
+{
+	int i;
+	int c;
+	struct cpu *cpup;
+
+	/*
+	 * Wait briefly for any previous xc_priority to have finished.
+	 */
+	for (c = 0; c < max_ncpus; ++c) {
+		cpup = cpu[c];
+		if (cpup == NULL || !(cpup->cpu_flags & CPU_READY))
+			continue;
+
+		/*
+		 * The value of 40000 here is from old kernel code. It
+		 * really should be changed to some time based value, since
+		 * under a hypervisor, there's no guarantee a remote CPU
+		 * is even scheduled.
+		 */
+		for (i = 0; BT_TEST(xc_priority_set, c) && i < 40000; ++i)
+			SMT_PAUSE();
+
+		/*
+		 * Some CPU did not respond to a previous priority request. It's
+		 * probably deadlocked with interrupts blocked or some such
+		 * problem. We'll just erase the previous request - which was
+		 * most likely a kmdb_enter that has already expired - and plow
+		 * ahead.
+		 */
+		if (BT_TEST(xc_priority_set, c)) {
+			BT_ATOMIC_CLEAR(xc_priority_set, c);
+			if (cpup->cpu_m.xc_work_cnt > 0)
+				xc_decrement(&cpup->cpu_m);
 		}
-		CPUSET_DEL(cpuset, cix);
+	}
+
+	/*
+	 * fill in cross call data
+	 */
+	xc_priority_data.xc_func = func;
+	xc_priority_data.xc_a1 = arg1;
+	xc_priority_data.xc_a2 = arg2;
+	xc_priority_data.xc_a3 = arg3;
+
+	/*
+	 * Post messages to all CPUs involved that are CPU_READY
+	 * We'll always IPI.
+	 */
+	for (c = 0; c < max_ncpus; ++c) {
+		if (!BT_TEST(set, c))
+			continue;
+		cpup = cpu[c];
+		if (cpup == NULL || !(cpup->cpu_flags & CPU_READY) ||
+		    cpup == CPU)
+			continue;
+		(void) xc_increment(&cpup->cpu_m);
+		BT_ATOMIC_SET(xc_priority_set, c);
+		send_dirint(c, IRQ_IPI_HI);
 	}
 }
 
+/*
+ * Do cross call to all other CPUs with absolutely no waiting or handshaking.
+ * This should only be used for extraordinary operations, like panic(), which
+ * need to work, in some fashion, in a not completely functional system.
+ * All other uses that want minimal waiting should use xc_call_nowait().
+ */
 void
-xc_call(
-	xc_arg_t arg0,
+xc_priority(
 	xc_arg_t arg1,
 	xc_arg_t arg2,
-	cpuset_t set,
+	xc_arg_t arg3,
+	ulong_t *set,
 	xc_func_t func)
 {
-	mutex_enter(&xc_mbox_lock);
-	xc_common(func, arg0, arg1, arg2, set, XC_CALL_OP);
-	mutex_exit(&xc_mbox_lock);
-}
+	extern int IGNORE_KERNEL_PREEMPTION;
+	int save_spl = splr(ipltospl(XC_HI_PIL));
+	int save_kernel_preemption = IGNORE_KERNEL_PREEMPTION;
 
-void
-xc_sync(
-	xc_arg_t arg0,
-	xc_arg_t arg1,
-	xc_arg_t arg2,
-	cpuset_t set,
-	xc_func_t func)
-{
-	mutex_enter(&xc_mbox_lock);
-	xc_common(func, arg0, arg1, arg2, set, XC_SYNC_OP);
-	mutex_exit(&xc_mbox_lock);
-}
-
-void
-xc_call_nowait(
-	xc_arg_t arg0,
-	xc_arg_t arg1,
-	xc_arg_t arg2,
-	cpuset_t set,
-	xc_func_t func)
-{
-	mutex_enter(&xc_mbox_lock);
-	xc_common(func, arg0, arg1, arg2, set, XC_ASYNC_OP);
-	mutex_exit(&xc_mbox_lock);
+	IGNORE_KERNEL_PREEMPTION = 1;
+	xc_priority_common((xc_func_t)func, arg1, arg2, arg3, set);
+	IGNORE_KERNEL_PREEMPTION = save_kernel_preemption;
+	splx(save_spl);
 }
 
 /*
@@ -356,9 +673,53 @@ kdi_xc_others(int this_cpu, void (*func)(void))
 	save_kernel_preemption = IGNORE_KERNEL_PREEMPTION;
 	IGNORE_KERNEL_PREEMPTION = 1;
 	CPUSET_ALL_BUT(set, this_cpu);
-	/*
-	 * XXXKDI: I think this should wait, but our xcall facilities are poor
-	 */
-	xc_call_nowait(0, 0, 0, set, (xc_func_t)func);
+	xc_priority_common((xc_func_t)func, 0, 0, 0, CPUSET2BV(set));
 	IGNORE_KERNEL_PREEMPTION = save_kernel_preemption;
+}
+
+
+
+/*
+ * Invoke function on specified processors. Remotes may continue after
+ * service with no waiting. xc_call_nowait() may return immediately too.
+ */
+void
+xc_call_nowait(
+	xc_arg_t arg1,
+	xc_arg_t arg2,
+	xc_arg_t arg3,
+	ulong_t *set,
+	xc_func_t func)
+{
+	xc_common(func, arg1, arg2, arg3, set, XC_MSG_ASYNC);
+}
+
+/*
+ * Invoke function on specified processors. Remotes may continue after
+ * service with no waiting. xc_call() returns only after remotes have finished.
+ */
+void
+xc_call(
+	xc_arg_t arg1,
+	xc_arg_t arg2,
+	xc_arg_t arg3,
+	ulong_t *set,
+	xc_func_t func)
+{
+	xc_common(func, arg1, arg2, arg3, set, XC_MSG_CALL);
+}
+
+/*
+ * Invoke function on specified processors. Remotes wait until all have
+ * finished. xc_sync() also waits until all remotes have finished.
+ */
+void
+xc_sync(
+	xc_arg_t arg1,
+	xc_arg_t arg2,
+	xc_arg_t arg3,
+	ulong_t *set,
+	xc_func_t func)
+{
+	xc_common(func, arg1, arg2, arg3, set, XC_MSG_SYNC);
 }

--- a/usr/src/uts/armv8/sys/machcpuvar.h
+++ b/usr/src/uts/armv8/sys/machcpuvar.h
@@ -35,6 +35,7 @@
 
 #include <sys/types.h>
 #include <sys/avintr.h>
+#include <sys/x_call.h>
 
 #ifdef	__cplusplus
 extern "C" {
@@ -44,11 +45,12 @@ struct	machcpu {
 	struct hat	*mcpu_current_hat;
 	int		mcpu_pri;
 
-	volatile int	xc_pend;
-	volatile int	xc_wait;
-	volatile int	xc_ack;
-	volatile int	xc_state;
-	volatile int	xc_retval;
+	struct xc_msg	*xc_msgbox;
+	struct xc_msg	*xc_curmsg;
+	struct xc_msg	*xc_free;
+	xc_data_t	xc_data;
+	uint32_t	xc_wait_cnt;
+	volatile uint32_t xc_work_cnt;
 
 	struct softint	mcpu_softinfo;
 	uint64_t	pil_high_start[HIGH_LEVELS];

--- a/usr/src/uts/armv8/sys/machsystm.h
+++ b/usr/src/uts/armv8/sys/machsystm.h
@@ -100,6 +100,11 @@ extern boolean_t efirt_is_active(void);
 extern uint64_t efirt_call_rt(uint64_t, uint64_t, uint64_t, uint64_t,
     uint64_t, uint64_t);
 
+/*
+ * CPU Dynamic Reconfiguration.
+ */
+extern boolean_t plat_dr_support_cpu(void);
+
 #endif /* _KERNEL */
 
 #ifdef __cplusplus

--- a/usr/src/uts/armv8/sys/x_call.h
+++ b/usr/src/uts/armv8/sys/x_call.h
@@ -22,12 +22,12 @@
 /*
  * Copyright 2009 Sun Microsystems, Inc.  All rights reserved.
  * Use is subject to license terms.
+ * Copyright 2018 Joyent, Inc.
+ * Copyright 2026 Michael van der Westhuizen
  */
 
 #ifndef _SYS_X_CALL_H
 #define	_SYS_X_CALL_H
-
-#include <sys/cpuvar.h>
 
 #ifdef	__cplusplus
 extern "C" {
@@ -35,23 +35,54 @@ extern "C" {
 
 #ifndef _ASM
 
+#define	XC_MSG_FREE	(0)	/* msg in xc_free queue */
+#define	XC_MSG_ASYNC	(1)	/* msg in slave xc_msgbox */
+#define	XC_MSG_CALL	(2)	/* msg in slave xc_msgbox */
+#define	XC_MSG_SYNC	(3)	/* msg in slave xc_msgbox */
+#define	XC_MSG_WAITING	(4)	/* msg in master xc_msgbox or xc_waiters */
+#define	XC_MSG_RELEASED	(5)	/* msg in slave xc_msgbox */
+#define	XC_MSG_DONE	(6)	/* msg in master xc_msgbox */
+
 typedef uintptr_t xc_arg_t;
 typedef int (*xc_func_t)(xc_arg_t, xc_arg_t, xc_arg_t);
+
+/*
+ * One of these is stored in each CPU's machcpu data, plus one extra for
+ * priority (ie panic) messages.
+ */
+typedef struct xc_data {
+	xc_func_t	xc_func;
+	xc_arg_t	xc_a1;
+	xc_arg_t	xc_a2;
+	xc_arg_t	xc_a3;
+} xc_data_t;
+
+/*
+ * This is kept as small as possible, since for N CPUs we need N * N of them.
+ */
+typedef struct xc_msg {
+	uint8_t		xc_command;
+	uint16_t	xc_master;
+	uint16_t	xc_slave;
+	struct xc_msg	*xc_next;
+} xc_msg_t;
 
 /*
  * Cross-call routines.
  */
 #if defined(_KERNEL)
 
-#if defined(_MACHDEP)
-/* XXXARM: this whole file needs to be closer to Intel */
-#define	CPUSET2BV(set)	(set)
-extern void	xc_init(void);
-extern void	xc_call(xc_arg_t, xc_arg_t, xc_arg_t, cpuset_t set, xc_func_t);
-extern void	xc_sync(xc_arg_t, xc_arg_t, xc_arg_t, cpuset_t set, xc_func_t);
-extern void	xc_call_nowait(xc_arg_t, xc_arg_t, xc_arg_t, cpuset_t set,
+extern void	xc_init_cpu(struct cpu *);
+extern void	xc_fini_cpu(struct cpu *);
+extern int	xc_flush_cpu(struct cpu *);
+
+#define	CPUSET2BV(set)	((ulong_t *)(void *)&(set))
+extern void	xc_call(xc_arg_t, xc_arg_t, xc_arg_t, ulong_t *, xc_func_t);
+extern void	xc_call_nowait(xc_arg_t, xc_arg_t, xc_arg_t, ulong_t *,
     xc_func_t);
-#endif
+extern void	xc_sync(xc_arg_t, xc_arg_t, xc_arg_t, ulong_t *, xc_func_t);
+extern void	xc_priority(xc_arg_t, xc_arg_t, xc_arg_t, ulong_t *,
+    xc_func_t);
 
 #endif	/* _KERNEL */
 


### PR DESCRIPTION
Replace the single-global-mutex xcall implementation with the Joyent lock-free per-CPU message-passing design from i86pc.

The new implementation uses atomic_cas_ptr and atomic_cas_32 to implement work queues for message passing between CPUs, allowing multiple concurrent cross calls to be in flight at the same time.

This eliminates the global xc_mbox_lock bottleneck and enables O(N) operations instead of O(N^2).

Important differences when compared to i86pc:
* IPI dispatch uses send_dirint(c, IRQ_IPI_HI) (SGI INTID) rather than the i86pc send_dirint(c, XC_HI_PIL) (PIL number).  This is an architectural difference in how IPIs are sent.
* Memory ordering: aarch64 atomic_cas_ptr/atomic_cas_32/atomic_dec_32 provide acquire-release ordering only (this is not true in arm64-gate at present, but it should be), not the full StoreLoad fence that x86 LOCK-prefixed instructions give.  ACQ_REL suffices for the CAS-based queue operations, and atomic bitset manipulation covers most of the remaining ordering requirements other than reading priority data after testing xc_priority_set.
* CPU poke is registered as a different, no-op, handler and does not use the heavyweight baggage associated with the cross-call functionality.  This is needed due to an architectural difference between i86pc and armv8, where on i86pc the APIC auto-EOIs the interrupt and the target CPU wakes from HLT/MWAIT, so no interrupt handler is needed there.  On Arm systems we need the handler to do minimal interrupt processing.

**Testing**:
Against arm64-gate, with atomics implemented as ACQ_REL (relaxed ordering):
* [rpi4](https://gist.github.com/r1mikey/91e8b21335b6bc9eb7a2b38d34f74dc6)
* [qemu](https://gist.github.com/r1mikey/11ade319d190095e558aadc61dac896b)
* [FreeBSD 16.0-CURRENT Bhyve](https://gist.github.com/r1mikey/eac4f96ab74d6166b54f4e3a28ced1ed)

Against the ACPI tree, with atomics implemented as ACQ_REL (relaxed ordering):
* [Altra Max](https://gist.github.com/r1mikey/fa26a69e0aa023c8198f3a21fd867ba9)
* [rpi4](https://gist.github.com/r1mikey/1d34c52daeb701974caacd63ca851021)
* [qemu-virt with edk2](https://gist.github.com/r1mikey/82e0d6746a7b0626256ec7905f4e5dce)

Against arm64-gate, with atomics as SEQ_CST (i.e. exactly what's in arm64-gate):
* [rpi4](https://gist.github.com/r1mikey/aef34c843124658e359a9a967ea9d42e)
* [qemu](https://gist.github.com/r1mikey/04b3dbedadd1c438724cfa9e4973e223)
* [FreeBSD 16.0-CURRENT Bhyve](https://gist.github.com/r1mikey/ea58c32e178d389156c62824800877aa)