### PR TITLE
Don't leak PROM internals when accessing clocks

### DIFF
--- a/usr/src/uts/aarch64/sys/prom_plat.h
+++ b/usr/src/uts/aarch64/sys/prom_plat.h
@@ -45,6 +45,8 @@ struct prom_hwclock {
 };
 
 extern int prom_fdt_get_reg(pnode_t node, int index, uint64_t *base);
+extern int prom_fdt_get_clock_by_index(pnode_t node, int index,
+    struct prom_hwclock *clock);
 extern int prom_fdt_get_clock_by_name(pnode_t node, const char *name,
     struct prom_hwclock *clock);
 extern boolean_t prom_fdt_is_compatible(pnode_t node, const char *name);

--- a/usr/src/uts/armv8/io/ns16550a/ns16550a.c
+++ b/usr/src/uts/armv8/io/ns16550a/ns16550a.c
@@ -984,24 +984,26 @@ ns16550attach(dev_info_t *devi, ddi_attach_cmd_t cmd)
 	}
 
 	uint_t uart_clock = 0;
+	int err;
 
-	struct prom_hwclock hwclock;
-	if (prom_fdt_get_clock_by_name(ddi_get_nodeid(devi),
-	    "uartclk", &hwclock) == 0) {
-		int err;
+	if (&plat_clk_get_rate_by_name) {
+		if ((err = plat_clk_get_rate_by_name(devi, "uartclk")) > 0) {
+			uart_clock = err;
+		}
+	}
 
-		if (&plat_hwclock_get_rate)
-			if ((err = plat_hwclock_get_rate(&hwclock)) > 0)
-				uart_clock = err;
+	if (uart_clock == 0 && &plat_clk_get_rate) {
+		if ((err = plat_clk_get_rate(devi, 0)) > 0) {
+			uart_clock = err;
+		}
 	}
 
 	if (uart_clock == 0) {
-		int err;
-
 		if ((err = ddi_prop_get_int(DDI_DEV_T_ANY, devi,
 		    DDI_PROP_DONTPASS, "clock-frequency", 0)) !=
-		    DDI_PROP_NOT_FOUND)
+		    DDI_PROP_NOT_FOUND) {
 			uart_clock = err;
+		}
 	}
 
 	ret = ddi_soft_state_zalloc(ns16550_soft_state, instance);

--- a/usr/src/uts/armv8/os/platmod.c
+++ b/usr/src/uts/armv8/os/platmod.c
@@ -15,6 +15,12 @@
 
 #include <sys/systm.h>
 #include <sys/machclock.h>
+#include <sys/promif.h>
+#include <sys/prom_plat.h>
+#include <sys/byteorder.h>
+#include <sys/sunddi.h>
+#include <sys/esunddi.h>
+#include <sys/sysmacros.h>
 #include <sys/efi.h>
 #include <sys/efirt.h>
 
@@ -46,4 +52,97 @@ set_platform_defaults(void)
 	if (efi_get_time(&t, &tc) == EFI_SUCCESS) {
 		tod_module_name = "efitod";
 	}
