### PR TITLE
loader: recognise FreeBSD Bhyve

### DIFF
--- a/usr/src/boot/efi/libfdtutil/bi.c
+++ b/usr/src/boot/efi/libfdtutil/bi.c
@@ -42,6 +42,12 @@ static const board_info_t board_info[] = {
 		.bi_hw_provider = "QEMU"
 	},
 	{
+		.bi_compat = "freebsd,bhyve",
+		.bi_impl_name = "FreeBSD,Bhyve",
+		.bi_mfg_name = "FreeBSD,Bhyve",
+		.bi_hw_provider = "The FreeBSD Project"
+	},
+	{
 		.bi_compat = NULL
 	}
 };


### PR DESCRIPTION
Add loader bits to give Bhyve under FreeBSD a clearer root nexus name.

FDT, for reference: https://gist.github.com/r1mikey/d93d2b83bfd3b01612e81fb9f94b606f

Boot log with this change: https://gist.github.com/r1mikey/978396690d24b77899abd4eba43f9aef (see line 108)

Also booted qemu-virt just to ensure that this does not cause any problems.