### PR TITLE
PCIe Operating System Capabilities negotiation abstraction for aarch64

### DIFF
--- a/usr/src/uts/aarch64/sys/pcie_aarch64.h
+++ b/usr/src/uts/aarch64/sys/pcie_aarch64.h
@@ -1,0 +1,35 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2026 Michael van der Westhuizen
+ */
+
+#ifndef _SYS_PCIE_AARCH64_H
+#define	_SYS_PCIE_AARCH64_H
+
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct pcie_aarch64_priv {
+	boolean_t	bus_osc;	/* Has _OSC been called */
+	boolean_t	bus_osc_hp;	/* Was native HP granted */
+	boolean_t	bus_osc_aer;	/* Was AER granted */
+} pcie_aarch64_priv_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _SYS_PCIE_AARCH64_H */

--- a/usr/src/uts/aarch64/sys/pcie_osc.h
+++ b/usr/src/uts/aarch64/sys/pcie_osc.h
@@ -1,0 +1,90 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2026 Michael van der Westhuizen
+ */
+
+#ifndef _SYS_PCIE_OSC_H
+#define	_SYS_PCIE_OSC_H
+
+/*
+ * PCI Host Bridge _OSC (Operating System Capabilities) definitions
+ * from PCI Firmware Specification 3.3, Section 4.5.1.
+ *
+ * These constants define the bit fields in the _OSC Capabilities
+ * Buffer for PCI/PCI-X/PCI Express hierarchies.  They are independent
+ * of the ACPI transport used to evaluate _OSC.
+ */
+
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Revision */
+#define	PCIE_OSC_REVISION_ID	1
+
+/* DWORD 1: Status (returned by firmware) */
+#define	PCIE_OSC_STS_QUERY	0x01	/* Query Support Flag */
+#define	PCIE_OSC_STS_FAILED	0x02	/* _OSC failure */
+#define	PCIE_OSC_STS_INV_UUID	0x04	/* Unrecognised UUID */
+#define	PCIE_OSC_STS_INV_REV	0x08	/* Unrecognised revision */
+#define	PCIE_OSC_STS_MASKED	0x10	/* Capabilities masked */
+
+#define	PCIE_OSC_STS_ERRORS \
+	(PCIE_OSC_STS_FAILED | PCIE_OSC_STS_INV_UUID | PCIE_OSC_STS_INV_REV)
+
+/* DWORD 2: Support Field (OS -> firmware) */
+#define	PCIE_OSC_SUP_EXT_CFG	0x01	/* Extended PCI Config Ops */
+#define	PCIE_OSC_SUP_ACT_PM	0x02	/* Active State PM */
+#define	PCIE_OSC_SUP_CLK_PM	0x04	/* Clock PM Capability */
+#define	PCIE_OSC_SUP_SEGS	0x08	/* PCI Segment Groups */
+#define	PCIE_OSC_SUP_MSI	0x10	/* MSI */
+#define	PCIE_OSC_SUP_OBFF	0x20	/* OBFF (PCI FW 3.2+) */
+#define	PCIE_OSC_SUP_ASPM_OPT	0x40	/* ASPM Optionality */
+#define	PCIE_OSC_SUP_EDR	0x80	/* Error Disconnect Recover */
+#define	PCIE_OSC_SUP_HPX_T3	0x100	/* _HPX Type 3 */
+
+/* DWORD 3: Control Field (OS <-> firmware) */
+#define	PCIE_OSC_CTL_NAT_HP	0x01	/* Native Hot Plug */
+#define	PCIE_OSC_CTL_SHPC_HP	0x02	/* SHPC Native Hot Plug */
+#define	PCIE_OSC_CTL_NAT_PM	0x04	/* Native Power Mgmt */
+#define	PCIE_OSC_CTL_AER	0x08	/* Adv Error Reporting */
+#define	PCIE_OSC_CTL_CAPS	0x10	/* PCIe Cap Structure */
+#define	PCIE_OSC_CTL_LTR	0x20	/* Latency Tolerance Reporting */
+#define	PCIE_OSC_CTL_SHR	0x40	/* Invalid data / Surprise Hot Remove */
+#define	PCIE_OSC_CTL_DPC	0x80	/* Downstream Port Containment */
+#define	PCIE_OSC_CTL_CTO	0x100	/* Completion Timeout Control */
+#define	PCIE_OSC_CTL_SFI	0x200	/* SFI Configuration Control */
+
+/*
+ * What we declare as supported.
+ */
+#define	PCIE_OSC_SUPPORT_INIT \
+	(PCIE_OSC_SUP_EXT_CFG | PCIE_OSC_SUP_ACT_PM | \
+	PCIE_OSC_SUP_CLK_PM | PCIE_OSC_SUP_MSI | PCIE_OSC_SUP_SEGS)
+
+/*
+ * Base control request (Caps only).
+ * AER and Hotplug bits added conditionally by the caller.
+ */
+#define	PCIE_OSC_CONTROL_INIT	(PCIE_OSC_CTL_CAPS)
+
+extern int pcie_osc(dev_info_t *dip, uint32_t support,
+    uint32_t ctrl_req, uint32_t *ctrl_ret);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _SYS_PCIE_OSC_H */