+}
+
+static int
+plat_devi_is_compatible(dev_info_t *dip, const char **compats, uint_t ncompats)
+{
+	char	**cmpats;
+	uint_t	ncmpats;
+	uint_t	n;
+	uint_t	i;
+
+	if (ddi_prop_lookup_string_array(DDI_DEV_T_ANY, dip, DDI_PROP_DONTPASS,
+	    OBP_COMPATIBLE, &cmpats, &ncmpats) == DDI_PROP_SUCCESS) {
+		for (n = 0; n < ncmpats; ++n) {
+			for (i = 0; i < ncompats; ++i) {
+				if (strcmp(cmpats[n], compats[i]) == 0) {
+					ddi_prop_free(cmpats);
+					return (1);
+				}
+			}
+		}
+
+		ddi_prop_free(cmpats);
+	}
+
+	return (0);
+}
+
+static int
+plat_devi_is_fixed_clock(dev_info_t *dip) {
+	static const char *fixed_clocks[] = {
+		"fixed-clock",
+	};
+	static const uint_t num_fixed_clocks = ARRAY_SIZE(fixed_clocks);
+
+	return (plat_devi_is_compatible(dip, fixed_clocks, num_fixed_clocks));
+}
+
+int
+plat_clk_get_rate(dev_info_t *dip, uint_t clkno)
+{
+	struct prom_hwclock hwclk;
+	dev_info_t *cdip;
+
+	if (prom_fdt_get_clock_by_index((pnode_t)ddi_get_nodeid(dip),
+	    clkno, &hwclk) != 0) {
+		return (-1);
+	}
+
+	if ((cdip = e_ddi_nodeid_to_dip((pnode_t)hwclk.node)) == NULL) {
+		return (-1);
+	}
+
+	if (plat_devi_is_fixed_clock(cdip)) {
+		int freq = ddi_prop_get_int(DDI_DEV_T_ANY, cdip,
+		    DDI_PROP_DONTPASS, "clock-frequency", -1);
+
+		if (freq != -1) {
+			ddi_release_devi(cdip);
+			return (freq);
+		}
+	}
+
+	ddi_release_devi(cdip);
+	return (-1);
+}
+
+int
+plat_clk_get_rate_by_name(dev_info_t *dip, const char *clkname)
+{
+	struct prom_hwclock hwclk;
+	dev_info_t *cdip;
+
+	if (prom_fdt_get_clock_by_name((pnode_t)ddi_get_nodeid(dip),
+	    clkname, &hwclk) != 0) {
+		return (-1);
+	}
+
+	if ((cdip = e_ddi_nodeid_to_dip((pnode_t)hwclk.node)) == NULL) {
+		return (-1);
+	}
+
+	if (plat_devi_is_fixed_clock(cdip)) {
+		int freq = ddi_prop_get_int(DDI_DEV_T_ANY, cdip,
+		    DDI_PROP_DONTPASS, "clock-frequency", -1);
+
+		if (freq != -1) {
+			ddi_release_devi(cdip);
+			return (freq);
+		}
+	}
+
+	ddi_release_devi(cdip);
+	return (-1);
 }

--- a/usr/src/uts/armv8/promif/prom_emul_fdt.c
+++ b/usr/src/uts/armv8/promif/prom_emul_fdt.c
@@ -593,35 +593,43 @@ static int
 promif_get_clock(pnode_t node, int index, struct prom_hwclock *clock)
 {
 	int len = promif_getproplen(node, "clocks");
-	if (len <= 0)
+	if (len <= 0) {
 		return (-1);
+	}
 
 	uint32_t *clocks = __builtin_alloca(len);
 	promif_getprop(node, "clocks", (caddr_t)clocks);
 
-	pnode_t clock_node;
-	clock_node = find_by_phandle(ntohl(clocks[0]));
-	if (clock_node < 0)
-		return (-1);
+	int ncells = BYTES_TO_1275_CELLS(len);
+	int pos = 0;
 
-	int clock_cells = get_prop_int(clock_node, "#clock-cells", 1);
-	if (clock_cells != 0 && clock_cells != 1)
-		return (-1);
+	for (int i = 0; pos < ncells; i++) {
+		pnode_t clock_node = find_by_phandle(ntohl(clocks[pos]));
+		if (clock_node < 0) {
+			return (-1);
+		}
 
-	if (len % (CELLS_1275_TO_BYTES(clock_cells + 1)) != 0)
-		return (-1);
-	if (len <= index * CELLS_1275_TO_BYTES(clock_cells + 1))
-		return (-1);
+		int clock_cells = get_prop_int(clock_node,
+		    "#clock-cells", 1);
+		if (clock_cells != 0 && clock_cells != 1) {
+			return (-1);
+		}
 
-	clock_node = find_by_phandle(
-	    ntohl(clocks[index * (clock_cells + 1)]));
-	if (clock_node < 0)
-		return (-1);
-	clock->node = clock_node;
-	clock->id = (clock_cells == 0 ? 0:
-	    ntohl(clocks[index * (clock_cells + 1) + 1]));
+		if (pos + 1 + clock_cells > ncells) {
+			return (-1);
+		}
 
-	return (0);
+		if (i == index) {
+			clock->node = clock_node;
+			clock->id = (clock_cells == 0 ? 0 :
+			    ntohl(clocks[pos + 1]));
+			return (0);
+		}
+
+		pos += 1 + clock_cells;
+	}
+
+	return (-1);
 }
 
 boolean_t
