### PR TITLE
fma: PCI topology enumeration and SMBIOS segment group fix

### DIFF
--- a/usr/src/lib/fm/topo/maps/armv8/armv8-legacy-hc-topology.xml
+++ b/usr/src/lib/fm/topo/maps/armv8/armv8-legacy-hc-topology.xml
@@ -26,8 +26,8 @@ Copyright 2019 Joyent, Inc.
 -->
 
 <!--
- This map file is loaded by the generic enumerator (x86pi.so) when
- an FMA-compliant SMBIOS can't be found.
+ This map file is loaded by the armv8pi enumerator when enumerating
+ the aarch64 hardware topology.
 -->
 
 <topology name='aarch64' scheme='hc'>
@@ -43,6 +43,9 @@ Copyright 2019 Joyent, Inc.
     </node>
 
     <dependents grouping='children'>
+      <range name='hostbridge' min='0' max='254'>
+        <enum-method name='hostbridge' version='1' />
+      </range>
       <range name='usb-mobo' min='0' max='100'>
         <enum-method name='usb' version='1' />
       </range>

--- a/usr/src/lib/fm/topo/modules/armv8/hostbridge/Makefile
+++ b/usr/src/lib/fm/topo/modules/armv8/hostbridge/Makefile
@@ -9,11 +9,12 @@
 # http://www.illumos.org/license/CDDL.
 #
 
-# Copyright 2023 Richard Lowe
+#
+# Copyright 2026 Michael van der Westhuizen
+#
 
-SUBDIRS = armv8pi hostbridge pcibus
+include $(SRC)/Makefile.master
 
-.PARALLEL: $(SUBDIRS)
+SUBDIRS = $(MACH64)
 
-include ../../../Makefile.subdirs
-
+include ../../../../Makefile.subdirs

--- a/usr/src/lib/fm/topo/modules/armv8/hostbridge/Makefile.common
+++ b/usr/src/lib/fm/topo/modules/armv8/hostbridge/Makefile.common
@@ -1,0 +1,37 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2026 Michael van der Westhuizen
+#
+
+MODULE = hostbridge
+ARCH = armv8
+CLASS = arch
+UTILDIR = ../../../common/pcibus
+UTILSRCS = did.c did_hash.c did_props.c util.c
+HBDIR = ../../../common/hostbridge
+HBSRCS = hostbridge.c hb_$(ARCH).c
+MODULESRCS = $(HBSRCS) $(UTILSRCS)
+
+include ../../../Makefile.plugin
+
+LDLIBS += -ldevinfo -lsmbios -lpcidb
+
+CPPFLAGS += -I$(UTILDIR) -I$(HBDIR)
+
+%.o: $(UTILDIR)/%.c
+	$(COMPILE.c) -o $@ $<
+	$(CTFCONVERT_O)
+
+%.o: $(HBDIR)/%.c
+	$(COMPILE.c) -o $@ $<
+	$(CTFCONVERT_O)

--- a/usr/src/lib/fm/topo/modules/armv8/hostbridge/aarch64/Makefile
+++ b/usr/src/lib/fm/topo/modules/armv8/hostbridge/aarch64/Makefile
@@ -9,11 +9,11 @@
 # http://www.illumos.org/license/CDDL.
 #
 
-# Copyright 2023 Richard Lowe
+#
+# Copyright 2026 Michael van der Westhuizen
+#
 
-SUBDIRS = armv8pi hostbridge pcibus
+include ../Makefile.common
+include ../../../Makefile.plugin.64
 
-.PARALLEL: $(SUBDIRS)
-
-include ../../../Makefile.subdirs
-
+install: $(ROOTPROG64)

