### PR TITLE
pci_prd: implement PCI slot naming via SMBIOS Type 9

### DIFF
--- a/usr/src/uts/aarch64/io/pciex/pcierc/pci_boot.c
+++ b/usr/src/uts/aarch64/io/pciex/pcierc/pci_boot.c
@@ -1193,6 +1193,8 @@ pci_reprogram(dev_info_t *rcdip, struct pci_bus_resource *pci_bus_res)
 	/* All dev programmed, so we can create available prop */
 	for (i = 0; i <= pci_boot_maxbus; i++)
 		add_bus_available_prop(pci_bus_res, i);
+	for (i = 0; i <= pci_boot_maxbus; i++)
+		pci_prd_slot_name(i, pci_bus_res[i].dip);
 }
 
 static struct memlist *

--- a/usr/src/uts/armv8/io/pci/pci_prd_armv8.c
+++ b/usr/src/uts/armv8/io/pci/pci_prd_armv8.c
@@ -12,13 +12,11 @@
 /*
  * Copyright 2023 Oxide Computer Company
  * Copyright 2024 Richard Lowe
+ * Copyright 2026 Michael van der Westhuizen
  */
 
 /*
- * PCI Resource Discovery on armv8.  We just ask the PROM device tree.
- *
- * XXXARM: Architecturally, I'm assuming that this module `pci_prd_armv8` is
- * devicetree based, and an acpi-based `pci_prd_sbsa` would exist.
+ * PCI Resource Discovery on armv8.  We just ask the device tree.
  */
 
 #include <sys/esunddi.h>
@@ -28,7 +26,11 @@
 #include <sys/pci.h>
 #include <sys/pci_impl.h>
 #include <sys/plat/pci_prd.h>
+#include <sys/sunndi.h>
 #include <sys/obpdefs.h>
