### PR TITLE
Add motherboard-serial-ports-pa for consistent UART naming

### DIFF
--- a/usr/src/boot/efi/libacpiuart/acpiuart.c
+++ b/usr/src/boot/efi/libacpiuart/acpiuart.c
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2025 Michael van der Westhuizen
+ * Copyright 2026 Michael van der Westhuizen
  */
 
 /*
@@ -91,7 +91,7 @@ typedef struct {
 	uint32_t		uad_uid;
 } uart_aux_data_t;
 
-#define	MAX_UARTS	26
+#define	MAX_UARTS	MMIO_UART_MAX_UARTS
 
 typedef struct {
 	uint32_t	data1;
@@ -916,6 +916,8 @@ acpiuart_discover_uarts(void)
 
 	if (getenv("default-uart-name") == NULL && first_tty != NULL)
 		setenv("default-uart-name", first_tty->c_name, 1);
+
+	mmio_uart_set_serial_ports_pa(mmio_uart, num_mmio_uart);
 
 	consoles[c] = NULL;
 }

--- a/usr/src/boot/efi/libfdtuart/fdtuart.c
+++ b/usr/src/boot/efi/libfdtuart/fdtuart.c
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2025 Michael van der Westhuizen
+ * Copyright 2026 Michael van der Westhuizen
  */
 
 /*
@@ -29,7 +29,7 @@
  *
  * This gives us ttya->ttyz.
  */
-#define	MAX_UARTS	26
+#define	MAX_UARTS	MMIO_UART_MAX_UARTS
 
 typedef struct {
 	const char		*fum_compatible;
@@ -478,6 +478,8 @@ fdtuart_discover_uarts(const void *fdtp)
 
 	if (getenv("default-uart-name") == NULL && first_tty != NULL)
 		setenv("default-uart-name", first_tty->c_name, 1);
+
+	mmio_uart_set_serial_ports_pa(mmio_uart, num_mmio_uart);
 
 	consoles[c] = NULL;
 }

--- a/usr/src/boot/efi/libmmio_uart/mmio_uart.c
+++ b/usr/src/boot/efi/libmmio_uart/mmio_uart.c
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2025 Michael van der Westhuizen
+ * Copyright 2026 Michael van der Westhuizen
  */
 
 /*
@@ -746,4 +746,71 @@ mmio_uart_make_tty(mmio_uart_t *uart)
 		(void) uart->mu_ops->op_getchar(uart);
 
 	return (tty);
+}
+
+/*
+ * Build the "motherboard-serial-ports-pa" environment variable from the
+ * discovered UART list.
+ *
+ * The value is a comma-separated list of hex CPU physical addresses,
+ * positionally indexed by tty letter: ttya = first, ttyb = second, etc.
+ * Interior gaps (missing tty letters) use "0x0" as an unmatchable sentinel.
+ * Trailing missing letters are omitted entirely.
+ *
+ * This is picked up by fakebop and converted to an int64 array property on
+ * the root device node, where asy(4D) uses it to assign COM port numbers
+ * on aarch64.
+ */
+void
+mmio_uart_set_serial_ports_pa(mmio_uart_t *uarts, size_t nuarts)
+{
+	/* "0x" + 16 hex digits + "," = 19 chars max per entry */
+	char buf[MMIO_UART_MAX_UARTS * 20];
+	char *p = buf;
+	uint32_t max_idx = 0;
+	uint32_t pos;
+	size_t i;
+	bool found = false;
+
+	if (nuarts == 0) {
+		return;
+	}
+
+	/* Find the highest serial alias index among valid UARTs */
+	for (i = 0; i < nuarts; i++) {
+		if (!(uarts[i].mu_flags & MMIO_UART_VALID)) {
+			continue;
+		}
+
+		if (uarts[i].mu_serial_idx > max_idx) {
+			max_idx = uarts[i].mu_serial_idx;
+		}
+
+		found = true;
+	}
+
+	if (!found || max_idx >= MMIO_UART_MAX_UARTS) {
+		return;
+	}
+
+	/* Build positional comma-separated hex string */
+	for (pos = 0; pos <= max_idx; pos++) {
+		uint64_t pa = 0;
+
+		for (i = 0; i < nuarts; i++) {
+			if ((uarts[i].mu_flags & MMIO_UART_VALID) &&
+			    uarts[i].mu_serial_idx == pos) {
+				pa = uarts[i].mu_base;
+				break;
+			}
+		}
+
+		if (pos > 0) {
+			*p++ = ',';
+		}
+
+		p += snprintf(p, sizeof (buf) - (p - buf), "0x%lx", pa);
+	}
+
+	setenv("motherboard-serial-ports-pa", buf, 1);
 }