--- a/usr/src/uts/armv8/Makefile.files
+++ b/usr/src/uts/armv8/Makefile.files
@@ -202,6 +202,7 @@ ASSYM_DEPS +=			\
 PCI_PRD_OBJS += pci_prd_armv8.o pci_memlist.o
 
 PCIE_MISC_OBJS += pcie_armv8.o
+PCIE_MISC_OBJS += pcie_osc.o
 
 PCIEB_OBJS += pcieb_armv8.o
 

--- a/usr/src/uts/armv8/io/pciex/pcie_armv8.c
+++ b/usr/src/uts/armv8/io/pciex/pcie_armv8.c
@@ -11,21 +11,32 @@
 
 /*
  * Copyright 2024 Richard Lowe
+ * Copyright 2026 Michael van der Westhuizen
  */
 
+#include <sys/types.h>
 #include <sys/ddi.h>
+#include <sys/kmem.h>
 #include <sys/sunddi.h>
+#include <sys/sunndi.h>
+#include <sys/pcie_impl.h>
+#include <sys/pcie_aarch64.h>
 
 #include <sys/plat/pci_prd.h>
 
 void
 pcie_init_plat(dev_info_t *dip)
 {
+	pcie_bus_t	*bus_p = PCIE_DIP2BUS(dip);
+	bus_p->bus_plat_private =
+	    kmem_zalloc(sizeof (pcie_aarch64_priv_t), KM_SLEEP);
 }
 
 void
 pcie_fini_plat(dev_info_t *dip)
 {
+	pcie_bus_t	*bus_p = PCIE_DIP2BUS(dip);
+	kmem_free(bus_p->bus_plat_private, sizeof (pcie_aarch64_priv_t));
 }
 
 int

--- a/usr/src/uts/armv8/io/pciex/pcie_osc.c
+++ b/usr/src/uts/armv8/io/pciex/pcie_osc.c
@@ -1,0 +1,43 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2026 Michael van der Westhuizen
+ */
+
+/*
+ * PCIe _OSC dispatch for aarch64.
+ *
+ * On platforms that implement the weak plat_pcie_osc symbol (ACPI), operating
+ * system capabilities are negotiated with the firmware.
+ *
+ * On platforms that do not implement the weak plat_pcie_osc symbol (FDT), all
+ * requested capabilities are automatically granted.
+ */
+
+#include <sys/types.h>
+#include <sys/ddi.h>
+#include <sys/sunddi.h>
+#include <sys/pcie_osc.h>
+#include <sys/platmod.h>
+
+int
+pcie_osc(dev_info_t *dip, uint32_t support,
+    uint32_t ctrl_req, uint32_t *ctrl_ret)
+{
+	if (&plat_pcie_osc != NULL) {
+		return (plat_pcie_osc(dip, support, ctrl_req, ctrl_ret));
+	}
+
+	/* no firmware to negotiate with */
+	*ctrl_ret = ctrl_req;
+	return (DDI_SUCCESS);
+}

