### PR TITLE
pcieb: MSI is now supported

### DIFF
--- a/usr/src/uts/armv8/io/pciex/pcieb_armv8.c
+++ b/usr/src/uts/armv8/io/pciex/pcieb_armv8.c
@@ -99,7 +99,7 @@ pcieb_plat_pwr_disable(dev_info_t *dip)
 boolean_t
 pcieb_plat_msi_supported(dev_info_t *dip)
 {
-	return (B_FALSE);	/* XXXARM: We don't right now, but need to */
+	return (B_TRUE);
 }
 
 void


### PR DESCRIPTION
What it says on the tin - this PR simply cleans up an `XXXARM` now that we have MSI/MSI-X support.