--- a/usr/src/boot/efi/libmmio_uart/mmio_uart.h
+++ b/usr/src/boot/efi/libmmio_uart/mmio_uart.h
@@ -10,7 +10,7 @@
  */
 
 /*
- * Copyright 2025 Michael van der Westhuizen
+ * Copyright 2026 Michael van der Westhuizen
  */
 
 #ifndef _MMIO_UART_MMIO_UART_H
@@ -22,6 +22,10 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <stddef.h>
+
+/* tty[a-z] - sync with sys/machsystm.h */
+#define	MMIO_UART_MAX_UARTS	(('z' - 'a') + 1)
 
 #ifdef __cplusplus
 extern "C" {
@@ -151,6 +155,8 @@ extern void mmio_uart_free_low_page(void *addr);
 
 extern void mmio_uart_puts(const char *s);
 extern void mmio_uart_putn(unsigned long n, int b);
+
+extern void mmio_uart_set_serial_ports_pa(mmio_uart_t *, size_t);
 
 #ifdef __cplusplus
 }

--- a/usr/src/uts/armv8/io/ns16550a/ns16550a.c
+++ b/usr/src/uts/armv8/io/ns16550a/ns16550a.c
@@ -33,6 +33,7 @@
 
 #include <sys/param.h>
 #include <sys/types.h>
+#include <sys/machsystm.h>
 #include <sys/signal.h>
 #include <sys/stream.h>
 #include <sys/termio.h>