+#include <sys/smbios.h>
+#include <sys/pcie_impl.h>
+#include <sys/cmn_err.h>
 
 /*
  * We always just tell the system to scan all PCI buses.
@@ -54,7 +56,157 @@ pci_prd_compat_flags(void)
 	return (PCI_PRD_COMPAT_1275);
 }
 
+/*
+ * Walk up the devinfo tree from dip to find the PCIe root complex
+ * ancestor and read its PCI segment number from the "linux,pci-domain"
+ * property.  The root complex is identified by its DEVI_PORT_TYPE_PCIRC
+ * registration (set by the RC driver at attach time).  Returns 0
+ * (single-segment default) if the property is absent on the RC node.
+ */
+static uint16_t
+pci_prd_get_segment(dev_info_t *dip)
+{
+	dev_info_t *pdip;
 
+	for (pdip = dip; pdip != NULL; pdip = ddi_get_parent(pdip)) {
+		if (ndi_port_type(pdip, B_TRUE, DEVI_PORT_TYPE_PCIRC)) {
+			return ((uint16_t)ddi_prop_get_int(DDI_DEV_T_ANY,
+			    pdip, DDI_PROP_DONTPASS,
+			    "linux,pci-domain", 0));
+		}
+	}
+
+	return (0);
+}
+
+/*
+ * SMBIOS Type 9 (System Slot) iteration state for pci_prd_slot_name.
+ *
+ * We collect per-device-number slot names, then emit the IEEE 1275
+ * "slot-names" property with strings ordered by device number.
+ */
+#define	PCI_PRD_MAX_DEV	32
+
+typedef struct pci_prd_slot_cb {
+	uint16_t	psc_seg;			/* matcher segment */
+	uint8_t		psc_bus;			/* matcher bus */
+	uint32_t	psc_mask;			/* device bitmask */
+	const char	*psc_name[PCI_PRD_MAX_DEV];	/* per-device name */
+} pci_prd_slot_cb_t;
+
+static int
+pci_prd_slot_iter_cb(smbios_hdl_t *shp, const smbios_struct_t *strp,
+    void *data)
+{
+	pci_prd_slot_cb_t *cbp = data;
+	smbios_slot_t slot;
+	uint8_t dev;
+
+	if (strp->smbstr_type != SMB_TYPE_SLOT) {
+		return (0);
+	}
+
+	if (smbios_info_slot(shp, strp->smbstr_id, &slot) != 0) {
+		return (0);
+	}
+
+	if (slot.smbl_sg != cbp->psc_seg || slot.smbl_bus != cbp->psc_bus) {
+		return (0);
+	}
+
+	dev = slot.smbl_df >> 3;
+	if (dev >= PCI_PRD_MAX_DEV) {	/* exposition only */
+		return (0);
+	}
+
+	cbp->psc_mask |= (1U << dev);
+	cbp->psc_name[dev] = slot.smbl_name;
+
+	return (0);
+}
+
+/*
+ * Use SMBIOS Type 9 (System Slot) records to set the "slot-names"
+ * property on bus devinfo nodes.  The property uses the IEEE 1275
+ * format: a uint32_t device bitmask followed by packed NUL-terminated
+ * name strings in ascending device-number order, padded to a 4-byte
+ * boundary.
+ *
+ * On multi-segment platforms (e.g. Ampere Altra Max with 8 root
+ * complexes), the SMBIOS segment group (smbl_sg) is matched against
+ * the "linux,pci-domain" property on the root complex ancestor of dip.
+ *
+ * If multiple SMBIOS records share the same device number (different
+ * functions on the same device), the last record wins.  The IEEE 1275
+ * slot-names format supports only one name per device number and this
+ * choice matches i86pc behaviour.
+ */
+void
+pci_prd_slot_name(uint32_t bus, dev_info_t *dip)
+{
+	pci_prd_slot_cb_t cb;
+	char *buf;
+	size_t totlen;
+	size_t len;
+
+	if (dip == NULL || ksmbios == NULL) {
+		return;
+	}
+
+	bzero(&cb, sizeof (cb));
+	cb.psc_seg = pci_prd_get_segment(dip);
+	cb.psc_bus = (uint8_t)bus;
+
+	(void) smbios_iter(ksmbios, pci_prd_slot_iter_cb, &cb);
+
+	if (cb.psc_mask == 0) {
+		return;
+	}
+
+	/* Build the slot-names property: bitmask and packed strings. */
+	totlen = sizeof (uint32_t);
+
+	for (uint_t dev = 0; dev < PCI_PRD_MAX_DEV; dev++) {
+		if (cb.psc_name[dev] == NULL) {
+			continue;
+		}
+
+		totlen += strlen(cb.psc_name[dev]) + 1;
+	}
+
+	while (totlen % sizeof (uint32_t) != 0) {
+		totlen++;
+	}
+
+	ASSERT((totlen % sizeof (int)) == 0);
+	buf = kmem_zalloc(totlen, KM_SLEEP);
+	ASSERT3P(buf, !=, NULL);
+
+	*(uint32_t *)buf = cb.psc_mask;
+	len = sizeof (uint32_t);
+
+	for (uint_t dev = 0; dev < PCI_PRD_MAX_DEV; dev++) {
+		size_t nlen;
+
+		if (cb.psc_name[dev] == NULL) {
+			continue;
+		}
+
+		nlen = strlen(cb.psc_name[dev]) + 1;
+		if (len + nlen > totlen) {
+			break;
+		}
+
+		bcopy(cb.psc_name[dev], buf + len, nlen);
+		len += nlen;
+	}
+
+	/* NUL padding is taken care of by kmem_zalloc */
+
+	(void) ndi_prop_update_int_array(DDI_DEV_T_NONE, dip, "slot-names",
+	    (int *)buf, totlen / sizeof (int));
+	kmem_free(buf, totlen);
+}
 
 static struct modlmisc pci_prd_modlmisc_armv8 = {
 	.misc_modops = &mod_miscops,


### PR DESCRIPTION
Add `pci_prd_slot_name` to `pci_prd_armv8.c`, the first consumer of SMBIOS Type 9 (System Slot) records on aarch64.

Three new functions:
* `pci_prd_get_segment`: walks up to the PCIe root complex ancestor (identified by `DEVI_PORT_TYPE_PCIRC` registration) and reads the PCI segment number from the "linux,pci-domain" property.
* `pci_prd_slot_iter_cb`: `smbios_iter` callback that matches records by segment group (`smbl_sg`) and bus number (`smbl_bus`), collecting slot name pointers indexed by device number (`smbl_df` >> 3).
* `pci_prd_slot_name`: entry point that iterates SMBIOS, builds the IEEE 1275 "slot-names" property (uint32_t device bitmask followed by packed NUL-terminated strings in ascending device-number order, padded to 4-byte boundary), and sets it via `ndi_prop_update_int_array`.

On multi-segment platforms (Ampere Altra Max with 8 root complexes), the segment group match ensures slots are attributed to the correct root complex.  If multiple SMBIOS records share the same device number, the last record wins, matching the i86pc behaviour.

Gracefully no-ops when dip is NULL, ksmbios is NULL, or no Type 9 records match the bus.

Hook slot-naming into pci_boot.

Slot names [look sensible](https://gist.github.com/r1mikey/b5761c579c9c87ace29f7d5612fa871c) when decoded:
* Segment 12: SLIM1-2, SLIM1-1, SLIM2-2, SLIM2-1 (devices 1-4) - all SlimSAS
* Segment 13: SLIM3-1, SLIM3-2, SLIM4-1, SLIM4-2 (devices 1-4) - all SlimSAS
* Segment 2: M2_1, M2_2, OCU1, OCU2 (devices 1-4) - Motherboard-mounted m.2 slots, OCuLink
* Segments 0,1,4,5: PCIE4, PCIE5, PCIE6, PCIE7 (device 1 each)

All [seven segments with Type 9 records](https://gist.github.com/r1mikey/ec7c4de0dde90c5ef96fb19924000cd1) got overwritten with the right names. The rest stayed as firmware pcie0.