--- a/usr/src/lib/fm/topo/modules/armv8/hostbridge/hb_armv8.c
+++ b/usr/src/lib/fm/topo/modules/armv8/hostbridge/hb_armv8.c
@@ -1,0 +1,127 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2026 Michael van der Westhuizen
+ */
+
+/*
+ * Platform-specific hostbridge enumeration for armv8 (aarch64).
+ *
+ * On aarch64, PCIe root complexes are driven by "ecam" or a platform-specific
+ * root complex driver and appear at the top of the devinfo tree.  Each ecam
+ * node's children are "pcieb" root port bridges, structurally equivalent to
+ * the NPE -> pcieb relationship on i86pc.
+ */
+
+#include <string.h>
+#include <libdevinfo.h>
+#include <fm/topo_mod.h>
+#include <fm/topo_hc.h>
+
+#include <hostbridge.h>
+#include <pcibus.h>
+#include <did.h>
+#include <did_props.h>
+#include <util.h>
+
+#define	ECAM	"ecam"
+#define	RPI4	"bcm2711_pcie"
+
+static int
+rc_process(topo_mod_t *mod, tnode_t *ptn, topo_instance_t hbi, di_node_t bn)
+{
+	tnode_t *hb;
+	tnode_t *rc;
+	did_t *hbdid;
+
+	if ((hbdid = did_create(mod, bn, 0, hbi, hbi, TRUST_BDF)) == NULL) {
+		return (-1);
+	}
+
+	if ((hb = pciexhostbridge_declare(mod, ptn, bn, hbi)) == NULL) {
+		return (-1);
+	}
+
+	if ((rc = pciexrc_declare(mod, hb, bn, hbi)) == NULL) {
+		return (-1);
+	}
+
+	if (topo_mod_enumerate(mod,
+	    rc, PCI_BUS, PCIEX_BUS, 0, MAX_HB_BUSES, (void *)hbdid) < 0) {
+		topo_node_unbind(hb);
+		topo_node_unbind(rc);
+		return (-1);
+	}
+
+	return (0);
+}
+
+int
+platform_hb_enum(topo_mod_t *mod, tnode_t *parent, const char *name __unused,
+    topo_instance_t imin __unused, topo_instance_t imax __unused)
+{
+	di_node_t devtree;
+	di_node_t pnode, cnode;
+	size_t i;
+	int hbcnt = 0;
+
+	static const char *drv_names[] = {
+		ECAM,
+		RPI4,
+	};
+	static const size_t num_drv_names = ARRAY_SIZE(drv_names);
+
+	devtree = topo_mod_devinfo(mod);
+	if (devtree == DI_NODE_NIL) {
+		topo_mod_dprintf(mod, "devinfo init failed.");
+		topo_node_range_destroy(parent, HOSTBRIDGE);
+		return (0);
+	}
+
+	/*
+	 * Scan for driver instances - these are PCIe root complexes on
+	 * aarch64.  Each node's pcieb children are root ports.
+	 */
+	for (i = 0; i < num_drv_names; ++i) {
+		if (drv_names[i] == NULL) {
+			continue;
+		}
+
+		pnode = di_drv_first_node(drv_names[i], devtree);
+		while (pnode != DI_NODE_NIL) {
+			for (cnode = di_child_node(pnode); cnode != DI_NODE_NIL;
+			    cnode = di_sibling_node(cnode)) {
+				if (di_driver_name(cnode) == NULL)
+					continue;
+				if (strcmp(di_driver_name(cnode), PCIEB) != 0)
+					continue;
+				if (rc_process(mod, parent, hbcnt, cnode) < 0) {
+					if (hbcnt == 0)
+						topo_node_range_destroy(parent,
+						    HOSTBRIDGE);
+					return (topo_mod_seterrno(mod,
+					    EMOD_PARTIAL_ENUM));
+				}
+				hbcnt++;
+			}
+			pnode = di_drv_next_node(pnode);
+		}
+	}
+
+	return (0);
+}
+
+int
+platform_hb_label(topo_mod_t *mod, tnode_t *node, nvlist_t *in, nvlist_t **out)
+{
+	return (labelmethod_inherit(mod, node, in, out));
+}

--- a/usr/src/lib/fm/topo/modules/armv8/pcibus/Makefile
+++ b/usr/src/lib/fm/topo/modules/armv8/pcibus/Makefile
@@ -9,11 +9,12 @@
 # http://www.illumos.org/license/CDDL.
 #
 
-# Copyright 2023 Richard Lowe
+#
+# Copyright 2026 Michael van der Westhuizen
+#
 
-SUBDIRS = armv8pi hostbridge pcibus
+include $(SRC)/Makefile.master
 
-.PARALLEL: $(SUBDIRS)
+SUBDIRS = $(MACH64)
 
-include ../../../Makefile.subdirs
-
+include ../../../../Makefile.subdirs