@@ -733,13 +741,22 @@ prom_fdt_get_reg_address(pnode_t node, int index, uint64_t *reg)
 }
 
 int
+prom_fdt_get_clock_by_index(pnode_t node,
+    int index, struct prom_hwclock *clock)
+{
+	if (index >= 0) {
+		return (promif_get_clock(node, index, clock));
+	}
+
+	return (-1);
+}
+
+int
 prom_fdt_get_clock_by_name(pnode_t node,
     const char *name, struct prom_hwclock *clock)
 {
 	int index = get_prop_index(node, "clock-names", name);
-	if (index >= 0)
-		return (promif_get_clock(node, index, clock));
-	return (-1);
+	return (prom_fdt_get_clock_by_index(node, index, clock));
 }
 
 /*

--- a/usr/src/uts/armv8/rpi4/os/rpi4.c
+++ b/usr/src/uts/armv8/rpi4/os/rpi4.c
@@ -54,7 +54,7 @@
  * Clock IDs from DT bindings
  *
  * These are the devicetree clock IDs, which will be internally mapped to
- * mailbox properties interface clock IDs in plat_hwclock_get_rate.
+ * mailbox properties interface clock IDs.
  *
  * The comments after each define show the decimal value, the symbolic
  * name of the mailbox properties interface clock ID and the decimal
@@ -196,10 +196,51 @@ plat_set_max_cpu_clock(int cpu_no)
 }
 
 int
-plat_hwclock_get_rate(struct prom_hwclock *clk)
+plat_clk_get_rate(dev_info_t *dip, uint_t clkno)
 {
-	return (plat_vc_hwclock_rate(clk, DTCLOCKID,
-	    VCPROPTAG_GET_CLOCKRATE, 0));
+	struct prom_hwclock hwclk;
+
+	if (prom_fdt_get_clock_by_index((pnode_t)ddi_get_nodeid(dip),
+	    clkno, &hwclk) != 0) {
+		return (-1);
+	}
+
+	if (prom_fdt_is_compatible(hwclk.node, "fixed-clock")) {
+		uint_t clock;
+		if (prom_getproplen(hwclk.node, "clock-frequency") ==
+		    sizeof (uint_t)) {
+			prom_getprop(hwclk.node, "clock-frequency",
+			    (caddr_t)&clock);
+			return (ntohl(clock));
+		}
+	}
+
+	return (plat_vc_hwclock_rate(&hwclk,
+	    DTCLOCKID, VCPROPTAG_GET_CLOCKRATE, 0));
+}
+
+int
+plat_clk_get_rate_by_name(dev_info_t *dip, const char *clkname)
+{
+	struct prom_hwclock hwclk;
+
+	if (prom_fdt_get_clock_by_name((pnode_t)ddi_get_nodeid(dip),
+	    clkname, &hwclk) != 0) {
+		return (-1);
+	}
+
+	if (prom_fdt_is_compatible(hwclk.node, "fixed-clock")) {
+		uint_t clock;
+		if (prom_getproplen(hwclk.node, "clock-frequency") ==
+		    sizeof (uint_t)) {
+			prom_getprop(hwclk.node, "clock-frequency",
+			    (caddr_t)&clock);
+			return (ntohl(clock));
+		}
+	}
+
+	return (plat_vc_hwclock_rate(&hwclk,
+	    DTCLOCKID, VCPROPTAG_GET_CLOCKRATE, 0));
 }
 
 int

--- a/usr/src/uts/armv8/sys/platmod.h
+++ b/usr/src/uts/armv8/sys/platmod.h
@@ -21,7 +21,7 @@
 
 /*
  * Copyright 2017 Hayashi Naoyuki
- * Copyright 2025 Michael van der Westhuizen
+ * Copyright 2026 Michael van der Westhuizen
  */
 
 #ifndef _SYS_PLATMOD_H
