### PR TITLE
CPU Low Power Idle framework and preparation

### DIFF
--- a/usr/src/pkg/manifests/system-kernel-platform.aarch64.inc
+++ b/usr/src/pkg/manifests/system-kernel-platform.aarch64.inc
@@ -55,6 +55,7 @@ file path=platform/armv8/kernel/drv/$(ARCH)/simple-bus
 file path=platform/armv8/kernel/drv/ns16550a.conf
 dir  path=platform/armv8/kernel/misc
 dir  path=platform/armv8/kernel/misc/$(ARCH)
+file path=platform/armv8/kernel/misc/$(ARCH)/cpuidle group=sys mode=0755
 file path=platform/armv8/kernel/misc/$(ARCH)/ffa group=sys mode=0755
 file path=platform/armv8/kernel/misc/$(ARCH)/gfx_private group=sys mode=0755
 file path=platform/armv8/kernel/misc/$(ARCH)/pci_prd group=sys mode=0755

--- a/usr/src/uts/aarch64/sys/cpu.h
+++ b/usr/src/uts/aarch64/sys/cpu.h
@@ -20,6 +20,7 @@
  */
 /*
  * Copyright 2017 Hayashi Naoyuki
+ * Copyright 2026 Michael van der Westhuizen
  */
 
 #ifndef	_SYS_CPU_H