--- a/usr/src/lib/fm/topo/modules/armv8/pcibus/Makefile.common
+++ b/usr/src/lib/fm/topo/modules/armv8/pcibus/Makefile.common
@@ -1,0 +1,40 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2026 Michael van der Westhuizen
+#
+
+MODULE = pcibus
+ARCH = armv8
+CLASS = arch
+UTILDIR = ../../../common/pcibus
+HBDIR = ../../../common/hostbridge
+NICDIR = ../../../common/nic
+USBDIR = ../../../common/usb
+UFMDIR = ../../../common/ufm
+SHAREDDIR = ../../../common/shared
+UTILSRCS = did.c did_hash.c did_props.c util.c
+PCISRCS = pcibus.c pcibus_labels.c pcibus_hba.c pci_sensor.c
+SHAREDSRCS = topo_sensor.c
+
+MODULESRCS = $(UTILSRCS) $(PCISRCS) pci_armv8.c
+
+include ../../../Makefile.plugin
+
+LDLIBS += -ldevinfo -lsmbios -lpcidb
+
+CPPFLAGS += -I$(UTILDIR) -I$(HBDIR) -I$(NICDIR) -I$(USBDIR) -I$(SHAREDDIR)
+CPPFLAGS += -I$(UFMDIR)
+
+%.o: $(SHAREDDIR)/%.c
+	$(COMPILE.c) -o $@ $<
+	$(CTFCONVERT_O)

--- a/usr/src/lib/fm/topo/modules/armv8/pcibus/aarch64/Makefile
+++ b/usr/src/lib/fm/topo/modules/armv8/pcibus/aarch64/Makefile
@@ -9,11 +9,11 @@
 # http://www.illumos.org/license/CDDL.
 #
 
-# Copyright 2023 Richard Lowe
+#
+# Copyright 2026 Michael van der Westhuizen
+#
 
-SUBDIRS = armv8pi hostbridge pcibus
+include ../Makefile.common
+include ../../../Makefile.plugin.64
 
-.PARALLEL: $(SUBDIRS)
-
-include ../../../Makefile.subdirs
-
+install: $(ROOTPROG64)

--- a/usr/src/lib/fm/topo/modules/armv8/pcibus/pci_armv8.c
+++ b/usr/src/lib/fm/topo/modules/armv8/pcibus/pci_armv8.c
@@ -1,0 +1,47 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2026 Michael van der Westhuizen
+ */
+
+/*
+ * Platform-specific PCI topology labeling for armv8 (aarch64).
+ *
+ * On aarch64, slot labels come from SMBIOS Type 9 records and don't
+ * need platform-specific rewrites or fixups.
+ */
+
+#include <fm/topo_mod.h>
+
+#include "pcibus.h"
+#include "pcibus_labels.h"
+
+/*
+ * No platform-specific slot label rewrites needed.
+ */
+slotnm_rewrite_t *Slot_Rewrites = NULL;
+physlot_names_t *Physlot_Names = NULL;
+missing_names_t *Missing_Names = NULL;
+
+int
+platform_pci_label(topo_mod_t *mod, tnode_t *node, nvlist_t *in,
+    nvlist_t **out)
+{
+	return (pci_label_cmn(mod, node, in, out));
+}
+
+int
+platform_pci_fru(topo_mod_t *mod, tnode_t *node, nvlist_t *in,
+    nvlist_t **out)
+{
+	return (pci_fru_cmn(mod, node, in, out));
+}

--- a/usr/src/lib/fm/topo/modules/common/pcibus/did.c
+++ b/usr/src/lib/fm/topo/modules/common/pcibus/did.c
@@ -106,8 +106,35 @@ di_devtype_get(topo_mod_t *mp, di_node_t src, char **devtype)
 typedef struct smbios_slot_cb {
 	int		cb_slotnum;
 	int		cb_bdf;
+#if defined(__aarch64__)
+	uint16_t	cb_sg;
+#endif
 	const char	*cb_label;
 } smbios_slot_cb_t;
