### PR TITLE
Extract SMCCC from PSCI

### DIFF
--- a/usr/src/uts/aarch64/sys/bootinfo.h
+++ b/usr/src/uts/aarch64/sys/bootinfo.h
@@ -53,11 +53,11 @@ _Static_assert(sizeof (xbi_bsvc_uart_type_t) == sizeof (int),
 #endif
 /* END CSTYLED */
 
-typedef enum {
-	BI_PSCI_CONDUIT_UNKNOWN,
-	BI_PSCI_CONDUIT_HVC,
-	BI_PSCI_CONDUIT_SMC,
-} bi_psci_conduit;
+typedef enum bi_smccc_conduit {
+	BI_SMCCC_CONDUIT_UNKNOWN,
+	BI_SMCCC_CONDUIT_HVC,
+	BI_SMCCC_CONDUIT_SMC,
+} bi_smccc_conduit_t;
 
 typedef enum boot_module_type {
 	BMT_ROOTFS,
@@ -122,7 +122,8 @@ struct xboot_info {
 	uint32_t		bi_pcierc_cnt;
 	uint32_t		bi_module_cnt;
 	uint32_t		bi_psci_version;
-	uint32_t		bi_psci_conduit_hvc;
+	uint32_t		bi_smccc_conduit;
+	uint32_t		bi_smccc_version;
 	uint32_t		bi_psci_cpu_suspend_id;
 	uint32_t		bi_psci_cpu_off_id;
 	uint32_t		bi_psci_cpu_on_id;

--- a/usr/src/uts/armv8/Makefile.files
+++ b/usr/src/uts/armv8/Makefile.files
@@ -80,6 +80,7 @@ CORE_OBJS +=			\
 	psci.o			\
 	smccc.o			\
 	smccc_impl.o		\
+	smccc_subr.o		\
 	arch_timer.o		\
 	earlybsa.o		\
 	cpuinfo.o		\

--- a/usr/src/uts/armv8/Makefile.files
+++ b/usr/src/uts/armv8/Makefile.files
@@ -78,6 +78,8 @@ CORE_OBJS +=			\
 	hold_page.o		\
 	ssp.o			\
 	psci.o			\
+	smccc.o			\
+	smccc_impl.o		\
 	arch_timer.o		\
 	earlybsa.o		\
 	cpuinfo.o		\
@@ -102,6 +104,7 @@ BOOT_DRIVER_OBJS =		\
 	boot_fb.o		\
 	boot_keyboard.o		\
 	boot_psci.o		\
+	boot_smccc.o		\
 	boot_services.o		\
 	boot_uart.o		\
 	$(FONT_OBJS)
@@ -120,6 +123,7 @@ DBOOT_OBJS +=			\
 	dboot_conf_uefi.o	\
 	dboot_memlist.o		\
 	dboot_psci.o		\
+	dboot_smccc.o		\
 	dboot_uefimem.o		\
 	dboot_standalloc.o	\
 	dboot_standalone.o	\

--- a/usr/src/uts/armv8/boot/boot_services.c
+++ b/usr/src/uts/armv8/boot/boot_services.c
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2025 Michael van der Westhuizen
+ * Copyright 2026 Michael van der Westhuizen
  */
 
 /*
@@ -23,6 +23,7 @@
 #include <sys/bootinfo.h>
 
 extern void boot_uart_init(struct xboot_info *);
+extern void boot_smccc_init(struct xboot_info *);
 extern void boot_psci_init(struct xboot_info *);
 
 extern int boot_uart_ischar(void);
@@ -46,5 +47,6 @@ void
 bsvc_init(struct xboot_info *xbp)
 {
 	boot_uart_init(xbp);
+	boot_smccc_init(xbp);
 	boot_psci_init(xbp);
 }

--- a/usr/src/uts/armv8/boot/boot_smccc.c
+++ b/usr/src/uts/armv8/boot/boot_smccc.c
@@ -1,0 +1,72 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2026 Michael van der Westhuizen
+ */
+
+/*
+ * Boot-time SMCCC initialization.
+ *
+ * This shim runs in the boot context (compiled into both BOOT_DRIVER_OBJS
+ * and CORE_OBJS).  It calls smccc_init which, depending on the link
+ * context, resolves to either the dboot or kernel implementation.
+ *
+ * Must be called before boot_psci_init so that the SMCCC transport
+ * layer is established before PSCI attempts to use it.
+ */
+
+#include <sys/types.h>
+#include <sys/null.h>
+#include <sys/bootinfo.h>
+#include <sys/smccc.h>
+#include <sys/linker_set.h>
+#include <asm/controlregs.h>
+
+extern void boot_uart_putchar(int c);
+
+void
+boot_smccc_init(struct xboot_info *xbp)
+{
+	static const char no_smccc[] = "boot: SMCCC init failed";
+	int rv;
+
+	if (xbp == NULL) {
+		return;
+	}
+
+	rv = smccc_init(xbp);
+	if (rv != 0) {
+		const char *p = no_smccc;
+		while (*p) {
+			boot_uart_putchar(*p++);
+		}
+		boot_uart_putchar('\n');
+
+		/*
+		 * Fatal: without the SMCCC transport we cannot call
+		 * PSCI and the system cannot boot.
+		 */
+		for (;;) {
+			/*
+			 * Mask all exceptions: Debug, SError, IRQ and FIQ.
+			 */
+			__asm__ __volatile__(
+			    "msr DAIFSet, #" __XSTRING(DAIF_SETCLEAR_ALL)
+			    ::: "memory"
+			);
+			__asm__ volatile("dsb sy":::"memory");
+			__asm__ volatile("isb sy":::"memory");
+			__asm__ volatile("wfi":::"memory");
+		}
+		/* UNREACHABLE */
+	}
+}

--- a/usr/src/uts/armv8/dboot/dboot_conf_acpi.c
+++ b/usr/src/uts/armv8/dboot/dboot_conf_acpi.c
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2025 Michael van der Westhuizen
+ * Copyright 2026 Michael van der Westhuizen
  */
 
 #include <sys/types.h>
@@ -298,7 +298,8 @@ dboot_configure_acpi(void)
 	if (!(flags & ACPI_FADT_PSCI_COMPLIANT))
 		panic("dboot: illumos requires PSCI");
 
-	bi->bi_psci_conduit_hvc = (flags & ACPI_FADT_PSCI_USE_HVC) ? 1 : 0;
+	bi->bi_smccc_conduit = (flags & ACPI_FADT_PSCI_USE_HVC) ?
+	    BI_SMCCC_CONDUIT_HVC : BI_SMCCC_CONDUIT_SMC;
 
 	boot_psci_init(bi);
 	dboot_count_pcierc(bi);

--- a/usr/src/uts/armv8/dboot/dboot_conf_acpi.c
+++ b/usr/src/uts/armv8/dboot/dboot_conf_acpi.c
@@ -34,6 +34,7 @@
 #define	ACPI_MADT_ONLINE_CAPABLE	(1 << 3)
 #endif
 
+extern void boot_smccc_init(struct xboot_info *);
 extern void boot_psci_init(struct xboot_info *);
 
 static const ACPI_TABLE_XSDT *
@@ -301,6 +302,7 @@ dboot_configure_acpi(void)
 	bi->bi_smccc_conduit = (flags & ACPI_FADT_PSCI_USE_HVC) ?
 	    BI_SMCCC_CONDUIT_HVC : BI_SMCCC_CONDUIT_SMC;
 
+	boot_smccc_init(bi);
 	boot_psci_init(bi);
 	dboot_count_pcierc(bi);
 	return (dboot_configure_acpi_cpuinfo(bi));

--- a/usr/src/uts/armv8/dboot/dboot_conf_fdt.c
+++ b/usr/src/uts/armv8/dboot/dboot_conf_fdt.c
@@ -27,6 +27,7 @@
 #include "dboot.h"
 #include "dboot_printf.h"
 
+extern void boot_smccc_init(struct xboot_info *);
 extern void boot_psci_init(struct xboot_info *);
 
 typedef enum {
@@ -507,6 +508,7 @@ dboot_configure_fdt(void)
 		    fdt32_to_cpu(*((const uint32_t *)pval));
 	}
 
+	boot_smccc_init(bi);
 	boot_psci_init(bi);
 
 	/*

--- a/usr/src/uts/armv8/dboot/dboot_conf_fdt.c
+++ b/usr/src/uts/armv8/dboot/dboot_conf_fdt.c
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2025 Michael van der Westhuizen
+ * Copyright 2026 Michael van der Westhuizen
  */
 
 #include <sys/types.h>
@@ -484,7 +484,8 @@ dboot_configure_fdt(void)
 		return (-1);
 	}
 
-	bi->bi_psci_conduit_hvc = strcmp(method, "hvc") == 0 ? 1 : 0;
+	bi->bi_smccc_conduit = strcmp(method, "hvc") == 0 ?
+	    BI_SMCCC_CONDUIT_HVC : BI_SMCCC_CONDUIT_SMC;
 
 	if ((pval = fdt_getprop(fdtp, nodeoff, "cpu_suspend", &plen)) != NULL) {
 		bi->bi_psci_cpu_suspend_id =

--- a/usr/src/uts/armv8/dboot/dboot_conf_uefi.c
+++ b/usr/src/uts/armv8/dboot/dboot_conf_uefi.c
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2025 Michael van der Westhuizen
+ * Copyright 2026 Michael van der Westhuizen
  */
 
 #include <sys/types.h>
@@ -24,8 +24,6 @@
 #include <sys/acpi/actbl.h>
 
 #include "dboot.h"
-
-extern void boot_psci_init(struct xboot_info *);
 
 static efi_guid_t acpi2 = EFI_ACPI_TABLE_GUID;
 static efi_guid_t smbios3 = SMBIOS3_TABLE_GUID;

--- a/usr/src/uts/armv8/dboot/dboot_machdep.c
+++ b/usr/src/uts/armv8/dboot/dboot_machdep.c
@@ -132,6 +132,8 @@ exitto(int (*entrypoint)(struct xboot_info *), struct xboot_info *bi)
 		dprintf("  %s: 0x%x\n", "bi_psci_version", bi->bi_psci_version);
 		dprintf("  %s: 0x%x\n", "bi_smccc_conduit",
 		    bi->bi_smccc_conduit);
+		dprintf("  %s: 0x%x\n", "bi_smccc_version",
+		    bi->bi_smccc_version);
 		dprintf("  %s: 0x%x\n", "bi_psci_cpu_suspend_id",
 		    bi->bi_psci_cpu_suspend_id);
 		dprintf("  %s: 0x%x\n", "bi_psci_cpu_off_id",
@@ -158,9 +160,14 @@ exitto(int (*entrypoint)(struct xboot_info *), struct xboot_info *bi)
 		    bi->bi_pcierc_cnt);
 		dboot_printf("  %s: %u.%u\n", "PSCI Version",
 		    bi->bi_psci_version >> 16, bi->bi_psci_version & 0xffff);
-		dboot_printf("  %s: %s\n", "PSCI Conduit",
+		dboot_printf("  %s: %s\n", "SMCCC Conduit",
 		    (bi->bi_smccc_conduit == BI_SMCCC_CONDUIT_HVC) ?
 		    "Hypervisor" : "Secure Monitor");
+		if (bi->bi_smccc_version != 0) {
+			dboot_printf("  %s: %u.%u\n", "SMCCC Version",
+			    bi->bi_smccc_version >> 16,
+			    bi->bi_smccc_version & 0xffff);
+		}
 		dboot_printf("Exception Level: %lu\n", el);
 		dboot_printf("%s: 0x%p\n", "Kernel Entrypoint", entrypoint);
 	}

--- a/usr/src/uts/armv8/dboot/dboot_machdep.c
+++ b/usr/src/uts/armv8/dboot/dboot_machdep.c
@@ -130,8 +130,8 @@ exitto(int (*entrypoint)(struct xboot_info *), struct xboot_info *bi)
 		dprintf("  %s: 0x%x\n", "bi_pcierc_cnt", bi->bi_pcierc_cnt);
 		dprintf("  %s: 0x%x\n", "bi_module_cnt", bi->bi_module_cnt);
 		dprintf("  %s: 0x%x\n", "bi_psci_version", bi->bi_psci_version);
-		dprintf("  %s: 0x%x\n", "bi_psci_conduit_hvc",
-		    bi->bi_psci_conduit_hvc);
+		dprintf("  %s: 0x%x\n", "bi_smccc_conduit",
+		    bi->bi_smccc_conduit);
 		dprintf("  %s: 0x%x\n", "bi_psci_cpu_suspend_id",
 		    bi->bi_psci_cpu_suspend_id);
 		dprintf("  %s: 0x%x\n", "bi_psci_cpu_off_id",
@@ -159,7 +159,8 @@ exitto(int (*entrypoint)(struct xboot_info *), struct xboot_info *bi)
 		dboot_printf("  %s: %u.%u\n", "PSCI Version",
 		    bi->bi_psci_version >> 16, bi->bi_psci_version & 0xffff);
 		dboot_printf("  %s: %s\n", "PSCI Conduit",
-		    bi->bi_psci_conduit_hvc ? "Hypervisor" : "Secure Monitor");
+		    (bi->bi_smccc_conduit == BI_SMCCC_CONDUIT_HVC) ?
+		    "Hypervisor" : "Secure Monitor");
 		dboot_printf("Exception Level: %lu\n", el);
 		dboot_printf("%s: 0x%p\n", "Kernel Entrypoint", entrypoint);
 	}

--- a/usr/src/uts/armv8/dboot/dboot_psci.c
+++ b/usr/src/uts/armv8/dboot/dboot_psci.c
@@ -23,8 +23,8 @@
  * Use is subject to license terms.
  */
 /*
- * Copyright 2025 Michael van der Westhuizen
  * Copyright 2017 Hayashi Naoyuki
+ * Copyright 2026 Michael van der Westhuizen
  */
 
 #include <sys/types.h>
@@ -94,7 +94,8 @@ psci_init(struct xboot_info *bi)
 	if (bi == NULL)
 		return (-1);
 
-	pcsi_method_is_hvc = bi->bi_psci_conduit_hvc ? B_TRUE : B_FALSE;
+	pcsi_method_is_hvc =
+	    (bi->bi_smccc_conduit == BI_SMCCC_CONDUIT_HVC) ? B_TRUE : B_FALSE;
 
 	if ((val = psci_version()) & 0x80000000)
 		return (-1);

--- a/usr/src/uts/armv8/dboot/dboot_psci.c
+++ b/usr/src/uts/armv8/dboot/dboot_psci.c
@@ -27,106 +27,65 @@
  * Copyright 2026 Michael van der Westhuizen
  */
 
+/*
+ * dboot PSCI - a thin client of the SMCCC transport layer.
+ *
+ * All firmware calls go through dboot_smccc_call which handles
+ * conduit selection (SMC/HVC).
+ */
+
 #include <sys/types.h>
 #include <sys/null.h>
 #include <sys/bootinfo.h>
 
 #include "dboot.h"
 
-static uint32_t pcsi_version_id = 0x84000000;
 static uint32_t psci_system_off_id = 0x84000008;
 static uint32_t psci_system_reset_id = 0x84000009;
-boolean_t pcsi_method_is_hvc = B_FALSE;
 boolean_t psci_initialized = B_FALSE;
 
-static uint32_t psci_version(void);
+extern uint64_t dboot_smccc_call(uint64_t, uint64_t, uint64_t, uint64_t);
 
-static inline uint64_t
-psci_smc64(uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3)
-{
-	register uint64_t x0 __asm__("x0") = a0;
-	register uint64_t x1 __asm__("x1") = a1;
-	register uint64_t x2 __asm__("x2") = a2;
-	register uint64_t x3 __asm__("x3") = a3;
-
-	__asm__ volatile("smc #0"
-	    : "+r"(x0), "+r"(x1), "+r"(x2), "+r"(x3)
-	    :
-	    :
-	    "x4", "x5", "x6", "x7", "x8", "x9", "x10", "x11",
-	    "x12", "x13", "x14", "x15", "x16", "x17", "x18", "memory", "cc");
-
-	return (x0);
-}
-
-static inline uint64_t
-psci_hvc64(uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3)
-{
-	register uint64_t x0 __asm__("x0") = a0;
-	register uint64_t x1 __asm__("x1") = a1;
-	register uint64_t x2 __asm__("x2") = a2;
-	register uint64_t x3 __asm__("x3") = a3;
-
-	__asm__ volatile("hvc #0"
-	    : "+r"(x0), "+r"(x1), "+r"(x2), "+r"(x3)
-	    :
-	    :
-	    "x4", "x5", "x6", "x7", "x8", "x9", "x10", "x11",
-	    "x12", "x13", "x14", "x15", "x16", "x17", "x18", "memory", "cc");
-
-	return (x0);
-}
-
-static inline uint64_t
-psci_call(uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3)
-{
-	if (pcsi_method_is_hvc)
-		return (psci_hvc64(a0, a1, a2, a3));
-	else
-		return (psci_smc64(a0, a1, a2, a3));
-}
-
+/*
+ * Initialize PSCI in dboot context.
+ *
+ * smccc_init must have been called first - it validates the conduit
+ * and populates bi_psci_version.  We just verify the version is valid
+ * and mark PSCI as usable.
+ */
 int
 psci_init(struct xboot_info *bi)
 {
-	uint32_t val;
-
-	if (bi == NULL)
+	if (bi == NULL) {
 		return (-1);
+	}
 
-	pcsi_method_is_hvc =
-	    (bi->bi_smccc_conduit == BI_SMCCC_CONDUIT_HVC) ? B_TRUE : B_FALSE;
-
-	if ((val = psci_version()) & 0x80000000)
+	if (bi->bi_psci_version & 0x80000000) {
 		return (-1);
+	}
 
-	bi->bi_psci_version = val;
 	psci_initialized = B_TRUE;
 	return (0);
-}
-
-static uint32_t
-psci_version(void)
-{
-	return (psci_call(pcsi_version_id, 0, 0, 0));
 }
 
 void
 psci_system_off(void)
 {
-	if (psci_initialized != B_TRUE)
+	if (psci_initialized != B_TRUE) {
 		for (;;)
 			/* spin forever */;
+	}
 
-	psci_call(psci_system_off_id, 0, 0, 0);
+	dboot_smccc_call(psci_system_off_id, 0, 0, 0);
 }
 
 void
 psci_system_reset(void)
 {
-	if (psci_initialized != B_TRUE)
+	if (psci_initialized != B_TRUE) {
 		for (;;)
 			/* spin forever */;
+	}
 
-	psci_call(psci_system_reset_id, 0, 0, 0);
+	dboot_smccc_call(psci_system_reset_id, 0, 0, 0);
 }

--- a/usr/src/uts/armv8/dboot/dboot_smccc.c
+++ b/usr/src/uts/armv8/dboot/dboot_smccc.c
@@ -1,0 +1,170 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2026 Michael van der Westhuizen
+ */
+
+/*
+ * SMCCC transport layer for dboot.
+ *
+ * Provides SMC/HVC trampolines and SMCCC version discovery.
+ *
+ * This runs very early during dboot when no kernel services are available.
+ * We use inline asm directly rather than the separate assembly trampolines
+ * used by the kernel proper, as this implementation is really all about
+ * discovery, not features.
+ *
+ * Discovery sequence:
+ * 1. Issue PSCI_VERSION via the conduit from bootinfo.
+ *    If this fails, the conduit is broken: no firmware calls are possible.
+ * 2. Issue PSCI_FEATURES(SMCCC_VERSION) to check for SMCCC 1.1+ support.
+ *    SMCCC 1.0 means "just the basic PSCI conduit", and does not include
+ *    SMCCC_VERSION.
+ * 3. If PSCI_FEATURES succeeds, issue SMCCC_VERSION to get
+ *    the actual SMCCC version, which will be 1.1+.
+ *
+ * Populates bi_psci_version and bi_smccc_version in xboot_info.
+ */
+
+#include <sys/types.h>
+#include <sys/null.h>
+#include <sys/bootinfo.h>
+#include <sys/smccc.h>
+
+#include "dboot.h"
+#include "dboot_printf.h"
+
+static boolean_t dboot_smccc_is_hvc = B_FALSE;
+
+static inline uint64_t
+dboot_smccc_smc(uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3)
+{
+	register uint64_t x0 __asm__("x0") = a0;
+	register uint64_t x1 __asm__("x1") = a1;
+	register uint64_t x2 __asm__("x2") = a2;
+	register uint64_t x3 __asm__("x3") = a3;
+
+	__asm__ volatile("smc #0"
+	    : "+r"(x0), "+r"(x1), "+r"(x2), "+r"(x3)
+	    :
+	    :
+	    "x4", "x5", "x6", "x7", "x8", "x9", "x10", "x11",
+	    "x12", "x13", "x14", "x15", "x16", "x17", "x18", "memory", "cc");
+
+	return (x0);
+}
+
+static inline uint64_t
+dboot_smccc_hvc(uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3)
+{
+	register uint64_t x0 __asm__("x0") = a0;
+	register uint64_t x1 __asm__("x1") = a1;
+	register uint64_t x2 __asm__("x2") = a2;
+	register uint64_t x3 __asm__("x3") = a3;
+
+	__asm__ volatile("hvc #0"
+	    : "+r"(x0), "+r"(x1), "+r"(x2), "+r"(x3)
+	    :
+	    :
+	    "x4", "x5", "x6", "x7", "x8", "x9", "x10", "x11",
+	    "x12", "x13", "x14", "x15", "x16", "x17", "x18", "memory", "cc");
+
+	return (x0);
+}
+
+/*
+ * Issue an SMCCC call in dboot context.  Exported so that dboot_psci.c
+ * can use it for PSCI firmware calls.
+ */
+uint64_t
+dboot_smccc_call(uint64_t fid, uint64_t a1, uint64_t a2, uint64_t a3)
+{
+	if (dboot_smccc_is_hvc) {
+		return (dboot_smccc_hvc(fid, a1, a2, a3));
+	} else {
+		return (dboot_smccc_smc(fid, a1, a2, a3));
+	}
+}
+
+/*
+ * Discover the SMCCC version.
+ *
+ * Returns 0 on success, -1 if the conduit doesn't work at all.
+ *
+ * On success, bi_smccc_version is set (1.0 if only PSCI-level, i.e., no
+ * SMCCC 1.1+ discovery).
+ */
+int
+smccc_init(struct xboot_info *bi)
+{
+	uint32_t psci_ver;
+	uint32_t feat_ret;
+	uint32_t smccc_ver;
+
+	if (bi == NULL) {
+		return (-1);
+	}
+
+	dboot_smccc_is_hvc =
+	    (bi->bi_smccc_conduit == BI_SMCCC_CONDUIT_HVC) ? B_TRUE : B_FALSE;
+
+	/*
+	 * Step 1: PSCI_VERSION: validate that the conduit works.
+	 */
+	psci_ver = (uint32_t)dboot_smccc_call(SMCCC_PSCI_VERSION_FID,
+	    0, 0, 0);
+	if (psci_ver & 0x80000000) {
+		dprintf("smccc_init: PSCI_VERSION failed (0x%x)\n", psci_ver);
+		bi->bi_smccc_version = 0;
+		return (-1);
+	}
+
+	dprintf("smccc_init: PSCI version %d.%d\n",
+	    (psci_ver >> 16) & 0x7FFF, psci_ver & 0xFFFF);
+	bi->bi_psci_version = psci_ver;
+
+	/*
+	 * Step 2: PSCI_FEATURES(SMCCC_VERSION): check if firmware
+	 * supports the SMCCC_VERSION call.  If not, then this is
+	 * just a basic PSCI implementation.
+	 */
+	feat_ret = (uint32_t)dboot_smccc_call(SMCCC_PSCI_FEATURES_FID,
+	    SMCCC_VERSION_FID, 0, 0);
+	if (feat_ret & 0x80000000) {
+		/*
+		 * No SMCCC 1.1+ support.  The conduit works (PSCI is
+		 * reachable) but there's no standalone SMCCC version.
+		 * This is fine, PSCI can still use the conduit directly.
+		 */
+		dprintf("smccc_init: PSCI_FEATURES(SMCCC_VERSION) not "
+		    "supported (0x%x), PSCI-only mode\n", feat_ret);
+		bi->bi_smccc_version = 0x00010000;
+		return (0);
+	}
+
+	/*
+	 * Step 3: SMCCC_VERSION: get the actual version.
+	 */
+	smccc_ver = (uint32_t)dboot_smccc_call(SMCCC_VERSION_FID, 0, 0, 0);
+	if (smccc_ver & 0x80000000) {
+		dprintf("smccc_init: SMCCC_VERSION call failed (0x%x)\n",
+		    smccc_ver);
+		bi->bi_smccc_version = 0x00010000;
+		return (0);
+	}
+
+	dprintf("smccc_init: SMCCC version %d.%d\n",
+	    (smccc_ver >> 16) & 0x7FFF, smccc_ver & 0xFFFF);
+	bi->bi_smccc_version = smccc_ver;
+
+	return (0);
+}

--- a/usr/src/uts/armv8/ml/smccc_impl.S
+++ b/usr/src/uts/armv8/ml/smccc_impl.S
@@ -1,0 +1,168 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2026 Michael van der Westhuizen
+ */
+
+	.file	"smccc_impl.S"
+
+/*
+ * SMCCC low-level assembly trampolines.
+ *
+ * Four entry points cover the matrix of {SMC,HVC} x {32-bit,64-bit}:
+ *   i_smccc_smc_call32 - SMC with w0..w7  (smccc32_args_t)
+ *   i_smccc_smc_call64 - SMC with x0..x17 (smccc64_args_t)
+ *   i_smccc_hvc_call32 - HVC with w0..w7  (smccc32_args_t)
+ *   i_smccc_hvc_call64 - HVC with x0..x17 (smccc64_args_t)
+ *
+ * 32-bit trampolines take a pointer to smccc32_args_t (8 x uint32_t).
+ * 64-bit trampolines take a pointer to smccc64_args_t (18 x uint64_t).
+ *
+ * Callee-saved x19 is used to hold the struct pointer across the call.
+ *
+ * This whole file is an SMCCC implementation detail and none of these
+ * functions should be called from outside of smccc.c.
+ */
+
+#include <sys/asm_linkage.h>
+
+/*
+ * i_smccc_smc_call32(smccc32_args_t *args)
+ *
+ * 32-bit SMC: loads w0..w7 from args, issues SMC #0, stores w0..w7 back.
+ */
+	ENTRY(i_smccc_smc_call32)
+	stp	x29, x30, [sp, #-16]!
+	mov	x29, sp
+	stp	x19, x20, [sp, #-16]!
+	mov	x19, x0			/* save args pointer */
+
+	ldp	w0, w1, [x19, #0]
+	ldp	w2, w3, [x19, #8]
+	ldp	w4, w5, [x19, #16]
+	ldp	w6, w7, [x19, #24]
+
+	smc	#0
+
+	stp	w0, w1, [x19, #0]
+	stp	w2, w3, [x19, #8]
+	stp	w4, w5, [x19, #16]
+	stp	w6, w7, [x19, #24]
+
+	ldp	x19, x20, [sp], #16
+	ldp	x29, x30, [sp], #16
+	ret
+	SET_SIZE(i_smccc_smc_call32)
+
+/*
+ * i_smccc_smc_call64(smccc64_args_t *args)
+ *
+ * 64-bit SMC: loads x0..x17 from args, issues SMC #0, stores x0..x17 back.
+ */
+	ENTRY(i_smccc_smc_call64)
+	stp	x29, x30, [sp, #-16]!
+	mov	x29, sp
+	stp	x19, x20, [sp, #-16]!
+	mov	x19, x0
+
+	ldp	x0, x1, [x19, #0]
+	ldp	x2, x3, [x19, #16]
+	ldp	x4, x5, [x19, #32]
+	ldp	x6, x7, [x19, #48]
+	ldp	x8, x9, [x19, #64]
+	ldp	x10, x11, [x19, #80]
+	ldp	x12, x13, [x19, #96]
+	ldp	x14, x15, [x19, #112]
+	ldp	x16, x17, [x19, #128]
+
+	smc	#0
+
+	stp	x0, x1, [x19, #0]
+	stp	x2, x3, [x19, #16]
+	stp	x4, x5, [x19, #32]
+	stp	x6, x7, [x19, #48]
+	stp	x8, x9, [x19, #64]
+	stp	x10, x11, [x19, #80]
+	stp	x12, x13, [x19, #96]
+	stp	x14, x15, [x19, #112]
+	stp	x16, x17, [x19, #128]
+
+	ldp	x19, x20, [sp], #16
+	ldp	x29, x30, [sp], #16
+	ret
+	SET_SIZE(i_smccc_smc_call64)
+
+/*
+ * i_smccc_hvc_call32(smccc32_args_t *args)
+ *
+ * 32-bit HVC: loads w0..w7 from args, issues HVC #0, stores w0..w7 back.
+ */
+	ENTRY(i_smccc_hvc_call32)
+	stp	x29, x30, [sp, #-16]!
+	mov	x29, sp
+	stp	x19, x20, [sp, #-16]!
+	mov	x19, x0
+
+	ldp	w0, w1, [x19, #0]
+	ldp	w2, w3, [x19, #8]
+	ldp	w4, w5, [x19, #16]
+	ldp	w6, w7, [x19, #24]
+
+	hvc	#0
+
+	stp	w0, w1, [x19, #0]
+	stp	w2, w3, [x19, #8]
+	stp	w4, w5, [x19, #16]
+	stp	w6, w7, [x19, #24]
+
+	ldp	x19, x20, [sp], #16
+	ldp	x29, x30, [sp], #16
+	ret
+	SET_SIZE(i_smccc_hvc_call32)
+
+/*
+ * i_smccc_hvc_call64(smccc64_args_t *args)
+ *
+ * 64-bit HVC: loads x0..x17 from args, issues HVC #0, stores x0..x17 back.
+ */
+	ENTRY(i_smccc_hvc_call64)
+	stp	x29, x30, [sp, #-16]!
+	mov	x29, sp
+	stp	x19, x20, [sp, #-16]!
+	mov	x19, x0
+
+	ldp	x0, x1, [x19, #0]
+	ldp	x2, x3, [x19, #16]
+	ldp	x4, x5, [x19, #32]
+	ldp	x6, x7, [x19, #48]
+	ldp	x8, x9, [x19, #64]
+	ldp	x10, x11, [x19, #80]
+	ldp	x12, x13, [x19, #96]
+	ldp	x14, x15, [x19, #112]
+	ldp	x16, x17, [x19, #128]
+
+	hvc	#0
+
+	stp	x0, x1, [x19, #0]
+	stp	x2, x3, [x19, #16]
+	stp	x4, x5, [x19, #32]
+	stp	x6, x7, [x19, #48]
+	stp	x8, x9, [x19, #64]
+	stp	x10, x11, [x19, #80]
+	stp	x12, x13, [x19, #96]
+	stp	x14, x15, [x19, #112]
+	stp	x16, x17, [x19, #128]
+
+	ldp	x19, x20, [sp], #16
+	ldp	x29, x30, [sp], #16
+	ret
+	SET_SIZE(i_smccc_hvc_call64)

--- a/usr/src/uts/armv8/os/mp_startup.c
+++ b/usr/src/uts/armv8/os/mp_startup.c
@@ -77,6 +77,7 @@
 #include <sys/platmod.h>
 #include <sys/irq.h>
 #include <sys/psci.h>
+#include <sys/sunddi.h>
 #include <sys/arm_features.h>
 #include <sys/cpuinfo.h>
 
@@ -296,7 +297,7 @@ wakeup_cpu(cpu_t *cp)
 	VERIFY3U(cp->cpu_m.mcpu_ci->ci_ppver, ==, CPUINFO_ENABLE_METHOD_PSCI);
 
 	if (psci_cpu_on(cp->cpu_m.affinity,
-	    secondary_vec_pa, cpu_startup_data_pa) != PSCI_SUCCESS) {
+	    secondary_vec_pa, cpu_startup_data_pa) != DDI_SUCCESS) {
 		return (-1);
 	}
 

--- a/usr/src/uts/armv8/os/psci.c
+++ b/usr/src/uts/armv8/os/psci.c
@@ -24,7 +24,7 @@
  */
 /*
  * Copyright 2017 Hayashi Naoyuki
- * Copyright 2025 Michael van der Westhuizen
+ * Copyright 2026 Michael van der Westhuizen
  */
 #include <sys/types.h>
 #include <sys/psci.h>
@@ -138,7 +138,8 @@ psci_init(struct xboot_info *xbp)
 	if (xbp == NULL || xbp->bi_psci_version & 0x80000000)
 		return (-1);
 
-	pcsi_method_is_hvc = xbp->bi_psci_conduit_hvc ? B_TRUE : B_FALSE;
+	pcsi_method_is_hvc =
+	    (xbp->bi_smccc_conduit == BI_SMCCC_CONDUIT_HVC) ? B_TRUE : B_FALSE;
 
 	/*
 	 * Identifier overrides are only valid (and are optional) prior

--- a/usr/src/uts/armv8/os/psci.c
+++ b/usr/src/uts/armv8/os/psci.c
@@ -26,11 +26,21 @@
  * Copyright 2017 Hayashi Naoyuki
  * Copyright 2026 Michael van der Westhuizen
  */
+
+/*
+ * Kernel PSCI - client of the SMCCC transport layer.
+ *
+ * All firmware calls go through smccc32_call or smccc64_call which
+ * handle conduit selection (SMC/HVC) and dispatch to the firmware.
+ */
+
 #include <sys/types.h>
 #include <sys/psci.h>
+#include <sys/smccc.h>
 #include <sys/promif.h>
 #include <sys/ddi.h>
 #include <sys/sunddi.h>
+#include <sys/systm.h>
 #include <sys/bootinfo.h>
 
 static uint32_t pcsi_version_id = 0x84000000;
@@ -53,79 +63,86 @@ static uint32_t psci_stat_residency_id = 0xc4000010;
 static uint32_t psci_stat_count_id = 0xc4000011;
 
 boolean_t psci_initialized = B_FALSE;
-static boolean_t pcsi_method_is_hvc = B_FALSE;
 
-static inline uint64_t
-psci_smc64(uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3)
+/*
+ * Internal helper: issue an SMC32 PSCI call via SMCCC.
+ *
+ * Wraps smccc32_call with PSCI-specific initialization checks and
+ * panic-path handling.  Returns the firmware result from w[0].
+ */
+static uint32_t
+psci_call32(uint32_t fid, uint32_t a1, uint32_t a2, uint32_t a3)
 {
-	register uint64_t x0 __asm__("x0") = a0;
-	register uint64_t x1 __asm__("x1") = a1;
-	register uint64_t x2 __asm__("x2") = a2;
-	register uint64_t x3 __asm__("x3") = a3;
+	int rv;
+	smccc32_args_t args = {
+		.w = { fid, a1, a2, a3 }
+	};
 
-	__asm__ volatile("smc #0"
-	    : "+r"(x0), "+r"(x1), "+r"(x2), "+r"(x3)
-	    :
-	    :
-	    "x4", "x5", "x6", "x7", "x8", "x9", "x10", "x11",
-	    "x12", "x13", "x14", "x15", "x16", "x17", "x18", "memory", "cc");
-
-	return (x0);
-}
-
-static inline uint64_t
-psci_hvc64(uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3)
-{
-	register uint64_t x0 __asm__("x0") = a0;
-	register uint64_t x1 __asm__("x1") = a1;
-	register uint64_t x2 __asm__("x2") = a2;
-	register uint64_t x3 __asm__("x3") = a3;
-
-	__asm__ volatile("hvc #0"
-	    : "+r"(x0), "+r"(x1), "+r"(x2), "+r"(x3)
-	    :
-	    :
-	    "x4", "x5", "x6", "x7", "x8", "x9", "x10", "x11",
-	    "x12", "x13", "x14", "x15", "x16", "x17", "x18", "memory", "cc");
-
-	return (x0);
-}
-
-static uint64_t
-psci_call_raw(uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3)
-{
-	if (pcsi_method_is_hvc) {
-		return (psci_hvc64(a0, a1, a2, a3));
-	}
-
-	return (psci_smc64(a0, a1, a2, a3));
-}
-
-static uint64_t
-psci_call(uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3)
-{
 	/*
-	 * We may get here very early if panicking, attempt to be useful, and
-	 * not panic recursively.  Unfortunately, we may also get here from
-	 * `$q` under kmdb and panic rather than rebooting.
+	 * We may get here very early if panicking; attempt to be useful
+	 * and not panic recursively.  Unfortunately, we may also get here
+	 * from `$q` under kmdb and panic rather than rebooting.
 	 */
-	if (!panicstr)
+	if (!panicstr) {
 		VERIFY(psci_initialized);
+	}
 
 	if (panicstr != NULL && !psci_initialized) {
 		prom_printf("ERROR: attempted PSCI call before "
 		    "it's initialized\n");
 		return (0);
-	} else {
-		return (psci_call_raw(a0, a1, a2, a3));
 	}
+
+	rv = smccc32_call(&args);
+	if (rv != DDI_SUCCESS) {
+		prom_printf("ERROR: SMCCC transport failed for PSCI "
+		    "call 0x%x (rv=%d)\n", fid, rv);
+		return (0);
+	}
+
+	return (args.w[0]);
+}
+
+/*
+ * Internal helper: issue an SMC64 PSCI call via SMCCC.
+ *
+ * Wraps smccc64_call with PSCI-specific initialization checks and
+ * panic-path handling.  Returns the firmware result from x[0].
+ */
+static uint64_t
+psci_call64(uint32_t fid, uint64_t a1, uint64_t a2, uint64_t a3)
+{
+	int rv;
+	smccc64_args_t args = {
+		.x = { fid, a1, a2, a3 }
+	};
+
+	if (!panicstr) {
+		VERIFY(psci_initialized);
+	}
+
+	if (panicstr != NULL && !psci_initialized) {
+		prom_printf("ERROR: attempted PSCI call before "
+		    "it's initialized\n");
+		return (0);
+	}
+
+	rv = smccc64_call(&args);
+	if (rv != DDI_SUCCESS) {
+		prom_printf("ERROR: SMCCC transport failed for PSCI "
+		    "call 0x%x (rv=%d)\n", fid, rv);
+		return (0);
+	}
+
+	return (args.x[0]);
 }
 
 int
 psci_init(struct xboot_info *xbp)
 {
-	if (psci_initialized == B_TRUE)
-		return (0);
+	if (psci_initialized == B_TRUE) {
+		return (DDI_SUCCESS);
+	}
 
 	/*
 	 * The version field is:
@@ -135,146 +152,154 @@ psci_init(struct xboot_info *xbp)
 	 * If bit 31 is set, then the version represents an error value (and
 	 * should not have been passed to UNIX).
 	 */
-	if (xbp == NULL || xbp->bi_psci_version & 0x80000000)
-		return (-1);
-
-	pcsi_method_is_hvc =
-	    (xbp->bi_smccc_conduit == BI_SMCCC_CONDUIT_HVC) ? B_TRUE : B_FALSE;
+	if (xbp == NULL || xbp->bi_psci_version & 0x80000000) {
+		return (DDI_FAILURE);
+	}
 
 	/*
 	 * Identifier overrides are only valid (and are optional) prior
 	 * to PSCI 1.0.
 	 */
 	if (((xbp->bi_psci_version & 0x7FFF0000) >> 16) == 0) {
-		if (xbp->bi_psci_cpu_suspend_id != 0)
+		if (xbp->bi_psci_cpu_suspend_id != 0) {
 			psci_cpu_suspend_id = xbp->bi_psci_cpu_suspend_id;
-		if (xbp->bi_psci_cpu_off_id != 0)
+		}
+
+		if (xbp->bi_psci_cpu_off_id != 0) {
 			psci_cpu_off_id = xbp->bi_psci_cpu_off_id;
-		if (xbp->bi_psci_cpu_on_id != 0)
+		}
+
+		if (xbp->bi_psci_cpu_on_id != 0) {
 			psci_cpu_on_id = xbp->bi_psci_cpu_on_id;
-		if (xbp->bi_psci_migrate_id != 0)
+		}
+
+		if (xbp->bi_psci_migrate_id != 0) {
 			psci_migrate_id = xbp->bi_psci_migrate_id;
+		}
 	}
 
 	psci_initialized = B_TRUE;
-	return (0);
+	return (DDI_SUCCESS);
 }
 
 uint32_t
 psci_version(void)
 {
-	return (psci_call(pcsi_version_id, 0, 0, 0));
+	return (psci_call32(pcsi_version_id, 0, 0, 0));
 }
 
 int32_t
 psci_cpu_suspend(uint32_t power_state, uint64_t entry_point_address,
     uint64_t context_id)
 {
-	return (psci_call(psci_cpu_suspend_id, power_state, entry_point_address,
-	    context_id));
+	return (psci_call64(psci_cpu_suspend_id, power_state,
+	    entry_point_address, context_id));
 }
 
 int32_t
 psci_cpu_off(void)
 {
-	return (psci_call(psci_cpu_off_id, 0, 0, 0));
+	return (psci_call32(psci_cpu_off_id, 0, 0, 0));
 }
 
 int32_t
 psci_cpu_on(uint64_t target_cpu, uint64_t entry_point_address,
     uint64_t context_id)
 {
-	return (psci_call(psci_cpu_on_id, target_cpu, entry_point_address,
+	return (psci_call64(psci_cpu_on_id, target_cpu, entry_point_address,
 	    context_id));
 }
 
 int32_t
 psci_affinity_info(uint64_t target_affinity, uint32_t lowest_affinity_level)
 {
-	return (psci_call(psci_affinity_info_id, target_affinity,
+	return (psci_call64(psci_affinity_info_id, target_affinity,
 	    lowest_affinity_level, 0));
 }
 
 int32_t
 psci_migrate(uint64_t target_cpu)
 {
-	return (psci_call(psci_migrate_id, target_cpu, 0, 0));
+	return (psci_call64(psci_migrate_id, target_cpu, 0, 0));
 }
 
 int32_t
 psci_migrate_info_type(void)
 {
-	return (psci_call(psci_migrate_info_type_id, 0, 0, 0));
+	return (psci_call32(psci_migrate_info_type_id, 0, 0, 0));
 }
 
 uint64_t
 psci_migrate_info_up_cpu(void)
 {
-	return (psci_call(psci_migrate_info_up_cpu_id, 0, 0, 0));
+	return (psci_call64(psci_migrate_info_up_cpu_id, 0, 0, 0));
 }
 
 void
 psci_system_off(void)
 {
-	psci_call(psci_system_off_id, 0, 0, 0);
+	psci_call32(psci_system_off_id, 0, 0, 0);
 }
 
 void
 psci_system_reset(void)
 {
-	psci_call(psci_system_reset_id, 0, 0, 0);
+	psci_call32(psci_system_reset_id, 0, 0, 0);
 
 	/* If we've got here we were asked to reset and could not, spin. */
-	for (;;)
+	for (;;) {
 		__asm__("wfi");
+	}
 }
 
 int32_t
 psci_features(uint32_t psci_func_id)
 {
-	return (psci_call(psci_features_id, psci_func_id, 0, 0));
+	return (psci_call32(psci_features_id, psci_func_id, 0, 0));
 }
 
 int32_t
 psci_cpu_freeze(void)
 {
-	return (psci_call(psci_cpu_freeze_id, 0, 0, 0));
+	return (psci_call32(psci_cpu_freeze_id, 0, 0, 0));
 }
 
 int32_t
 psci_cpu_default_suspend(uint64_t entry_point_address, uint64_t context_id)
 {
-	return (psci_call(psci_cpu_default_suspend_id, entry_point_address,
+	return (psci_call64(psci_cpu_default_suspend_id, entry_point_address,
 	    context_id, 0));
 }
 
 int32_t
 psci_node_hw_state(uint64_t target_cpu, uint32_t power_level)
 {
-	return (psci_call(psci_node_hw_state_id, target_cpu, power_level, 0));
+	return (psci_call64(psci_node_hw_state_id, target_cpu, power_level,
+	    0));
 }
 
 int32_t
 psci_system_suspend(uint64_t entry_point_address, uint64_t context_id)
 {
-	return (psci_call(psci_system_suspend_id, entry_point_address,
+	return (psci_call64(psci_system_suspend_id, entry_point_address,
 	    context_id, 0));
 }
 
 int32_t
 psci_set_suspend_mode(uint32_t mode)
 {
-	return (psci_call(psci_set_suspend_mode_id, mode, 0, 0));
+	return (psci_call32(psci_set_suspend_mode_id, mode, 0, 0));
 }
 
 uint64_t
 psci_stat_residency(uint64_t target_cpu, uint32_t power_state)
 {
-	return (psci_call(psci_stat_residency_id, target_cpu, power_state, 0));
+	return (psci_call64(psci_stat_residency_id, target_cpu,
+	    power_state, 0));
 }
 
 uint64_t
 psci_stat_count(uint64_t target_cpu, uint32_t power_state)
 {
-	return (psci_call(psci_stat_count_id, target_cpu, power_state, 0));
+	return (psci_call64(psci_stat_count_id, target_cpu, power_state, 0));
 }

--- a/usr/src/uts/armv8/os/psci.c
+++ b/usr/src/uts/armv8/os/psci.c
@@ -32,6 +32,28 @@
  *
  * All firmware calls go through smccc32_call or smccc64_call which
  * handle conduit selection (SMC/HVC) and dispatch to the firmware.
+ *
+ * Public functions return DDI error codes for transport and PSCI-level
+ * status.  Firmware result values (affinity states, version numbers,
+ * feature flags, etc.) are returned via out parameters where needed.
+ *
+ * The PSCI error-to-DDI mapping is:
+ *   PSCI_SUCCESS             ->  DDI_SUCCESS
+ *   PSCI_NOT_SUPPORTED       ->  DDI_ENOTSUP
+ *   PSCI_INVALID_PARAMETERS  ->  DDI_EINVAL
+ *   PSCI_INVALID_ADDRESS     ->  DDI_EINVAL
+ *   PSCI_DENIED              ->  DDI_FAILURE
+ *   PSCI_ALREADY_ON          ->  DDI_EALREADY
+ *   PSCI_ON_PENDING          ->  DDI_SUCCESS
+ *   PSCI_INTERNAL_FAILURE    ->  DDI_FAILURE
+ *   PSCI_NOT_PRESENT         ->  DDI_FAILURE
+ *   PSCI_DISABLED            ->  DDI_FAILURE
+ *
+ * Any undocumented return code, and any return from a function not
+ * documented to return on success that does not have the error bit
+ * set, maps to DDI_FAILURE.
+ *
+ * Specification references in this module are against DEN0022F.b.
  */
 
 #include <sys/types.h>
@@ -43,41 +65,69 @@
 #include <sys/systm.h>
 #include <sys/bootinfo.h>
 
-static uint32_t pcsi_version_id = 0x84000000;
-static uint32_t psci_cpu_suspend_id = PSCI_CPU_SUSPEND_ID;
-static uint32_t psci_cpu_off_id = PSCI_CPU_OFF_ID;
-static uint32_t psci_cpu_on_id = PSCI_CPU_ON_ID;
-static uint32_t psci_affinity_info_id = 0xc4000004;
-static uint32_t psci_migrate_id = PSCI_MIGRATE_ID;
-static uint32_t psci_migrate_info_type_id = 0x84000006;
-static uint32_t psci_migrate_info_up_cpu_id = 0xc4000007;
-static uint32_t psci_system_off_id = 0x84000008;
-static uint32_t psci_system_reset_id = 0x84000009;
-static uint32_t psci_features_id = 0x8400000a;
-static uint32_t psci_cpu_freeze_id = 0x8400000b;
-static uint32_t psci_cpu_default_suspend_id = 0xc400000c;
-static uint32_t psci_node_hw_state_id = 0xc400000d;
-static uint32_t psci_system_suspend_id = 0xc400000e;
-static uint32_t psci_set_suspend_mode_id = 0x8400000f;
-static uint32_t psci_stat_residency_id = 0xc4000010;
-static uint32_t psci_stat_count_id = 0xc4000011;
+/*
+ * Function IDs.  SMC64 versions are preferred where available.
+ */
+static uint32_t psci_version_id = 0x84000000;			/* SMC32 */
+static uint32_t psci_cpu_suspend_id = PSCI_CPU_SUSPEND_ID;	/* SMC64 */
+static uint32_t psci_cpu_off_id = PSCI_CPU_OFF_ID;		/* SMC32 */
+static uint32_t psci_cpu_on_id = PSCI_CPU_ON_ID;		/* SMC64 */
+static uint32_t psci_affinity_info_id = 0xc4000004;		/* SMC64 */
+static uint32_t psci_migrate_id = PSCI_MIGRATE_ID;		/* SMC64 */
+static uint32_t psci_migrate_info_type_id = 0x84000006;		/* SMC32 */
+static uint32_t psci_migrate_info_up_cpu_id = 0xc4000007;	/* SMC64 */
+static uint32_t psci_system_off_id = 0x84000008;		/* SMC32 */
+static uint32_t psci_system_reset_id = 0x84000009;		/* SMC32 */
+static uint32_t psci_features_id = 0x8400000a;			/* SMC32 */
+static uint32_t psci_cpu_freeze_id = 0x8400000b;		/* SMC32 */
+static uint32_t psci_cpu_default_suspend_id = 0xc400000c;	/* SMC64 */
+static uint32_t psci_node_hw_state_id = 0xc400000d;		/* SMC64 */
+static uint32_t psci_system_suspend_id = 0xc400000e;		/* SMC64 */
+static uint32_t psci_set_suspend_mode_id = 0x8400000f;		/* SMC32 */
+static uint32_t psci_stat_residency_id = 0xc4000010;		/* SMC64 */
+static uint32_t psci_stat_count_id = 0xc4000011;		/* SMC64 */
+static uint32_t psci_system_reset2_id = 0xc4000012;		/* SMC64 */
+static uint32_t psci_mem_protect_id = 0x84000013;		/* SMC32 */
+static uint32_t psci_mem_protect_check_range_id = 0xc4000014;	/* SMC64 */
+static uint32_t psci_system_off2_id = 0xc4000015;		/* SMC64 */
 
 boolean_t psci_initialized = B_FALSE;
 
 /*
- * Internal helper: issue an SMC32 PSCI call via SMCCC.
- *
- * Wraps smccc32_call with PSCI-specific initialization checks and
- * panic-path handling.  Returns the firmware result from w[0].
+ * Translate a PSCI error code (int32_t) to a DDI return value.
  */
-static uint32_t
-psci_call32(uint32_t fid, uint32_t a1, uint32_t a2, uint32_t a3)
+static int
+psci_to_ddi(int32_t psci_ret)
 {
-	int rv;
-	smccc32_args_t args = {
-		.w = { fid, a1, a2, a3 }
-	};
+	switch (psci_ret) {
+	case PSCI_SUCCESS:		/* fallthrough */
+	case PSCI_ON_PENDING:
+		return (DDI_SUCCESS);
+	case PSCI_NOT_SUPPORTED:
+		return (DDI_ENOTSUP);
+	case PSCI_INVALID_PARAMETERS:	/* fallthrough */
+	case PSCI_INVALID_ADDRESS:
+		return (DDI_EINVAL);
+	case PSCI_ALREADY_ON:
+		return (DDI_EALREADY);
+	case PSCI_DENIED:		/* fallthrough */
+	case PSCI_INTERNAL_FAILURE:	/* fallthrough */
+	case PSCI_NOT_PRESENT:		/* fallthrough */
+	case PSCI_DISABLED:		/* fallthrough */
+	default:
+		return (DDI_FAILURE);
+	}
+}
 
+/*
+ * Common PSCI pre-call checks.
+ *
+ * Returns DDI_SUCCESS if the call may proceed, DDI_ETRANSPORT during
+ * panic before initialization, or DDI_ENOTSUP for a zero function ID.
+ */
+static int
+psci_check(uint32_t fid)
+{
 	/*
 	 * We may get here very early if panicking; attempt to be useful
 	 * and not panic recursively.  Unfortunately, we may also get here
@@ -90,51 +140,82 @@ psci_call32(uint32_t fid, uint32_t a1, uint32_t a2, uint32_t a3)
 	if (panicstr != NULL && !psci_initialized) {
 		prom_printf("ERROR: attempted PSCI call before "
 		    "it's initialized\n");
-		return (0);
+		return (DDI_ETRANSPORT);
+	}
+
+	if (fid == 0) {
+		return (DDI_ENOTSUP);
+	}
+
+	return (DDI_SUCCESS);
+}
+
+/*
+ * Internal helper: issue an SMC32 PSCI call via SMCCC.
+ *
+ * Returns a DDI error code for transport-level status.  On DDI_SUCCESS
+ * the firmware result is stored in *resultp (if non-NULL).
+ */
+static int
+psci_call32(uint32_t fid, uint32_t a1, uint32_t a2, uint32_t a3,
+    uint32_t *resultp)
+{
+	int rv;
+	smccc32_args_t args = {
+		.w = { fid, a1, a2, a3 }
+	};
+
+	rv = psci_check(fid);
+	if (rv != DDI_SUCCESS) {
+		return (rv);
 	}
 
 	rv = smccc32_call(&args);
 	if (rv != DDI_SUCCESS) {
 		prom_printf("ERROR: SMCCC transport failed for PSCI "
 		    "call 0x%x (rv=%d)\n", fid, rv);
-		return (0);
+		return (DDI_ETRANSPORT);
 	}
 
-	return (args.w[0]);
+	if (resultp != NULL) {
+		*resultp = args.w[0];
+	}
+
+	return (DDI_SUCCESS);
 }
 
 /*
  * Internal helper: issue an SMC64 PSCI call via SMCCC.
  *
- * Wraps smccc64_call with PSCI-specific initialization checks and
- * panic-path handling.  Returns the firmware result from x[0].
+ * Returns a DDI error code for transport-level status.  On DDI_SUCCESS
+ * the firmware result is stored in *resultp (if non-NULL).
  */
-static uint64_t
-psci_call64(uint32_t fid, uint64_t a1, uint64_t a2, uint64_t a3)
+static int
+psci_call64(uint32_t fid, uint64_t a1, uint64_t a2, uint64_t a3,
+    uint64_t *resultp)
 {
 	int rv;
 	smccc64_args_t args = {
 		.x = { fid, a1, a2, a3 }
 	};
 
-	if (!panicstr) {
-		VERIFY(psci_initialized);
-	}
-
-	if (panicstr != NULL && !psci_initialized) {
-		prom_printf("ERROR: attempted PSCI call before "
-		    "it's initialized\n");
-		return (0);
+	rv = psci_check(fid);
+	if (rv != DDI_SUCCESS) {
+		return (rv);
 	}
 
 	rv = smccc64_call(&args);
 	if (rv != DDI_SUCCESS) {
 		prom_printf("ERROR: SMCCC transport failed for PSCI "
 		    "call 0x%x (rv=%d)\n", fid, rv);
-		return (0);
+		return (DDI_ETRANSPORT);
 	}
 
-	return (args.x[0]);
+	if (resultp != NULL) {
+		*resultp = args.x[0];
+	}
+
+	return (DDI_SUCCESS);
 }
 
 int
@@ -150,7 +231,7 @@ psci_init(struct xboot_info *xbp)
 	 * - [15:0] : Minor version
 	 *
 	 * If bit 31 is set, then the version represents an error value (and
-	 * should not have been passed to UNIX).
+	 * should not have been passed to unix).
 	 */
 	if (xbp == NULL || xbp->bi_psci_version & 0x80000000) {
 		return (DDI_FAILURE);
@@ -182,124 +263,517 @@ psci_init(struct xboot_info *xbp)
 	return (DDI_SUCCESS);
 }
 
-uint32_t
-psci_version(void)
+/*
+ * PSCI_VERSION (§5.1.1)
+ */
+int
+psci_version(uint32_t *versionp)
 {
-	return (psci_call32(pcsi_version_id, 0, 0, 0));
+	uint32_t result;
+	int rv;
+
+	rv = psci_call32(psci_version_id, 0, 0, 0, &result);
+	if (rv != DDI_SUCCESS) {
+		return (rv);
+	}
+
+	/*
+	 * Bit 31 set indicates an error from the firmware.
+	 */
+	if (result & 0x80000000) {
+		return (DDI_FAILURE);
+	}
+
+	if (versionp != NULL) {
+		*versionp = result;
+	}
+
+	return (DDI_SUCCESS);
 }
 
-int32_t
+/*
+ * CPU_SUSPEND (§5.1.2)
+ *
+ * Returns on wakeup from standby; does not return on powerdown (resumes
+ * at entry_point_address).
+ */
+int
 psci_cpu_suspend(uint32_t power_state, uint64_t entry_point_address,
     uint64_t context_id)
 {
-	return (psci_call64(psci_cpu_suspend_id, power_state,
-	    entry_point_address, context_id));
+	uint64_t result;
+	int rv;
+
+	rv = psci_call64(psci_cpu_suspend_id, power_state,
+	    entry_point_address, context_id, &result);
+	if (rv != DDI_SUCCESS) {
+		return (rv);
+	}
+
+	return (psci_to_ddi((int32_t)result));
 }
 
-int32_t
+/*
+ * CPU_OFF (§5.1.3)
+ *
+ * Does not return on success.
+ */
+int
 psci_cpu_off(void)
 {
-	return (psci_call32(psci_cpu_off_id, 0, 0, 0));
+	uint32_t result;
+	int rv;
+
+	rv = psci_call32(psci_cpu_off_id, 0, 0, 0, &result);
+	if (rv != DDI_SUCCESS) {
+		return (rv);
+	}
+
+	/*
+	 * CPU_OFF does not return on success.  Any return is an error.
+	 */
+	return (psci_to_ddi((int32_t)result));
 }
 
-int32_t
+/*
+ * CPU_ON (§5.1.4)
+ *
+ * ALREADY_ON is mapped to DDI_EALREADY so that callers (mp_startup)
+ * can distinguish it from SUCCESS - the core is already running and
+ * will not go through the entry point as expected.
+ *
+ * ON_PENDING is mapped to DDI_SUCCESS - the call is async and a prior
+ * CPU_ON is still in flight, which is functionally equivalent.
+ */
+int
 psci_cpu_on(uint64_t target_cpu, uint64_t entry_point_address,
     uint64_t context_id)
 {
-	return (psci_call64(psci_cpu_on_id, target_cpu, entry_point_address,
-	    context_id));
+	uint64_t result;
+	int rv;
+
+	rv = psci_call64(psci_cpu_on_id, target_cpu,
+	    entry_point_address, context_id, &result);
+	if (rv != DDI_SUCCESS) {
+		return (rv);
+	}
+
+	return (psci_to_ddi((int32_t)result));
 }
 
-int32_t
-psci_affinity_info(uint64_t target_affinity, uint32_t lowest_affinity_level)
+/*
+ * AFFINITY_INFO (§5.1.5)
+ *
+ * Mixes positive status values (0=ON, 1=OFF, 2=ON_PENDING) with
+ * negative error codes, so the affinity state is returned via *statep.
+ */
+int
+psci_affinity_info(uint64_t target_affinity, uint32_t lowest_affinity_level,
+    uint32_t *statep)
 {
-	return (psci_call64(psci_affinity_info_id, target_affinity,
-	    lowest_affinity_level, 0));
+	uint64_t result;
+	int rv;
+
+	rv = psci_call64(psci_affinity_info_id, target_affinity,
+	    lowest_affinity_level, 0, &result);
+	if (rv != DDI_SUCCESS) {
+		return (rv);
+	}
+
+	if ((int32_t)result < 0) {
+		return (psci_to_ddi((int32_t)result));
+	}
+
+	/*
+	 * Documented values are 0 (ON), 1 (OFF), 2 (ON_PENDING).
+	 * Any undocumented non-negative value is treated as DDI_FAILURE.
+	 */
+	if ((uint32_t)result > 2) {
+		return (DDI_FAILURE);
+	}
+
+	if (statep != NULL) {
+		*statep = (uint32_t)result;
+	}
+
+	return (DDI_SUCCESS);
 }
 
-int32_t
+/*
+ * MIGRATE (§5.1.6)
+ */
+int
 psci_migrate(uint64_t target_cpu)
 {
-	return (psci_call64(psci_migrate_id, target_cpu, 0, 0));
+	uint64_t result;
+	int rv;
+
+	rv = psci_call64(psci_migrate_id, target_cpu, 0, 0, &result);
+	if (rv != DDI_SUCCESS) {
+		return (rv);
+	}
+
+	return (psci_to_ddi((int32_t)result));
 }
 
-int32_t
-psci_migrate_info_type(void)
+/*
+ * MIGRATE_INFO_TYPE (§5.1.7)
+ *
+ * Mixes positive type values (0/1/2) with NOT_SUPPORTED.
+ */
+int
+psci_migrate_info_type(uint32_t *typep)
 {
-	return (psci_call32(psci_migrate_info_type_id, 0, 0, 0));
+	uint32_t result;
+	int rv;
+
+	rv = psci_call32(psci_migrate_info_type_id, 0, 0, 0, &result);
+	if (rv != DDI_SUCCESS) {
+		return (rv);
+	}
+
+	if ((int32_t)result < 0) {
+		return (psci_to_ddi((int32_t)result));
+	}
+
+	if (result > 2) {
+		return (DDI_FAILURE);
+	}
+
+	if (typep != NULL) {
+		*typep = result;
+	}
+
+	return (DDI_SUCCESS);
 }
 
-uint64_t
-psci_migrate_info_up_cpu(void)
+/*
+ * MIGRATE_INFO_UP_CPU (§5.1.8)
+ *
+ * Returns an MPIDR value; only valid if MIGRATE_INFO_TYPE returns 0 or 1.
+ */
+int
+psci_migrate_info_up_cpu(uint64_t *mpidp)
 {
-	return (psci_call64(psci_migrate_info_up_cpu_id, 0, 0, 0));
+	uint64_t result;
+	int rv;
+
+	rv = psci_call64(psci_migrate_info_up_cpu_id, 0, 0, 0, &result);
+	if (rv != DDI_SUCCESS) {
+		return (rv);
+	}
+
+	if (mpidp != NULL) {
+		*mpidp = result;
+	}
+
+	return (DDI_SUCCESS);
 }
 
+/*
+ * SYSTEM_OFF (§5.1.9)
+ *
+ * Does not return.
+ */
 void
 psci_system_off(void)
 {
-	psci_call32(psci_system_off_id, 0, 0, 0);
+	(void) psci_call32(psci_system_off_id, 0, 0, 0, NULL);
 }
 
+/*
+ * SYSTEM_RESET (§5.1.11)
+ *
+ * Does not return.
+ */
 void
 psci_system_reset(void)
 {
-	psci_call32(psci_system_reset_id, 0, 0, 0);
+	(void) psci_call32(psci_system_reset_id, 0, 0, 0, NULL);
 
-	/* If we've got here we were asked to reset and could not, spin. */
+	/* If we've got here we were asked to reset and could not, spin */
 	for (;;) {
 		__asm__("wfi");
 	}
 }
 
-int32_t
-psci_features(uint32_t psci_func_id)
+/*
+ * PSCI_FEATURES (§5.1.15)
+ *
+ * NOT_SUPPORTED is an error; bit[31]=0 with bits[30:0] as feature flags.
+ */
+int
+psci_features(uint32_t psci_func_id, uint32_t *flagsp)
 {
-	return (psci_call32(psci_features_id, psci_func_id, 0, 0));
+	uint32_t result;
+	int rv;
+
+	rv = psci_call32(psci_features_id, psci_func_id, 0, 0, &result);
+	if (rv != DDI_SUCCESS) {
+		return (rv);
+	}
+
+	if ((int32_t)result < 0) {
+		return (psci_to_ddi((int32_t)result));
+	}
+
+	if (flagsp != NULL) {
+		*flagsp = result;
+	}
+
+	return (DDI_SUCCESS);
 }
 
-int32_t
+/*
+ * CPU_FREEZE (§5.1.16)
+ *
+ * Does not return on success.
+ */
+int
 psci_cpu_freeze(void)
 {
-	return (psci_call32(psci_cpu_freeze_id, 0, 0, 0));
+	uint32_t result;
+	int rv;
+
+	rv = psci_call32(psci_cpu_freeze_id, 0, 0, 0, &result);
+	if (rv != DDI_SUCCESS) {
+		return (rv);
+	}
+
+	return (psci_to_ddi((int32_t)result));
 }
 
-int32_t
+/*
+ * CPU_DEFAULT_SUSPEND (§5.1.17)
+ */
+int
 psci_cpu_default_suspend(uint64_t entry_point_address, uint64_t context_id)
 {
-	return (psci_call64(psci_cpu_default_suspend_id, entry_point_address,
-	    context_id, 0));
+	uint64_t result;
+	int rv;
+
+	rv = psci_call64(psci_cpu_default_suspend_id, entry_point_address,
+	    context_id, 0, &result);
+	if (rv != DDI_SUCCESS) {
+		return (rv);
+	}
+
+	return (psci_to_ddi((int32_t)result));
 }
 
-int32_t
-psci_node_hw_state(uint64_t target_cpu, uint32_t power_level)
+/*
+ * NODE_HW_STATE (§5.1.18)
+ *
+ * Mixes positive state values (0=HW_ON, 1=HW_OFF, 2=HW_STANDBY) with
+ * negative error codes.
+ */
+int
+psci_node_hw_state(uint64_t target_cpu, uint32_t power_level,
+    uint32_t *statep)
 {
-	return (psci_call64(psci_node_hw_state_id, target_cpu, power_level,
-	    0));
+	uint64_t result;
+	int rv;
+
+	rv = psci_call64(psci_node_hw_state_id, target_cpu, power_level,
+	    0, &result);
+	if (rv != DDI_SUCCESS) {
+		return (rv);
+	}
+
+	if ((int32_t)result < 0) {
+		return (psci_to_ddi((int32_t)result));
+	}
+
+	if ((uint32_t)result > 2) {
+		return (DDI_FAILURE);
+	}
+
+	if (statep != NULL) {
+		*statep = (uint32_t)result;
+	}
+
+	return (DDI_SUCCESS);
 }
 
-int32_t
+/*
+ * SYSTEM_SUSPEND (§5.1.19)
+ *
+ * Does not return on success.
+ */
+int
 psci_system_suspend(uint64_t entry_point_address, uint64_t context_id)
 {
-	return (psci_call64(psci_system_suspend_id, entry_point_address,
-	    context_id, 0));
+	uint64_t result;
+	int rv;
+
+	rv = psci_call64(psci_system_suspend_id, entry_point_address,
+	    context_id, 0, &result);
+	if (rv != DDI_SUCCESS) {
+		return (rv);
+	}
+
+	return (psci_to_ddi((int32_t)result));
 }
 
-int32_t
+/*
+ * PSCI_SET_SUSPEND_MODE (§5.1.20)
+ */
+int
 psci_set_suspend_mode(uint32_t mode)
 {
-	return (psci_call32(psci_set_suspend_mode_id, mode, 0, 0));
+	uint32_t result;
+	int rv;
+
+	rv = psci_call32(psci_set_suspend_mode_id, mode, 0, 0, &result);
+	if (rv != DDI_SUCCESS) {
+		return (rv);
+	}
+
+	return (psci_to_ddi((int32_t)result));
 }
 
-uint64_t
-psci_stat_residency(uint64_t target_cpu, uint32_t power_state)
+/*
+ * PSCI_STAT_RESIDENCY (§5.1.21)
+ *
+ * Returns microseconds spent in a given power state.
+ */
+int
+psci_stat_residency(uint64_t target_cpu, uint32_t power_state,
+    uint64_t *residencyp)
 {
-	return (psci_call64(psci_stat_residency_id, target_cpu,
-	    power_state, 0));
+	uint64_t result;
+	int rv;
+
+	rv = psci_call64(psci_stat_residency_id, target_cpu, power_state,
+	    0, &result);
+	if (rv != DDI_SUCCESS) {
+		return (rv);
+	}
+
+	if (residencyp != NULL) {
+		*residencyp = result;
+	}
+
+	return (DDI_SUCCESS);
 }
 
-uint64_t
-psci_stat_count(uint64_t target_cpu, uint32_t power_state)
+/*
+ * PSCI_STAT_COUNT (§5.1.22)
+ *
+ * Returns count of entries into a given power state.
+ */
+int
+psci_stat_count(uint64_t target_cpu, uint32_t power_state,
+    uint64_t *countp)
 {
-	return (psci_call64(psci_stat_count_id, target_cpu, power_state, 0));
+	uint64_t result;
+	int rv;
+
+	rv = psci_call64(psci_stat_count_id, target_cpu, power_state,
+	    0, &result);
+	if (rv != DDI_SUCCESS) {
+		return (rv);
+	}
+
+	if (countp != NULL) {
+		*countp = result;
+	}
+
+	return (DDI_SUCCESS);
+}
+
+/*
+ * SYSTEM_OFF2 (§5.1.10)
+ *
+ * PSCI 1.3.  Does not return on success.
+ */
+int
+psci_system_off2(uint32_t type, uint64_t cookie)
+{
+	uint64_t result;
+	int rv;
+
+	rv = psci_call64(psci_system_off2_id, type, cookie, 0, &result);
+	if (rv != DDI_SUCCESS) {
+		return (rv);
+	}
+
+	/*
+	 * SYSTEM_OFF2 does not return on success.  Any return is an error.
+	 */
+	return (psci_to_ddi((int32_t)result));
+}
+
+/*
+ * SYSTEM_RESET2 (§5.1.12)
+ *
+ * PSCI 1.1.  Does not return on success.
+ */
+int
+psci_system_reset2(uint32_t reset_type, uint64_t cookie)
+{
+	uint64_t result;
+	int rv;
+
+	rv = psci_call64(psci_system_reset2_id, reset_type, cookie, 0,
+	    &result);
+	if (rv != DDI_SUCCESS) {
+		return (rv);
+	}
+
+	/*
+	 * SYSTEM_RESET2 does not return on success.  Any return is an error.
+	 */
+	return (psci_to_ddi((int32_t)result));
+}
+
+/*
+ * MEM_PROTECT (§5.1.13)
+ *
+ * PSCI 1.1.  On success returns previous state (0=disabled, 1=enabled).
+ */
+int
+psci_mem_protect(uint32_t enable, uint32_t *prev_statep)
+{
+	uint32_t result;
+	int rv;
+
+	rv = psci_call32(psci_mem_protect_id, enable, 0, 0, &result);
+	if (rv != DDI_SUCCESS) {
+		return (rv);
+	}
+
+	if ((int32_t)result < 0) {
+		return (psci_to_ddi((int32_t)result));
+	}
+
+	if (result > 1) {
+		return (DDI_FAILURE);
+	}
+
+	if (prev_statep != NULL) {
+		*prev_statep = result;
+	}
+
+	return (DDI_SUCCESS);
+}
+
+/*
+ * MEM_PROTECT_CHECK_RANGE (§5.1.14)
+ *
+ * PSCI 1.1.
+ */
+int
+psci_mem_protect_check_range(uint64_t base, uint64_t length)
+{
+	uint64_t result;
+	int rv;
+
+	rv = psci_call64(psci_mem_protect_check_range_id, base, length,
+	    0, &result);
+	if (rv != DDI_SUCCESS) {
+		return (rv);
+	}
+
+	return (psci_to_ddi((int32_t)result));
 }

--- a/usr/src/uts/armv8/os/smccc.c
+++ b/usr/src/uts/armv8/os/smccc.c
@@ -1,0 +1,176 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2026 Michael van der Westhuizen
+ */
+
+/*
+ * Kernel SMCCC transport layer.
+ *
+ * Reconstructs state from xboot_info at smccc_init time and provides
+ * smccc32_call/smccc64_call, which dispatch to the width-appropriate
+ * assembly trampolines.
+ */
+
+#include <sys/types.h>
+#include <sys/ddi.h>
+#include <sys/sunddi.h>
+#include <sys/systm.h>
+#include <sys/bootinfo.h>
+#include <sys/smccc.h>
+#include <sys/promif.h>
+
+/*
+ * Assembly trampoline prototypes (smccc_impl.S).
+ */
+extern void i_smccc_smc_call32(smccc32_args_t *);
+extern void i_smccc_smc_call64(smccc64_args_t *);
+extern void i_smccc_hvc_call32(smccc32_args_t *);
+extern void i_smccc_hvc_call64(smccc64_args_t *);
+
+static boolean_t smccc_inited = B_FALSE;
+static boolean_t smccc_is_hvc = B_FALSE;
+static uint32_t smccc_ver = 0;
+
+/*
+ * Initialize the kernel SMCCC layer.
+ *
+ * Called from the unix boot path after xboot_info has been populated by
+ * dboot.
+ *
+ * The conduit type and SMCCC version were already discovered during dboot
+ * and stored in xboot_info.
+ */
+int
+smccc_init(struct xboot_info *xbp)
+{
+	if (xbp == NULL) {
+		return (DDI_FAILURE);
+	}
+
+	if (smccc_inited) {
+		return (DDI_SUCCESS);
+	}
+
+	smccc_is_hvc =
+	    (xbp->bi_smccc_conduit == BI_SMCCC_CONDUIT_HVC) ? B_TRUE : B_FALSE;
+	smccc_ver = xbp->bi_smccc_version;
+	smccc_inited = B_TRUE;
+
+	return (DDI_SUCCESS);
+}
+
+/*
+ * Common transport checks for smccc32_call and smccc64_call.
+ *
+ * Returns DDI_SUCCESS if the call may proceed, DDI_FAILURE if SMCCC is
+ * not initialized, or DDI_ETRANSPORT during panic when not initialized.
+ */
+static int
+smccc_check(void)
+{
+	/*
+	 * Panic-path safety: if we're panicking and SMCCC isn't up,
+	 * return gracefully rather than recursively panicking.
+	 */
+	if (!smccc_inited) {
+		if (panicstr != NULL) {
+			prom_printf("WARNING: SMCCC call during panic "
+			    "before initialization\n");
+			return (DDI_ETRANSPORT);
+		}
+
+		return (DDI_FAILURE);
+	}
+
+	return (DDI_SUCCESS);
+}
+
+/*
+ * Issue a 32-bit SMCCC call via the appropriate trampoline.
+ *
+ * The conduit (SMC/HVC) is chosen based on smccc_is_hvc.
+ *
+ * Clients pass a populated smccc32_args_t with the function ID in
+ * args->w[0].  Results from firmware are written back to the passed
+ * structure for interpretation by the caller.
+ *
+ * Returns DDI_SUCCESS on successful dispatch, DDI_FAILURE if SMCCC is
+ * not initialized, or DDI_ETRANSPORT during panic when not initialized.
+ */
+int
+smccc32_call(smccc32_args_t *args)
+{
+	int rv;
+
+	rv = smccc_check();
+	if (rv != DDI_SUCCESS) {
+		return (rv);
+	}
+
+	if (smccc_is_hvc) {
+		i_smccc_hvc_call32(args);
+	} else {
+		i_smccc_smc_call32(args);
+	}
+
+	return (DDI_SUCCESS);
+}
+
+/*
+ * Issue a 64-bit SMCCC call via the appropriate trampoline.
+ *
+ * The conduit (SMC/HVC) is chosen based on smccc_is_hvc.
+ *
+ * Clients pass a populated smccc64_args_t with the function ID in
+ * args->x[0].  Results from firmware are written back to the passed
+ * structure for interpretation by the caller.
+ *
+ * Returns DDI_SUCCESS on successful dispatch, DDI_FAILURE if SMCCC is
+ * not initialized, or DDI_ETRANSPORT during panic when not initialized.
+ */
+int
+smccc64_call(smccc64_args_t *args)
+{
+	int rv;
+
+	rv = smccc_check();
+	if (rv != DDI_SUCCESS) {
+		return (rv);
+	}
+
+	if (smccc_is_hvc) {
+		i_smccc_hvc_call64(args);
+	} else {
+		i_smccc_smc_call64(args);
+	}
+
+	return (DDI_SUCCESS);
+}
+
+/*
+ * Returns true if full SMCCC (1.1+) is available.
+ */
+boolean_t
+smccc_available(void)
+{
+	return (smccc_inited && smccc_ver > 0x00010000);
+}
+
+/*
+ * Return the negotiated SMCCC version, or 1.0 if PSCI-only.
+ */
+uint32_t
+smccc_version(void)
+{
+	return (smccc_ver);
+}

--- a/usr/src/uts/armv8/os/smccc_subr.c
+++ b/usr/src/uts/armv8/os/smccc_subr.c
@@ -1,0 +1,378 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2026 Michael van der Westhuizen
+ */
+
+/*
+ * Arm Architecture Service functions (DEN0028 Chapter 7).
+ *
+ * Thin wrappers around smccc32_call/smccc64_call that present typed
+ * interfaces and return DDI error codes.  Each function gates on
+ * smccc_available, which requires SMCCC 1.1 or later.  Callers
+ * discover individual function support via smccc_arch_features before
+ * use.
+ *
+ * There are some rules and complexities to using these functions,
+ * so callers should consult DEN0028 before using these functions.
+ *
+ * Specification references are against DEN0028 v1.7.
+ */
+
+#include <sys/types.h>
+#include <sys/smccc.h>
+#include <sys/ddi.h>
+#include <sys/sunddi.h>
+#include <sys/debug.h>
+#include <sys/systm.h>
+
+/*
+ * Translate a DEN0028 firmware return code to a DDI error.
+ */
+static int
+smccc_to_ddi(int32_t fw_ret)
+{
+	switch (fw_ret) {
+	case SMCCC_SUCCESS:
+		return (DDI_SUCCESS);
+	case SMCCC_NOT_SUPPORTED:
+		return (DDI_ENOTSUP);
+	case SMCCC_NOT_REQUIRED:
+		return (DDI_ENOTSUP);
+	case SMCCC_INVALID_PARAMETER:
+		return (DDI_EINVAL);
+	case SMCCC_RATE_LIMITED:	/* fallthrough */
+	case SMCCC_BUSY:
+		return (DDI_EAGAIN);
+	default:
+		return (DDI_FAILURE);
+	}
+}
+
+/*
+ * SMCCC_ARCH_FEATURES (§7.3)
+ *
+ * Query whether a specific Arm Architecture Service function is implemented
+ * and retrieve its feature flags.
+ *
+ * The raw firmware return is passed through *resultp for per-function
+ * interpretation: negative = not implemented, 0 = implemented,
+ * positive = implemented with feature flags.
+ */
+int
+smccc_arch_features(uint32_t arch_func_id, int32_t *resultp)
+{
+	smccc32_args_t args = {
+		.w = { SMCCC_ARCH_FEATURES_FID, arch_func_id },
+	};
+	int rv;
+
+	if (!smccc_available()) {
+		return (DDI_ENOTSUP);
+	}
+
+	rv = smccc32_call(&args);
+	if (rv != DDI_SUCCESS) {
+		return (rv);
+	}
+
+	if (resultp != NULL) {
+		*resultp = (int32_t)args.w[0];
+	}
+
+	return (DDI_SUCCESS);
+}
+
+/*
+ * SMCCC_ARCH_SOC_ID (§7.4) - types 0 (version) and 1 (revision).
+ *
+ * Returns the silicon provider defined SoC identification value in *valuep.
+ *
+ * Use SMCCC_SOC_ID_VERSION or SMCCC_SOC_ID_REVISION for soc_id_type.
+ *
+ * SMCCC_SOC_ID_NAME is implemented in smccc_arch_soc_id_name.
+ */
+int
+smccc_arch_soc_id(uint32_t soc_id_type, uint32_t *valuep)
+{
+	smccc32_args_t args = {
+		.w = { SMCCC_ARCH_SOC_ID_FID, soc_id_type },
+	};
+	int rv;
+
+	VERIFY3U(soc_id_type, <=, 1);
+	VERIFY3P(valuep, !=, NULL);
+
+	if (!smccc_available()) {
+		return (DDI_ENOTSUP);
+	}
+
+	rv = smccc32_call(&args);
+	if (rv != DDI_SUCCESS) {
+		return (rv);
+	}
+
+	if ((int32_t)args.w[0] < 0) {
+		return (smccc_to_ddi((int32_t)args.w[0]));
+	}
+
+	*valuep = args.w[0];
+	return (DDI_SUCCESS);
+}
+
+/*
+ * SMCCC_ARCH_SOC_ID type 2 (§7.4) - SoC name.
+ *
+ * Returns the silicon provider defined SoC name as a null-terminated UTF-8
+ * string in the passed buffer structure pointer.
+ */
+int
+smccc_arch_soc_id_name(smccc_soc_name_t *namep)
+{
+	smccc64_args_t args = {
+		.x = { SMCCC_ARCH_SOC_ID64_FID, SMCCC_SOC_ID_NAME },
+	};
+	int rv;
+
+	VERIFY(namep != NULL);
+
+	if (!smccc_available()) {
+		return (DDI_ENOTSUP);
+	}
+
+	rv = smccc64_call(&args);
+	if (rv != DDI_SUCCESS) {
+		return (rv);
+	}
+
+	if ((int32_t)args.x[0] < 0) {
+		return (smccc_to_ddi((int32_t)args.x[0]));
+	}
+
+	/*
+	 * X1-X17 carry the UTF-8 string in LE byte order, no BOM, guaranteed
+	 * NUL-terminated.
+	 *
+	 * 17 registers * 8 bytes = 136 bytes = SMCCC_SOC_NAME_MAXSZ.
+	 */
+	bcopy(&args.x[1], namep->sn_data, SMCCC_SOC_NAME_MAXSZ);
+	return (DDI_SUCCESS);
+}
+
+/*
+ * SMCCC_ARCH_WORKAROUND_1 (§7.5)
+ *
+ * Execute the firmware mitigation for CVE-2017-5715 on the calling PE.
+ *
+ * The firmware call has no return value.
+ *
+ * DO NOT JUST CALL THIS FUNCTION - read DEN0028 first.
+ */
+int
+smccc_arch_workaround_1(void)
+{
+	smccc32_args_t args = {
+		.w = { SMCCC_ARCH_WORKAROUND_1_FID },
+	};
+
+	if (!smccc_available()) {
+		return (DDI_ENOTSUP);
+	}
+
+	return (smccc32_call(&args));
+}
+
+/*
+ * SMCCC_ARCH_WORKAROUND_2 (§7.6)
+ *
+ * Enable or disable the firmware mitigation for CVE-2018-3639 on the calling
+ * PE.  A non-zero enable value enables the mitigation.
+ *
+ * The firmware call has no return value.
+ *
+ * DO NOT JUST CALL THIS FUNCTION - read DEN0028 first.
+ */
+int
+smccc_arch_workaround_2(uint32_t enable)
+{
+	smccc32_args_t args = {
+		.w = { SMCCC_ARCH_WORKAROUND_2_FID, enable },
+	};
+
+	if (!smccc_available()) {
+		return (DDI_ENOTSUP);
+	}
+
+	return (smccc32_call(&args));
+}
+
+/*
+ * SMCCC_ARCH_WORKAROUND_3 (§7.7)
+ *
+ * Execute the firmware mitigation for CVE-2017-5715 and CVE-2022-23960 on the
+ * calling PE.  Supersedes WORKAROUND_1.
+ *
+ * The firmware call has no return value.
+ *
+ * DO NOT JUST CALL THIS FUNCTION - read DEN0028 first.
+ */
+int
+smccc_arch_workaround_3(void)
+{
+	smccc32_args_t args = {
+		.w = { SMCCC_ARCH_WORKAROUND_3_FID },
+	};
+
+	if (!smccc_available()) {
+		return (DDI_ENOTSUP);
+	}
+
+	return (smccc32_call(&args));
+}
+
+/*
+ * SMCCC_ARCH_FEATURE_AVAILABILITY (§7.8)
+ *
+ * Discover architectural features enabled by EL3 firmware for use by callers.
+ *
+ * The bitmask_selector identifies which set of features to query (encoded as
+ * the opcode of the related system register, e.g. SCR_EL3, CPTR_EL3,
+ * MDCR_EL3, MPAM3_EL3).
+ */
+int
+smccc_arch_feature_availability(uint64_t bitmask_selector, uint64_t *bitmaskp)
+{
+	smccc64_args_t args = {
+		.x = { SMCCC_ARCH_FEATURE_AVAILABILITY_FID, bitmask_selector },
+	};
+	int rv;
+
+	VERIFY(bitmaskp != NULL);
+
+	if (!smccc_available()) {
+		return (DDI_ENOTSUP);
+	}
+
+	rv = smccc64_call(&args);
+	if (rv != DDI_SUCCESS) {
+		return (rv);
+	}
+
+	if ((int32_t)args.x[0] != SMCCC_SUCCESS) {
+		return (smccc_to_ddi((int32_t)args.x[0]));
+	}
+
+	*bitmaskp = args.x[1];
+	return (DDI_SUCCESS);
+}
+
+/*
+ * SMCCC_ARCH_WORKAROUND_4 (§7.9)
+ *
+ * Presence check only.  The spec states that this function is a NOP and
+ * should never be invoked; its presence via SMCCC_ARCH_FEATURES signals
+ * that EL3 firmware mitigates CVE-2024-7881.
+ *
+ * Read DEN0028 to learn how this is supposed to be used.
+ */
+boolean_t
+smccc_arch_workaround_4_present(void)
+{
+	int32_t result;
+
+	if (smccc_arch_features(SMCCC_ARCH_WORKAROUND_4_FID, &result)
+	    != DDI_SUCCESS) {
+		return (B_FALSE);
+	}
+
+	return (result >= 0 ? B_TRUE : B_FALSE);
+}
+
+/*
+ * SMCCC_ARCH_CLEAN_INV_MEMREGION (§7.10)
+ *
+ * Clean and invalidate all caches (including system caches) that hold
+ * copies of locations in the specified physical address range.
+ *
+ * flags: SMCCC_CLEAN_INV_FLAG_DRYRUN to probe without flushing.
+ *
+ * Returns DDI_EAGAIN for RATE_LIMITED or BUSY.
+ */
+int
+smccc_arch_clean_inv_memregion(uint64_t base, uint64_t length, uint64_t flags)
+{
+	smccc64_args_t args = {
+		.x = {
+			SMCCC_ARCH_CLEAN_INV_MEMREGION_FID,
+			base,
+			length,
+			flags,
+		},
+	};
+	int rv;
+
+	if (!smccc_available()) {
+		return (DDI_ENOTSUP);
+	}
+
+	rv = smccc64_call(&args);
+	if (rv != DDI_SUCCESS) {
+		return (rv);
+	}
+
+	if ((int32_t)args.x[0] != SMCCC_SUCCESS) {
+		return (smccc_to_ddi((int32_t)args.x[0]));
+	}
+
+	return (DDI_SUCCESS);
+}
+
+/*
+ * SMCCC_ARCH_CLEAN_INV_MEMREGION_ATTRIBUTES (§7.11)
+ *
+ * Discover the attributes of the CLEAN_INV_MEMREGION function.
+ * Mandatory if CLEAN_INV_MEMREGION is implemented.
+ */
+int
+smccc_arch_clean_inv_memregion_attributes(smccc_memregion_attr_t *attrp)
+{
+	smccc64_args_t args = {
+		.x = { SMCCC_ARCH_CLEAN_INV_MEMREGION_ATTR_FID },
+	};
+	int rv;
+
+	VERIFY(attrp != NULL);
+
+	if (!smccc_available()) {
+		return (DDI_ENOTSUP);
+	}
+
+	rv = smccc64_call(&args);
+	if (rv != DDI_SUCCESS) {
+		return (rv);
+	}
+
+	if ((int32_t)args.x[0] != SMCCC_SUCCESS) {
+		return (smccc_to_ddi((int32_t)args.x[0]));
+	}
+
+	/* X1: attr_flags, bit 0 = global flush */
+	attrp->sma_global = (args.x[1] & 1) ? B_TRUE : B_FALSE;
+	/* X2: attr_1[31:0] = worst-case latency in microseconds */
+	attrp->sma_latency_us = (uint32_t)(args.x[2] & 0xffffffff);
+	/* X3: attr_2 = max calls per second */
+	attrp->sma_rate_limit = args.x[3];
+	/* X4: attr_3 = break-even size in bytes */
+	attrp->sma_breakeven_sz = args.x[4];
+
+	return (DDI_SUCCESS);
+}

--- a/usr/src/uts/armv8/sys/psci.h
+++ b/usr/src/uts/armv8/sys/psci.h
@@ -21,7 +21,7 @@
  */
 /*
  * Copyright 2017 Hayashi Naoyuki
- * Copyright 2025 Michael van der Westhuizen
+ * Copyright 2026 Michael van der Westhuizen
  */
 
 #ifndef _SYS_PSCI_H
@@ -33,11 +33,20 @@
 extern "C" {
 #endif
 
+/*
+ * PSCI function IDs (SMC64 where available).
+ */
 #define	PSCI_CPU_SUSPEND_ID	0xC4000001
 #define	PSCI_CPU_OFF_ID		0x84000002
 #define	PSCI_CPU_ON_ID		0xC4000003
 #define	PSCI_MIGRATE_ID		0xC4000005
 
+/*
+ * PSCI firmware return codes (DEN0022F Table 14).
+ *
+ * These are kept for internal translation by psci.c.  Callers should
+ * work with DDI error codes returned by the wrapper functions.
+ */
 enum {
 	PSCI_SUCCESS		= 0,
 	PSCI_NOT_SUPPORTED	= -1,
@@ -55,31 +64,38 @@ struct xboot_info;
 
 extern int psci_init(struct xboot_info *xbp);
 #if !defined(_BOOT)
-extern uint32_t psci_version(void);
-extern int32_t psci_cpu_suspend(uint32_t power_state,
+extern int psci_version(uint32_t *versionp);
+extern int psci_cpu_suspend(uint32_t power_state,
 	uint64_t entry_point_address, uint64_t context_id);
-extern int32_t psci_cpu_off(void);
-extern int32_t psci_cpu_on(uint64_t target_cpu,
+extern int psci_cpu_off(void);
+extern int psci_cpu_on(uint64_t target_cpu,
 	uint64_t entry_point_address, uint64_t context_id);
-extern int32_t psci_affinity_info(uint64_t target_affinity,
-	uint32_t lowest_affinity_level);
-extern int32_t psci_migrate(uint64_t target_cpu);
-extern int32_t psci_migrate_info_type(void);
-extern uint64_t psci_migrate_info_up_cpu(void);
+extern int psci_affinity_info(uint64_t target_affinity,
+	uint32_t lowest_affinity_level, uint32_t *statep);
+extern int psci_migrate(uint64_t target_cpu);
+extern int psci_migrate_info_type(uint32_t *typep);
+extern int psci_migrate_info_up_cpu(uint64_t *mpidp);
 #endif
 extern void psci_system_off(void);
 extern void psci_system_reset(void);
 #if !defined(_BOOT)
-extern int32_t psci_features(uint32_t psci_func_id);
-extern int32_t psci_cpu_freeze(void);
-extern int32_t psci_cpu_default_suspend(uint64_t entry_point_address,
+extern int psci_features(uint32_t psci_func_id, uint32_t *flagsp);
+extern int psci_cpu_freeze(void);
+extern int psci_cpu_default_suspend(uint64_t entry_point_address,
 	uint64_t context_id);
-extern int32_t psci_node_hw_state(uint64_t target_cpu, uint32_t power_level);
-extern int32_t psci_system_suspend(uint64_t entry_point_address,
+extern int psci_node_hw_state(uint64_t target_cpu, uint32_t power_level,
+	uint32_t *statep);
+extern int psci_system_suspend(uint64_t entry_point_address,
 	uint64_t context_id);
-extern int32_t psci_set_suspend_mode(uint32_t mode);
-extern uint64_t psci_stat_residency(uint64_t target_cpu, uint32_t power_state);
-extern uint64_t psci_stat_count(uint64_t target_cpu, uint32_t power_state);
+extern int psci_set_suspend_mode(uint32_t mode);
+extern int psci_stat_residency(uint64_t target_cpu, uint32_t power_state,
+	uint64_t *residencyp);
+extern int psci_stat_count(uint64_t target_cpu, uint32_t power_state,
+	uint64_t *countp);
+extern int psci_system_off2(uint32_t type, uint64_t cookie);
+extern int psci_system_reset2(uint32_t reset_type, uint64_t cookie);
+extern int psci_mem_protect(uint32_t enable, uint32_t *prev_statep);
+extern int psci_mem_protect_check_range(uint64_t base, uint64_t length);
 #endif
 
 #ifdef	__cplusplus

--- a/usr/src/uts/armv8/sys/smccc.h
+++ b/usr/src/uts/armv8/sys/smccc.h
@@ -20,11 +20,10 @@
  * SMC Calling Convention (SMCCC) per Arm DEN0028 v1.7.
  *
  * SMCCC provides the transport layer for firmware calls via SMC or HVC
- * instructions.  PSCI, PCI config space access (DEN0115) and ACPI FFH
- * OpRegions are clients of this interface.
+ * instructions.  SMCCC architectural functions, PSCI, PCI config space
+ * access (DEN0115) and ACPI FFH OpRegions are clients of this interface.
  *
- * SMCCC includes a number of functions, none of which are required at
- * this time.
+ * Specification references are against DEN0028 v1.7.
  */
 
 #include <sys/types.h>
@@ -54,10 +53,22 @@ typedef struct smccc64_args {
 } smccc64_args_t;
 
 /*
- * Well-known SMCCC function IDs used during discovery.
+ * Arm Architecture Service function IDs (DEN0028 Chapter 7).
+ *
+ * VERSION and ARCH_FEATURES also serve as the discovery mechanism
+ * for the remaining functions.
  */
-#define	SMCCC_VERSION_FID		0x80000000
-#define	SMCCC_ARCH_FEATURES_FID		0x80000001
+#define	SMCCC_VERSION_FID			0x80000000
+#define	SMCCC_ARCH_FEATURES_FID			0x80000001
+#define	SMCCC_ARCH_SOC_ID_FID			0x80000002
+#define	SMCCC_ARCH_SOC_ID64_FID			0xC0000002
+#define	SMCCC_ARCH_WORKAROUND_1_FID		0x80008000
+#define	SMCCC_ARCH_WORKAROUND_2_FID		0x80007FFF
+#define	SMCCC_ARCH_WORKAROUND_3_FID		0x80003FFF
+#define	SMCCC_ARCH_FEATURE_AVAILABILITY_FID	0xC0000003
+#define	SMCCC_ARCH_WORKAROUND_4_FID		0x80000004
+#define	SMCCC_ARCH_CLEAN_INV_MEMREGION_FID	0xC0000005
+#define	SMCCC_ARCH_CLEAN_INV_MEMREGION_ATTR_FID	0xC0000006
 
 /*
  * PSCI function IDs used internally by SMCCC for discovery.
@@ -66,6 +77,53 @@ typedef struct smccc64_args {
  */
 #define	SMCCC_PSCI_VERSION_FID		0x84000000
 #define	SMCCC_PSCI_FEATURES_FID		0x8400000A
+
+/*
+ * DEN0028 return codes (§7.1).
+ *
+ * These are firmware return values; callers typically work with
+ * DDI error codes via the wrapper functions below.
+ */
+#define	SMCCC_SUCCESS			0
+#define	SMCCC_NOT_SUPPORTED		(-1)
+#define	SMCCC_NOT_REQUIRED		(-2)
+#define	SMCCC_INVALID_PARAMETER		(-3)
+#define	SMCCC_RATE_LIMITED		(-4)
+#define	SMCCC_BUSY			(-5)
+
+/*
+ * SMCCC_ARCH_SOC_ID type values (§7.4).
+ */
+#define	SMCCC_SOC_ID_VERSION		0
+#define	SMCCC_SOC_ID_REVISION		1
+#define	SMCCC_SOC_ID_NAME		2
+
+/*
+ * Buffer for SMCCC_ARCH_SOC_ID type 2 (SoC name).
+ *
+ * The name is a null-terminated UTF-8 string occupying at most
+ * 136 bytes including the terminator, packed across X1-X17.
+ */
+#define	SMCCC_SOC_NAME_MAXSZ		136
+
+typedef struct smccc_soc_name {
+	char	sn_data[SMCCC_SOC_NAME_MAXSZ];
+} smccc_soc_name_t;
+
+/*
+ * Attributes returned by SMCCC_ARCH_CLEAN_INV_MEMREGION_ATTRIBUTES (§7.11).
+ */
+typedef struct smccc_memregion_attr {
+	boolean_t	sma_global;		/* global flush (all caches) */
+	uint32_t	sma_latency_us;		/* worst-case latency (us) */
+	uint64_t	sma_rate_limit;		/* max calls/sec */
+	uint64_t	sma_breakeven_sz;	/* break-even size */
+} smccc_memregion_attr_t;
+
+/*
+ * SMCCC_ARCH_CLEAN_INV_MEMREGION flags (§7.10).
+ */
+#define	SMCCC_CLEAN_INV_FLAG_DRYRUN	0x1
 
 struct xboot_info;
 
@@ -76,6 +134,24 @@ extern int smccc32_call(smccc32_args_t *);
 extern int smccc64_call(smccc64_args_t *);
 extern boolean_t smccc_available(void);
 extern uint32_t smccc_version(void);
+
+/*
+ * Arm Architecture Service wrappers (DEN0028 Chapter 7).
+ *
+ * Each returns DDI error codes.  Where the spec defines an overloaded
+ * return value (e.g. ARCH_FEATURES), the raw firmware result is passed
+ * through an out-parameter for per-function interpretation.
+ */
+extern int smccc_arch_features(uint32_t, int32_t *);
+extern int smccc_arch_soc_id(uint32_t, uint32_t *);
+extern int smccc_arch_soc_id_name(smccc_soc_name_t *);
+extern int smccc_arch_workaround_1(void);
+extern int smccc_arch_workaround_2(uint32_t);
+extern int smccc_arch_workaround_3(void);
+extern int smccc_arch_feature_availability(uint64_t, uint64_t *);
+extern boolean_t smccc_arch_workaround_4_present(void);
+extern int smccc_arch_clean_inv_memregion(uint64_t, uint64_t, uint64_t);
+extern int smccc_arch_clean_inv_memregion_attributes(smccc_memregion_attr_t *);
 #endif
 
 #ifdef	__cplusplus

--- a/usr/src/uts/armv8/sys/smccc.h
+++ b/usr/src/uts/armv8/sys/smccc.h
@@ -1,0 +1,85 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2026 Michael van der Westhuizen
+ */
+
+#ifndef _SYS_SMCCC_H
+#define	_SYS_SMCCC_H
+
+/*
+ * SMC Calling Convention (SMCCC) per Arm DEN0028 v1.7.
+ *
+ * SMCCC provides the transport layer for firmware calls via SMC or HVC
+ * instructions.  PSCI, PCI config space access (DEN0115) and ACPI FFH
+ * OpRegions are clients of this interface.
+ *
+ * SMCCC includes a number of functions, none of which are required at
+ * this time.
+ */
+
+#include <sys/types.h>
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+/*
+ * Argument/result structure for SMC32 calls.
+ *
+ * w[0] holds the function ID on entry; results are written back in place.
+ * 32-bit calls use W0..W7 per SMCCC §5.1.
+ */
+typedef struct smccc32_args {
+	uint32_t w[8];
+} smccc32_args_t;
+
+/*
+ * Argument/result structure for SMC64 calls.
+ *
+ * x[0] holds the function ID on entry; results are written back in place.
+ * 64-bit calls use X0..X17 per SMCCC §5.2.
+ */
+typedef struct smccc64_args {
+	uint64_t x[18];
+} smccc64_args_t;
+
+/*
+ * Well-known SMCCC function IDs used during discovery.
+ */
+#define	SMCCC_VERSION_FID		0x80000000
+#define	SMCCC_ARCH_FEATURES_FID		0x80000001
+
+/*
+ * PSCI function IDs used internally by SMCCC for discovery.
+ *
+ * These are private to the SMCCC implementation.
+ */
+#define	SMCCC_PSCI_VERSION_FID		0x84000000
+#define	SMCCC_PSCI_FEATURES_FID		0x8400000A
+
+struct xboot_info;
+
+extern int smccc_init(struct xboot_info *);
+
+#if !defined(_BOOT)
+extern int smccc32_call(smccc32_args_t *);
+extern int smccc64_call(smccc64_args_t *);
+extern boolean_t smccc_available(void);
+extern uint32_t smccc_version(void);
+#endif
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif	/* _SYS_SMCCC_H */


### PR DESCRIPTION
_This is one of many PRs for upstreaming my ACPI tree._

Factor the SMC Calling Convention (SMCCC, Arm DEN0028 v1.7) transport layer out of the PSCI implementation into its own module.  PSCI becomes a client of the SMCCC transport rather than owning the firmware call mechanism.

SMCCC-defined function calls (in DEN0028) are implemented, though they are as--of-yet unused.