@@ -35,6 +36,43 @@ extern "C" {
 
 #define	SMT_PAUSE()	\
     __asm__ __volatile__("isb":::"memory")
+
+/*
+ * Idle state for the cpu_idle_enter/cpu_idle_exit callback framework.
+ *
+ * IDLE_STATE_NORMAL indicates the CPU is not in an idle state.
+ *
+ * On aarch64, the state value encodes both the firmware-specific
+ * index (1-based) in bits [31:20] and context loss flags in bits [19:0].
+ *
+ * This arrangement provides tracing consumers visibility into which low power
+ * idle state was entered and what context will be lost.  Since
+ * IDLE_STATE_NORMAL is 0, it indicates that there is no context loss.
+ */
+#define	IDLE_STATE_NORMAL	0
+
+#define	LPI_STATE_IDX_SHIFT	20
+#define	LPI_STATE_IDX_MASK	0xFFF00000U
+#define	LPI_STATE_CTX_MASK	0x000FFFFFU
+
+/* Compose a state value from a 1-based LPI index and context loss flags */
+#define	LPI_IDLE_STATE(idx, flags)	\
+	(((uint_t)(idx) << LPI_STATE_IDX_SHIFT) | \
+	((uint_t)(flags) & LPI_STATE_CTX_MASK))
+
+/* Extract components from a state value */
+#define	LPI_STATE_IDX(state)	\
+	(((uint_t)(state) >> LPI_STATE_IDX_SHIFT) & 0xFFFU)
+#define	LPI_STATE_CTX(state)	\
+	((uint_t)(state) & LPI_STATE_CTX_MASK)
+
+/*
+ * LPI context loss flags (bits [19:0] of the idle state value).
+ */
+#define	LPI_CTX_LOSS_TIMER	(1U << 0)	/* Timer context lost */
+#define	LPI_CTX_LOSS_GICR	(1U << 1)	/* GIC Redistributor lost */
+#define	LPI_CTX_LOSS_GICD	(1U << 2)	/* GIC Distributor lost */
+#define	LPI_CTX_LOSS_CPU	(1U << 3)	/* CPU register state lost */
 
 #endif
 

--- a/usr/src/uts/armv8/Makefile.armv8
+++ b/usr/src/uts/armv8/Makefile.armv8
@@ -241,6 +241,7 @@ DACF_KMODS += consconfig_dacf
 #	'Misc' Modules (/kernel/misc):
 #
 MISC_KMODS += bootdev
+MISC_KMODS += cpuidle
 MISC_KMODS += ffa
 MISC_KMODS += gfx_private
 MISC_KMODS += pci_prd

--- a/usr/src/uts/armv8/Makefile.files
+++ b/usr/src/uts/armv8/Makefile.files
@@ -188,6 +188,8 @@ EFIFB_OBJS		+= efifb.o
 
 BOOTDEV_OBJS		+= bootdev.o
 
+CPUIDLE_OBJS +=	cpuidle.o
+
 ASSYM_DEPS +=			\
 	aarch64_subr.o		\
 	copy.o			\

--- a/usr/src/uts/armv8/cpuidle/Makefile
+++ b/usr/src/uts/armv8/cpuidle/Makefile
@@ -1,0 +1,62 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source.  A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+#
+
+#
+# Copyright 2026 Michael van der Westhuizen
+#
+
+#
+#	Path to the base of the uts directory tree (usually /usr/src/uts).
+#
+UTSBASE	= ../..
+
+#
+#	Define the module and object file sets.
+#
+MODULE		= cpuidle
+OBJECTS		= $(CPUIDLE_OBJS:%=$(OBJS_DIR)/%)
+ROOTMODULE	= $(ROOT_PSM_MISC_DIR)/$(MODULE)
+
+#
+#	Include common rules.
+#
+include $(UTSBASE)/armv8/Makefile.armv8
+
+#
+#       Define targets
+#
+ALL_TARGET	= $(BINARY)
+INSTALL_TARGET	= $(BINARY) $(ROOTMODULE)
+
+#
+# No external module dependencies.  Firmware-specific drivers
+# depend on this module, not the other way around.
+#
+
+#
+#	Default build targets.
+#
+.KEEP_STATE:
+
+all:		$(ALL_DEPS)
+
+def:		$(DEF_DEPS)
+
+clean:		$(CLEAN_DEPS)
+
+clobber:	$(CLOBBER_DEPS)
+
+install:	$(INSTALL_DEPS)
+
+#
+#	Include common targets.
+#
+include $(UTSBASE)/armv8/Makefile.targ

--- a/usr/src/uts/armv8/io/cpuidle.c
+++ b/usr/src/uts/armv8/io/cpuidle.c
@@ -1,0 +1,493 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2026 Michael van der Westhuizen
+ */
+
+/*
+ * CPU idle framework for aarch64.
+ *
+ * This misc module provides a cpu_halt loop body (cpu_lpi_halt) and a
+ * registration interface for firmware-specific idle state drivers.  On _init
+ * it replaces the default CPU halt implementation with the cpu_lpi_halt
+ * function pointer.  cpu_halt's outer loop handles the illumos-level heavy
+ * lifting (haltset, disp_nrunnable and spurious-wakeup logic), this body
+ * function handles "how should I halt?": state selection, idle callbacks,
+ * and the actual WFI or PSCI CPU_SUSPEND.
+ *
+ * Per-CPU idle states are populated by firmware-specific drivers:
+ * - cpudrv (devicetree): parses idle-states on DT cpu nodes
+ * - cpudrv (ACPI): parses _LPI on ACPI0007 processor devices
+ * Both call cpuidle_register_states() to hand their parsed state arrays
+ * to this framework.
+ *
+ * At present we only support states with no architectural context loss.  In
+ * future we will need to add resume trampolines and GIC/timer save-restore for
+ * powerdown states.
+ *
+ * State selection is backward-looking (like i86pc): the duration of the
+ * previous idle period is used to predict the next, and the deepest eligible
+ * state whose minimum residency requirement is met is chosen.
+ */
+
+#include <sys/types.h>
+#include <sys/param.h>
+#include <sys/modctl.h>
+#include <sys/cpu.h>
+#include <sys/cpuvar.h>
+#include <sys/machcpuvar.h>
+#include <sys/machsystm.h>
+#include <sys/cpuidle.h>
+#include <sys/cpuinfo.h>
+#include <sys/cpu_event.h>
+#include <sys/disp.h>
+#include <sys/archsystm.h>
+#include <sys/psci.h>
+#include <sys/cmn_err.h>
+#include <sys/kmem.h>
+#include <sys/sunddi.h>
+#include <sys/systm.h>
+#include <sys/kstat.h>
+#include <util/qsort.h>
+
+/* Per-CPU idle duration tracking, indexed by cpu_id */
+static hrtime_t *lpi_last_idle;
+
+/*
+ * Per-CPU array of kstat pointers, one per idle state.
+ *
+ * Indexed as lpi_kstats[cpu_id][state_idx].
+ */
+static kstat_t ***lpi_kstats;
+
+/*
+ * kstat data template for a single idle state.
+ */
+typedef struct cpuidle_kstat {
+	kstat_named_t	cik_type;		/* "WFI" or "PSCI" */
+	kstat_named_t	cik_min_residency;	/* us */
+	kstat_named_t	cik_wake_latency;	/* us */
+	kstat_named_t	cik_ctx_loss;		/* LPI_CTX_LOSS_* flags */
+	kstat_named_t	cik_entries;		/* times entered */
+	kstat_named_t	cik_residency_ns;	/* total ns in this state */
+} cpuidle_kstat_t;
+
+static int
+cpuidle_kstat_update(kstat_t *ksp, int rw)
+{
+	cpuidle_kstat_t *kd = ksp->ks_data;
+	lpi_state_t *ls = ksp->ks_private;
+
+	if (rw == KSTAT_WRITE) {
+		return (EACCES);
+	}
+
+	kstat_named_setstr(&kd->cik_type,
+	    ls->ls_entry_type == LPI_ENTRY_WFI ? "WFI" : "PSCI");
+	kd->cik_min_residency.value.ui32 = ls->ls_min_residency;
+	kd->cik_wake_latency.value.ui32 = ls->ls_wake_latency;
+	kd->cik_ctx_loss.value.ui32 = ls->ls_ctx_loss_flags;
+	kd->cik_entries.value.ui64 = ls->ls_entries;
+	kd->cik_residency_ns.value.ui64 = ls->ls_residency_ns;
+
+	return (0);
+}
+
+static void
+cpuidle_kstat_create(processorid_t cpuid, lpi_state_t *states, int nstates)
+{
+	int i;
+	char name[KSTAT_STRLEN];
+	cpuidle_kstat_t *kd;
+	kstat_t *ksp;
+
+	ASSERT3P(cpu[cpuid], !=, NULL);
+
+	lpi_kstats[cpuid] = kmem_zalloc(nstates * sizeof (kstat_t *),
+	    KM_SLEEP);
+
+	for (i = 0; i < nstates; i++) {
+		(void) snprintf(name, sizeof (name), "state%d", i);
+
+		kd = kmem_zalloc(sizeof (cpuidle_kstat_t), KM_SLEEP);
+		kstat_named_init(&kd->cik_type, "type",
+		    KSTAT_DATA_STRING);
+		kstat_named_init(&kd->cik_min_residency, "min_residency_us",
+		    KSTAT_DATA_UINT32);
+		kstat_named_init(&kd->cik_wake_latency, "wake_latency_us",
+		    KSTAT_DATA_UINT32);
+		kstat_named_init(&kd->cik_ctx_loss, "ctx_loss_flags",
+		    KSTAT_DATA_UINT32);
+		kstat_named_init(&kd->cik_entries, "entries",
+		    KSTAT_DATA_UINT64);
+		kstat_named_init(&kd->cik_residency_ns, "residency_ns",
+		    KSTAT_DATA_UINT64);
+
+		ksp = kstat_create("cpuidle", cpuid, name, "misc",
+		    KSTAT_TYPE_NAMED,
+		    sizeof (cpuidle_kstat_t) / sizeof (kstat_named_t),
+		    KSTAT_FLAG_VIRTUAL);
+
+		if (ksp != NULL) {
+			ksp->ks_data = kd;
+			ksp->ks_private = &states[i];
+			ksp->ks_update = cpuidle_kstat_update;
+			ksp->ks_data_size += MAXNAMELEN;
+			kstat_install(ksp);
+			lpi_kstats[cpuid][i] = ksp;
+		} else {
+			kmem_free(kd, sizeof (cpuidle_kstat_t));
+			cmn_err(CE_NOTE,
+			    "!cpu%d: failed to create kstat %s", cpuid, name);
+		}
+	}
+}
+
+/*
+ * State selection
+ */
+
+/*
+ * Select the deepest eligible idle state for the current idle period.
+ *
+ * Walk from deepest to shallowest.  Skip states with context loss (for now)
+ * or whose total commitment time (min_residency + wake_latency) exceeds the
+ * predicted idle duration.  The commitment time is the minimum idle period
+ * needed to enter the state, remain for the minimum useful residency, and
+ * exit again.  For DT, wake_latency defaults to entry + exit latency, so
+ * the threshold is entry + min_residency + exit.
+ *
+ * Always returns a valid index: index 0 (WFI) is the fallback.
+ */
+static int
+lpi_select_state(lpi_state_t *states, int nstates, hrtime_t last_idle_ns)
+{
+	int i;
+	hrtime_t threshold_ns;
+
+	for (i = nstates - 1; i > 0; i--) {
+		if (states[i].ls_ctx_loss_flags != 0) {
+			continue;
+		}
+
+		if (!states[i].ls_enabled) {
+			continue;
+		}
+
+		threshold_ns =
+		    ((hrtime_t)states[i].ls_min_residency +
+		    (hrtime_t)states[i].ls_wake_latency) *
+		    NANOSEC / MICROSEC;
+
+		if (last_idle_ns >= threshold_ns) {
+			return (i);
+		}
+	}
+
+	return (0);
+}
+
+/*
+ * Loop body function
+ */
+
+/*
+ * LPI-aware cpu_halt loop body.
+ *
+ * Called from inside cpu_halt()'s inner loop with interrupts disabled.  Selects
+ * an idle state, enters cpu_idle callbacks, executes WFI or PSCI CPU_SUSPEND,
+ * runs the exit callbacks, and returns.  cpu_halt handles interrupt unmasking
+ * and loop re-evaluation.
+ *
+ * For CPUs whose idle states have not been populated (or that lack firmware
+ * data entirely), falls back to a plain WFI.
+ */
+static void
+cpu_lpi_halt(void)
+{
+	cpu_t *cpup = CPU;
+	processorid_t cpuid = cpup->cpu_id;
+	lpi_state_t *states;
+	int nstates;
+	int state_idx;
+	int state;
+	hrtime_t enter_ts;
+	hrtime_t exit_ts;
+
+	states = cpup->cpu_m.mcpu_lpi_states;
+	nstates = cpup->cpu_m.mcpu_lpi_nstates;
+
+	if (states == NULL || nstates == 0) {
+		/* no idle states; plain WFI through the normal callback path */
+		state = LPI_IDLE_STATE(1, 0);
+
+		if (cpu_idle_enter(state, 0, NULL, NULL) != 0) {
+			return;
+		}
+
+		enter_ts = gethrtime_unscaled();
+		__asm__ __volatile__("wfi" ::: "memory");
+		cpu_idle_exit(CPU_IDLE_CB_FLAG_IDLE);
+		exit_ts = gethrtime_unscaled();
+		lpi_last_idle[cpuid] = exit_ts - enter_ts;
+		return;
+	}
+
+	/* Select idle state based on previous idle duration */
+	state_idx = lpi_select_state(states, nstates,
+	    lpi_last_idle[cpuid]);
+	state = LPI_IDLE_STATE(state_idx + 1,
+	    states[state_idx].ls_ctx_loss_flags);
+
+	if (cpu_idle_enter(state, 0, NULL, NULL) != 0) {
+		return;
+	}
+
+	enter_ts = gethrtime_unscaled();
+
+	if (states[state_idx].ls_entry_type == LPI_ENTRY_WFI) {
+		__asm__ __volatile__("wfi" ::: "memory");
+	} else {
+		ASSERT3U(states[state_idx].ls_entry_type, ==,
+		    LPI_ENTRY_PSCI);
+		(void) psci_cpu_suspend(
+		    states[state_idx].ls_psci_state, 0, 0);
+	}
+
+	/*
+	 * Woken by interrupt or spuriously.  Interrupts are still disabled.
+	 * Run the idle exit callbacks from the idle thread.  If a pending
+	 * interrupt later fires and its handler calls cpu_idle_exit(INTR),
+	 * the index will already be zero and that call is a no-op.
+	 */
+	cpu_idle_exit(CPU_IDLE_CB_FLAG_IDLE);
+
+	exit_ts = gethrtime_unscaled();
+	lpi_last_idle[cpuid] = exit_ts - enter_ts;
+	states[state_idx].ls_entries++;
+	states[state_idx].ls_residency_ns += (exit_ts - enter_ts);
+}
+
+/*
+ * cpuidle_register_states
+ */
+
+/*
+ * Populate a synthetic WFI idle state.
+ *
+ * WFI is the implicit default on all aarch64 CPUs.  When firmware does
+ * not supply it (unfortunately, common), the cpuidle framework synthesises
+ * it so there is always a fallback.
+ */
+static void
+cpuidle_synth_wfi(lpi_state_t *lsp)
+{
+	ASSERT3P(lsp, !=, NULL);
+
+	lsp->ls_min_residency = 1;
+	lsp->ls_wake_latency = 1;
+	lsp->ls_ctx_loss_flags = 0;
+	lsp->ls_psci_state = 0;
+	lsp->ls_entry_type = LPI_ENTRY_WFI;
+	lsp->ls_enabled = B_TRUE;
+}
+
+/*
+ * Return B_TRUE if the states array already contains a WFI entry.
+ */
+static boolean_t
+cpuidle_has_wfi(lpi_state_t *states, int nstates)
+{
+	int i;
+
+	for (i = 0; i < nstates; i++) {
+		if (states[i].ls_entry_type == LPI_ENTRY_WFI) {
+			return (B_TRUE);
+		}
+	}
+
+	return (B_FALSE);
+}
+
+/*
+ * Comparison function for sorting idle states by min_residency ascending.
+ *
+ * This gives the state selector a stable invariant: index 0 is the
+ * shallowest state (highly likely to be WFI, residency 1us) and the highest
+ * index is the deepest.  lpi_select_state() walks from deepest to shallowest,
+ * so this ordering is required for correct state selection.
+ */
+static int
+cpuidle_state_cmp(const void *a, const void *b)
+{
+	const lpi_state_t *sa = a;
+	const lpi_state_t *sb = b;
+
+	if (sa->ls_min_residency < sb->ls_min_residency) {
+		return (-1);
+	}
+
+	if (sa->ls_min_residency > sb->ls_min_residency) {
+		return (1);
+	}
+
+	/* tiebreak: prefer lower wake latency */
+	if (sa->ls_wake_latency < sb->ls_wake_latency) {
+		return (-1);
+	}
+
+	if (sa->ls_wake_latency > sb->ls_wake_latency) {
+		return (1);
+	}
+
+	return (0);
+}
+
+/*
+ * Ensure the states array contains a WFI entry and is sorted by
+ * min_residency ascending (shallowest first, deepest last).
+ *
+ * If the caller's array does not contain a WFI entry, one is added
+ * by growing the array.  The array is then sorted so that
+ * lpi_select_state() can walk from deepest to shallowest.  The sort
+ * is necessary, as there is no guarantee that firmware contains
+ * sorted entries.
+ *
+ * If the caller supplied NULL/0 (no firmware states), a single-element
+ * WFI-only array is created.
+ *
+ * On return *statesp and *nstatesp reflect the (possibly new) array.
+ */
+static void
+cpuidle_ensure_wfi(lpi_state_t **statesp, int *nstatesp)
+{
+	lpi_state_t *states;
+	lpi_state_t *grown;
+	int nstates;
+
+	ASSERT3P(statesp, !=, NULL);
+	ASSERT3P(nstatesp, !=, NULL);
+
+	states = *statesp;
+	nstates = *nstatesp;
+
+	if (states == NULL || nstates == 0) {
+		/* No firmware states - create a WFI-only array */
+		states = kmem_zalloc(sizeof (lpi_state_t), KM_SLEEP);
+		cpuidle_synth_wfi(&states[0]);
+		*statesp = states;
+		*nstatesp = 1;
+		return;
+	}
+
+	if (!cpuidle_has_wfi(states, nstates)) {
+		/* Grow the array by one and append WFI */
+		grown = kmem_zalloc((nstates + 1) * sizeof (lpi_state_t),
+		    KM_SLEEP);
+		memcpy(grown, states, nstates * sizeof (lpi_state_t));
+		kmem_free(states, nstates * sizeof (lpi_state_t));
+
+		cpuidle_synth_wfi(&grown[nstates]);
+		nstates++;
+
+		states = grown;
+	}
+
+	/* Sort shallowest-first so the state selector can rely on order */
+	qsort(states, nstates, sizeof (lpi_state_t), cpuidle_state_cmp);
+
+	*statesp = states;
+	*nstatesp = nstates;
+}
+
+/*
+ * Register idle states for a CPU.
+ *
+ * Ensures a WFI entry exists in the array, adding one if the caller
+ * did not supply it, then sorts the array by min_residency ascending.
+ * Passing NULL/0 is valid and registers the CPU with WFI only.
+ *
+ * Takes ownership of the caller-allocated states array.  On failure
+ * both the caller's and any synthesised array are freed.
+ */
+int
+cpuidle_register_states(processorid_t cpuid, lpi_state_t *states, int nstates)
+{
+	cpu_t *cp;
+
+	ASSERT(states != NULL || nstates == 0);
+
+	/* Guarantee WFI is present and array is sorted */
+	cpuidle_ensure_wfi(&states, &nstates);
+
+	/*
+	 * Store in the cpu_t.  The caller is the CPU's own driver, so the
+	 * cpu_t is guaranteed to exist.
+	 */
+	cp = cpu[cpuid];
+	ASSERT3P(cp, !=, NULL);
+
+	cp->cpu_m.mcpu_lpi_states = states;
+	cp->cpu_m.mcpu_lpi_nstates = nstates;
+
+	cpuidle_kstat_create(cpuid, states, nstates);
+
+	return (0);
+}
+
+/*
+ * Module infrastructure
+ */
+
+static struct modlmisc modlmisc = {
+	.misc_modops	= &mod_miscops,
+	.misc_linkinfo	= "CPU idle framework"
+};
+
+static struct modlinkage modlinkage = {
+	.ml_rev		= MODREV_1,
+	.ml_linkage	= { &modlmisc, NULL }
+};
+
+int
+_init(void)
+{
+	int err;
+
+	lpi_last_idle = kmem_zalloc(max_ncpus * sizeof (hrtime_t), KM_SLEEP);
+	lpi_kstats = kmem_zalloc(max_ncpus * sizeof (kstat_t **), KM_SLEEP);
+
+	err = mod_install(&modlinkage);
+	if (err != 0) {
+		kmem_free(lpi_kstats, max_ncpus * sizeof (kstat_t **));
+		lpi_kstats = NULL;
+		kmem_free(lpi_last_idle, max_ncpus * sizeof (hrtime_t));
+		lpi_last_idle = NULL;
+		return (err);
+	}
+
+	cpu_halt_impl = cpu_lpi_halt;
+	return (0);
+}
+
+int
+_fini(void)
+{
+	/* Do not allow unload; cpu_halt_impl is in use */
+	return (EBUSY);
+}
+
+int
+_info(struct modinfo *modinfop)
+{
+	return (mod_info(&modlinkage, modinfop));
+}

--- a/usr/src/uts/armv8/os/mp_machdep.c
+++ b/usr/src/uts/armv8/os/mp_machdep.c
@@ -100,7 +100,24 @@ mach_cpu_pause(volatile char *safe)
 		SMT_PAUSE();
 }
 