--- a/usr/src/uts/armv8/io/pciex/pcieb_armv8.c
+++ b/usr/src/uts/armv8/io/pciex/pcieb_armv8.c
@@ -23,6 +23,7 @@
  * Use is subject to license terms.
  *
  * Copyright 2019 Joyent, Inc.
+ * Copyright 2026 Michael van der Westhuizen
  */
 
 /* armv8 specific code used by the pcieb driver */
@@ -36,6 +37,8 @@
 #include <sys/pcie.h>
 #include <sys/pci_cap.h>
 #include <sys/pcie_impl.h>
+#include <sys/pcie_osc.h>
+#include <sys/pcie_aarch64.h>
 #include <sys/hotplug/hpctrl.h>
 #include <io/pciex/pcieb.h>
 #include <sys/obpdefs.h>
@@ -67,8 +70,9 @@ pcieb_plat_peekpoke(dev_info_t *dip, dev_info_t *rdip, ddi_ctl_enum_t ctlop,
 	pcieb_devstate_t *pcieb = ddi_get_soft_state(pcieb_state,
 	    ddi_get_instance(dip));
 
-	if (!PCIE_IS_RP(PCIE_DIP2BUS(dip)))
+	if (!PCIE_IS_RP(PCIE_DIP2BUS(dip))) {
 		return (ddi_ctlops(dip, rdip, ctlop, arg, result));
+	}
 
 	return (pci_peekpoke_check(dip, rdip, ctlop, arg, result,
 	    ddi_ctlops, &pcieb->pcieb_err_mutex,
@@ -77,7 +81,7 @@ pcieb_plat_peekpoke(dev_info_t *dip, dev_info_t *rdip, ddi_ctl_enum_t ctlop,
 }
 
 void
-pcieb_plat_attach_workaround(dev_info_t *dip)
+pcieb_plat_attach_workaround(dev_info_t *dip __unused)
 {
 }
 
@@ -88,24 +92,82 @@ pcieb_plat_intr_ops(dev_info_t *dip, dev_info_t *rdip, ddi_intr_op_t intr_op,
 	return (i_ddi_intr_ops(dip, rdip, intr_op, hdlp, result));
 }
 
-/*ARGSUSED*/
 boolean_t
-pcieb_plat_pwr_disable(dev_info_t *dip)
+pcieb_plat_pwr_disable(dev_info_t *dip __unused)
 {
 	/* Always disable on armv8 */
 	return (B_TRUE);
 }
 
 boolean_t
-pcieb_plat_msi_supported(dev_info_t *dip)
+pcieb_plat_msi_supported(dev_info_t *dip __unused)
 {
 	return (B_TRUE);
+}
+
+/*
+ * Check whether _OSC has been called for this device.
+ * Used to avoid duplicate calls when hotplug init has
+ * already evaluated _OSC.
+ */
+static boolean_t
+pcieb_is_osc(dev_info_t *dip)
+{
+	pcie_bus_t		*bus_p = PCIE_DIP2BUS(dip);
+	pcie_aarch64_priv_t	*osc_p;
+
+	if (bus_p == NULL || bus_p->bus_plat_private == NULL) {
+		return (B_FALSE);
+	}
+
+	osc_p = (pcie_aarch64_priv_t *)bus_p->bus_plat_private;
+	return (osc_p->bus_osc);
+}
+
+static void
+pcieb_init_osc(dev_info_t *devi)
+{
+	pcie_bus_t		*bus_p = PCIE_DIP2UPBUS(devi);
+	pcie_aarch64_priv_t	*osc_p;
+	uint32_t		support = PCIE_OSC_SUPPORT_INIT;
+	uint32_t		ctrl_req = PCIE_OSC_CONTROL_INIT;
+	uint32_t		ctrl_ret = 0;
+
+	if (!PCIE_IS_RP(bus_p)) {
+		return;
+	}
+
+	if (PCIE_HAS_AER(bus_p)) {
+		ctrl_req |= PCIE_OSC_CTL_AER;
+	}
+
+	osc_p = (pcie_aarch64_priv_t *)bus_p->bus_plat_private;
+	if (osc_p == NULL) {
+		return;
+	}
+
+	/* Mark that _OSC has been attempted for this device */
+	osc_p->bus_osc = B_TRUE;
+
+	/*
+	 * TODO: add PCIE_OSC_CTL_NAT_HP | PCIE_OSC_CTL_NAT_PM
+	 * when native PCIe hotplug is implemented.
+	 */
+
+	if (pcie_osc(devi, support, ctrl_req, &ctrl_ret) == DDI_SUCCESS) {
+		osc_p->bus_osc_hp =
+		    (ctrl_ret & PCIE_OSC_CTL_NAT_HP) ? B_TRUE : B_FALSE;
+		osc_p->bus_osc_aer =
+		    (ctrl_ret & PCIE_OSC_CTL_AER) ? B_TRUE : B_FALSE;
+	}
 }
 
 void
 pcieb_plat_intr_attach(pcieb_devstate_t *pcieb)
 {
-
+	if (!pcieb_is_osc(pcieb->pcieb_dip)) {
+		pcieb_init_osc(pcieb->pcieb_dip);
+	}
 }
 
 void
@@ -119,8 +181,9 @@ pcieb_plat_initchild(dev_info_t *child)
 		pdptr->par_intr = (struct intrspec *)(pdptr + 1);
 		pdptr->par_nintr = 1;
 		ddi_set_parent_data(child, pdptr);
-	} else
+	} else {
 		ddi_set_parent_data(child, NULL);
+	}
 }
 
 void