@@ -354,6 +355,9 @@ static void	nsasync_flowcontrol_hw_output(struct ns16550com *ns16550,
 
 static kmutex_t ns16550_glob_lock; /* lock protecting global data manipulation */
 static void *ns16550_soft_state;
+
+static uint64_t *com_ports_pa;
+static uint_t num_com_ports_pa;
 
 #ifdef	DEBUG
 /*
@@ -829,6 +833,11 @@ _fini(void)
 		    modldrv.drv_linkinfo);
 		ASSERT(max_ns16550_instance == -1);
 		mutex_destroy(&ns16550_glob_lock);
+		if (com_ports_pa != NULL) {
+			ddi_prop_free(com_ports_pa);
+			com_ports_pa = NULL;
+		}
+		num_com_ports_pa = 0;
 		ddi_soft_state_fini(&ns16550_soft_state);
 	}
 	return (i);
@@ -973,6 +982,21 @@ ns16550attach(dev_info_t *devi, ddi_attach_cmd_t cmd)
 		DDI_STRICTORDER_ACC,
 	};
 
+	mutex_enter(&ns16550_glob_lock);
+	if (com_ports_pa == NULL) {
+		if (ddi_prop_lookup_int64_array(DDI_DEV_T_ANY,
+		    ddi_root_node(), 0, "motherboard-serial-ports-pa",
+		    (int64_t **)&com_ports_pa,
+		    &num_com_ports_pa) != DDI_PROP_SUCCESS) {
+			com_ports_pa = NULL;
+			num_com_ports_pa = 0;
+		}
+		if (num_com_ports_pa > MMIO_UART_MAX_UARTS) {
+			num_com_ports_pa = MMIO_UART_MAX_UARTS;
+		}
+	}
+	mutex_exit(&ns16550_glob_lock);
+
 	instance = ddi_get_instance(devi);	/* find out which unit */
 
 	switch (cmd) {
@@ -1032,7 +1056,22 @@ ns16550attach(dev_info_t *devi, ddi_attach_cmd_t cmd)
 	DEBUGCONT2(NS16550_DEBUG_INIT, "ns16550%dattach: UART @ %p\n",
 	    instance, (void *)ns16550->ns16550_ioaddr);
 
-	ns16550->ns16550_com_port = instance + 1;
+	if (num_com_ports_pa > 0) {
+		struct regspec *rp;
+		uint64_t cpu_pa;
+
+		rp = i_ddi_rnumber_to_regspec(devi, 0);
+		if (rp != NULL && i_ddi_bus_to_cpu(devi, rp->regspec_addr,
+		    rp->regspec_size, &cpu_pa) == DDI_SUCCESS) {
+			for (i = 0; i < num_com_ports_pa; i++) {
+				if (com_ports_pa[i] != 0 &&
+				    com_ports_pa[i] == cpu_pa) {
+					ns16550->ns16550_com_port = i + 1;
+					break;
+				}
+			}
+		}
+	}
 
 	/*
 	 * It appears that there was async hardware that on reset
@@ -1052,50 +1091,59 @@ ns16550attach(dev_info_t *devi, ddi_attach_cmd_t cmd)
 #endif
 	mcr = 0;				/* don't enable until open */
 
-	/*
-	 * For motherboard ports, emulate tty eeprom properties.
-	 * Actually, we can't tell if a port is motherboard or not,
-	 * so for "motherboard ports", read standard DOS COM ports.
-	 */
-	switch (ns16550_getproperty(devi, ns16550, "ignore-cd")) {
-	case 0:				/* *-ignore-cd=False */
-		DEBUGCONT1(NS16550_DEBUG_MODEM,
-		    "ns16550%dattach: clear NS16550_IGNORE_CD\n", instance);
-		ns16550->ns16550_flags &= ~NS16550_IGNORE_CD; /* wait for cd */
-		break;
-	case 1:				/* *-ignore-cd=True */
-		/*FALLTHRU*/
-	default:			/* *-ignore-cd not defined */
+	if (ns16550->ns16550_com_port != 0) {
 		/*
-		 * We set rather silly defaults of soft carrier on
-		 * and DTR/RTS raised here because it might be that
-		 * one of the motherboard ports is the system console.
+		 * For motherboard ports, emulate tty eeprom properties.
+		 * Actually, we can't tell if a port is motherboard or not,
+		 * so for "motherboard ports", read ports recognised by loader.
 		 */
-		DEBUGCONT1(NS16550_DEBUG_MODEM,
-		    "ns16550%dattach: set NS16550_IGNORE_CD, set RTS & DTR\n",
-		    instance);
-		mcr = ns16550->ns16550_mcr;		/* rts/dtr on */
-		ns16550->ns16550_flags |= NS16550_IGNORE_CD;	/* ignore cd */
-		break;
-	}
+		switch (ns16550_getproperty(devi, ns16550, "ignore-cd")) {
+		case 0:				/* *-ignore-cd=False */
+			DEBUGCONT1(NS16550_DEBUG_MODEM, "ns16550%dattach: "
+			    "clear NS16550_IGNORE_CD\n", instance);
+			/* wait for cd */
+			ns16550->ns16550_flags &= ~NS16550_IGNORE_CD;
+			break;
+		case 1:				/* *-ignore-cd=True */
+			/*FALLTHRU*/
+		default:			/* *-ignore-cd not defined */
+			/*
+			 * We set rather silly defaults of soft carrier on
+			 * and DTR/RTS raised here because it might be that
+			 * one of the motherboard ports is the system console.
+			 */
+			DEBUGCONT1(NS16550_DEBUG_MODEM, "ns16550%dattach: "
+			    "set NS16550_IGNORE_CD, set RTS & DTR\n", instance);
+			mcr = ns16550->ns16550_mcr;		/* rts/dtr on */
+			/* ignore cd */
+			ns16550->ns16550_flags |= NS16550_IGNORE_CD;
+			break;
+		}
 
-	/* Property for not raising DTR/RTS */
-	switch (ns16550_getproperty(devi, ns16550, "rts-dtr-off")) {
-	case 0:				/* *-rts-dtr-off=False */
-		ns16550->ns16550_flags |= NS16550_RTS_DTR_OFF;	/* OFF */
-		mcr = ns16550->ns16550_mcr;		/* rts/dtr on */
+		/* Property for not raising DTR/RTS */
+		switch (ns16550_getproperty(devi, ns16550, "rts-dtr-off")) {
+		case 0:				/* *-rts-dtr-off=False */
+			/* OFF */
+			ns16550->ns16550_flags |= NS16550_RTS_DTR_OFF;
+			mcr = ns16550->ns16550_mcr;	/* rts/dtr on */
+			DEBUGCONT1(NS16550_DEBUG_MODEM, "ns16550%dattach: "
+			    "NS16550_RTS_DTR_OFF set and DTR & RTS set\n",
+			    instance);
+			break;
+		case 1:				/* *-rts-dtr-off=True */
+			/*FALLTHRU*/
+		default:			/* *-rts-dtr-off undefined */
+			break;
+		}
+
+		/* Parse property for tty modes */
+		ns16550_parse_mode(devi, ns16550);
+	} else {
 		DEBUGCONT1(NS16550_DEBUG_MODEM, "ns16550%dattach: "
-		    "NS16550_RTS_DTR_OFF set and DTR & RTS set\n",
-		    instance);
-		break;
-	case 1:				/* *-rts-dtr-off=True */
-		/*FALLTHRU*/
-	default:			/* *-rts-dtr-off undefined */
-		break;
+		    "clear NS16550_IGNORE_CD, clear RTS & DTR\n", instance);
+		/* wait for cd */
+		ns16550->ns16550_flags &= ~NS16550_IGNORE_CD;
 	}
-
-	/* Parse property for tty modes */
-	ns16550_parse_mode(devi, ns16550);
 
 	/*
 	 * Get icookie for mutexes initialization
@@ -1187,14 +1235,23 @@ ns16550attach(dev_info_t *devi, ddi_attach_cmd_t cmd)
 	ns16550init(ns16550);	/* initialize the nsasyncline structure */
 
 	/* create minor device nodes for this device */
-	/*
-	 * For DOS COM ports, add letter suffix so
-	 * devfsadm can create correct link names.
-	 */
-	name[0] = ns16550->ns16550_com_port + 'a' - 1;
-	name[1] = '\0';
+	if (ns16550->ns16550_com_port != 0) {
+		/*
+		 * for COM ports identified by loader, add letter suffix so
+		 * devfsadm can create correct link names.
+		 */
+		name[0] = ns16550->ns16550_com_port + 'a' - 1;
+		name[1] = '\0';
+	} else {
+		/*
+		 * ports not identified by loader get a numeric name based
+		 * on instance.
+		 */
+		(void) snprintf(name, NS16550_MINOR_LEN, "%d", instance);
+	}
 	status = ddi_create_minor_node(devi, name, S_IFCHR, instance,
-	    ns16550->ns16550_com_port != 0 ? DDI_NT_SERIAL_MB : DDI_NT_SERIAL, 0);
+	    ns16550->ns16550_com_port != 0 ?
+	    DDI_NT_SERIAL_MB : DDI_NT_SERIAL, 0);
 	if (status == DDI_SUCCESS) {
 		(void) strcat(name, ",cu");
 		status = ddi_create_minor_node(devi, name, S_IFCHR,

--- a/usr/src/uts/armv8/os/fakebop.c
+++ b/usr/src/uts/armv8/os/fakebop.c
@@ -1172,6 +1172,57 @@ process_boot_environment(struct boot_modules *benv, char *space)
 			bsetprops(name, propval);
 			continue;
 		}
+
+		/*
+		 * Loader property `motherboard-serial-ports-pa' is a
+		 * comma-separated list of CPU physical addresses (in
+		 * hex, e.g. "0x9000000,0x9040000") identifying MMIO
+		 * UARTs positionally by tty letter: first entry is
+		 * ttya, second is ttyb, and so on.  Interior gaps
+		 * use 0x0 as an unmatchable sentinel.
+		 *
+		 * Convert to an int64 array boot property so that
+		 * asy(4D) can look it up via
+		 * ddi_prop_lookup_int64_array on the root node.
+		 *
+		 * If the loader string is malformed the parseable
+		 * entries are what gets propagated to boot props.
+		 */
+		if (strcmp(name, "motherboard-serial-ports-pa") == 0) {
+			uint64_t addrs[MMIO_UART_MAX_UARTS];
+			uint_t naddrs = 0;
+			char *p = value;
+
+			while (*p != '\0' && naddrs < MMIO_UART_MAX_UARTS) {
+				uint64_t v;
+				char *ep;
+
+				while (*p == ',' || *p == ' ') {
+					p++;
+				}
+
+				if (*p == '\0') {
+					break;
+				}
+
+				if (ddi_strtoul(p, &ep, 0, &v) != 0) {
+					break;
+				}
+
+				addrs[naddrs++] = v;
+				p = ep;
+			}
+
+			if (naddrs > 0) {
+				bsetprop(DDI_PROP_TYPE_INT64,
+				    "motherboard-serial-ports-pa",
+				    strlen("motherboard-serial-ports-pa"),
+				    addrs, naddrs * sizeof (uint64_t));
+			}
+
+			continue;
+		}
+
 		if (name_is_blocklisted(name) == B_TRUE)
 			continue;
 

--- a/usr/src/uts/armv8/sys/machsystm.h
+++ b/usr/src/uts/armv8/sys/machsystm.h
@@ -67,6 +67,9 @@ extern struct cpu	*cpu[];		/* pointer to all cpus */
 extern unsigned int microdata;
 extern uintptr_t hole_start, hole_end;
 
+/* tty[a-z] - sync with libmmio_uart/mmio_uart.h */
+#define	MMIO_UART_MAX_UARTS	(('z' - 'a') + 1)
+
 #define	INVALID_VADDR(a)	\
 	(((a) >= (caddr_t)hole_start && (a) < (caddr_t)hole_end))
 


### PR DESCRIPTION
i86pc, in asy(4), uses the `motherboard-serial-ports` root nexus property to consistently apply loader serial port names to those discovered by the OS.

Tragically, `motherboard-serial-ports` traffics in I/O ports, so introduce `motherboard-serial-ports-pa` to do the same, but with 64bit physical MMIO addresses.

Pass this from loader, through dboot to fakebop, where it's picked up and transformed to a proper integer array for use by UART drivers. Finally, integrate the property into `ns16550a`.