-void
+/*
+ * Default cpu_halt loop body: execute WFI and return.
+ */
+static void
+cpu_halt_wfi(void)
+{
+	__asm__ __volatile__("wfi" ::: "memory");
+}
+
+/*
+ * Pluggable cpu_halt loop body.
+ *
+ * This implementation hook is called with interrupts disabled from
+ * the inner loop of cpu_halt.
+ */
+void (*cpu_halt_impl)(void) = cpu_halt_wfi;
+
+static void
 cpu_halt(void)
 {
 	cpu_t *cpup = CPU;
@@ -192,7 +209,7 @@ cpu_halt(void)
 	while (*p == 0 &&
 	    ((hset_update && bitset_in_set(&cp->cp_haltset, cpu_sid)) ||
 	    (!hset_update && (CPU->cpu_flags & CPU_OFFLINE)))) {
-		__asm__ volatile("wfi");
+		cpu_halt_impl();
 		restore_interrupts(s);
 		s = disable_interrupts();
 	}

--- a/usr/src/uts/armv8/sys/cpuidle.h
+++ b/usr/src/uts/armv8/sys/cpuidle.h
@@ -1,0 +1,69 @@
+/*
+ * This file and its contents are supplied under the terms of the
+ * Common Development and Distribution License ("CDDL"), version 1.0.
+ * You may only use this file in accordance with the terms of version
+ * 1.0 of the CDDL.
+ *
+ * A full copy of the text of the CDDL should have accompanied this
+ * source.  A copy of the CDDL is also available via the Internet at
+ * http://www.illumos.org/license/CDDL.
+ */
+
+/*
+ * Copyright 2026 Michael van der Westhuizen
+ */
+
+#ifndef	_SYS_CPUIDLE_H
+#define	_SYS_CPUIDLE_H
+
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * CPU idle state descriptor.
+ *
+ * Common currency between the cpuidle framework and firmware-specific drivers
+ * (cpudrv for devicetree with idle-states, and a separate cpudrv for ACPI).
+ *
+ * The entry method is encoded as an entry type and a PSCI power_state
+ * parameter (for PSCI-based states).
+ */
+
+/* Entry types */
+#define	LPI_ENTRY_WFI		0	/* ARM WFI instruction */
+#define	LPI_ENTRY_PSCI		1	/* PSCI CPU_SUSPEND */
+
+typedef struct lpi_state {
+	uint32_t	ls_min_residency;	/* Min residency (us) */
+	/* Worst-case wake latency (us) */
+	uint32_t	ls_wake_latency;
+	uint32_t	ls_ctx_loss_flags;	/* LPI_CTX_LOSS_* flags */
+	/* PSCI CPU_SUSPEND power_state */
+	uint32_t	ls_psci_state;
+	uint8_t		ls_entry_type;		/* LPI_ENTRY_* */
+	boolean_t	ls_enabled;		/* State is usable */
+	/* Runtime counters - written only from the owning CPU's idle thread */
+	uint64_t	ls_entries;		/* Times state was entered */
+	uint64_t	ls_residency_ns;	/* Total time in this state */
+} lpi_state_t;
+
+/*
+ * PSCI CPU_SUSPEND power_state field encoding (PSCI 1.0+ extended format).
+ *   Bit 30: StateType  0 = standby, 1 = powerdown
+ */
+#define	PSCI_STATE_TYPE_POWERDOWN	(1U << 30)
+
+/*
+ * Register idle states for a CPU.
+ */
+extern int cpuidle_register_states(processorid_t cpuid,
+    lpi_state_t *states, int nstates);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif	/* _SYS_CPUIDLE_H */

--- a/usr/src/uts/armv8/sys/machcpuvar.h
+++ b/usr/src/uts/armv8/sys/machcpuvar.h
@@ -25,7 +25,7 @@
  *
  * Copyright 2011 Joyent, Inc. All rights reserved.
  * Copyright 2017 Hayashi Naoyuki
- * Copyright 2025 Michael van der Westhuizen
+ * Copyright 2026 Michael van der Westhuizen
  */
 
 #ifndef _SYS_MACHCPUVAR_H
@@ -67,6 +67,10 @@ struct	machcpu {
 	uint64_t	mcpu_boot_el;
 
 	struct cpuinfo	*mcpu_ci;
+
+	/* Low power idle state array, populated from firmware */
+	struct lpi_state *mcpu_lpi_states;
+	int		mcpu_lpi_nstates;
 };
 
 #ifndef NINTR_THREADS

--- a/usr/src/uts/armv8/sys/machsystm.h
+++ b/usr/src/uts/armv8/sys/machsystm.h
@@ -96,6 +96,13 @@ extern void kcpc_hw_fini(cpu_t *cp);
 extern void siron(void);
 
 /*
+ * Pluggable cpu_halt loop body (in mp_machdep.c).
+ *
+ * The default implementation just uses WFI.
+ */
+extern void (*cpu_halt_impl)(void);
+
+/*
  * UEFI Runtime Services (efirt_machdep.c/efirt_call.S)
  */
 extern void efirt_init(void);

--- a/usr/src/uts/common/os/cpu_event.c
+++ b/usr/src/uts/common/os/cpu_event.c
@@ -61,7 +61,7 @@
 #include <sys/sunddi.h>
 #if defined(__sparc)
 #include <sys/machsystm.h>
-#elif defined(__x86)
+#elif defined(__x86) || defined(__aarch64__)
 #include <sys/archsystm.h>
 #endif
 #include <sys/cpu_event.h>
@@ -639,6 +639,8 @@ cpu_idle_enter(int state, int flag,
 	cpu_idle_callback_context_t ctx;
 #if defined(__x86)
 	ulong_t iflags;
+#elif defined(__aarch64__)
+	uint64_t daif;
 #endif
 
 	ctx = CPU_IDLE_GET_CTX(CPU);
@@ -662,20 +664,24 @@ cpu_idle_enter(int state, int flag,
 	}
 
 	/*
-	 * On x86, cpu_idle_enter can be called from idle thread with either
-	 * interrupts enabled or disabled, so we need to make sure interrupts
-	 * are disabled here.
+	 * On x86 and aarch64, cpu_idle_enter can be called from idle thread
+	 * with either interrupts enabled or disabled, so we need to make
+	 * sure interrupts are disabled here.
 	 * On SPARC, cpu_idle_enter will be called from idle thread with
 	 * interrupt disabled, so no special handling necessary.
 	 */
 #if defined(__x86)
 	iflags = intr_clear();
+#elif defined(__aarch64__)
+	daif = disable_interrupts();
 #endif
 
 	/* Skip calling callback if state is not ready for current CPU. */
 	if (cpu_idle_enter_state(sp, state) == 0) {
 #if defined(__x86)
 		intr_restore(iflags);
+#elif defined(__aarch64__)
+		restore_interrupts(daif);
 #endif
 		return (0);
 	}
@@ -721,6 +727,8 @@ cpu_idle_enter(int state, int flag,
 			if (sp->v.index != i + 1) {
 #if defined(__x86)
 				intr_restore(iflags);
+#elif defined(__aarch64__)
+				restore_interrupts(daif);
 #endif
 				return (EBUSY);
 			}
@@ -728,6 +736,8 @@ cpu_idle_enter(int state, int flag,
 	}
 #if defined(__x86)
 	intr_restore(iflags);
+#elif defined(__aarch64__)
+	restore_interrupts(daif);
 #endif
 
 	return (0);
@@ -736,13 +746,14 @@ cpu_idle_enter(int state, int flag,
 void
 cpu_idle_exit(int flag)
 {
-	/* XXXARM */
-	int i __unused;
-	cpu_idle_cb_item_t *cip __unused;
-	cpu_idle_cb_state_t *sp __unused;
-	cpu_idle_callback_context_t ctx __unused;
+	int i;
+	cpu_idle_cb_item_t *cip;
+	cpu_idle_cb_state_t *sp;
+	cpu_idle_callback_context_t ctx;
 #if defined(__x86)
 	ulong_t iflags;
+#elif defined(__aarch64__)
+	uint64_t daif;
 #endif
 
 	ASSERT(CPU->cpu_seqid < max_ncpus);
@@ -807,6 +818,49 @@ cpu_idle_exit(int flag)
 			sp->v.index = 0;
 		}
 		intr_restore(iflags);
+	}
+#elif defined(__aarch64__)
+	/*
+	 * On aarch64, cpu_idle_exit will be called from idle thread or
+	 * interrupt handler.  When called from interrupt handler, interrupts
+	 * will be disabled.  When called from idle thread, interrupts may be
+	 * disabled or enabled.
+	 */
+
+	/* Called from interrupt, interrupts are already disabled. */
+	if (flag & CPU_IDLE_CB_FLAG_INTR) {
+		/*
+		 * Return if cpu_idle_exit already called or
+		 * there is no registered callback.
+		 */
+		if (sp->v.index == 0) {
+			return;
+		}
+		ctx = CPU_IDLE_GET_CTX(CPU);
+		cpu_idle_exit_state(sp);
+		for (i = sp->v.index - 1; i >= 0; i--) {
+			cip = &cpu_idle_cb_array[i];
+			if (cip->exit != NULL) {
+				cip->exit(cip->arg, ctx, flag);
+			}
+		}
+		sp->v.index = 0;
+
+	/* Called from idle thread, need to disable interrupts. */
+	} else {
+		daif = disable_interrupts();
+		if (sp->v.index != 0) {
+			ctx = CPU_IDLE_GET_CTX(CPU);
+			cpu_idle_exit_state(sp);
+			for (i = sp->v.index - 1; i >= 0; i--) {
+				cip = &cpu_idle_cb_array[i];
+				if (cip->exit != NULL) {
+					cip->exit(cip->arg, ctx, flag);
+				}
+			}
+			sp->v.index = 0;
+		}
+		restore_interrupts(daif);
 	}
 #endif
 }


### PR DESCRIPTION
__LPI replaces C-states on non-Intel (and hardware-reduced) platforms - the implementation is trivially shareable between FDT and ACPI systems._

Prepare for low power idle via two changes:
1. Make the `cpu_halt` loop body pluggable, defaulting to a simple WFI as it does today.
2. Introduce a `cpuidle` module, which hooks the `cpu_halt` loop body function pointer and implements low-power-idle dispatch via PSCI when configured to do so by a consumer (a CPU driver is responsible for parsing firmware tables and registering per-CPU idle states with this module). The default behaviour continues to simply use WFI.

The PSCI idle mechanism is to call CPU_SUSPEND with a SoC-specific argument. That argument is what gets parsed by firmware-specific CPU drivers and passed to this module in the LPI states array.

Selection of idle state (or depth) is the same as i86pc in that the algorithm looks at how long the previous idle was to predict the length of the next idle, then use that to select the deepest a low power idle method that meets the expected idle time.

Since idle depth is recalculated every time the CPU awakens, perhaps spuriously, spurious wakeups will simply drive the CPU into deeper idle states.

Idle states that involve state loss are explicitly skipped for now - at least until more machdep support is in place.

**Spec References:**
* FDT: https://www.kernel.org/doc/Documentation/devicetree/bindings/arm/idle-states.txt
* ACPI: ACPI 6.6 §8.4.3.3 "_LPI (Low Power Idle States)" and §8.4.3.3.3 "Power, Minimum Residency, and Worst Case Wakeup Latency"

**Testing:**
* [rpi4](https://gist.github.com/r1mikey/31b3709518eaff6bfaab49993663259e)
* [qemu FDT](https://gist.github.com/r1mikey/7f84d3d040b9f7895721ed564a1bfabc)
* qemu edk2 (later in the series)
* Altra Max (later in the series)