### PR TITLE
cpu_event: address existing bugs

### DIFF
--- a/usr/src/uts/common/os/cpu_event.c
+++ b/usr/src/uts/common/os/cpu_event.c
@@ -325,7 +325,7 @@ cpu_event_init(void)
 		___INIT_P(last_busy, CPU_IDLE_PROP_IDX_LAST_BUSY);
 		___INIT_P(total_idle, CPU_IDLE_PROP_IDX_TOTAL_IDLE);
 		___INIT_P(total_busy, CPU_IDLE_PROP_IDX_TOTAL_BUSY);
-		___INIT_P(last_idle, CPU_IDLE_PROP_IDX_INTR_CNT);
+		___INIT_P(intr_cnt, CPU_IDLE_PROP_IDX_INTR_CNT);
 #undef	___INIT_P
 	}
 

--- a/usr/src/uts/common/sys/cpu_event.h
+++ b/usr/src/uts/common/sys/cpu_event.h
@@ -82,7 +82,7 @@ extern "C" {
 #define	CPU_IDLE_PROP_LAST_BUSY_TIME	"last-busy-time"
 #define	CPU_IDLE_PROP_TOTAL_IDLE_TIME	"total-idle-time"
 #define	CPU_IDLE_PROP_TOTAL_BUSY_TIME	"total-busy-time"
-#define	CPU_IDLE_PROP_INTERRUPT_COUNT	"interupt-count"
+#define	CPU_IDLE_PROP_INTERRUPT_COUNT	"interrupt-count"
 
 /*
  * sizeof(cpu_idle_prop_value_t) should be power of 2 to align on cache line.


### PR DESCRIPTION
Some drive-by fixes for existing and long-standing issues in `cpu_idle`.

Two defects here:
1. The "interrupt-count" property is mis-spelt as "interupt-count"
2. CPU_IDLE_PROP_IDX_INTR_CNT is initialised to point to last_idle

These defects are against [PSARC 2009/115](https://illumos.org/opensolaris/ARChive/PSARC/2009/115/spec.txt).

The first one affects user-visible behaviour, the second is a plain old bug.