@@ -128,8 +191,9 @@ pcieb_plat_uninitchild(dev_info_t *child)
 {
 	struct ddi_parent_private_data	*pdptr;
 
-	if ((pdptr = ddi_get_parent_data(child)) != NULL)
+	if ((pdptr = ddi_get_parent_data(child)) != NULL) {
 		kmem_free(pdptr, (sizeof (*pdptr) + sizeof (struct intrspec)));
+	}
 
 	ddi_set_parent_data(child, NULL);
 }
@@ -146,8 +210,9 @@ pcieb_plat_ctlops(dev_info_t *rdip, ddi_ctl_enum_t ctlop, void *arg)
 		switch (ds->when) {
 		case DDI_POST:
 			if (ds->cmd == DDI_SUSPEND) {
-				if (pci_post_suspend(rdip) != DDI_SUCCESS)
+				if (pci_post_suspend(rdip) != DDI_SUCCESS) {
 					return (DDI_FAILURE);
+				}
 			}
 			break;
 		default:
@@ -159,8 +224,9 @@ pcieb_plat_ctlops(dev_info_t *rdip, ddi_ctl_enum_t ctlop, void *arg)
 		switch (as->when) {
 		case DDI_PRE:
 			if (as->cmd == DDI_RESUME) {
-				if (pci_pre_resume(rdip) != DDI_SUCCESS)
+				if (pci_pre_resume(rdip) != DDI_SUCCESS) {
 					return (DDI_FAILURE);
+				}
 			}
 			break;
 		case DDI_POST:

--- a/usr/src/uts/armv8/sys/platmod.h
+++ b/usr/src/uts/armv8/sys/platmod.h
@@ -55,6 +55,8 @@ struct prom_hwclock;
 #pragma weak	plat_gpio_set
 #pragma weak	plat_clk_get_rate
 #pragma weak	plat_clk_get_rate_by_name
+#pragma weak	plat_pcie_osc_set
+#pragma weak	plat_pcie_osc
 
 /*
  * Called in mp_startup.c from init_cpu_info (twice).
@@ -72,6 +74,28 @@ extern int plat_gpio_set(struct gpio_ctrl *, int);
 
 extern int plat_clk_get_rate(dev_info_t *, uint_t);
 extern int plat_clk_get_rate_by_name(dev_info_t *, const char *);
+
+/*
+ * PCIe _OSC negotiation.
+ *
+ * plat_pcie_osc: Evaluate PCIe Host Bridge _OSC for a given bridge.
+ *   dip:         bridge dev_info_t
+ *   support:     Support Field bits to declare (DWORD 2)
+ *   ctrl_req:    Control Field bits to request (DWORD 3)
+ *   ctrl_ret:    on success, granted Control Field bits
+ *
+ *   Returns DDI_SUCCESS/DDI_FAILURE.
+ *
+ * plat_pcie_osc_set: Called by ACPI layer to register the _OSC
+ *   evaluator.  When the weak symbol is absent (DT platforms),
+ *   pcie_osc.c falls through to grant all requested bits.
+ */
+typedef int (*plat_pcie_osc_func_t)(dev_info_t *dip,
+    uint32_t support, uint32_t ctrl_req, uint32_t *ctrl_ret);
+
+extern void plat_pcie_osc_set(plat_pcie_osc_func_t);
+extern int plat_pcie_osc(dev_info_t *dip,
+    uint32_t support, uint32_t ctrl_req, uint32_t *ctrl_ret);
 
 #endif	/* _KERNEL */
 


### PR DESCRIPTION
Introduce `_OSC` capability negotiation for aarch64.

`_OSC` is an ACPI concept, where PCIe root complexes and the platform itself execute AML to coordinate handover of functionality from ACPI based on what the platform supports. In the FDT tree this is a no-op, while in the ACPI tree this is necessary for, for example, native PCIe hotplug and AER.

Abstract this firmware coupling behind platmod, leaving FDT platforms with no implementation of the weak symbols. Wrap the interface up so that it's more naturally callable, in a similar way to how i86pc does it. The wrapper simply grants any requested capabilities, since there is no firmware fallback on FDT systems.

ACPI `_OSC` support is fleshed out much later in `acpidev_osc.c`, which plugs into the platmod interface introduced here.

The PCIe capabilities defines come from PCI Firmware Specification 3.3, and are not ACPI-specific, so those are introduced here and basic hookup of `_OSC` negotiation is done using these defines.

The various layers here compose as follows (including the ACPI pieces that come later):
```
pcieb_armv8.c::pcieb_plat_intr_attach
  -> pcieb_is_osc (check bus_osc flag)
  -> pcieb_init_osc
     -> pcie_osc (dispatch in pcie_osc.c)
        -> [FDT] grant all
        -> [ACPI] plat_pcie_osc (platmod weak symbol)
           -> sbbr.c::plat_pcie_osc (call through stored fn pointer)
              -> acpidev_osc.c::acpidev_pcie_osc (query-then-commit ACPI eval)
```

## Key design difference from i86pc
On i86pc, the ACPI handle lookup, _OSC evaluation, and bus_osc flag management are all in a single function (`pcie_acpi_osc` in `pcie_acpi.c`). Both `pcieb` and `pciehpc` call this directly.

On aarch64, these are split across layers:
* `pcie_osc()` is a thin dispatch (no state, no ACPI)
* The caller (`pcieb_init_osc`) manages `bus_osc`
* The ACPI evaluator (`acpidev_osc.c`) handles query-then-commit (i86pc only does commit)

The platmod indirection means FDT platforms work with no ACPI linkage. No hotplug hookup is done yet - that will come after ACPI is landed.