### PR TITLE
gicthree: provide rationale for lack of SGI batching

### DIFF
--- a/usr/src/uts/armv8/io/gicthree.c
+++ b/usr/src/uts/armv8/io/gicthree.c
@@ -1433,10 +1433,28 @@ gicv3_send_ipi(spo_ctx_t ctx, cpuset_t cpuset, intr_intid_t intid)
 	dsb(ish);
 
 	/*
-	 * There is almost definitely a better way to do this, populating
-	 * targetlist/RS and issuing SGI with CPUs clustered by AFF3-1+RS.
+	 * There is an obvious optimisation here that we're not doing, and this
+	 * begs some explanation.
 	 *
-	 * However, this is obviously correct, which will do for now.
+	 * It is possible to batch ICC_SGI1R_EL1 writes by using the route
+	 * key from the SGIR, then packing the CPU selection bit from all
+	 * matching entries with the same route key into the batched value,
+	 * resulting in up to a 16x ICC_SGI1R_EL1 write reduction.  Since
+	 * writing ICC_SGI1R_EL1 is relatively expensive this appears to
+	 * be a very attractive optimisation, even though the pathological
+	 * complexity (each CPU having its own routing key) would be a very
+	 * expensive O(N**2).
+	 *
+	 * Real world machines with large CPU counts would see the most
+	 * benefit, but looking at ACPI tables for Altra Max, Nvidia Grace
+	 * and the Arm AGI CPU, all three differentiate by Aff2/Aff1, with
+	 * Aff0 as zero (72 CPU Grace is even worse, with only Aff2
+	 * differentiating).  So, in all observed cases the real world _is_ the
+	 * pathological case.
+	 *
+	 * This is not to say we might not see some benefit on future
+	 * platforms, but for now this simple and obviously correct approach
+	 * will do and will not add overhead.
 	 */
 	CPUSET_AND(cpuset, gc->gc_cpuset);
 	CPUSET_DEL(cpuset, CPU->cpu_id);


### PR DESCRIPTION
I've been looking into batching SGIs, which I thought would reduce the number of SGIs issued on Altra Max to 8 for an all-CPU IPI.

After implementing this I dug around the data for the large platforms I have access to, looking at the MPIDRs for all CPUs (from the MADT table). To my surprise, all real world machines cleanly map to the pathological `O(N**2)` outcome with no current server class machine gaining any benefit from batching.

So: leave a comment about why we're not doing the obvious optimisation.

For the record, here's what the optimisation looks like - the commit message has some discussion of the complexity. https://github.com/r1mikey/illumos-gate/commit/84cd4d52ecfe12a53ca2e1f4fa7bfca3d801c7ba.

Altra Max MPIDRs: https://gist.github.com/r1mikey/f9e9c7b3a0257f55682070672cfbac25
Grace MPIDRs: https://gist.github.com/r1mikey/e82e714a159d0923aa27d8b220cbfc4c
Arm AGI CPU MPIDRs: https://gist.github.com/r1mikey/9c9e30231ec3f7b768cab5cedd7a72e9