@@ -53,7 +53,8 @@ struct prom_hwclock;
 #pragma weak	plat_set_cpu_supp_freqs
 #pragma weak	plat_gpio_get
 #pragma weak	plat_gpio_set
-#pragma weak	plat_hwclock_get_rate
+#pragma weak	plat_clk_get_rate
+#pragma weak	plat_clk_get_rate_by_name
 
 /*
  * Called in mp_startup.c from init_cpu_info (twice).
@@ -69,10 +70,8 @@ struct gpio_ctrl;
 extern int plat_gpio_get(struct gpio_ctrl *);
 extern int plat_gpio_set(struct gpio_ctrl *, int);
 
-/*
- * Called in ns16550a.c to get the clock frequency driving the UART.
- */
-extern int plat_hwclock_get_rate(struct prom_hwclock *);
+extern int plat_clk_get_rate(dev_info_t *, uint_t);
+extern int plat_clk_get_rate_by_name(dev_info_t *, const char *);
 
 #endif	/* _KERNEL */
 

--- a/usr/src/uts/armv8/virt/os/virt.c
+++ b/usr/src/uts/armv8/virt/os/virt.c
@@ -31,6 +31,8 @@
 #include <sys/cmn_err.h>
 #include <sys/platmod.h>
 #include <sys/promif.h>
+#include <sys/prom_plat.h>
+#include <sys/sunddi.h>
 
 /*
  * Platform power management drivers list - empty by default
@@ -66,4 +68,50 @@ plat_get_cpu_clock(int cpu_no)
 	}
 
 	return (1000 * 1000 * 1000);
+}
+
+int
+plat_clk_get_rate(dev_info_t *dip, uint_t clkno)
+{
+	struct prom_hwclock hwclk;
+
+	if (prom_fdt_get_clock_by_index((pnode_t)ddi_get_nodeid(dip),
+	    clkno, &hwclk) != 0) {
+		return (-1);
+	}
+
+	if (prom_fdt_is_compatible(hwclk.node, "fixed-clock")) {
+		uint_t clock;
+		if (prom_getproplen(hwclk.node, "clock-frequency") ==
+		    sizeof (uint_t)) {
+			prom_getprop(hwclk.node, "clock-frequency",
+			    (caddr_t)&clock);
+			return (ntohl(clock));
+		}
+	}
+
+	return (-1);
+}
+
+int
+plat_clk_get_rate_by_name(dev_info_t *dip, const char *clkname)
+{
+	struct prom_hwclock hwclk;
+
+	if (prom_fdt_get_clock_by_name((pnode_t)ddi_get_nodeid(dip),
+	    clkname, &hwclk) != 0) {
+		return (-1);
+	}
+
+	if (prom_fdt_is_compatible(hwclk.node, "fixed-clock")) {
+		uint_t clock;
+		if (prom_getproplen(hwclk.node, "clock-frequency") ==
+		    sizeof (uint_t)) {
+			prom_getprop(hwclk.node, "clock-frequency",
+			    (caddr_t)&clock);
+			return (ntohl(clock));
+		}
+	}
+
+	return (-1);
 }


### PR DESCRIPTION
_This is one of many PRs for upstreaming my ACPI tree._

At the moment, platform drivers need to know about prom internals and data structures, and the code underling the prom hardware clock retrieval was buggy anyway (the stride through clock handles is variable).

Clean this all up to deal in `dev_info_t` so that we can hide the prom internals behind the platmod.

While we're here, recognise and deal with the standard fixed-clock node, which does not need hardware access.

This is all terrible, and should really be replaced with a full DDI clock framework in the future, but it'll do for now.