+
+#if defined(__aarch64__)
+/*
+ * Walk up the devinfo tree from src to find the PCI segment group number.
+ * PCIRC nodes carry a "pci-segment" and/or "linux,pci-domain" property set
+ * during ACPI/FDT enumeration.  Default to segment 0 if the property is absent.
+ */
+static uint16_t
+di_pci_segment_get(topo_mod_t *mp, di_node_t src)
+{
+	di_node_t dn;
+	uint_t seg;
+
+	for (dn = src; dn != DI_NODE_NIL; dn = di_parent_node(dn)) {
+		if (di_uintprop_get(mp, dn, "pci-segment", &seg) == 0) {
+			return ((uint16_t)seg);
+		}
+		if (di_uintprop_get(mp, dn, "linux,pci-domain", &seg) == 0) {
+			return ((uint16_t)seg);
+		}
+	}
+	return (0);
+}
+#endif /* defined(__aarch64__) */
 
 static int
 di_smbios_find_slot_by_bdf(smbios_hdl_t *shp, const smbios_struct_t *strp,
@@ -124,7 +151,11 @@ di_smbios_find_slot_by_bdf(smbios_hdl_t *shp, const smbios_struct_t *strp,
 	    smbios_info_slot(shp, strp->smbstr_id, &slot) != 0)
 		return (0);
 
-	if (slot.smbl_bus == bus && slot.smbl_df == df) {
+	if (
+#if defined(__aarch64__)
+	    slot.smbl_sg == cbp->cb_sg &&
+#endif
+	    slot.smbl_bus == bus && slot.smbl_df == df) {
 		cbp->cb_label = slot.smbl_name;
 		cbp->cb_slotnum = slot.smbl_id;
 		return (1);
@@ -210,6 +241,9 @@ di_physlotinfo_get(topo_mod_t *mp, di_node_t src, int bdf, int *slotnum,
 
 		cbdata.cb_slotnum = *slotnum;
 		cbdata.cb_bdf = bdf;
+#if defined(__aarch64__)
+		cbdata.cb_sg = di_pci_segment_get(mp, src);
+#endif
 		cbdata.cb_label = NULL;
 
 		/*

--- a/usr/src/pkg/manifests/service-fault-management.p5m
+++ b/usr/src/pkg/manifests/service-fault-management.p5m
@@ -529,6 +529,10 @@ $(aarch64_ONLY)dir path=usr/platform/armv8/lib/fm/topo/plugins
 $(aarch64_ONLY)link path=usr/platform/armv8/lib/fm/topo/plugins/64 target=.
 $(aarch64_ONLY)file path=usr/platform/armv8/lib/fm/topo/plugins/armv8pi.so \
     mode=0555
+$(aarch64_ONLY)file path=usr/platform/armv8/lib/fm/topo/plugins/hostbridge.so \
+    mode=0555
+$(aarch64_ONLY)file path=usr/platform/armv8/lib/fm/topo/plugins/pcibus.so \
+    mode=0555
 $(i386_ONLY)dir path=usr/platform/i86pc group=sys
 $(i386_ONLY)dir path=usr/platform/i86pc/lib
 $(i386_ONLY)dir path=usr/platform/i86pc/lib/fm


### PR DESCRIPTION
Add armv8 platform versions of the hostbridge and pcibus FMA topology modules to enable fmtopo PCI enumeration on aarch64.

The hostbridge module (hb_armv8.c) scans for ecam driver nodes (the aarch64 PCIe root complex driver) as well as platform-specific root complex drivers (bcm2711_pcie for rpi4) and iterates their pcieb children via rc_process(), mirroring the i86pc pattern.

The pcibus module (pci_armv8.c) provides minimal platform glue with NULL rewrite tables and passthrough label/fru functions.

The armv8-legacy-hc-topology.xml map is extended with a hostbridge range under the motherboard node.

In common code (did.c), fix di_smbios_find_slot_by_bdf() to match the SMBIOS Type 9 segment group field (smbl_sg) in addition to bus+devfn.  On multi-segment aarch64 platforms such as the Ampere Altra Max (8 PCIe root complexes, bus numbers repeat across segments), matching by bus+devfn alone produces wrong slot assignments.  A new helper di_pci_segment_get() walks up the devinfo tree looking for the linux,pci-domain property to determine the PCI segment group.  All changes in common code are preprocessor-guarded for __aarch64__.

Packaging updated to deliver hostbridge.so and pcibus.so.

Results [look sensible](https://gist.github.com/r1mikey/8aba0fac20feb4b5fe0a09cc2e75c432) on Altra Max.